### PR TITLE
Refine network UI and persist file type labels

### DIFF
--- a/Sources/WebInspectorKit/WebInspector/Views/WINetworkDetailView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WINetworkDetailView.swift
@@ -156,6 +156,7 @@ private struct WINetworkBodySection: View {
                     .frame(maxWidth:.infinity,alignment:.leading)
                     .font(.caption.monospaced())
                     .textSelection(.enabled)
+                    .truncationMode(.tail)
                     .lineLimit(12)
                  
             } else {
@@ -277,22 +278,6 @@ extension WINetworkEntry {
             }
         }
         return url
-    }
-
-    var fileTypeLabel: String {
-        if let mimeType {
-            let trimmed = mimeType.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true).first ?? ""
-            if let subtype = trimmed.split(separator: "/").last, !subtype.isEmpty {
-                return subtype.lowercased()
-            }
-        }
-        if let pathExtension = URL(string: url)?.pathExtension, !pathExtension.isEmpty {
-            return pathExtension.lowercased()
-        }
-        if let requestType, !requestType.isEmpty {
-            return requestType
-        }
-        return "-"
     }
 
     var host: String? {

--- a/Sources/WebInspectorKit/WebInspector/Views/WINetworkView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WINetworkView.swift
@@ -77,6 +77,7 @@ private struct WINetworkTableView: View {
                     HStack(spacing: 6) {
                         Circle()
                             .fill(entry.statusTint)
+                            .animation(.smooth(duration:0.22),value:entry.statusTint)
                             .frame(width: 8, height: 8)
                         Text(entry.statusLabel)
                     }
@@ -140,14 +141,9 @@ private struct WINetworkListView: View {
                 viewModel.displayEntries,
             ) { entry in
                 WINetworkRow(entry: entry)
-                    .contentShape(.rect)
-                    .onTapGesture {
-                        viewModel.selectedEntryID = entry.id
-                    }
             }
         }
         .scrollContentBackground(.hidden)
-        .listStyle(.plain)
         .sheet(isPresented: viewModel.isShowingDetail) {
             NavigationStack {
                 if let isSelectedEntryID = viewModel.selectedEntryID,
@@ -169,20 +165,20 @@ private struct WINetworkRow: View {
     let entry: WINetworkEntry
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack{
-                Circle()
-                    .fill(entry.statusTint)
-                    .frame(width: 8, height: 8)
-                Text(entry.displayName)
-                    .font(.subheadline.weight(.semibold))
-                    .lineLimit(2)
-                    .foregroundStyle(.primary)
-                Spacer(minLength: 0)
-                Text(entry.method)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
+        HStack{
+            Circle()
+                .fill(entry.statusTint)
+                .animation(.smooth(duration:0.22),value:entry.statusTint)
+                .frame(width: 8, height: 8)
+            Text(entry.displayName)
+                .font(.subheadline.weight(.semibold))
+                .truncationMode(.middle)
+                .lineLimit(2)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 0)
+            Text(entry.fileTypeLabel)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			mainGroup = ABA353BF2EDFF1EC00489A00;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				ABA353FE2EDFF28300489A00 /* XCLocalSwiftPackageReference "../../../WebInspectorKit" */,
+				ABA353FE2EDFF28300489A00 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = ABA353C92EDFF1EC00489A00 /* Products */;
@@ -646,9 +646,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		ABA353FE2EDFF28300489A00 /* XCLocalSwiftPackageReference "../../../WebInspectorKit" */ = {
+		ABA353FE2EDFF28300489A00 /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../../WebInspectorKit;
+			relativePath = ../..;
 		};
 /* End XCLocalSwiftPackageReference section */
 


### PR DESCRIPTION
## Summary
- cache and refresh file type labels on network entries
- polish compact/table list visuals (status animation, truncation, type display)
- point MiniBrowser package reference at repo root

## Testing
- swift build