### PR TITLE
Rename detail tab to element

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For a more complete preview setup, see [`Sources/WebInspectorKit/WebInspector/Vi
 ```swift
 WebInspectorView(inspector, webView: pageWebView) {
     WITab.dom()
-    WITab.detail()
+    WITab.element()
     WITab("Custom", systemImage: "folder") { _ in
         List{
             Text("Custom tab content")

--- a/Sources/WebInspectorKit/Localizable.xcstrings
+++ b/Sources/WebInspectorKit/Localizable.xcstrings
@@ -286,7 +286,7 @@
         }
       }
     },
-    "dom.detail.attributes.empty" : {
+    "dom.element.attributes.empty" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -428,7 +428,7 @@
         }
       }
     },
-    "dom.detail.copy.selector_path" : {
+    "dom.element.copy.selector_path" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -570,7 +570,7 @@
         }
       }
     },
-    "dom.detail.hint" : {
+    "dom.element.hint" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -712,7 +712,7 @@
         }
       }
     },
-    "dom.detail.section.attributes" : {
+    "dom.element.section.attributes" : {
       "comment" : "Section title for DOM attributes list.",
       "localizations" : {
         "ar" : {
@@ -855,7 +855,7 @@
         }
       }
     },
-    "dom.detail.section.element" : {
+    "dom.element.section.element" : {
       "comment" : "Section title for the selected DOM element preview.",
       "localizations" : {
         "ar" : {
@@ -998,7 +998,7 @@
         }
       }
     },
-    "dom.detail.section.selector" : {
+    "dom.element.section.selector" : {
       "comment" : "Section title for CSS selector path.",
       "localizations" : {
         "ar" : {
@@ -1141,7 +1141,7 @@
         }
       }
     },
-    "dom.detail.select_prompt" : {
+    "dom.element.select_prompt" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1568,145 +1568,145 @@
         }
       }
     },
-    "inspector.tab.detail" : {
-      "comment" : "Tab title that shows details of the selected node.",
+    "inspector.tab.element" : {
+      "comment" : "Tab title for the selected DOM element.",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التفاصيل"
+            "value" : "العنصر"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Details"
+            "value" : "Element"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detail"
+            "value" : "Element"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detail"
+            "value" : "Element"
           }
         },
         "en-IN" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detail"
+            "value" : "Element"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detalles"
+            "value" : "Elemento"
           }
         },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detalles"
+            "value" : "Elemento"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Détails"
+            "value" : "Élément"
           }
         },
         "fr-CA" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Détails"
+            "value" : "Élément"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "विवरण"
+            "value" : "तत्व"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rincian"
+            "value" : "Elemen"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dettagli"
+            "value" : "Elemento"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "詳細"
+            "value" : "要素"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "상세"
+            "value" : "요소"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Details"
+            "value" : "Element"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detalhes"
+            "value" : "Elemento"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detalhes"
+            "value" : "Elemento"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detalii"
+            "value" : "Element"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Детали"
+            "value" : "Элемент"
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "รายละเอียด"
+            "value" : "องค์ประกอบ"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detay"
+            "value" : "Öğe"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "详情"
+            "value" : "元素"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "詳細"
+            "value" : "元素"
           }
         }
       }

--- a/Sources/WebInspectorKit/WebInspector/Views/Tabs/WIDefaultTab.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/Tabs/WIDefaultTab.swift
@@ -2,15 +2,15 @@ import SwiftUI
 
 enum WIDefaultTab: Int, CaseIterable {
     case dom
-    case detail
+    case element
     case network
 
     var title: LocalizedStringResource {
         switch self {
         case .dom:
             LocalizedStringResource("inspector.tab.dom", bundle: .module)
-        case .detail:
-            LocalizedStringResource("inspector.tab.detail", bundle: .module)
+        case .element:
+            LocalizedStringResource("inspector.tab.element", bundle: .module)
         case .network:
             LocalizedStringResource("inspector.tab.network", bundle: .module)
         }
@@ -20,7 +20,7 @@ enum WIDefaultTab: Int, CaseIterable {
         switch self {
         case .dom:
             "chevron.left.forwardslash.chevron.right"
-        case .detail:
+        case .element:
             "info.circle"
         case .network:
             "waveform.path.ecg.rectangle"
@@ -31,8 +31,8 @@ enum WIDefaultTab: Int, CaseIterable {
         switch self {
         case .dom:
             "wi_dom"
-        case .detail:
-            "wi_detail"
+        case .element:
+            "wi_element"
         case .network:
             "wi_network"
         }
@@ -55,17 +55,17 @@ public extension WITab {
         )
     }
 
-    static func detail(
+    static func element(
         title: LocalizedStringResource? = nil,
         systemImage: String? = nil
     ) -> WITab {
         WITab(
-            title ?? WIDefaultTab.detail.title,
-            systemImage: systemImage ?? WIDefaultTab.detail.systemImage,
-            value: WIDefaultTab.detail.identifier,
+            title ?? WIDefaultTab.element.title,
+            systemImage: systemImage ?? WIDefaultTab.element.systemImage,
+            value: WIDefaultTab.element.identifier,
             role: .inspector,
             content: { model in
-                WIDetailView(viewModel: model.dom)
+                WIDOMElementView(viewModel: model.dom)
             }
         )
     }

--- a/Sources/WebInspectorKit/WebInspector/Views/WIDOMElementView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WIDOMElementView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-public struct WIDetailView: View {
+public struct WIDOMElementView: View {
     private var viewModel: WIDOMViewModel
     
     public init(viewModel: WIDOMViewModel) {
@@ -22,7 +22,7 @@ public struct WIDetailView: View {
                         .listRowStyle()
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }header: {
-                        Text("dom.detail.section.element")
+                        Text("dom.element.section.element")
                     }
                     Section {
                         SelectionPreviewTextRepresentable(
@@ -33,11 +33,11 @@ public struct WIDetailView: View {
                         .listRowStyle()
                         .frame(maxWidth: .infinity, alignment: .leading)
                     } header: {
-                        Text("dom.detail.section.selector")
+                        Text("dom.element.section.selector")
                     }
                     Section {
                         if viewModel.selection.attributes.isEmpty {
-                            Text("dom.detail.attributes.empty")
+                            Text("dom.element.attributes.empty")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                                 .listRowSeparator(.hidden)
@@ -68,7 +68,7 @@ public struct WIDetailView: View {
                             }
                         }
                     }header:{
-                        Text("dom.detail.section.attributes")
+                        Text("dom.element.section.attributes")
                     }
                 }
                 .listSectionSeparator(.hidden)
@@ -79,9 +79,9 @@ public struct WIDetailView: View {
                 .contentMargins(.bottom, 24 ,for: .scrollContent)
             }else{
                 ContentUnavailableView(
-                    String(localized:"dom.detail.select_prompt",bundle:.module),
+                    String(localized:"dom.element.select_prompt",bundle:.module),
                     systemImage: "cursorarrow.rays",
-                    description: Text("dom.detail.hint")
+                    description: Text("dom.element.hint")
                 )
             }
         }
@@ -272,7 +272,7 @@ public final class SelectionUITextView: UITextView, UITextViewDelegate {
 
 #if DEBUG
 @MainActor
-private func makeWIDetailPreviewModel(selection: WIDOMSelection?) -> WIDOMViewModel {
+private func makeWIDOMElementPreviewModel(selection: WIDOMSelection?) -> WIDOMViewModel {
     let model = WIDOMViewModel()
     if let selection {
         model.selection.nodeId = selection.nodeId
@@ -287,7 +287,7 @@ private func makeWIDetailPreviewModel(selection: WIDOMSelection?) -> WIDOMViewMo
 }
 
 @MainActor
-private enum WIDetailPreviewData {
+private enum WIDOMElementPreviewData {
     static let selected = WIDOMSelection(
         nodeId: 128,
         preview: "<article class=\"entry\">Preview post content</article>",
@@ -322,14 +322,14 @@ private enum WIDetailPreviewData {
 }
 
 #Preview("DOM Selected") {
-    WIDetailView(viewModel: makeWIDetailPreviewModel(selection: WIDetailPreviewData.selected))
+    WIDOMElementView(viewModel: makeWIDOMElementPreviewModel(selection: WIDOMElementPreviewData.selected))
 }
 
 #Preview("Attributes Empty") {
-    WIDetailView(viewModel: makeWIDetailPreviewModel(selection: WIDetailPreviewData.attributesEmpty))
+    WIDOMElementView(viewModel: makeWIDOMElementPreviewModel(selection: WIDOMElementPreviewData.attributesEmpty))
 }
 
 #Preview("No DOM Selection") {
-    WIDetailView(viewModel: makeWIDetailPreviewModel(selection: nil))
+    WIDOMElementView(viewModel: makeWIDOMElementPreviewModel(selection: nil))
 }
 #endif

--- a/Sources/WebInspectorKit/WebInspector/Views/WebInspectorToolbarModifier.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WebInspectorToolbarModifier.swift
@@ -31,7 +31,7 @@ struct WebInspectorToolbarModifier: ViewModifier {
                             Button {
                                 model.copySelection(.selectorPath)
                             } label: {
-                                Text("dom.detail.copy.selector_path")
+                                Text("dom.element.copy.selector_path")
                             }
                             Button {
                                 model.copySelection(.xpath)

--- a/Sources/WebInspectorKit/WebInspector/Views/WebInspectorView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WebInspectorView.swift
@@ -29,7 +29,7 @@ public struct WebInspectorView: View {
     ) {
         self.init(viewModel, webView: webView) {
             WITab.dom()
-            WITab.detail()
+            WITab.element()
             WITab.network()
         }
     }


### PR DESCRIPTION
## Summary
- rename the default detail tab to element and keep localized labels aligned
- rename WIDetailView to WIDOMElementView and update toolbar copy key
- refresh README example to use the new element tab helper

## Testing
- swift build
