### PR TITLE
fix: background superclear in network views

### DIFF
--- a/Sources/WebInspectorKit/WebInspector/Views/WINetworkDetailView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WINetworkDetailView.swift
@@ -153,6 +153,7 @@ private struct WINetworkBodySection: View {
             }
             NavigationLink {
                 WINetworkBodyPreviewView(entry: entry, viewModel: viewModel, bodyState: bodyState)
+                    .background(.superClear)
             } label: {
                 HStack {
                     Label {

--- a/Sources/WebInspectorKit/WebInspector/Views/WINetworkView.swift
+++ b/Sources/WebInspectorKit/WebInspector/Views/WINetworkView.swift
@@ -182,6 +182,7 @@ private struct WINetworkListView: View {
                 WINetworkDetailView(entry: entry, viewModel: viewModel)
                     .navigationTitle(entry.displayName)
 #if os(iOS)
+                    .background(.superClear)
                     .navigationBarTitleDisplayMode(.inline)
 #endif
             } else {


### PR DESCRIPTION
Summary:
- Add superClear background to network detail and list views to avoid background artifacts

Testing:
- swift build