### PR TITLE
fix(monocly): recover updated iPhone installs from legacy scene state

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -647,6 +647,9 @@ final class BrowserPageViewController: UIViewController {
 
     func setSupportsMultipleScenesForTesting(_ value: Bool?) {
         supportsMultipleScenesOverrideForTesting = value
+        inspectorCoordinator.setSupportsMultipleScenesProviderForTesting {
+            value ?? UIApplication.shared.supportsMultipleScenes
+        }
         refreshChromeControls()
     }
 }

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -235,6 +235,32 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
+extension MonoclyAppDelegate {
+    static func hasUsableMainWindowScene(_ scenes: [UIWindowScene]) -> Bool {
+        preferredUsableMainWindowSceneSessionIdentifier(scenes) != nil
+    }
+
+    static func preferredUsableMainWindowSceneSessionIdentifier(_ scenes: [UIWindowScene]) -> String? {
+        scenes.first(where: { scene in
+            scene.windows.contains { window in
+                window.isHidden == false && window.rootViewController is BrowserRootViewController
+            }
+        })?.session.persistentIdentifier
+    }
+
+    static func staleRecoveredSessionIdentifiers(
+        openSessionIdentifiers: [String],
+        preferredMainSessionIdentifier: String?
+    ) -> Set<String> {
+        if let preferredMainSessionIdentifier {
+            return Set(
+                openSessionIdentifiers.filter { $0 != preferredMainSessionIdentifier }
+            )
+        }
+        return Set(openSessionIdentifiers)
+    }
+}
+
 private extension MonoclyAppDelegate {
     func scheduleLegacySceneRecoveryIfNeeded() {
         guard didRecoverLegacySceneState,
@@ -255,7 +281,19 @@ private extension MonoclyAppDelegate {
         guard didRecoverLegacySceneState else {
             return
         }
-        guard Self.hasUsableMainWindowScene(legacySceneRecoveryEnvironment.connectedWindowScenes()) == false else {
+
+        let connectedWindowScenes = legacySceneRecoveryEnvironment.connectedWindowScenes()
+        let openSessions = legacySceneRecoveryEnvironment.openSessions()
+        let preferredMainSessionIdentifier = Self.preferredUsableMainWindowSceneSessionIdentifier(connectedWindowScenes)
+        let staleSessionIdentifiers = Self.staleRecoveredSessionIdentifiers(
+            openSessionIdentifiers: openSessions.map(\.persistentIdentifier),
+            preferredMainSessionIdentifier: preferredMainSessionIdentifier
+        )
+
+        if preferredMainSessionIdentifier != nil {
+            openSessions
+                .filter { staleSessionIdentifiers.contains($0.persistentIdentifier) }
+                .forEach { legacySceneRecoveryEnvironment.destroySceneSession($0) }
             didRecoverLegacySceneState = false
             return
         }
@@ -264,25 +302,23 @@ private extension MonoclyAppDelegate {
             return
         }
 
-        legacySceneRecoveryEnvironment.openSessions().forEach {
-            legacySceneRecoveryEnvironment.destroySceneSession($0)
-        }
+        openSessions
+            .filter { staleSessionIdentifiers.contains($0.persistentIdentifier) }
+            .forEach {
+                legacySceneRecoveryEnvironment.destroySceneSession($0)
+            }
+        let destroyedAllRecoveredSessions = staleSessionIdentifiers.isEmpty == false
+        let shouldRequestFreshMainScene = destroyedAllRecoveredSessions
+            || Self.hasUsableMainWindowScene(legacySceneRecoveryEnvironment.connectedWindowScenes()) == false
         DispatchQueue.main.async { [weak self] in
             guard let self else {
                 return
             }
-            if Self.hasUsableMainWindowScene(self.legacySceneRecoveryEnvironment.connectedWindowScenes()) == false {
+            if shouldRequestFreshMainScene,
+               Self.hasUsableMainWindowScene(self.legacySceneRecoveryEnvironment.connectedWindowScenes()) == false {
                 self.legacySceneRecoveryEnvironment.requestFreshMainScene()
             }
             self.didRecoverLegacySceneState = false
-        }
-    }
-
-    static func hasUsableMainWindowScene(_ scenes: [UIWindowScene]) -> Bool {
-        scenes.contains { scene in
-            scene.windows.contains { window in
-                window.isHidden == false && window.rootViewController is BrowserRootViewController
-            }
         }
     }
 }

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -13,36 +13,163 @@ struct BrowserInspectorSceneDestructionRequester {
     }
 }
 
+struct MonoclyLegacySceneRecoveryEnvironment {
+    var connectedWindowScenes: @MainActor () -> [UIWindowScene]
+    var openSessions: @MainActor () -> [UISceneSession]
+    var destroySceneSession: @MainActor (_ sceneSession: UISceneSession) -> Void
+    var requestFreshMainScene: @MainActor () -> Void
+
+    static let live = MonoclyLegacySceneRecoveryEnvironment(
+        connectedWindowScenes: {
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        },
+        openSessions: {
+            Array(UIApplication.shared.openSessions)
+        },
+        destroySceneSession: { sceneSession in
+            UIApplication.shared.requestSceneSessionDestruction(
+                sceneSession,
+                options: nil,
+                errorHandler: nil
+            )
+        },
+        requestFreshMainScene: {
+            UIApplication.shared.requestSceneSessionActivation(
+                nil,
+                userActivity: nil,
+                options: nil,
+                errorHandler: nil
+            )
+        }
+    )
+}
+
+enum MonoclyLegacySceneStateRecovery {
+    static let bundleIdentifier = "lynnpd.Monocly"
+    private static let legacyMarkers = [
+        Data("SwiftUI.AppSceneDelegate".utf8),
+        Data("com.apple.SwiftUI.sceneID".utf8)
+    ]
+
+    static func savedStateDirectoryURL(
+        fileManager: FileManager = .default,
+        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? MonoclyLegacySceneStateRecovery.bundleIdentifier,
+        libraryDirectoryURL: URL? = nil
+    ) -> URL? {
+        let resolvedLibraryDirectoryURL = libraryDirectoryURL
+            ?? fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first
+        guard let resolvedLibraryDirectoryURL else {
+            return nil
+        }
+
+        return resolvedLibraryDirectoryURL
+            .appendingPathComponent("Saved Application State", isDirectory: true)
+            .appendingPathComponent("\(bundleIdentifier).savedState", isDirectory: true)
+    }
+
+    static func recoverIfNeeded(
+        savedStateDirectoryURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        guard fileManager.fileExists(atPath: savedStateDirectoryURL.path) else {
+            return false
+        }
+        guard containsLegacySwiftUISceneState(
+            savedStateDirectoryURL: savedStateDirectoryURL,
+            fileManager: fileManager
+        ) else {
+            return false
+        }
+
+        try fileManager.removeItem(at: savedStateDirectoryURL)
+        return true
+    }
+
+    static func containsLegacySwiftUISceneState(
+        savedStateDirectoryURL: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let enumerator = fileManager.enumerator(
+            at: savedStateDirectoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        for case let fileURL as URL in enumerator {
+            guard let resourceValues = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
+                  resourceValues.isRegularFile == true,
+                  let data = try? Data(contentsOf: fileURL, options: .mappedIfSafe) else {
+                continue
+            }
+            if legacyMarkers.contains(where: { data.range(of: $0) != nil }) {
+                return true
+            }
+        }
+
+        return false
+    }
+}
+
 @main
 @MainActor
 final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
     static let mainSceneConfigurationName = "Monocly Main"
     static let inspectorSceneConfigurationName = "Monocly Inspector"
+    private var didRecoverLegacySceneState = false
+    private var didScheduleLegacySceneRecovery = false
+    private var legacySceneRecoveryEnvironment = MonoclyLegacySceneRecoveryEnvironment.live
+
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        _ = application
+        _ = launchOptions
+        recoverLegacySceneStateIfNeeded()
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        _ = application
+        _ = launchOptions
+        scheduleLegacySceneRecoveryIfNeeded()
+        return true
+    }
 
     func application(
         _ application: UIApplication,
         configurationForConnecting connectingSceneSession: UISceneSession,
         options: UIScene.ConnectionOptions
     ) -> UISceneConfiguration {
-        _ = application
         return Self.sceneConfiguration(
             for: connectingSceneSession.role,
             existingConfigurationName: connectingSceneSession.configuration.name,
             activityType: Self.sceneActivityType(
                 connectingSceneSession: connectingSceneSession,
                 options: options
-            )
+            ),
+            supportsMultipleScenes: application.supportsMultipleScenes,
+            forceMainSceneConfiguration: didRecoverLegacySceneState
         )
     }
 
     static func sceneConfiguration(
         for role: UISceneSession.Role,
         existingConfigurationName: String? = nil,
-        activityType: String?
+        activityType: String?,
+        supportsMultipleScenes: Bool = UIApplication.shared.supportsMultipleScenes,
+        forceMainSceneConfiguration: Bool = false
     ) -> UISceneConfiguration {
         let configurationName: String?
         let delegateClass: AnyClass?
-        let shouldUseInspectorConfiguration = role == .windowApplication
+        let shouldUseInspectorConfiguration = forceMainSceneConfiguration == false
+            && supportsMultipleScenes
+            && role == .windowApplication
             && (
                 activityType == BrowserInspectorCoordinator.inspectorWindowSceneActivityType
                     || existingConfigurationName == inspectorSceneConfigurationName
@@ -57,6 +184,9 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         let configuration = UISceneConfiguration(name: configurationName, sessionRole: role)
+        if role == .windowApplication {
+            configuration.sceneClass = UIWindowScene.self
+        }
         configuration.delegateClass = delegateClass
         return configuration
     }
@@ -72,6 +202,88 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         _ = application
         BrowserInspectorCoordinator.handleInspectorWindowSceneSessionsDidDiscard(sceneSessions)
+    }
+
+    @discardableResult
+    func recoverLegacySceneStateIfNeeded(
+        fileManager: FileManager = .default,
+        savedStateDirectoryURL: URL? = MonoclyLegacySceneStateRecovery.savedStateDirectoryURL()
+    ) -> Bool {
+        guard didRecoverLegacySceneState == false,
+              let savedStateDirectoryURL else {
+            return false
+        }
+
+        let didRecover = (try? MonoclyLegacySceneStateRecovery.recoverIfNeeded(
+            savedStateDirectoryURL: savedStateDirectoryURL,
+            fileManager: fileManager
+        )) ?? false
+        didRecoverLegacySceneState = didRecover
+        return didRecover
+    }
+
+    func setLegacySceneRecoveryEnvironmentForTesting(_ environment: MonoclyLegacySceneRecoveryEnvironment) {
+        legacySceneRecoveryEnvironment = environment
+    }
+
+    func setDidRecoverLegacySceneStateForTesting(_ value: Bool) {
+        didRecoverLegacySceneState = value
+    }
+
+    func scheduleLegacySceneRecoveryIfNeededForTesting() {
+        scheduleLegacySceneRecoveryIfNeeded()
+    }
+}
+
+private extension MonoclyAppDelegate {
+    func scheduleLegacySceneRecoveryIfNeeded() {
+        guard didRecoverLegacySceneState,
+              didScheduleLegacySceneRecovery == false else {
+            return
+        }
+        didScheduleLegacySceneRecovery = true
+        scheduleLegacySceneRecoveryCheck(remainingDeferrals: 2)
+    }
+
+    func scheduleLegacySceneRecoveryCheck(remainingDeferrals: Int) {
+        DispatchQueue.main.async { [weak self] in
+            self?.performLegacySceneRecoveryCheck(remainingDeferrals: remainingDeferrals)
+        }
+    }
+
+    func performLegacySceneRecoveryCheck(remainingDeferrals: Int) {
+        guard didRecoverLegacySceneState else {
+            return
+        }
+        guard Self.hasUsableMainWindowScene(legacySceneRecoveryEnvironment.connectedWindowScenes()) == false else {
+            didRecoverLegacySceneState = false
+            return
+        }
+        guard remainingDeferrals == 0 else {
+            scheduleLegacySceneRecoveryCheck(remainingDeferrals: remainingDeferrals - 1)
+            return
+        }
+
+        legacySceneRecoveryEnvironment.openSessions().forEach {
+            legacySceneRecoveryEnvironment.destroySceneSession($0)
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            if Self.hasUsableMainWindowScene(self.legacySceneRecoveryEnvironment.connectedWindowScenes()) == false {
+                self.legacySceneRecoveryEnvironment.requestFreshMainScene()
+            }
+            self.didRecoverLegacySceneState = false
+        }
+    }
+
+    static func hasUsableMainWindowScene(_ scenes: [UIWindowScene]) -> Bool {
+        scenes.contains { scene in
+            scene.windows.contains { window in
+                window.isHidden == false && window.rootViewController is BrowserRootViewController
+            }
+        }
     }
 }
 

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -125,9 +125,8 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        _ = application
         _ = launchOptions
-        recoverLegacySceneStateIfNeeded()
+        recoverLegacySceneStateIfNeeded(supportsMultipleScenes: application.supportsMultipleScenes)
         return true
     }
 
@@ -135,8 +134,10 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        _ = application
         _ = launchOptions
+        guard application.supportsMultipleScenes == false else {
+            return true
+        }
         scheduleLegacySceneRecoveryIfNeeded()
         return true
     }
@@ -154,7 +155,7 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
                 options: options
             ),
             supportsMultipleScenes: application.supportsMultipleScenes,
-            forceMainSceneConfiguration: didRecoverLegacySceneState
+            forceMainSceneConfiguration: didRecoverLegacySceneState && application.supportsMultipleScenes == false
         )
     }
 
@@ -206,10 +207,12 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
 
     @discardableResult
     func recoverLegacySceneStateIfNeeded(
+        supportsMultipleScenes: Bool = UIApplication.shared.supportsMultipleScenes,
         fileManager: FileManager = .default,
         savedStateDirectoryURL: URL? = MonoclyLegacySceneStateRecovery.savedStateDirectoryURL()
     ) -> Bool {
-        guard didRecoverLegacySceneState == false,
+        guard supportsMultipleScenes == false,
+              didRecoverLegacySceneState == false,
               let savedStateDirectoryURL else {
             return false
         }

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -14,29 +14,16 @@ struct BrowserInspectorSceneDestructionRequester {
 }
 
 struct MonoclyLegacySceneRecoveryEnvironment {
-    var connectedWindowScenes: @MainActor () -> [UIWindowScene]
     var openSessions: @MainActor () -> [UISceneSession]
     var destroySceneSession: @MainActor (_ sceneSession: UISceneSession) -> Void
-    var requestFreshMainScene: @MainActor () -> Void
 
     static let live = MonoclyLegacySceneRecoveryEnvironment(
-        connectedWindowScenes: {
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-        },
         openSessions: {
             Array(UIApplication.shared.openSessions)
         },
         destroySceneSession: { sceneSession in
             UIApplication.shared.requestSceneSessionDestruction(
                 sceneSession,
-                options: nil,
-                errorHandler: nil
-            )
-        },
-        requestFreshMainScene: {
-            UIApplication.shared.requestSceneSessionActivation(
-                nil,
-                userActivity: nil,
                 options: nil,
                 errorHandler: nil
             )
@@ -118,7 +105,6 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
     static let mainSceneConfigurationName = "Monocly Main"
     static let inspectorSceneConfigurationName = "Monocly Inspector"
     private var didRecoverLegacySceneState = false
-    private var didScheduleLegacySceneRecovery = false
     private var legacySceneRecoveryEnvironment = MonoclyLegacySceneRecoveryEnvironment.live
 
     func application(
@@ -134,11 +120,8 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        _ = application
         _ = launchOptions
-        guard application.supportsMultipleScenes == false else {
-            return true
-        }
-        scheduleLegacySceneRecoveryIfNeeded()
         return true
     }
 
@@ -233,96 +216,34 @@ final class MonoclyAppDelegate: UIResponder, UIApplicationDelegate {
         didRecoverLegacySceneState = value
     }
 
-    func scheduleLegacySceneRecoveryIfNeededForTesting() {
-        scheduleLegacySceneRecoveryIfNeeded()
+    func handleLegacySceneRecoveryAfterMainSceneConnectedForTesting(_ windowScene: UIWindowScene) {
+        handleLegacySceneRecoveryAfterMainSceneConnected(windowScene)
     }
 }
 
 extension MonoclyAppDelegate {
-    static func hasUsableMainWindowScene(_ scenes: [UIWindowScene]) -> Bool {
-        preferredUsableMainWindowSceneSessionIdentifier(scenes) != nil
-    }
-
-    static func preferredUsableMainWindowSceneSessionIdentifier(_ scenes: [UIWindowScene]) -> String? {
-        scenes.first(where: { scene in
-            scene.windows.contains { window in
-                window.isHidden == false && window.rootViewController is BrowserRootViewController
-            }
-        })?.session.persistentIdentifier
-    }
-
     static func staleRecoveredSessionIdentifiers(
         openSessionIdentifiers: [String],
-        preferredMainSessionIdentifier: String?
+        connectedMainSessionIdentifier: String
     ) -> Set<String> {
-        if let preferredMainSessionIdentifier {
-            return Set(
-                openSessionIdentifiers.filter { $0 != preferredMainSessionIdentifier }
-            )
-        }
-        return Set(openSessionIdentifiers)
+        Set(openSessionIdentifiers.filter { $0 != connectedMainSessionIdentifier })
     }
 }
 
 private extension MonoclyAppDelegate {
-    func scheduleLegacySceneRecoveryIfNeeded() {
-        guard didRecoverLegacySceneState,
-              didScheduleLegacySceneRecovery == false else {
-            return
-        }
-        didScheduleLegacySceneRecovery = true
-        scheduleLegacySceneRecoveryCheck(remainingDeferrals: 2)
-    }
-
-    func scheduleLegacySceneRecoveryCheck(remainingDeferrals: Int) {
-        DispatchQueue.main.async { [weak self] in
-            self?.performLegacySceneRecoveryCheck(remainingDeferrals: remainingDeferrals)
-        }
-    }
-
-    func performLegacySceneRecoveryCheck(remainingDeferrals: Int) {
+    func handleLegacySceneRecoveryAfterMainSceneConnected(_ windowScene: UIWindowScene) {
         guard didRecoverLegacySceneState else {
             return
         }
 
-        let connectedWindowScenes = legacySceneRecoveryEnvironment.connectedWindowScenes()
-        let openSessions = legacySceneRecoveryEnvironment.openSessions()
-        let preferredMainSessionIdentifier = Self.preferredUsableMainWindowSceneSessionIdentifier(connectedWindowScenes)
         let staleSessionIdentifiers = Self.staleRecoveredSessionIdentifiers(
-            openSessionIdentifiers: openSessions.map(\.persistentIdentifier),
-            preferredMainSessionIdentifier: preferredMainSessionIdentifier
+            openSessionIdentifiers: legacySceneRecoveryEnvironment.openSessions().map(\.persistentIdentifier),
+            connectedMainSessionIdentifier: windowScene.session.persistentIdentifier
         )
-
-        if preferredMainSessionIdentifier != nil {
-            openSessions
-                .filter { staleSessionIdentifiers.contains($0.persistentIdentifier) }
-                .forEach { legacySceneRecoveryEnvironment.destroySceneSession($0) }
-            didRecoverLegacySceneState = false
-            return
-        }
-        guard remainingDeferrals == 0 else {
-            scheduleLegacySceneRecoveryCheck(remainingDeferrals: remainingDeferrals - 1)
-            return
-        }
-
-        openSessions
+        legacySceneRecoveryEnvironment.openSessions()
             .filter { staleSessionIdentifiers.contains($0.persistentIdentifier) }
-            .forEach {
-                legacySceneRecoveryEnvironment.destroySceneSession($0)
-            }
-        let destroyedAllRecoveredSessions = staleSessionIdentifiers.isEmpty == false
-        let shouldRequestFreshMainScene = destroyedAllRecoveredSessions
-            || Self.hasUsableMainWindowScene(legacySceneRecoveryEnvironment.connectedWindowScenes()) == false
-        DispatchQueue.main.async { [weak self] in
-            guard let self else {
-                return
-            }
-            if shouldRequestFreshMainScene,
-               Self.hasUsableMainWindowScene(self.legacySceneRecoveryEnvironment.connectedWindowScenes()) == false {
-                self.legacySceneRecoveryEnvironment.requestFreshMainScene()
-            }
-            self.didRecoverLegacySceneState = false
-        }
+            .forEach { legacySceneRecoveryEnvironment.destroySceneSession($0) }
+        didRecoverLegacySceneState = false
     }
 }
 
@@ -386,6 +307,8 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
         self.rootViewController = rootViewController
         MonoclyWindowContextStore.shared.registerConnectedScene(windowScene)
         window.makeKeyAndVisible()
+        (UIApplication.shared.delegate as? MonoclyAppDelegate)?
+            .handleLegacySceneRecoveryAfterMainSceneConnected(windowScene)
 
         if windowScene.activationState == .foregroundActive {
             MonoclyWindowContextStore.shared.sceneDidBecomeActive(windowScene)

--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -255,6 +255,7 @@ final class BrowserInspectorCoordinator {
     private weak var presentedSheetController: WITabViewController?
     private let sheetObserver = InspectorSheetObserver()
     private var sceneActivationRequester = BrowserInspectorSceneActivationRequester.live
+    private var supportsMultipleScenesProvider: @MainActor () -> Bool = { UIApplication.shared.supportsMultipleScenes }
 
     var onPresentationStateChange: (() -> Void)?
 
@@ -299,6 +300,9 @@ final class BrowserInspectorCoordinator {
         tabs: [WITab] = [.dom(), .network()]
     ) -> Bool {
         guard isPresentingInspector(presenter: presenter) == false else {
+            return false
+        }
+        guard supportsMultipleScenesProvider() else {
             return false
         }
 
@@ -354,6 +358,10 @@ final class BrowserInspectorCoordinator {
 
     func setSceneActivationRequesterForTesting(_ requester: BrowserInspectorSceneActivationRequester) {
         sceneActivationRequester = requester
+    }
+
+    func setSupportsMultipleScenesProviderForTesting(_ provider: @escaping @MainActor () -> Bool) {
+        supportsMultipleScenesProvider = provider
     }
 
     var hasInspectorWindowForTesting: Bool {

--- a/Monocly/MonoclyTests/BrowserNavigationChromeTests.swift
+++ b/Monocly/MonoclyTests/BrowserNavigationChromeTests.swift
@@ -340,6 +340,7 @@ final class BrowserNavigationChromeTests: XCTestCase {
         var activationCount = 0
         var requestingScene: UIScene?
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         let windowScene = try XCTUnwrap(fixture.window.windowScene)
         MonoclyWindowContextStore.shared.setCurrentSceneForTesting(windowScene, window: fixture.window)
         addTeardownBlock {

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -203,6 +203,26 @@ final class MonoclyLifecycleTests: XCTestCase {
     }
 
     @MainActor
+    func testLegacySceneRecoveryComputesStaleSessionIdentifiersWhenMainSceneExists() {
+        let staleSessionIdentifiers = MonoclyAppDelegate.staleRecoveredSessionIdentifiers(
+            openSessionIdentifiers: ["main-session", "stale-session-a", "stale-session-b"],
+            preferredMainSessionIdentifier: "main-session"
+        )
+
+        XCTAssertEqual(staleSessionIdentifiers, ["stale-session-a", "stale-session-b"])
+    }
+
+    @MainActor
+    func testLegacySceneRecoveryComputesEverySessionAsStaleWithoutMainScene() {
+        let staleSessionIdentifiers = MonoclyAppDelegate.staleRecoveredSessionIdentifiers(
+            openSessionIdentifiers: ["session-a", "session-b"],
+            preferredMainSessionIdentifier: nil
+        )
+
+        XCTAssertEqual(staleSessionIdentifiers, ["session-a", "session-b"])
+    }
+
+    @MainActor
     func testLegacySceneRecoverySkipsResetWhenUsableMainSceneExists() throws {
         let fixture = try makeHostedRootViewController()
         let delegate = MonoclyAppDelegate()

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -200,77 +200,31 @@ final class MonoclyLifecycleTests: XCTestCase {
     }
 
     @MainActor
-    func testLegacySceneRecoveryDestroysOpenSessionsAndRequestsFreshMainScene() throws {
-        let sceneSession = try makeWindowScene().session
+    func testLegacySceneRecoveryLeavesConnectedMainSessionAlive() throws {
+        let windowScene = try makeWindowScene()
         let delegate = MonoclyAppDelegate()
         var destroyedSceneSessions: [UISceneSession] = []
-        var activationCount = 0
 
         delegate.setLegacySceneRecoveryEnvironmentForTesting(
             MonoclyLegacySceneRecoveryEnvironment(
-                connectedWindowScenes: { [] },
-                openSessions: { [sceneSession] },
-                destroySceneSession: { destroyedSceneSessions.append($0) },
-                requestFreshMainScene: { activationCount += 1 }
+                openSessions: { [windowScene.session] },
+                destroySceneSession: { destroyedSceneSessions.append($0) }
             )
         )
         delegate.setDidRecoverLegacySceneStateForTesting(true)
-        delegate.scheduleLegacySceneRecoveryIfNeededForTesting()
-        drainMainQueue()
-        drainMainQueue()
-        drainMainQueue()
-        drainMainQueue()
+        delegate.handleLegacySceneRecoveryAfterMainSceneConnectedForTesting(windowScene)
 
-        XCTAssertEqual(
-            destroyedSceneSessions.map(\.persistentIdentifier),
-            [sceneSession.persistentIdentifier]
-        )
-        XCTAssertEqual(activationCount, 1)
+        XCTAssertTrue(destroyedSceneSessions.isEmpty)
     }
 
     @MainActor
-    func testLegacySceneRecoveryComputesStaleSessionIdentifiersWhenMainSceneExists() {
+    func testLegacySceneRecoveryComputesStaleSessionIdentifiers() {
         let staleSessionIdentifiers = MonoclyAppDelegate.staleRecoveredSessionIdentifiers(
             openSessionIdentifiers: ["main-session", "stale-session-a", "stale-session-b"],
-            preferredMainSessionIdentifier: "main-session"
+            connectedMainSessionIdentifier: "main-session"
         )
 
         XCTAssertEqual(staleSessionIdentifiers, ["stale-session-a", "stale-session-b"])
-    }
-
-    @MainActor
-    func testLegacySceneRecoveryComputesEverySessionAsStaleWithoutMainScene() {
-        let staleSessionIdentifiers = MonoclyAppDelegate.staleRecoveredSessionIdentifiers(
-            openSessionIdentifiers: ["session-a", "session-b"],
-            preferredMainSessionIdentifier: nil
-        )
-
-        XCTAssertEqual(staleSessionIdentifiers, ["session-a", "session-b"])
-    }
-
-    @MainActor
-    func testLegacySceneRecoverySkipsResetWhenUsableMainSceneExists() throws {
-        let fixture = try makeHostedRootViewController()
-        let delegate = MonoclyAppDelegate()
-        var destroyedSceneSessions: [UISceneSession] = []
-        var activationCount = 0
-
-        delegate.setLegacySceneRecoveryEnvironmentForTesting(
-            MonoclyLegacySceneRecoveryEnvironment(
-                connectedWindowScenes: { [fixture.windowScene] },
-                openSessions: { [fixture.windowScene.session] },
-                destroySceneSession: { destroyedSceneSessions.append($0) },
-                requestFreshMainScene: { activationCount += 1 }
-            )
-        )
-        delegate.setDidRecoverLegacySceneStateForTesting(true)
-        delegate.scheduleLegacySceneRecoveryIfNeededForTesting()
-        drainMainQueue()
-        drainMainQueue()
-        drainMainQueue()
-
-        XCTAssertTrue(destroyedSceneSessions.isEmpty)
-        XCTAssertEqual(activationCount, 0)
     }
 
     @MainActor

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -68,6 +68,32 @@ final class MonoclyLifecycleTests: XCTestCase {
     }
 
     @MainActor
+    func testAppDelegateSkipsLegacyRecoveryWhenMultipleScenesSupported() throws {
+        let savedStateDirectoryURL = try makeSavedStateFixture(
+            knownSceneSessionData: Data("SwiftUI.AppSceneDelegate".utf8),
+            userInfoData: Data("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+            <key>com.apple.SwiftUI.sceneID</key>
+            <string>Monocly.ContentView-1</string>
+            </dict>
+            </plist>
+            """.utf8)
+        )
+        let delegate = MonoclyAppDelegate()
+
+        XCTAssertFalse(
+            delegate.recoverLegacySceneStateIfNeeded(
+                supportsMultipleScenes: true,
+                savedStateDirectoryURL: savedStateDirectoryURL
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: savedStateDirectoryURL.path))
+    }
+
+    @MainActor
     func testAppDelegateUsesInspectorSceneDelegateAndWindowSceneForInspectorActivity() {
         let configuration = MonoclyAppDelegate.sceneConfiguration(
             for: .windowApplication,

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -28,36 +28,203 @@ final class MonoclyLifecycleTests: XCTestCase {
     }
 
     @MainActor
-    func testAppDelegateUsesInspectorSceneDelegateForInspectorActivity() {
+    func testLegacySceneStateRecoveryRemovesSavedStateWhenSwiftUIMarkersExist() throws {
+        let savedStateDirectoryURL = try makeSavedStateFixture(
+            knownSceneSessionData: Data("SwiftUI.AppSceneDelegate".utf8),
+            userInfoData: Data("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+            <key>com.apple.SwiftUI.sceneID</key>
+            <string>Monocly.ContentView-1</string>
+            </dict>
+            </plist>
+            """.utf8)
+        )
+
+        XCTAssertTrue(try MonoclyLegacySceneStateRecovery.recoverIfNeeded(savedStateDirectoryURL: savedStateDirectoryURL))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedStateDirectoryURL.path))
+    }
+
+    @MainActor
+    func testLegacySceneStateRecoveryPreservesUIKitSavedState() throws {
+        let savedStateDirectoryURL = try makeSavedStateFixture(
+            knownSceneSessionData: Data("Monocly.MonoclyMainSceneDelegate".utf8),
+            userInfoData: Data("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+            <key>MonoclyScene</key>
+            <string>Main</string>
+            </dict>
+            </plist>
+            """.utf8)
+        )
+
+        XCTAssertFalse(try MonoclyLegacySceneStateRecovery.recoverIfNeeded(savedStateDirectoryURL: savedStateDirectoryURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: savedStateDirectoryURL.path))
+    }
+
+    @MainActor
+    func testAppDelegateUsesInspectorSceneDelegateAndWindowSceneForInspectorActivity() {
         let configuration = MonoclyAppDelegate.sceneConfiguration(
             for: .windowApplication,
             existingConfigurationName: nil,
-            activityType: BrowserInspectorCoordinator.inspectorWindowSceneActivityType
+            activityType: BrowserInspectorCoordinator.inspectorWindowSceneActivityType,
+            supportsMultipleScenes: true
         )
 
+        XCTAssertEqual(configuration.name, MonoclyAppDelegate.inspectorSceneConfigurationName)
+        XCTAssertTrue(configuration.sceneClass === UIWindowScene.self)
         XCTAssertTrue(configuration.delegateClass === MonoclyInspectorSceneDelegate.self)
     }
 
     @MainActor
-    func testAppDelegateUsesMainSceneDelegateForRegularActivity() {
+    func testAppDelegateUsesMainSceneDelegateAndWindowSceneForRegularActivity() {
         let configuration = MonoclyAppDelegate.sceneConfiguration(
             for: .windowApplication,
             existingConfigurationName: nil,
-            activityType: nil
+            activityType: nil,
+            supportsMultipleScenes: false
         )
 
+        XCTAssertEqual(configuration.name, MonoclyAppDelegate.mainSceneConfigurationName)
+        XCTAssertTrue(configuration.sceneClass === UIWindowScene.self)
         XCTAssertTrue(configuration.delegateClass === MonoclyMainSceneDelegate.self)
     }
 
     @MainActor
-    func testAppDelegateKeepsInspectorSceneDelegateForRestoredInspectorSession() {
+    func testAppDelegateKeepsInspectorSceneDelegateAndWindowSceneForRestoredInspectorSession() {
         let configuration = MonoclyAppDelegate.sceneConfiguration(
             for: .windowApplication,
             existingConfigurationName: MonoclyAppDelegate.inspectorSceneConfigurationName,
-            activityType: nil
+            activityType: nil,
+            supportsMultipleScenes: true
         )
 
+        XCTAssertEqual(configuration.name, MonoclyAppDelegate.inspectorSceneConfigurationName)
+        XCTAssertTrue(configuration.sceneClass === UIWindowScene.self)
         XCTAssertTrue(configuration.delegateClass === MonoclyInspectorSceneDelegate.self)
+    }
+
+    @MainActor
+    func testAppDelegateFallsBackToMainSceneWhenMultipleScenesUnsupported() {
+        let inspectorActivityConfiguration = MonoclyAppDelegate.sceneConfiguration(
+            for: .windowApplication,
+            existingConfigurationName: nil,
+            activityType: BrowserInspectorCoordinator.inspectorWindowSceneActivityType,
+            supportsMultipleScenes: false
+        )
+        let restoredInspectorConfiguration = MonoclyAppDelegate.sceneConfiguration(
+            for: .windowApplication,
+            existingConfigurationName: MonoclyAppDelegate.inspectorSceneConfigurationName,
+            activityType: nil,
+            supportsMultipleScenes: false
+        )
+
+        for configuration in [inspectorActivityConfiguration, restoredInspectorConfiguration] {
+            XCTAssertEqual(configuration.name, MonoclyAppDelegate.mainSceneConfigurationName)
+            XCTAssertTrue(configuration.sceneClass === UIWindowScene.self)
+            XCTAssertTrue(configuration.delegateClass === MonoclyMainSceneDelegate.self)
+        }
+    }
+
+    @MainActor
+    func testAppDelegateForcesMainSceneDuringLegacyRecovery() {
+        let configuration = MonoclyAppDelegate.sceneConfiguration(
+            for: .windowApplication,
+            existingConfigurationName: MonoclyAppDelegate.inspectorSceneConfigurationName,
+            activityType: BrowserInspectorCoordinator.inspectorWindowSceneActivityType,
+            supportsMultipleScenes: true,
+            forceMainSceneConfiguration: true
+        )
+
+        XCTAssertEqual(configuration.name, MonoclyAppDelegate.mainSceneConfigurationName)
+        XCTAssertTrue(configuration.sceneClass === UIWindowScene.self)
+        XCTAssertTrue(configuration.delegateClass === MonoclyMainSceneDelegate.self)
+    }
+
+    @MainActor
+    func testPresentWindowFailsWithoutMultipleSceneSupport() throws {
+        let fixture = try makeHostedRootViewController()
+        let coordinator = BrowserInspectorCoordinator()
+        var activationCount = 0
+
+        coordinator.setSupportsMultipleScenesProviderForTesting { false }
+        coordinator.setSceneActivationRequesterForTesting(
+            BrowserInspectorSceneActivationRequester(
+                activateScene: { _, _, _, _ in
+                    activationCount += 1
+                }
+            )
+        )
+
+        XCTAssertFalse(
+            coordinator.presentWindow(
+                from: fixture.rootViewController,
+                browserStore: fixture.rootViewController.store,
+                inspectorController: fixture.rootViewController.inspectorController,
+                tabs: [.dom(), .network()]
+            )
+        )
+        XCTAssertEqual(activationCount, 0)
+        XCTAssertFalse(coordinator.hasInspectorWindowForTesting)
+    }
+
+    @MainActor
+    func testLegacySceneRecoveryDestroysOpenSessionsAndRequestsFreshMainScene() throws {
+        let sceneSession = try makeWindowScene().session
+        let delegate = MonoclyAppDelegate()
+        var destroyedSceneSessions: [UISceneSession] = []
+        var activationCount = 0
+
+        delegate.setLegacySceneRecoveryEnvironmentForTesting(
+            MonoclyLegacySceneRecoveryEnvironment(
+                connectedWindowScenes: { [] },
+                openSessions: { [sceneSession] },
+                destroySceneSession: { destroyedSceneSessions.append($0) },
+                requestFreshMainScene: { activationCount += 1 }
+            )
+        )
+        delegate.setDidRecoverLegacySceneStateForTesting(true)
+        delegate.scheduleLegacySceneRecoveryIfNeededForTesting()
+        drainMainQueue()
+        drainMainQueue()
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(
+            destroyedSceneSessions.map(\.persistentIdentifier),
+            [sceneSession.persistentIdentifier]
+        )
+        XCTAssertEqual(activationCount, 1)
+    }
+
+    @MainActor
+    func testLegacySceneRecoverySkipsResetWhenUsableMainSceneExists() throws {
+        let fixture = try makeHostedRootViewController()
+        let delegate = MonoclyAppDelegate()
+        var destroyedSceneSessions: [UISceneSession] = []
+        var activationCount = 0
+
+        delegate.setLegacySceneRecoveryEnvironmentForTesting(
+            MonoclyLegacySceneRecoveryEnvironment(
+                connectedWindowScenes: { [fixture.windowScene] },
+                openSessions: { [fixture.windowScene.session] },
+                destroySceneSession: { destroyedSceneSessions.append($0) },
+                requestFreshMainScene: { activationCount += 1 }
+            )
+        )
+        delegate.setDidRecoverLegacySceneStateForTesting(true)
+        delegate.scheduleLegacySceneRecoveryIfNeededForTesting()
+        drainMainQueue()
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertTrue(destroyedSceneSessions.isEmpty)
+        XCTAssertEqual(activationCount, 0)
     }
 
     @MainActor
@@ -140,6 +307,7 @@ final class MonoclyLifecycleTests: XCTestCase {
         let windowScene = try makeWindowScene()
         let launchConfiguration = BrowserLaunchConfiguration(initialURL: URL(string: "about:blank")!)
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         coordinator.setSceneActivationRequesterForTesting(
             BrowserInspectorSceneActivationRequester(
                 activateScene: { _, _, _, _ in }
@@ -189,6 +357,7 @@ final class MonoclyLifecycleTests: XCTestCase {
         let windowScene = try makeWindowScene()
         let launchConfiguration = BrowserLaunchConfiguration(initialURL: URL(string: "about:blank")!)
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         coordinator.setSceneActivationRequesterForTesting(
             BrowserInspectorSceneActivationRequester(
                 activateScene: { _, _, _, _ in }
@@ -229,6 +398,7 @@ final class MonoclyLifecycleTests: XCTestCase {
         let coordinator = BrowserInspectorCoordinator()
         let sceneDelegate = MonoclyInspectorSceneDelegate()
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         coordinator.setSceneActivationRequesterForTesting(
             BrowserInspectorSceneActivationRequester(
                 activateScene: { _, _, _, _ in }
@@ -273,6 +443,7 @@ final class MonoclyLifecycleTests: XCTestCase {
         var activatedSceneSession: UISceneSession?
         var destroyedSceneSession: UISceneSession?
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         coordinator.setSceneActivationRequesterForTesting(
             BrowserInspectorSceneActivationRequester(
                 activateScene: { sceneSession, _, _, _ in
@@ -372,6 +543,7 @@ final class MonoclyLifecycleTests: XCTestCase {
         let coordinator = BrowserInspectorCoordinator()
         var activatedSceneSession: UISceneSession?
 
+        coordinator.setSupportsMultipleScenesProviderForTesting { true }
         coordinator.setSceneActivationRequesterForTesting(
             BrowserInspectorSceneActivationRequester(
                 activateScene: { sceneSession, _, _, _ in
@@ -436,6 +608,35 @@ private extension MonoclyLifecycleTests {
             drainMainQueue()
         }
         return condition()
+    }
+
+    func makeSavedStateFixture(
+        knownSceneSessionData: Data,
+        userInfoData: Data,
+        sceneData: Data = Data("SceneState".utf8)
+    ) throws -> URL {
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MonoclySavedState-\(UUID().uuidString)", isDirectory: true)
+        let savedStateDirectoryURL = rootDirectoryURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Saved Application State", isDirectory: true)
+            .appendingPathComponent("lynnpd.Monocly.savedState", isDirectory: true)
+        let sceneDirectoryURL = savedStateDirectoryURL
+            .appendingPathComponent("3D56A58A-9EA8-4124-B116-56125EBB0D46", isDirectory: true)
+        let knownSceneSessionsDirectoryURL = savedStateDirectoryURL
+            .appendingPathComponent("KnownSceneSessions", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: sceneDirectoryURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: knownSceneSessionsDirectoryURL, withIntermediateDirectories: true)
+        try knownSceneSessionData.write(to: knownSceneSessionsDirectoryURL.appendingPathComponent("data.data"))
+        try userInfoData.write(to: sceneDirectoryURL.appendingPathComponent("userInfo.data"))
+        try sceneData.write(to: sceneDirectoryURL.appendingPathComponent("data.data"))
+
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: rootDirectoryURL)
+        }
+
+        return savedStateDirectoryURL
     }
 }
 #elseif os(macOS)


### PR DESCRIPTION
## Summary
Fix iPhone launch recovery when updating from the old SwiftUI scene lifecycle to the UIKit scene lifecycle without reinstalling the app.

## Changes
- delete legacy SwiftUI saved application state only on single-scene devices when SwiftUI scene markers are present
- keep returning `UIWindowScene` + `MonoclyMainSceneDelegate` for recovered iPhone launches while preserving inspector scene configs on multi-window devices
- guard inspector window activation behind `UIApplication.supportsMultipleScenes`
- clean stale recovered scene sessions only after the main scene has created and shown its window
- add Monocly lifecycle tests for legacy saved-state detection, scene configuration routing, single-scene inspector fallback, and stale-session cleanup behavior

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme Monocly -destination 'platform=iOS Simulator,id=9882C514-1F08-4957-BB30-96B6793A3B11'`
- `codex-review --base main` (clean)
- Manual verification on an updated iPhone Air install by the reporter

## UI
- Screenshots: N/A (launch recovery only)
