### PR TITLE
Handle recording stop without buffering network events

### DIFF
--- a/Sources/WebInspectorKit/WebInspector/Models/WINetworkStore.swift
+++ b/Sources/WebInspectorKit/WebInspector/Models/WINetworkStore.swift
@@ -646,14 +646,17 @@ public final class WINetworkWebSocketInfo: Identifiable, Equatable, Hashable{
     @ObservationIgnored private var indexByEntryID: [UUID: Int] = [:]
 
     func applyEvent(_ event: HTTPNetworkEvent) {
+        guard isRecording else { return }
         applyHTTPEvent(event)
     }
 
     func applyEvent(_ event: WSNetworkEvent) {
+        guard isRecording else { return }
         applyWSEvent(event)
     }
 
     func applyBatchedInsertions(_ batch: NetworkEventBatch) {
+        guard isRecording else { return }
         let events = batch.events
         guard !events.isEmpty else { return }
 

--- a/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentHTTP.js
+++ b/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentHTTP.js
@@ -9,14 +9,14 @@ const installFetchPatch = () => {
         return;
     }
     const patched = async function() {
-        const shouldTrack = true;
+        const shouldTrack = !!networkState.enabled;
         const args = Array.from(arguments);
         const [input, init = {}] = args;
         const method = init.method || (input && input.method) || "GET";
         const requestId = shouldTrack ? nextRequestID() : null;
         const url = typeof input === "string" ? input : (input && input.url) || "";
-        const headers = normalizeHeaders(init.headers || (input && input.headers));
-        const requestBodyInfo = serializeRequestBody(init.body);
+        const headers = shouldTrack ? normalizeHeaders(init.headers || (input && input.headers)) : {};
+        const requestBodyInfo = shouldTrack ? serializeRequestBody(init.body) : null;
 
         if (shouldTrack && requestId != null) {
             recordStart(
@@ -107,7 +107,7 @@ const installXHRPatch = () => {
     };
 
     XMLHttpRequest.prototype.send = function() {
-        const shouldTrack = !!this.__wiNetwork;
+        const shouldTrack = !!this.__wiNetwork && !!networkState.enabled;
         const requestId = shouldTrack ? nextRequestID() : null;
         const info = this.__wiNetwork;
         if (shouldTrack && requestId != null && info) {

--- a/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentUtils.js
+++ b/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentUtils.js
@@ -123,7 +123,6 @@ const enqueueEvent = event => {
 
 const postHTTPEvent = payload => {
     if (!networkState.enabled) {
-        enqueueEvent({kind: "http", payload});
         return;
     }
     try {
@@ -134,7 +133,6 @@ const postHTTPEvent = payload => {
 
 const postHTTPBatchEvents = payloads => {
     if (!networkState.enabled) {
-        enqueueEvent({kind: "httpBatch", payloads});
         return;
     }
     if (!Array.isArray(payloads) || !payloads.length) {
@@ -572,6 +570,9 @@ const shouldTrackResourceEntry = entry => {
 };
 
 const handleResourceEntry = entry => {
+    if (!networkState.enabled) {
+        return null;
+    }
     if (!shouldTrackResourceEntry(entry)) {
         return null;
     }


### PR DESCRIPTION
- Skip enqueuing HTTP/WS events while logging is disabled and clear caches when toggled off
- Guard store application with isRecording so paused sessions do not resurrect logs