### PR TITLE
fix(dom): move secondary actions into overflow menu

### DIFF
--- a/Sources/WebInspectorUI/DOM/Root/WIDOMViewController+UIKit.swift
+++ b/Sources/WebInspectorUI/DOM/Root/WIDOMViewController+UIKit.swift
@@ -68,7 +68,7 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
     }
 
     var usesDeferredSecondaryMenuForTesting: Bool {
-        resolveActiveNavigationItem().additionalOverflowItems != nil
+        resolveActiveNavigationItem().additionalOverflowItems === deferredSecondaryOverflowItems
     }
 
     var inspectorColumnViewControllerForTesting: UIViewController? {
@@ -95,6 +95,7 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
         item.accessibilityIdentifier = "WI.DOM.PickButton"
         return item
     }()
+    private lazy var deferredSecondaryOverflowItems = makeDeferredDOMSecondaryOverflowItems()
 
     public init(inspector: WIDOMInspector) {
         self.inspector = inspector
@@ -195,7 +196,7 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
         navigationItem.hidesSearchBarWhenScrolling = false
         navigationItem.setLeftBarButtonItems(nil, animated: false)
         navigationItem.setRightBarButtonItems([pickItem], animated: false)
-        navigationItem.additionalOverflowItems = makeDeferredDOMSecondaryOverflowItems()
+        navigationItem.additionalOverflowItems = deferredSecondaryOverflowItems
     }
 
     private func clearNavigationItemState(on navigationItem: UINavigationItem) {

--- a/Sources/WebInspectorUI/DOM/Root/WIDOMViewController+UIKit.swift
+++ b/Sources/WebInspectorUI/DOM/Root/WIDOMViewController+UIKit.swift
@@ -68,7 +68,7 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
     }
 
     var usesDeferredSecondaryMenuForTesting: Bool {
-        menuItem.menu?.children.contains(where: { $0 is UIDeferredMenuElement }) == true
+        resolveActiveNavigationItem().additionalOverflowItems != nil
     }
 
     var inspectorColumnViewControllerForTesting: UIViewController? {
@@ -93,15 +93,6 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
             action: #selector(toggleSelectionMode)
         )
         item.accessibilityIdentifier = "WI.DOM.PickButton"
-        return item
-    }()
-
-    private lazy var menuItem: UIBarButtonItem = {
-        let item = UIBarButtonItem(
-            image: UIImage(systemName: "ellipsis"),
-            menu: makeDeferredDOMSecondaryMenu()
-        )
-        item.accessibilityIdentifier = "WI.DOM.MenuButton"
         return item
     }()
 
@@ -203,8 +194,8 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
         navigationItem.preferredSearchBarPlacement = .automatic
         navigationItem.hidesSearchBarWhenScrolling = false
         navigationItem.setLeftBarButtonItems(nil, animated: false)
-        navigationItem.setRightBarButtonItems([menuItem, pickItem], animated: false)
-        navigationItem.additionalOverflowItems = nil
+        navigationItem.setRightBarButtonItems([pickItem], animated: false)
+        navigationItem.additionalOverflowItems = makeDeferredDOMSecondaryOverflowItems()
     }
 
     private func clearNavigationItemState(on navigationItem: UINavigationItem) {
@@ -345,12 +336,10 @@ public final class WIDOMViewController: UISplitViewController, UISplitViewContro
         return items
     }
 
-    private func makeDeferredDOMSecondaryMenu() -> UIMenu {
-        UIMenu(children: [
-            UIDeferredMenuElement.uncached { [weak self] completion in
-                completion((self?.makeDOMSecondaryMenu() ?? UIMenu()).children)
-            }
-        ])
+    private func makeDeferredDOMSecondaryOverflowItems() -> UIDeferredMenuElement {
+        UIDeferredMenuElement.uncached { [weak self] completion in
+            completion((self?.makeDOMSecondaryMenu() ?? UIMenu()).children)
+        }
     }
 
     private func makeDOMSecondaryMenu() -> UIMenu {

--- a/Tests/WebInspectorIntegrationLongTests/TabViewControllerUITabTests.swift
+++ b/Tests/WebInspectorIntegrationLongTests/TabViewControllerUITabTests.swift
@@ -743,7 +743,8 @@ struct TabViewControllerUITabTests {
         #expect(domViewController.activeHostViewControllerForTesting is UISplitViewController)
         #expect(compactColumn.topViewController is WIDOMTreeViewController)
         let buttonIdentifiers = compactColumn.topViewController?.navigationItem.rightBarButtonItems?.compactMap(\.accessibilityIdentifier) ?? []
-        #expect(buttonIdentifiers == ["WI.DOM.MenuButton", "WI.DOM.PickButton"])
+        #expect(buttonIdentifiers == ["WI.DOM.PickButton"])
+        #expect(compactColumn.topViewController?.navigationItem.additionalOverflowItems != nil)
         if #available(iOS 26.0, *) {
             #expect(domViewController.primaryColumnViewControllerForTesting == nil)
             #expect(secondaryColumn.topViewController is WIDOMTreeViewController)
@@ -980,7 +981,8 @@ struct TabViewControllerUITabTests {
         drainMainQueue()
 
         let buttonIdentifiers = hostNavigationItem.rightBarButtonItems?.compactMap(\.accessibilityIdentifier) ?? []
-        #expect(buttonIdentifiers == ["WI.DOM.MenuButton", "WI.DOM.PickButton"])
+        #expect(buttonIdentifiers == ["WI.DOM.PickButton"])
+        #expect(hostNavigationItem.additionalOverflowItems != nil)
     }
 
     @Test


### PR DESCRIPTION
Summary:
- Move the UIKit DOM root secondary actions from a dedicated ellipsis bar button into `UINavigationItem.additionalOverflowItems`
- Keep the pick control as the only visible trailing bar button while preserving deferred menu resolution for selection-driven action state
- Update the DOM tab integration tests to assert overflow-backed actions in compact and regular hosts

Testing:
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationLongTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`