### PR TITLE
Fix network payload sizing and charset handling

### DIFF
--- a/Sources/WebInspectorKit/WebInspector/Models/WINetworkStore.swift
+++ b/Sources/WebInspectorKit/WebInspector/Models/WINetworkStore.swift
@@ -485,7 +485,7 @@ public class WINetworkEntry: Identifiable, Equatable, Hashable {
     }
 
     convenience init(startPayload payload: HTTPNetworkEvent) {
-        let method = payload.method ?? "GET"
+        let method = (payload.method?.isEmpty == false ? payload.method : nil) ?? "UNKNOWN"
         let url = payload.url ?? ""
         self.init(
             sessionID: payload.sessionID,

--- a/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentWebSocket.js
+++ b/Sources/WebInspectorKit/WebInspector/Support/NetworkAgent/NetworkAgentWebSocket.js
@@ -5,9 +5,11 @@ const serializeFramePayload = async data => {
         return {payload: "", base64: false, size: 0, truncated: false};
     }
     if (typeof data === "string") {
-        const truncated = data.length > MAX_WS_FRAME_BODY_LENGTH;
-        const body = truncated ? data.slice(0, MAX_WS_FRAME_BODY_LENGTH) : data;
-        return {payload: body, base64: false, size: data.length, truncated: truncated};
+        const encoded = encodeTextToBytes(data);
+        const size = encoded ? encoded.byteLength : data.length;
+        const clamped = clampStringToByteLength(data, MAX_WS_FRAME_BODY_LENGTH, encoded);
+        const truncated = clamped.truncated || (Number.isFinite(size) && size > MAX_WS_FRAME_BODY_LENGTH);
+        return {payload: clamped.text, base64: false, size: size, truncated: truncated};
     }
     try {
         let bytes = null;


### PR DESCRIPTION
- Measure text bodies and WebSocket frames by UTF-8 byte length instead of code units
- Decode response bodies using charset from Content-Type or fall back to base64
- Improve resource timing fallback data for size/method accuracy