### PR TITLE
Refactor network body preview and fetch handling

### DIFF
--- a/Sources/WebInspectorKit/WebInspector/Models/WINetworkBodyPreviewData.swift
+++ b/Sources/WebInspectorKit/WebInspector/Models/WINetworkBodyPreviewData.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct WINetworkBodyPreviewData {
+    let text: String?
+    let jsonNodes: [WINetworkJSONNode]?
+}
+
+extension WINetworkBody {
+    var previewData: WINetworkBodyPreviewData {
+        let decoded = decodedPreviewText
+        let text = decoded ?? full ?? preview ?? summary
+        let jsonNodes = decoded.flatMap(WINetworkJSONNode.nodes(from:))
+        return WINetworkBodyPreviewData(text: text, jsonNodes: jsonNodes)
+    }
+
+    var canFetchBody: Bool {
+        guard let reference, !reference.isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    private var decodedPreviewText: String? {
+        guard kind != .binary else {
+            return nil
+        }
+        guard let candidate = full ?? preview else {
+            return nil
+        }
+        guard isBase64Encoded else {
+            return candidate
+        }
+        guard let data = Data(base64Encoded: candidate) else {
+            return nil
+        }
+        if let decoded = String(data: data, encoding: .utf8) {
+            return decoded
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/WebInspectorKit/WebInspector/Models/WINetworkJSONNode.swift
+++ b/Sources/WebInspectorKit/WebInspector/Models/WINetworkJSONNode.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+struct WINetworkJSONNode: Identifiable {
+    fileprivate enum JSONValue {
+        case object([String: JSONValue])
+        case array([JSONValue])
+        case string(String)
+        case number(String)
+        case bool(Bool)
+        case null
+    }
+
+    enum DisplayKind {
+        case object(count: Int)
+        case array(count: Int)
+        case string(String)
+        case number(String)
+        case bool(Bool)
+        case null
+    }
+
+    let id = UUID()
+    let key: String
+    let isIndex: Bool
+    private let value: JSONValue
+    let children: [WINetworkJSONNode]?
+
+    var displayKind: DisplayKind {
+        switch value {
+        case .object(let dictionary):
+            return .object(count: dictionary.count)
+        case .array(let array):
+            return .array(count: array.count)
+        case .string(let value):
+            return .string(value)
+        case .number(let value):
+            return .number(value)
+        case .bool(let value):
+            return .bool(value)
+        case .null:
+            return .null
+        }
+    }
+
+    private init(key: String, value: JSONValue, isIndex: Bool) {
+        self.key = key
+        self.isIndex = isIndex
+        self.value = value
+        self.children = WINetworkJSONNode.makeChildren(from: value)
+    }
+
+    static func nodes(from text: String) -> [WINetworkJSONNode]? {
+        guard let data = text.data(using: .utf8) else {
+            return nil
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return nil
+        }
+        return nodes(from: object)
+    }
+
+    private static func nodes(from object: Any) -> [WINetworkJSONNode] {
+        let value = JSONValue.make(from: object)
+        return makeChildren(from: value) ?? [WINetworkJSONNode(key: "", value: value, isIndex: false)]
+    }
+
+    private static func makeChildren(from value: JSONValue) -> [WINetworkJSONNode]? {
+        switch value {
+        case .object(let dictionary):
+            let keys = Array(dictionary.keys)
+            return keys.map { key in
+                WINetworkJSONNode(key: key, value: dictionary[key] ?? .null, isIndex: false)
+            }
+        case .array(let array):
+            return array.enumerated().map { index, item in
+                WINetworkJSONNode(key: String(index), value: item, isIndex: true)
+            }
+        default:
+            return nil
+        }
+    }
+
+    private static func truncate(_ value: String, limit: Int = 160) -> String {
+        guard value.count > limit else {
+            return value
+        }
+        let index = value.index(value.startIndex, offsetBy: limit)
+        return String(value[..<index]) + "..."
+    }
+}
+
+private extension WINetworkJSONNode.JSONValue {
+    static func make(from object: Any) -> WINetworkJSONNode.JSONValue {
+        if let dictionary = object as? [String: Any] {
+            var mapped: [String: WINetworkJSONNode.JSONValue] = [:]
+            dictionary.forEach { key, value in
+                mapped[key] = make(from: value)
+            }
+            return .object(mapped)
+        }
+        if let array = object as? [Any] {
+            return .array(array.map { make(from: $0) })
+        }
+        if let string = object as? String {
+            return .string(string)
+        }
+        if let number = object as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            return .number(String(describing: number))
+        }
+        if object is NSNull {
+            return .null
+        }
+        return .string(String(describing: object))
+    }
+}

--- a/Tests/WebInspectorKitTests/WINetworkBodyFetchTests.swift
+++ b/Tests/WebInspectorKitTests/WINetworkBodyFetchTests.swift
@@ -1,0 +1,206 @@
+import Testing
+@testable import WebInspectorKit
+
+@MainActor
+struct WINetworkBodyFetchTests {
+    @Test
+    func fetchBodyIfNeeded_fetchesBodyAndAppliesFullResponse() async {
+        let entry = makeEntry(requestID: 1)
+        let body = makeBody(role: .response, preview: "{", reference: "body-ref", isTruncated: true)
+        entry.responseBody = body
+
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { entry, role in
+            callCount += 1
+            body.applyFullBody(
+                "full-response",
+                isBase64Encoded: false,
+                isTruncated: false,
+                size: nil
+            )
+            if role == .response, let size = body.size {
+                entry.decodedBodyLength = size
+            }
+            return nil
+        })
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+
+        #expect(callCount == 1)
+        #expect(body.fetchState == .full)
+        #expect(body.full == "full-response")
+        #expect(entry.decodedBodyLength == "full-response".count)
+    }
+
+    @Test
+    func fetchBodyIfNeeded_retriesAfterFailure() async {
+        let entry = makeEntry(requestID: 2)
+        let body = makeBody(role: .request, preview: "partial", reference: "body-ref", isTruncated: true)
+        entry.requestBody = body
+
+        var responses: [WINetworkBody.FetchError?] = [.unavailable, nil]
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { entry, role in
+            callCount += 1
+            let response = responses.removeFirst()
+            if response == nil {
+                body.applyFullBody(
+                    "retry-body",
+                    isBase64Encoded: false,
+                    isTruncated: false,
+                    size: nil
+                )
+                if role == .request, let size = body.size {
+                    entry.requestBodyBytesSent = size
+                }
+            }
+            return response
+        })
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+        #expect(body.fetchState == .failed(.unavailable))
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+        #expect(body.fetchState == .full)
+        #expect(body.full == "retry-body")
+        #expect(callCount == 2)
+    }
+
+    @Test
+    func fetchBodyIfNeeded_keepsFailingWhenFetchFailsRepeatedly() async {
+        let entry = makeEntry(requestID: 3)
+        let body = makeBody(role: .response, preview: "partial", reference: "body-ref", isTruncated: true)
+        entry.responseBody = body
+
+        var responses: [WINetworkBody.FetchError?] = [
+            .decodeFailed,
+            .decodeFailed,
+            .decodeFailed
+        ]
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { _, _ in
+            callCount += 1
+            return responses.removeFirst()
+        })
+
+        for _ in 0..<3 {
+            await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+        }
+
+        #expect(callCount == 3)
+        #expect(body.fetchState == .failed(.decodeFailed))
+        #expect(body.full == nil)
+    }
+
+    @Test
+    func fetchBodyIfNeeded_skipsWhenReferenceMissing() async {
+        let entry = makeEntry(requestID: 4)
+        let body = makeBody(role: .request, preview: "partial", reference: "", isTruncated: true)
+        entry.requestBody = body
+
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { _, _ in
+            callCount += 1
+            return nil
+        })
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+
+        #expect(callCount == 0)
+        #expect(body.fetchState == .inline)
+    }
+
+    @Test
+    func fetchBodyIfNeeded_allowsForcedFetchWhenAlreadyFull() async {
+        let entry = makeEntry(requestID: 5)
+        let body = makeBody(
+            role: .response,
+            preview: "cached",
+            full: "cached",
+            reference: "body-ref",
+            isTruncated: false
+        )
+        entry.responseBody = body
+
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { _, _ in
+            callCount += 1
+            body.applyFullBody(
+                "forced-refresh",
+                isBase64Encoded: false,
+                isTruncated: false,
+                size: nil
+            )
+            return nil
+        })
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+        #expect(callCount == 0)
+        #expect(body.full == "cached")
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body, force: true)
+        #expect(callCount == 1)
+        #expect(body.full == "forced-refresh")
+    }
+
+    @Test
+    func fetchBodyIfNeeded_skipsWhenAlreadyFetching() async {
+        let entry = makeEntry(requestID: 6)
+        let body = makeBody(
+            role: .response,
+            preview: "partial",
+            reference: "body-ref",
+            isTruncated: true,
+            fetchState: .fetching
+        )
+        entry.responseBody = body
+
+        var callCount = 0
+        let viewModel = WINetworkViewModel(session: WINetworkSession(), bodyFetchHandler: { _, _ in
+            callCount += 1
+            return nil
+        })
+
+        await viewModel.fetchBodyIfNeeded(for: entry, body: body)
+
+        #expect(callCount == 0)
+        #expect(body.fetchState == .fetching)
+    }
+
+    private func makeEntry(requestID: Int) -> WINetworkEntry {
+        WINetworkEntry(
+            sessionID: "",
+            requestID: requestID,
+            url: "https://example.com",
+            method: "GET",
+            requestHeaders: WINetworkHeaders(),
+            startTimestamp: 0,
+            wallTime: nil
+        )
+    }
+
+    private func makeBody(
+        role: WINetworkBody.Role,
+        preview: String?,
+        full: String? = nil,
+        reference: String?,
+        isTruncated: Bool,
+        fetchState: WINetworkBody.FetchState? = nil
+    ) -> WINetworkBody {
+        let body = WINetworkBody(
+            kind: .text,
+            preview: preview,
+            full: full,
+            size: nil,
+            isBase64Encoded: false,
+            isTruncated: isTruncated,
+            summary: nil,
+            reference: reference,
+            formEntries: [],
+            fetchState: fetchState,
+            role: role
+        )
+        body.role = role
+        return body
+    }
+}


### PR DESCRIPTION
Summary:
- Move network body preview data and JSON parsing into model helpers
- Inject a body fetch handler into WINetworkViewModel for testability
- Add WINetworkBodyFetchTests covering success, retry, and failure flows

Testing:
- swift test