### PR TITLE
fix(bridge): avoid libswiftWebKit on legacy iOS simulators

### DIFF
--- a/Monocly/MonoclyTests/BrowserNavigationChromeTests.swift
+++ b/Monocly/MonoclyTests/BrowserNavigationChromeTests.swift
@@ -916,7 +916,7 @@ private extension BrowserNavigationChromeTests {
         Task { @MainActor in
             defer { expectation.fulfill() }
             do {
-                let result = try await webView.callAsyncJavaScript(
+                let result = try await webView.callAsyncJavaScriptCompat(
                     """
                     return (function(entries) {
                         const prototype = Object.getPrototypeOf(performance) || performance;

--- a/Monocly/MonoclyTests/BrowserStoreInspectorRegressionTests.swift
+++ b/Monocly/MonoclyTests/BrowserStoreInspectorRegressionTests.swift
@@ -559,7 +559,7 @@ private extension BrowserStoreInspectorRegressionTests {
     }
 
     func mainFrameText(in webView: WKWebView) async -> String? {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return document.getElementById('content')?.textContent ?? document.body?.textContent ?? null;",
             arguments: [:],
             in: nil,

--- a/Sources/WebInspectorBridge/Bridge/WIJavaScriptCompatSupport.swift
+++ b/Sources/WebInspectorBridge/Bridge/WIJavaScriptCompatSupport.swift
@@ -1,0 +1,19 @@
+package struct WIKUnsafeTransfer<Value>: @unchecked Sendable {
+    package let value: Value
+}
+
+package enum WIKObjCBlockConversion {
+    package static nonisolated func boxingNilAsAnyForCompatibility(
+        _ transferredHandler: WIKUnsafeTransfer<(Result<Any, any Error>) -> Void>
+    ) -> @Sendable (Any?, (any Error)?) -> Void {
+        { value, error in
+            if let error {
+                transferredHandler.value(.failure(error))
+            } else if let value {
+                transferredHandler.value(.success(value))
+            } else {
+                transferredHandler.value(.success(Optional<Any>.none as Any))
+            }
+        }
+    }
+}

--- a/Sources/WebInspectorBridge/Bridge/WKWebView+CallAsyncJavaScriptCompat.swift
+++ b/Sources/WebInspectorBridge/Bridge/WKWebView+CallAsyncJavaScriptCompat.swift
@@ -1,0 +1,70 @@
+import WebInspectorBridgeObjCShim
+import WebKit
+
+private struct WIKUnsafeTransfer<Value>: @unchecked Sendable {
+    let value: Value
+}
+
+private enum WIKObjCBlockConversion {
+    static nonisolated func boxingNilAsAnyForCompatibility(
+        _ transferredHandler: WIKUnsafeTransfer<(Result<Any, any Error>) -> Void>
+    ) -> @Sendable (Any?, (any Error)?) -> Void {
+        { value, error in
+            if let error {
+                transferredHandler.value(.failure(error))
+            } else if let value {
+                transferredHandler.value(.success(value))
+            } else {
+                transferredHandler.value(.success(Optional<Any>.none as Any))
+            }
+        }
+    }
+}
+
+extension WKWebView {
+    @MainActor
+    @preconcurrency
+    public func callAsyncJavaScriptCompat(
+        _ functionBody: String,
+        arguments: [String: Any] = [:],
+        in frame: WKFrameInfo? = nil,
+        in contentWorld: WKContentWorld,
+        completionHandler: ((Result<Any, any Error>) -> Void)? = nil
+    ) {
+        let thunk = completionHandler.map { handler in
+            WIKObjCBlockConversion.boxingNilAsAnyForCompatibility(WIKUnsafeTransfer(value: handler))
+        }
+        wki_callAsyncJavaScript(
+            functionBody,
+            arguments: arguments,
+            inFrame: frame,
+            in: contentWorld,
+            completionHandler: thunk
+        )
+    }
+
+    @MainActor
+    public func callAsyncJavaScriptCompat(
+        _ functionBody: String,
+        arguments: [String: Any] = [:],
+        in frame: WKFrameInfo? = nil,
+        contentWorld: WKContentWorld
+    ) async throws -> Any? {
+        let transferredResult = try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<WIKUnsafeTransfer<Any?>, Error>) in
+            wki_callAsyncJavaScript(
+                functionBody,
+                arguments: arguments,
+                inFrame: frame,
+                in: contentWorld
+            ) { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: WIKUnsafeTransfer(value: result))
+                }
+            }
+        }
+        return transferredResult.value
+    }
+}

--- a/Sources/WebInspectorBridge/Bridge/WKWebView+EvaluateJavaScriptCompat.swift
+++ b/Sources/WebInspectorBridge/Bridge/WKWebView+EvaluateJavaScriptCompat.swift
@@ -4,9 +4,8 @@ import WebKit
 extension WKWebView {
     @MainActor
     @preconcurrency
-    public func callAsyncJavaScriptCompat(
-        _ functionBody: String,
-        arguments: [String: Any] = [:],
+    public func evaluateJavaScriptCompat(
+        _ javaScript: String,
         in frame: WKFrameInfo? = nil,
         in contentWorld: WKContentWorld,
         completionHandler: ((Result<Any, any Error>) -> Void)? = nil
@@ -14,9 +13,9 @@ extension WKWebView {
         let thunk = completionHandler.map { handler in
             WIKObjCBlockConversion.boxingNilAsAnyForCompatibility(WIKUnsafeTransfer(value: handler))
         }
-        self.wi_callAsyncJavaScript(
-            functionBody,
-            arguments: arguments,
+        WIKRuntimeBridge.evaluateJavaScript(
+            on: self,
+            javaScript: javaScript,
             inFrame: frame,
             in: contentWorld,
             completionHandler: thunk
@@ -24,26 +23,26 @@ extension WKWebView {
     }
 
     @MainActor
-    public func callAsyncJavaScriptCompat(
-        _ functionBody: String,
-        arguments: [String: Any] = [:],
+    public func evaluateJavaScriptCompat(
+        _ javaScript: String,
         in frame: WKFrameInfo? = nil,
         contentWorld: WKContentWorld
     ) async throws -> Any? {
         let transferredResult = try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<WIKUnsafeTransfer<Any?>, Error>) in
-            self.wi_callAsyncJavaScript(
-                functionBody,
-                arguments: arguments,
+            WIKRuntimeBridge.evaluateJavaScript(
+                on: self,
+                javaScript: javaScript,
                 inFrame: frame,
-                in: contentWorld
-            ) { result, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: WIKUnsafeTransfer(value: result))
+                in: contentWorld,
+                completionHandler: { result, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: WIKUnsafeTransfer(value: result))
+                    }
                 }
-            }
+            )
         }
         return transferredResult.value
     }

--- a/Sources/WebInspectorBridge/ObjCShim/WIKRuntimeBridge.m
+++ b/Sources/WebInspectorBridge/ObjCShim/WIKRuntimeBridge.m
@@ -1,4 +1,5 @@
 #import "WIKRuntimeBridge.h"
+#import "WKWebView+EvaluateJavaScriptCompat.h"
 
 #if TARGET_OS_OSX
 #import <objc/runtime.h>
@@ -316,6 +317,15 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
     Setter function = (Setter)implementation;
     function(webView, selector, delegate);
     return YES;
+}
+
++ (void)evaluateJavaScriptOnWebView:(WKWebView *)webView
+                         javaScript:(NSString *)javaScript
+                            inFrame:(WKFrameInfo *)frame
+                     inContentWorld:(WKContentWorld *)contentWorld
+                  completionHandler:(void (^)(id _Nullable, NSError * _Nullable))completionHandler
+{
+    [webView wi_evaluateJavaScript:javaScript inFrame:frame inContentWorld:contentWorld completionHandler:completionHandler];
 }
 
 + (WKContentWorld *)makeContentWorldWithConfigurationClassName:(NSString *)configurationClassName

--- a/Sources/WebInspectorBridge/ObjCShim/WKWebView+CallAsyncJavaScriptCompat.m
+++ b/Sources/WebInspectorBridge/ObjCShim/WKWebView+CallAsyncJavaScriptCompat.m
@@ -2,7 +2,7 @@
 
 @implementation WKWebView (WIKCallAsyncJavaScriptCompat)
 
-- (void)wki_callAsyncJavaScript:(NSString *)functionBody
+- (void)wi_callAsyncJavaScript:(NSString *)functionBody
                       arguments:(NSDictionary<NSString *, id> *)arguments
                         inFrame:(WKFrameInfo *)frame
                  inContentWorld:(WKContentWorld *)contentWorld

--- a/Sources/WebInspectorBridge/ObjCShim/WKWebView+CallAsyncJavaScriptCompat.m
+++ b/Sources/WebInspectorBridge/ObjCShim/WKWebView+CallAsyncJavaScriptCompat.m
@@ -1,0 +1,14 @@
+#import "WKWebView+CallAsyncJavaScriptCompat.h"
+
+@implementation WKWebView (WIKCallAsyncJavaScriptCompat)
+
+- (void)wki_callAsyncJavaScript:(NSString *)functionBody
+                      arguments:(NSDictionary<NSString *, id> *)arguments
+                        inFrame:(WKFrameInfo *)frame
+                 inContentWorld:(WKContentWorld *)contentWorld
+              completionHandler:(void (^)(id, NSError *))completionHandler
+{
+    [self callAsyncJavaScript:functionBody arguments:arguments inFrame:frame inContentWorld:contentWorld completionHandler:completionHandler];
+}
+
+@end

--- a/Sources/WebInspectorBridge/ObjCShim/WKWebView+EvaluateJavaScriptCompat.m
+++ b/Sources/WebInspectorBridge/ObjCShim/WKWebView+EvaluateJavaScriptCompat.m
@@ -1,0 +1,13 @@
+#import "WKWebView+EvaluateJavaScriptCompat.h"
+
+@implementation WKWebView (WIKEvaluateJavaScriptCompat)
+
+- (void)wi_evaluateJavaScript:(NSString *)javaScript
+                       inFrame:(WKFrameInfo *)frame
+                inContentWorld:(WKContentWorld *)contentWorld
+             completionHandler:(void (^)(id, NSError *))completionHandler
+{
+    [self evaluateJavaScript:javaScript inFrame:frame inContentWorld:contentWorld completionHandler:completionHandler];
+}
+
+@end

--- a/Sources/WebInspectorBridge/ObjCShim/include/WIKRuntimeBridge.h
+++ b/Sources/WebInspectorBridge/ObjCShim/include/WIKRuntimeBridge.h
@@ -36,6 +36,11 @@ typedef NS_ERROR_ENUM(WIKRuntimeBridgeErrorDomain, WIKRuntimeBridgeErrorCode) {
 + (BOOL)invokeSetResourceLoadDelegateOnWebView:(WKWebView *)webView
                                   selectorName:(NSString *)selectorName
                                       delegate:(nullable id)delegate;
++ (void)evaluateJavaScriptOnWebView:(WKWebView *)webView
+                         javaScript:(NSString *)javaScript
+                            inFrame:(nullable WKFrameInfo *)frame
+                     inContentWorld:(WKContentWorld *)contentWorld
+                  completionHandler:(void (^ _Nullable)(id _Nullable result, NSError * _Nullable error))completionHandler;
 
 + (nullable WKContentWorld *)makeContentWorldWithConfigurationClassName:(NSString *)configurationClassName
                                                        worldSelectorName:(NSString *)worldSelectorName

--- a/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+CallAsyncJavaScriptCompat.h
+++ b/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+CallAsyncJavaScriptCompat.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKWebView (WIKCallAsyncJavaScriptCompat)
+
+- (void)wki_callAsyncJavaScript:(NSString *)functionBody
+                      arguments:(nullable NSDictionary<NSString *, id> *)arguments
+                        inFrame:(nullable WKFrameInfo *)frame
+                 inContentWorld:(WKContentWorld *)contentWorld
+              completionHandler:(void (^ _Nullable)(id _Nullable result, NSError * _Nullable error))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+CallAsyncJavaScriptCompat.h
+++ b/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+CallAsyncJavaScriptCompat.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WKWebView (WIKCallAsyncJavaScriptCompat)
 
-- (void)wki_callAsyncJavaScript:(NSString *)functionBody
+- (void)wi_callAsyncJavaScript:(NSString *)functionBody
                       arguments:(nullable NSDictionary<NSString *, id> *)arguments
                         inFrame:(nullable WKFrameInfo *)frame
                  inContentWorld:(WKContentWorld *)contentWorld

--- a/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+EvaluateJavaScriptCompat.h
+++ b/Sources/WebInspectorBridge/ObjCShim/include/WKWebView+EvaluateJavaScriptCompat.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKWebView (WIKEvaluateJavaScriptCompat)
+
+- (void)wi_evaluateJavaScript:(NSString *)javaScript
+                       inFrame:(nullable WKFrameInfo *)frame
+                inContentWorld:(WKContentWorld *)contentWorld
+             completionHandler:(void (^ _Nullable)(id _Nullable result, NSError * _Nullable error))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/WebInspectorEngine/Common/WKWebView+AsyncJS.swift
+++ b/Sources/WebInspectorEngine/Common/WKWebView+AsyncJS.swift
@@ -10,7 +10,7 @@ package extension WKWebView {
         in frame: WKFrameInfo? = nil,
         contentWorld: WKContentWorld
     ) async throws {
-        _ = try await callAsyncJavaScript(
+        _ = try await callAsyncJavaScriptCompat(
             "(() => { \(script); })();",
             arguments: arguments,
             in: frame,

--- a/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
+++ b/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
@@ -1320,7 +1320,7 @@ private extension DOMPageAgent {
         guard let webView else {
             return
         }
-        webView.evaluateJavaScript(
+        webView.evaluateJavaScriptCompat(
             "window.webInspectorDOM && window.webInspectorDOM.detach && window.webInspectorDOM.detach();",
             in: nil,
             in: bridgeWorld,

--- a/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
+++ b/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
@@ -248,7 +248,7 @@ extension DOMPageAgent {
         guard let webView else {
             throw WebInspectorCoreError.scriptUnavailable
         }
-        let rawResult = try await webView.callAsyncJavaScript(
+        let rawResult = try await webView.callAsyncJavaScriptCompat(
             "return window.webInspectorDOM.startSelection()",
             arguments: [:],
             in: nil,
@@ -380,7 +380,7 @@ extension DOMPageAgent {
         }
         await waitForPreparedPageContextSyncIfNeeded()
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOM.removeNode(target, expectedPageEpoch, expectedDocumentScopeID)",
                 arguments: [
                     "target": targetArgument,
@@ -414,7 +414,7 @@ extension DOMPageAgent {
         }
         await waitForPreparedPageContextSyncIfNeeded()
         do {
-            let rawValue = try await webView.callAsyncJavaScript(
+            let rawValue = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOM.removeNodeWithUndo(identifier, expectedPageEpoch, expectedDocumentScopeID)",
                 arguments: [
                     "identifier": identifier,
@@ -445,7 +445,7 @@ extension DOMPageAgent {
         }
         await waitForPreparedPageContextSyncIfNeeded()
         do {
-            let rawValue = try await webView.callAsyncJavaScript(
+            let rawValue = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOM.undoRemoveNode(token, expectedPageEpoch, expectedDocumentScopeID)",
                 arguments: [
                     "token": undoToken,
@@ -473,7 +473,7 @@ extension DOMPageAgent {
         }
         await waitForPreparedPageContextSyncIfNeeded()
         do {
-            let rawValue = try await webView.callAsyncJavaScript(
+            let rawValue = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOM.redoRemoveNode(token, expectedPageEpoch, expectedDocumentScopeID)",
                 arguments: [
                     "token": undoToken,
@@ -516,7 +516,7 @@ extension DOMPageAgent {
                 return .failed
             }
             do {
-                let rawValue = try await webView.callAsyncJavaScript(
+                let rawValue = try await webView.callAsyncJavaScriptCompat(
                     "return window.webInspectorDOM.setAttributeForNode(target, name, value, expectedPageEpoch, expectedDocumentScopeID)",
                     arguments: [
                         "target": targetArgument,
@@ -563,7 +563,7 @@ extension DOMPageAgent {
         }
         await waitForPreparedPageContextSyncIfNeeded()
         do {
-            let rawValue = try await webView.callAsyncJavaScript(
+            let rawValue = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOM.removeAttributeForNode(target, name, expectedPageEpoch, expectedDocumentScopeID)",
                 arguments: [
                     "target": targetArgument,
@@ -1145,7 +1145,7 @@ private extension DOMPageAgent {
         }
 #endif
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 return (function() {
                     if (!window.webInspectorDOM || typeof window.webInspectorDOM.debugStatus !== "function") {
@@ -1198,7 +1198,7 @@ private extension DOMPageAgent {
         }
 #endif
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 return (function(documentScopeID) {
                     if (!window.webInspectorDOM || typeof window.webInspectorDOM.setDocumentScopeID !== "function") {
@@ -1245,7 +1245,7 @@ private extension DOMPageAgent {
             return true
         }
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 return (function(epoch, documentScopeID) {
                     if (!window.webInspectorDOM) {
@@ -1355,7 +1355,7 @@ private extension DOMPageAgent {
         options: NSDictionary
     ) async throws -> Bool {
         for attempt in 0..<autoSnapshotConfigureRetryCount {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 if (!window.webInspectorDOM || typeof window.webInspectorDOM.configureAutoSnapshot !== "function") {
                     return false;
@@ -1453,7 +1453,7 @@ private extension DOMPageAgent {
         guard let targetArgument = javascriptTargetArgument(for: target) else {
             return ""
         }
-        let rawResult = try await webView.callAsyncJavaScript(
+        let rawResult = try await webView.callAsyncJavaScriptCompat(
             script,
             arguments: ["target": targetArgument],
             in: nil,
@@ -1488,7 +1488,7 @@ private extension DOMPageAgent {
             captureExpression = "window.webInspectorDOM.captureSnapshot(maxDepth)"
             captureEnvelopeExpression = "window.webInspectorDOM.captureSnapshotEnvelope(maxDepth)"
         }
-        let rawResult = try await webView.callAsyncJavaScript(
+        let rawResult = try await webView.callAsyncJavaScriptCompat(
             preferEnvelope
                 ? """
                 if (window.webInspectorDOM && typeof window.webInspectorDOM.captureSnapshotEnvelope === "function") {
@@ -1537,7 +1537,7 @@ private extension DOMPageAgent {
         guard let targetArgument = javascriptTargetArgument(for: target) else {
             throw WebInspectorCoreError.subtreeUnavailable
         }
-        let rawResult = try await webView.callAsyncJavaScript(
+        let rawResult = try await webView.callAsyncJavaScriptCompat(
             preferEnvelope
                 ? """
                 if (window.webInspectorDOM && typeof window.webInspectorDOM.captureSubtreeEnvelope === "function") {
@@ -1650,7 +1650,7 @@ private extension DOMPageAgent {
                 expectedPageEpoch: expectedPageEpoch,
                 reveal: reveal
             )
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 invocation.script,
                 arguments: invocation.arguments,
                 in: nil,
@@ -1680,7 +1680,7 @@ private extension DOMPageAgent {
         }
 
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 if (!window.webInspectorDOM || typeof window.webInspectorDOM.createNodeHandle !== "function") {
                     return unavailable;

--- a/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
@@ -492,9 +492,9 @@ private extension NetworkPageAgent {
                 controller.addUserScript(checkScript)
             }
             do {
-                _ = try await webView.evaluateJavaScript(tokenBootstrapScript, in: nil, contentWorld: .page)
+                _ = try await webView.evaluateJavaScriptCompat(tokenBootstrapScript, in: nil, contentWorld: .page)
                 if let scriptSource {
-                    _ = try await webView.evaluateJavaScript(scriptSource, in: nil, contentWorld: .page)
+                    _ = try await webView.evaluateJavaScriptCompat(scriptSource, in: nil, contentWorld: .page)
                 }
             } catch {
                 networkLogger.error("failed to refresh network agent bootstrap: \(error.localizedDescription, privacy: .public)")
@@ -525,8 +525,8 @@ private extension NetworkPageAgent {
         controllerStateRegistry.setNetworkBridgeScriptInstalled(true, on: controller)
 
         do {
-            _ = try await webView.evaluateJavaScript(tokenBootstrapScript, in: nil, contentWorld: .page)
-            _ = try await webView.evaluateJavaScript(scriptSource, in: nil, contentWorld: .page)
+            _ = try await webView.evaluateJavaScriptCompat(tokenBootstrapScript, in: nil, contentWorld: .page)
+            _ = try await webView.evaluateJavaScriptCompat(scriptSource, in: nil, contentWorld: .page)
         } catch {
             networkLogger.error("failed to install network agent: \(error.localizedDescription, privacy: .public)")
         }
@@ -582,7 +582,7 @@ private extension NetworkPageAgent {
 
     private func probeBodyFetchAvailability(in webView: WKWebView) async -> BodyFetchAvailability {
         do {
-            let raw = try await webView.evaluateJavaScript(
+            let raw = try await webView.evaluateJavaScriptCompat(
                 """
                 (() => ({
                     hasGetBody: Boolean(

--- a/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
@@ -712,7 +712,7 @@ private extension NetworkPageAgent {
         in webView: WKWebView
     ) async -> NetworkBodyFetchResult {
         do {
-            let result = try await webView.callAsyncJavaScript(
+            let result = try await webView.callAsyncJavaScriptCompat(
                 """
                 return (function(handle, agentUnavailable, bodyUnavailable) {
                     if (!window.webInspectorNetworkAgent || typeof window.webInspectorNetworkAgent.getBodyForHandle !== "function") {
@@ -767,7 +767,7 @@ private extension NetworkPageAgent {
         in webView: WKWebView
     ) async -> NetworkBodyFetchResult {
         do {
-            let result = try await webView.callAsyncJavaScript(
+            let result = try await webView.callAsyncJavaScriptCompat(
                 """
                 return (function(ref, agentUnavailable, bodyUnavailable) {
                     if (!window.webInspectorNetworkAgent || typeof window.webInspectorNetworkAgent.getBody !== "function") {

--- a/Sources/WebInspectorKitSPI/WIImageCacheSPI.swift
+++ b/Sources/WebInspectorKitSPI/WIImageCacheSPI.swift
@@ -18,8 +18,6 @@ public struct WIDisplayedImageCacheEntry: Sendable, Equatable {
 
 public enum WIImageCacheSPIError: Error, Sendable, Equatable {
     case frameEnumerationUnavailable
-    case webArchiveCreationFailed
-    case webArchiveDecodeFailed
     case resourceFetchFailed
 }
 
@@ -31,7 +29,7 @@ public enum WIImageCacheSPI {
     /// This lookup does not evaluate JavaScript and does not determine whether the
     /// image is currently rendered or visible. It queries the current page's loaded
     /// subresources by walking the main frame before subframes and returning the
-    /// first currently fetchable match.
+    /// first directly fetchable match.
     public static func displayedImageCache(
         for imageURL: URL,
         in webView: WKWebView
@@ -46,30 +44,6 @@ package protocol WIFrameInfoProviding {
 }
 
 package typealias WIFrameResourceLookup = (URL, WKFrameInfo, WKWebView) async throws -> WISPIFetchedResource?
-
-private enum WIDirectImageLookupError: Error {
-    case fallbackToArchive
-}
-
-private final class WIArchiveRequestState: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Data, Error>?
-
-    func install(_ continuation: CheckedContinuation<Data, Error>) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.continuation = continuation
-    }
-
-    func resume(with result: Result<Data, Error>) {
-        lock.lock()
-        let continuation = self.continuation
-        self.continuation = nil
-        lock.unlock()
-
-        continuation?.resume(with: result)
-    }
-}
 
 @MainActor
 package struct WIImageCacheLoader {
@@ -97,10 +71,10 @@ package struct WIImageCacheLoader {
         guard let mainFrameInfo = frameInfos.first(where: \.isMainFrame) else {
             throw WIImageCacheSPIError.frameEnumerationUnavailable
         }
+
         let subframeInfos = frameInfos.filter { frameInfo in
-            return frameInfo !== mainFrameInfo
+            frameInfo !== mainFrameInfo
         }
-        var shouldTryArchiveFallback = false
 
         func lookupResource(in frameInfo: WKFrameInfo) async throws -> WISPIFetchedResource? {
             do {
@@ -108,66 +82,36 @@ package struct WIImageCacheLoader {
             } catch is CancellationError {
                 throw CancellationError()
             } catch let error as NSError {
-                if let code = WISPIResourceLookupBridgeError(error) {
-                    switch code {
-                    case .invalidArgument:
-                        throw WIImageCacheSPIError.resourceFetchFailed
-                    case .urlCreationFailed,
-                         .pageUnavailable,
-                         .frameHandleUnavailable,
-                         .frameUnavailable,
-                         .symbolUnavailable:
-                        throw WIDirectImageLookupError.fallbackToArchive
-                    }
+                if WISPIResourceLookupBridgeError(error) == .invalidArgument {
+                    throw WIImageCacheSPIError.resourceFetchFailed
                 }
-                throw WIDirectImageLookupError.fallbackToArchive
+                return nil
             } catch {
                 return nil
             }
         }
 
-        do {
-            if let resource = try await lookupResource(in: mainFrameInfo) {
-                return try Self.makeEntry(resource: resource, frameInfo: mainFrameInfo, resolvedURL: imageURL)
-            }
-        } catch WIDirectImageLookupError.fallbackToArchive {
-            shouldTryArchiveFallback = true
+        if let resource = try await lookupResource(in: mainFrameInfo) {
+            return try Self.makeEntry(resource: resource, frameInfo: mainFrameInfo, resolvedURL: imageURL)
         }
 
         var firstSubframeMatch: (resource: WISPIFetchedResource, frameInfo: WKFrameInfo)?
         for frameInfo in subframeInfos {
-            do {
-                if let resource = try await lookupResource(in: frameInfo) {
-                    firstSubframeMatch = (resource, frameInfo)
-                    break
-                }
-            } catch WIDirectImageLookupError.fallbackToArchive {
-                shouldTryArchiveFallback = true
+            if let resource = try await lookupResource(in: frameInfo) {
+                firstSubframeMatch = (resource, frameInfo)
+                break
             }
         }
 
         if let firstSubframeMatch {
-            do {
-                if let resource = try await lookupResource(in: mainFrameInfo) {
-                    return try Self.makeEntry(resource: resource, frameInfo: mainFrameInfo, resolvedURL: imageURL)
-                }
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch WIDirectImageLookupError.fallbackToArchive {
-                shouldTryArchiveFallback = true
-            } catch {
-                // Keep an already-fetched subframe hit if the re-check races with frame teardown.
+            if let resource = try await lookupResource(in: mainFrameInfo) {
+                return try Self.makeEntry(resource: resource, frameInfo: mainFrameInfo, resolvedURL: imageURL)
             }
             return try Self.makeEntry(
                 resource: firstSubframeMatch.resource,
                 frameInfo: firstSubframeMatch.frameInfo,
                 resolvedURL: imageURL
             )
-        }
-
-        let shouldUseArchiveFallback = shouldTryArchiveFallback || firstSubframeMatch == nil
-        if shouldUseArchiveFallback {
-            return try await Self.fallbackArchiveEntry(for: imageURL, frameInfos: frameInfos, webView: webView)
         }
 
         return nil
@@ -189,93 +133,6 @@ package struct WIImageCacheLoader {
             frameID: frameID
         )
     }
-
-    private static func fallbackArchiveEntry(
-        for imageURL: URL,
-        frameInfos: [WKFrameInfo],
-        webView: WKWebView
-    ) async throws -> WIDisplayedImageCacheEntry? {
-        let archiveData: Data
-        do {
-            archiveData = try await createWebArchiveData(from: webView)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            throw WIImageCacheSPIError.webArchiveCreationFailed
-        }
-
-        guard let matchedResource = try WIWebArchiveResourceLookup.matchingResource(
-            for: imageURL,
-            in: archiveData
-        ) else {
-            return nil
-        }
-
-        guard let frameID = resolveArchiveFrameID(for: matchedResource, frameInfos: frameInfos) else {
-            throw WIImageCacheSPIError.frameEnumerationUnavailable
-        }
-
-        return WIDisplayedImageCacheEntry(
-            data: matchedResource.data,
-            mimeType: matchedResource.mimeType,
-            resolvedURL: imageURL,
-            frameID: frameID
-        )
-    }
-
-    private static func createWebArchiveData(from webView: WKWebView) async throws -> Data {
-        try await requestArchiveData { completionHandler in
-            webView.createWebArchiveData { result in
-                completionHandler(result.mapError { $0 as Error })
-            }
-        }
-    }
-
-    package static func requestArchiveData(
-        _ startRequest: (@escaping @Sendable (Result<Data, Error>) -> Void) -> Void
-    ) async throws -> Data {
-        let state = WIArchiveRequestState()
-
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                state.install(continuation)
-
-                if Task.isCancelled {
-                    state.resume(with: .failure(CancellationError()))
-                    return
-                }
-
-                startRequest { result in
-                    state.resume(with: result)
-                }
-            }
-        } onCancel: {
-            state.resume(with: .failure(CancellationError()))
-        }
-    }
-
-    private static func resolveArchiveFrameID(
-        for matchedResource: WIWebArchiveResourceLookup.MatchedResource,
-        frameInfos: [WKFrameInfo]
-    ) -> UInt64? {
-        let frameInfo: WKFrameInfo?
-        if matchedResource.isMainFrame {
-            frameInfo = frameInfos.first(where: { $0.isMainFrame })
-        } else if let frameURL = matchedResource.frameURL {
-            frameInfo = frameInfos.first(where: {
-                !$0.isMainFrame && $0.request.url?.absoluteString == frameURL
-            }) ?? frameInfos.first(where: {
-                $0.request.url?.absoluteString == frameURL
-            })
-        } else {
-            frameInfo = nil
-        }
-
-        guard let frameInfo else {
-            return nil
-        }
-        return WISPIFrameBridge.frameID(for: frameInfo)
-    }
 }
 
 @MainActor
@@ -284,112 +141,5 @@ package struct WIFrameInfoProvider: WIFrameInfoProviding {
 
     package func frameInfos(in webView: WKWebView) async -> [WKFrameInfo]? {
         await WISPIFrameBridge.frameInfos(for: webView)
-    }
-}
-
-private enum WIWebArchiveResourceLookup {
-    struct MatchedResource {
-        let data: Data
-        let mimeType: String?
-        let frameURL: String?
-        let isMainFrame: Bool
-    }
-
-    private static let mainResourceKey = "WebMainResource"
-    private static let subresourcesKey = "WebSubresources"
-    private static let subframeArchivesKey = "WebSubframeArchives"
-    private static let resourceURLKey = "WebResourceURL"
-    private static let resourceDataKey = "WebResourceData"
-    private static let resourceMIMETypeKey = "WebResourceMIMEType"
-
-    static func matchingResource(for targetURL: URL, in archiveData: Data) throws -> MatchedResource? {
-        let propertyList: Any
-        do {
-            propertyList = try unsafe PropertyListSerialization.propertyList(from: archiveData, options: [], format: nil)
-        } catch {
-            throw WIImageCacheSPIError.webArchiveDecodeFailed
-        }
-
-        guard let archive = propertyList as? [String: Any] else {
-            throw WIImageCacheSPIError.webArchiveDecodeFailed
-        }
-
-        return matchingResource(
-            forAbsoluteURL: targetURL.absoluteString,
-            in: archive,
-            frameURL: archiveFrameURL(from: archive),
-            isMainFrame: true
-        )
-    }
-
-    private static func matchingResource(
-        forAbsoluteURL targetURL: String,
-        in archive: [String: Any],
-        frameURL: String?,
-        isMainFrame: Bool
-    ) -> MatchedResource? {
-        if let mainResource = archive[mainResourceKey] as? [String: Any],
-           let matchedResource = matchedResource(
-            in: mainResource,
-            targetURL: targetURL,
-            frameURL: frameURL,
-            isMainFrame: isMainFrame
-           ) {
-            return matchedResource
-        }
-
-        if let subresources = archive[subresourcesKey] as? [[String: Any]] {
-            for subresource in subresources {
-                if let matchedResource = matchedResource(
-                    in: subresource,
-                    targetURL: targetURL,
-                    frameURL: frameURL,
-                    isMainFrame: isMainFrame
-                ) {
-                    return matchedResource
-                }
-            }
-        }
-
-        if let subframeArchives = archive[subframeArchivesKey] as? [[String: Any]] {
-            for subframeArchive in subframeArchives {
-                if let matchedResource = matchingResource(
-                    forAbsoluteURL: targetURL,
-                    in: subframeArchive,
-                    frameURL: archiveFrameURL(from: subframeArchive),
-                    isMainFrame: false
-                ) {
-                    return matchedResource
-                }
-            }
-        }
-
-        return nil
-    }
-
-    private static func matchedResource(
-        in resource: [String: Any],
-        targetURL: String,
-        frameURL: String?,
-        isMainFrame: Bool
-    ) -> MatchedResource? {
-        guard resource[resourceURLKey] as? String == targetURL,
-              let data = resource[resourceDataKey] as? Data else {
-            return nil
-        }
-
-        return MatchedResource(
-            data: data,
-            mimeType: resource[resourceMIMETypeKey] as? String,
-            frameURL: frameURL,
-            isMainFrame: isMainFrame
-        )
-    }
-
-    private static func archiveFrameURL(from archive: [String: Any]) -> String? {
-        guard let mainResource = archive[mainResourceKey] as? [String: Any] else {
-            return nil
-        }
-        return mainResource[resourceURLKey] as? String
     }
 }

--- a/Sources/WebInspectorRuntime/DOM/DOMInspectorRuntime.swift
+++ b/Sources/WebInspectorRuntime/DOM/DOMInspectorRuntime.swift
@@ -1881,7 +1881,7 @@ extension DOMInspectorRuntime {
             return false
         }
         do {
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 "return window.webInspectorDOMFrontend?.applySelectionPayload?.(selectionPayload, pageEpoch, documentScopeID) ?? false",
                 arguments: [
                     "selectionPayload": payload,

--- a/Sources/WebInspectorRuntime/DOM/DOMMutationPipeline.swift
+++ b/Sources/WebInspectorRuntime/DOM/DOMMutationPipeline.swift
@@ -377,7 +377,7 @@ final class DOMMutationSender {
 
         do {
             activeDispatchGeneration = generation
-            let rawResult = try await webView.callAsyncJavaScript(
+            let rawResult = try await webView.callAsyncJavaScriptCompat(
                 """
                 if (!window.webInspectorDOMFrontend || typeof window.webInspectorDOMFrontend.applyMutationBuffer !== "function") {
                     return false;

--- a/Tests/WebInspectorEngineTests/DOMPageAgentTests.swift
+++ b/Tests/WebInspectorEngineTests/DOMPageAgentTests.swift
@@ -213,7 +213,7 @@ struct DOMSessionTests {
         _ = await session.attach(to: webView)
         await loadHTML("<html><body><p>hi</p></body></html>", in: webView)
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             "(() => Boolean(window.webInspectorDOM && window.webInspectorDOM.__installed))();",
             in: nil,
             contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -237,7 +237,7 @@ struct DOMSessionTests {
         _ = await session.attach(to: webView)
         await loadHTML("<html><body><p>hi</p></body></html>", in: webView)
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             "(() => Boolean(window.webInspectorDOM && window.webInspectorDOM.__installed))();",
             in: nil,
             contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -762,7 +762,7 @@ struct DOMSessionTests {
         await session.setAutoSnapshot(enabled: true)
         await waitForAutoSnapshotEnabled(on: webView)
 
-        let rawStatus = try await webView.evaluateJavaScript(
+        let rawStatus = try await webView.evaluateJavaScriptCompat(
             "(() => window.webInspectorDOM?.debugStatus?.() ?? null)();",
             in: nil,
             contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -1108,7 +1108,7 @@ struct DOMSessionTests {
 
     private func waitForAutoSnapshotEnabled(on webView: WKWebView) async {
         for _ in 0..<100 {
-            let raw = try? await webView.evaluateJavaScript(
+            let raw = try? await webView.evaluateJavaScriptCompat(
                 "(() => Boolean(window.webInspectorDOM?.debugStatus?.().snapshotAutoUpdateEnabled))();",
                 in: nil,
                 contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -1140,7 +1140,7 @@ struct DOMSessionTests {
     }
 
     private func autoSnapshotStatus(on webView: WKWebView) async -> [String: Any]? {
-        let rawStatus = try? await webView.evaluateJavaScript(
+        let rawStatus = try? await webView.evaluateJavaScriptCompat(
             "(() => window.webInspectorDOM?.debugStatus?.() ?? null)();",
             in: nil,
             contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -1277,7 +1277,7 @@ private func extractDocumentScopeID(from agent: DOMPageAgent) -> UInt64? {
 
 @MainActor
 private func currentDOMAgentPageEpoch(in webView: WKWebView) async throws -> Int? {
-    let rawValue = try await webView.evaluateJavaScript(
+    let rawValue = try await webView.evaluateJavaScriptCompat(
         "(() => window.webInspectorDOM?.debugStatus?.().pageEpoch ?? null)();",
         in: nil,
         contentWorld: WISPIContentWorldProvider.bridgeWorld()
@@ -1296,7 +1296,7 @@ private func currentDOMAgentPageEpoch(in webView: WKWebView) async throws -> Int
 
 @MainActor
 private func currentDOMAgentDocumentScopeID(in webView: WKWebView) async throws -> UInt64? {
-    let rawValue = try await webView.evaluateJavaScript(
+    let rawValue = try await webView.evaluateJavaScriptCompat(
         "(() => window.webInspectorDOM?.debugStatus?.().documentScopeID ?? null)();",
         in: nil,
         contentWorld: WISPIContentWorldProvider.bridgeWorld()

--- a/Tests/WebInspectorEngineTests/DOMPageAgentTests.swift
+++ b/Tests/WebInspectorEngineTests/DOMPageAgentTests.swift
@@ -1056,7 +1056,7 @@ struct DOMSessionTests {
             return
         }
 
-        let didDisableHandleAPI = try await webView.callAsyncJavaScript(
+        let didDisableHandleAPI = try await webView.callAsyncJavaScriptCompat(
             """
             return (function() {
                 if (!window.webInspectorDOM) {
@@ -1226,7 +1226,7 @@ struct DOMSessionTests {
     }
 
     private func domNodeExists(withID id: String, in webView: WKWebView) async -> Bool {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return document.getElementById(identifier) !== null;",
             arguments: ["identifier": id],
             in: nil,
@@ -1240,7 +1240,7 @@ struct DOMSessionTests {
         attributeName: String,
         in webView: WKWebView
     ) async -> String? {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return document.getElementById(identifier)?.getAttribute(attributeName) ?? null;",
             arguments: [
                 "identifier": elementID,

--- a/Tests/WebInspectorEngineTests/NetworkPageAgentTests.swift
+++ b/Tests/WebInspectorEngineTests/NetworkPageAgentTests.swift
@@ -240,7 +240,7 @@ struct NetworkPageAgentTests {
         await attachAndWait(agent, to: webView)
         await loadHTML("<html><body><p>hello</p></body></html>", in: webView)
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             "(() => Boolean(window.webInspectorNetworkAgent && window.webInspectorNetworkAgent.__installed))();",
             in: nil,
             contentWorld: .page
@@ -265,7 +265,7 @@ struct NetworkPageAgentTests {
         await attachAndWait(agent, to: webView)
         await loadHTML("<html><body><p>hello</p></body></html>", in: webView)
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             "(() => Boolean(window.webInspectorNetworkAgent && window.webInspectorNetworkAgent.__installed))();",
             in: nil,
             contentWorld: .page
@@ -282,7 +282,7 @@ struct NetworkPageAgentTests {
         await attachAndWait(agent, to: webView)
         await loadHTML("<html><body><p>patch-check</p></body></html>", in: webView)
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             """
             (() => ({
                 xhrPatched: Boolean(XMLHttpRequest.prototype.open && XMLHttpRequest.prototype.open.__wiNetworkPatched),
@@ -328,7 +328,7 @@ struct NetworkPageAgentTests {
         let body = await agent.fetchBody(bodyRef: nil, bodyHandle: "token" as NSString, role: .response)
         #expect(body?.full == "token")
 
-        let raw = try await webView.evaluateJavaScript(
+        let raw = try await webView.evaluateJavaScriptCompat(
             "(() => Boolean(window.webInspectorNetworkAgent && window.webInspectorNetworkAgent.__installed))();",
             in: nil,
             contentWorld: .page
@@ -445,7 +445,7 @@ struct NetworkPageAgentTests {
             #expect(firstBody?.full == "token")
         }
 
-        let rawRepairCountAfterFirstFetch = try await webView.evaluateJavaScript(
+        let rawRepairCountAfterFirstFetch = try await webView.evaluateJavaScriptCompat(
             "window.__wiRepairCount ? window.__wiRepairCount() : -1;",
             in: nil,
             contentWorld: .page
@@ -464,7 +464,7 @@ struct NetworkPageAgentTests {
             #expect(secondBody?.full == "token")
         }
 
-        let rawRepairCount = try await webView.evaluateJavaScript(
+        let rawRepairCount = try await webView.evaluateJavaScriptCompat(
             "window.__wiRepairCount ? window.__wiRepairCount() : -1;",
             in: nil,
             contentWorld: .page

--- a/Tests/WebInspectorEngineTests/NetworkPageAgentTests.swift
+++ b/Tests/WebInspectorEngineTests/NetworkPageAgentTests.swift
@@ -348,7 +348,7 @@ struct NetworkPageAgentTests {
         await loadHTML("<html><body><p>handle retry</p></body></html>", in: webView)
         await agent.waitForPendingConfigurationForTesting()
 
-        let patched = try await webView.callAsyncJavaScript(
+        let patched = try await webView.callAsyncJavaScriptCompat(
             """
             return (function() {
                 if (!window.webInspectorNetworkAgent) {
@@ -391,7 +391,7 @@ struct NetworkPageAgentTests {
         await loadHTML("<html><body><p>fallback without repair</p></body></html>", in: webView)
         await agent.waitForPendingConfigurationForTesting()
 
-        let prepared = try await webView.callAsyncJavaScript(
+        let prepared = try await webView.callAsyncJavaScriptCompat(
             """
             return (function() {
                 if (!window.webInspectorNetworkAgent || typeof window.webInspectorNetworkAgent.configure !== "function") {
@@ -485,7 +485,7 @@ struct NetworkPageAgentTests {
         await loadHTML("<html><body><p>fallback</p></body></html>", in: webView)
 
         let modeBeforeFallback = agent.currentBridgeMode
-        let didDisableHandleAPI = try await webView.callAsyncJavaScript(
+        let didDisableHandleAPI = try await webView.callAsyncJavaScriptCompat(
             """
             return (function() {
                 if (!window.webInspectorNetworkAgent) {

--- a/Tests/WebInspectorIntegrationTests/DOMInspectorTests.swift
+++ b/Tests/WebInspectorIntegrationTests/DOMInspectorTests.swift
@@ -1218,7 +1218,7 @@ struct DOMInspectorTests {
     }
 
     private func domNodeExists(withID id: String, in webView: WKWebView) async -> Bool {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return document.getElementById(identifier) !== null;",
             arguments: ["identifier": id],
             in: nil,
@@ -1228,7 +1228,7 @@ struct DOMInspectorTests {
     }
 
     private func selectionIsActive(in webView: WKWebView) async -> Bool {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return window.webInspectorDOM.debugStatus().selectionActive;",
             arguments: [:],
             in: nil,
@@ -1238,7 +1238,7 @@ struct DOMInspectorTests {
     }
 
     private func domAgentDebugStatus(in webView: WKWebView) async -> [String: Any]? {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return window.webInspectorDOM.debugStatus();",
             arguments: [:],
             in: nil,
@@ -1266,7 +1266,7 @@ struct DOMInspectorTests {
     }
 
     private func clickElement(withID elementID: String, in webView: WKWebView) async -> Bool {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             """
             return (function(elementID) {
                 const element = document.getElementById(elementID);
@@ -1285,7 +1285,7 @@ struct DOMInspectorTests {
     }
 
     private func triggerElementSelection(elementID: String, in webView: WKWebView) async -> Bool {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             """
             return (function(elementID, shieldAttribute) {
                 const target = document.getElementById(elementID);
@@ -1320,7 +1320,7 @@ struct DOMInspectorTests {
         newElementID: String,
         in webView: WKWebView
     ) async throws -> Bool {
-        let rawValue = try await webView.callAsyncJavaScript(
+        let rawValue = try await webView.callAsyncJavaScriptCompat(
             """
             return (function(parentElementID, newElementID) {
                 const parent = document.getElementById(parentElementID);
@@ -1350,7 +1350,7 @@ struct DOMInspectorTests {
         count: Int,
         in webView: WKWebView
     ) async throws -> Bool {
-        let rawValue = try await webView.callAsyncJavaScript(
+        let rawValue = try await webView.callAsyncJavaScriptCompat(
             """
             return (function(parentElementID, elementIDPrefix, count) {
                 const parent = document.getElementById(parentElementID);
@@ -1383,7 +1383,7 @@ struct DOMInspectorTests {
         beforeElementID: String,
         in webView: WKWebView
     ) async throws -> Bool {
-        let rawValue = try await webView.callAsyncJavaScript(
+        let rawValue = try await webView.callAsyncJavaScriptCompat(
             """
             return (function(parentElementID, movingElementID, beforeElementID) {
                 const parent = document.getElementById(parentElementID);
@@ -1412,7 +1412,7 @@ struct DOMInspectorTests {
         attributeName: String,
         in webView: WKWebView
     ) async -> String? {
-        let rawValue = try? await webView.callAsyncJavaScript(
+        let rawValue = try? await webView.callAsyncJavaScriptCompat(
             "return document.getElementById(elementID)?.getAttribute(attributeName) ?? null;",
             arguments: [
                 "elementID": elementID,

--- a/Tests/WebInspectorIntegrationTests/WKWebViewCallAsyncJavaScriptCompatTests.swift
+++ b/Tests/WebInspectorIntegrationTests/WKWebViewCallAsyncJavaScriptCompatTests.swift
@@ -1,0 +1,125 @@
+import Testing
+import WebInspectorTestSupport
+import WebKit
+@testable import WebInspectorEngine
+
+private struct UnsafeTestTransfer<Value>: @unchecked Sendable {
+    let value: Value
+}
+
+@MainActor
+@Suite(.serialized, .webKitIsolated)
+struct WKWebViewCallAsyncJavaScriptCompatTests {
+    @Test
+    func asyncCallReturnsExpectedValue() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.callAsyncJavaScriptCompat(
+            "return a + b;",
+            arguments: [
+                "a": 1,
+                "b": 2,
+            ],
+            contentWorld: .page
+        ) as? Int
+
+        #expect(result == 3)
+    }
+
+    @Test
+    func asyncCallReturnsNilForUndefined() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.callAsyncJavaScriptCompat(
+            "console.log('hello');",
+            contentWorld: .page
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test
+    func completionCallBoxesNilForUndefined() async {
+        let webView = makeIsolatedTestWebView()
+
+        let result = await withCheckedContinuation {
+            (continuation: CheckedContinuation<UnsafeTestTransfer<Result<Any, any Error>>, Never>) in
+            webView.callAsyncJavaScriptCompat(
+                "console.log('hello');",
+                in: nil,
+                in: .page,
+                completionHandler: { result in
+                    continuation.resume(returning: UnsafeTestTransfer(value: result))
+                }
+            )
+        }.value
+
+        switch result {
+        case .success(let value):
+            let mirror = Mirror(reflecting: value)
+            #expect(mirror.displayStyle == .optional)
+            #expect(mirror.children.isEmpty)
+        case .failure(let error):
+            Issue.record("Expected success but received error: \(error)")
+        }
+    }
+
+    @Test
+    func asyncCallReturnsNSNullForNull() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.callAsyncJavaScriptCompat(
+            "return null;",
+            contentWorld: .page
+        )
+
+        #expect(result is NSNull)
+    }
+
+    @Test
+    func asyncCallPreservesNestedArguments() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.callAsyncJavaScriptCompat(
+            """
+            return payload.items.map(item => item.name).join(',') + ':' + payload.count;
+            """,
+            arguments: [
+                "payload": [
+                    "items": [
+                        ["name": "alpha"],
+                        ["name": "beta"],
+                    ],
+                    "count": 2,
+                ],
+            ],
+            contentWorld: .page
+        ) as? String
+
+        #expect(result == "alpha,beta:2")
+    }
+
+    @Test
+    func asyncCallPropagatesJavaScriptExceptions() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        await #expect(throws: (any Error).self) {
+            _ = try await webView.callAsyncJavaScriptCompat(
+                "throw new Error('boom');",
+                contentWorld: .page
+            )
+        }
+    }
+
+    @Test
+    func asyncCallPropagatesRejectedPromises() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        await #expect(throws: (any Error).self) {
+            _ = try await webView.callAsyncJavaScriptCompat(
+                "return Promise.reject('boom');",
+                contentWorld: .page
+            )
+        }
+    }
+}

--- a/Tests/WebInspectorIntegrationTests/WKWebViewEvaluateJavaScriptCompatTests.swift
+++ b/Tests/WebInspectorIntegrationTests/WKWebViewEvaluateJavaScriptCompatTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import WebInspectorTestSupport
+import WebKit
+@testable import WebInspectorBridge
+
+private struct UnsafeEvaluateTestTransfer<Value>: @unchecked Sendable {
+    let value: Value
+}
+
+@MainActor
+@Suite(.serialized, .webKitIsolated)
+struct WKWebViewEvaluateJavaScriptCompatTests {
+    @Test
+    func asyncEvaluateReturnsExpectedValue() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.evaluateJavaScriptCompat(
+            "1 + 2",
+            in: nil,
+            contentWorld: .page
+        ) as? Int
+
+        #expect(result == 3)
+    }
+
+    @Test
+    func asyncEvaluateReturnsNilForUndefined() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        let result = try await webView.evaluateJavaScriptCompat(
+            "console.log('x')",
+            in: nil,
+            contentWorld: .page
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test
+    func completionEvaluateBoxesNilForUndefined() async {
+        let webView = makeIsolatedTestWebView()
+
+        let result = await withCheckedContinuation {
+            (continuation: CheckedContinuation<UnsafeEvaluateTestTransfer<Result<Any, any Error>>, Never>) in
+            webView.evaluateJavaScriptCompat(
+                "console.log('x')",
+                in: nil,
+                in: .page,
+                completionHandler: { result in
+                    continuation.resume(returning: UnsafeEvaluateTestTransfer(value: result))
+                }
+            )
+        }.value
+
+        switch result {
+        case .success(let value):
+            let mirror = Mirror(reflecting: value)
+            #expect(mirror.displayStyle == .optional)
+            #expect(mirror.children.isEmpty)
+        case .failure(let error):
+            Issue.record("Expected success but received error: \(error)")
+        }
+    }
+
+    @Test
+    func asyncEvaluatePropagatesJavaScriptExceptions() async throws {
+        let webView = makeIsolatedTestWebView()
+
+        await #expect(throws: (any Error).self) {
+            _ = try await webView.evaluateJavaScriptCompat(
+                "throw new Error('boom')",
+                in: nil,
+                contentWorld: .page
+            )
+        }
+    }
+}

--- a/Tests/WebInspectorSPITests/WIImageCacheSPITests.swift
+++ b/Tests/WebInspectorSPITests/WIImageCacheSPITests.swift
@@ -131,29 +131,6 @@ struct WIImageCacheSPITests {
     }
 
     @Test
-    func archiveFallbackRequestStopsAwaitingWhenTaskIsCancelled() async throws {
-        let state = SlowArchiveRequestState()
-
-        let task = Task {
-            try await WIImageCacheLoader.requestArchiveData { completionHandler in
-                state.completionHandler = completionHandler
-            }
-        }
-
-        let requestStarted = await waitUntil {
-            state.completionHandler != nil
-        }
-        #expect(requestStarted)
-        task.cancel()
-
-        await #expect(throws: CancellationError.self) {
-            try await task.value
-        }
-
-        state.completionHandler?(.success(Data()))
-    }
-
-    @Test
     func frameBridgeThrowsWhenDirectLookupCannotResolvePage() async throws {
         let fixture = try makeFixtureSite(
             indexHTML: """
@@ -176,7 +153,7 @@ struct WIImageCacheSPITests {
     }
 
     @Test
-    func displayedImageCacheFallsBackToArchiveWhenDirectSymbolsAreUnavailable() async throws {
+    func displayedImageCacheReturnsNilWhenDirectSymbolsAreUnavailable() async throws {
         let fixture = try makeFixtureSite(
             indexHTML: """
             <!doctype html>
@@ -202,12 +179,11 @@ struct WIImageCacheSPITests {
             in: webView
         )
 
-        #expect(entry?.data == Self.pngData)
-        #expect(entry?.mimeType == "image/png")
+        #expect(entry == nil)
     }
 
     @Test
-    func displayedImageCacheFallsBackToArchiveWhenPageLookupFails() async throws {
+    func displayedImageCacheReturnsNilWhenPageLookupFails() async throws {
         let fixture = try makeFixtureSite(
             indexHTML: """
             <!doctype html>
@@ -233,12 +209,11 @@ struct WIImageCacheSPITests {
             in: webView
         )
 
-        #expect(entry?.data == Self.pngData)
-        #expect(entry?.mimeType == "image/png")
+        #expect(entry == nil)
     }
 
     @Test
-    func displayedImageCacheFallsBackToArchiveWhenDirectLookupReturnsGenericNSError() async throws {
+    func displayedImageCacheReturnsNilWhenDirectLookupReturnsGenericNSError() async throws {
         let fixture = try makeFixtureSite(
             indexHTML: """
             <!doctype html>
@@ -261,8 +236,7 @@ struct WIImageCacheSPITests {
             in: webView
         )
 
-        #expect(entry?.data == Self.pngData)
-        #expect(entry?.mimeType == "image/png")
+        #expect(entry == nil)
     }
 
     @Test
@@ -673,11 +647,6 @@ private final class SlowResourceRequestState {
 }
 
 @MainActor
-private final class SlowArchiveRequestState {
-    var completionHandler: ((Result<Data, Error>) -> Void)?
-}
-
-@MainActor
 private struct StubFrameInfoProvider: WIFrameInfoProviding {
     let frameInfos: [WKFrameInfo]?
 
@@ -715,6 +684,16 @@ private final class FallbackFrameTestWebView: WKWebView {
     @objc(_mainFrame)
     func test_mainFrame() -> AnyObject {
         fallbackHandle
+    }
+
+    @objc(_frames:)
+    func test_frames(_ completionHandler: @escaping (AnyObject?) -> Void) {
+        completionHandler(nil)
+    }
+
+    @objc(_frameTrees:)
+    func test_frameTrees(_ completionHandler: @escaping (NSSet?) -> Void) {
+        completionHandler(nil)
     }
 
     @objc(_frameInfoFromHandle:completionHandler:)
@@ -769,6 +748,11 @@ private final class FrameTreesFallbackWebView: WKWebView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc(_frames:)
+    func test_frames(_ completionHandler: @escaping (AnyObject?) -> Void) {
+        completionHandler(nil)
     }
 
     @objc(_frameTrees:)


### PR DESCRIPTION
Summary:
- Route `WKWebView.callAsyncJavaScript` and `evaluateJavaScript` through ObjC-backed compat shims so the test bundles no longer load the Swift WebKit overlay on older iOS simulators.
- Share the Swift nil-boxing/continuation support and migrate the affected bridge, engine, and integration test call sites to the compat APIs.
- Remove the `WIImageCacheSPI` WebArchive fallback and `createWebArchiveData` usage so the SPI path also drops its remaining `libswiftWebKit` dependency.

Testing:
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorIntegrationTests/WKWebViewCallAsyncJavaScriptCompatTests -only-testing:WebInspectorIntegrationTests/WKWebViewEvaluateJavaScriptCompatTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorIntegrationTests/WKWebViewEvaluateJavaScriptCompatTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorIntegrationTests/WKWebViewEvaluateJavaScriptCompatTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorSPITests -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `otool -L ~/Library/Developer/Xcode/DerivedData/.../WebInspectorIntegrationTests.xctest/WebInspectorIntegrationTests`
- `xcrun dyld_info -imports ~/Library/Developer/Xcode/DerivedData/.../WebInspectorIntegrationTests.xctest/WebInspectorIntegrationTests`
- `otool -L ~/Library/Developer/Xcode/DerivedData/.../WebInspectorSPITests.xctest/WebInspectorSPITests`
- `xcrun dyld_info -imports ~/Library/Developer/Xcode/DerivedData/.../WebInspectorSPITests.xctest/WebInspectorSPITests`