### PR TITLE
feat(deps): switch MachOKit to upstream v0.49.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "3297cbd1630c6413d7f0a0e08300d28ee4821bbabfad308cd967fdcfeaf64a3a",
+  "originHash" : "eed9c7b070ea1047a887a497b4faf3d4a8b8928454bcdd85b7330501e31d4dc4",
   "pins" : [
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/MachOKit.git",
+      "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "f5d856c6b7c04d43a8a023e5eb8e4dabd0ef65e1"
+        "revision" : "ff3c258b4b676cbd873b03ee3f11e3bc2b11d5af",
+        "version" : "0.49.0"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/ObjectArchiveKit.git",
       "state" : {
-        "revision" : "c47d1b2df06168bacb396a1765ae5bf7fa2868fb",
-        "version" : "0.3.0"
+        "revision" : "96d782a576273b73b277b577943a2a25b00b919e",
+        "version" : "0.5.0"
       }
     },
     {
@@ -25,6 +26,15 @@
       "state" : {
         "revision" : "90f85df63a93816b8802da192c47d4163f616527",
         "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -52,6 +62,15 @@
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,8 +51,8 @@ let package = Package(
             exact: "0.6.1"
         ),
         .package(
-            url: "https://github.com/lynnswap/MachOKit.git",
-            revision: "f5d856c6b7c04d43a8a023e5eb8e4dabd0ef65e1"
+            url: "https://github.com/p-x9/MachOKit.git",
+            exact: "0.49.0"
         )
     ],
     targets: [

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "7f78598663ca5d784049b3e1f8c5f411a153f573ccc8c8f9454685440c1c0a43",
+  "originHash" : "a9116118722f7bc07ae2178efe7911bccc3257158d1eb0a459c445dbdbb54a4f",
   "pins" : [
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/MachOKit.git",
+      "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "f5d856c6b7c04d43a8a023e5eb8e4dabd0ef65e1"
+        "revision" : "ff3c258b4b676cbd873b03ee3f11e3bc2b11d5af",
+        "version" : "0.49.0"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/ObjectArchiveKit.git",
       "state" : {
-        "revision" : "c47d1b2df06168bacb396a1765ae5bf7fa2868fb",
-        "version" : "0.3.0"
+        "revision" : "96d782a576273b73b277b577943a2a25b00b919e",
+        "version" : "0.5.0"
       }
     },
     {
@@ -25,6 +26,15 @@
       "state" : {
         "revision" : "90f85df63a93816b8802da192c47d4163f616527",
         "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -52,6 +62,15 @@
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {


### PR DESCRIPTION
## Purpose
- Switch `MachOKit` from the temporary fork pin to the upstream `p-x9/MachOKit` `v0.49.0` release.

## Summary
- Update `Package.swift` to depend on `https://github.com/p-x9/MachOKit.git` with an exact `0.49.0` version.
- Refresh the root and workspace `Package.resolved` files to point `machokit` at the upstream repo and version.
- Accept the upstream transitive dependency updates introduced by `MachOKit` `v0.49.0`, including `ObjectArchiveKit 0.5.0`, `swift-crypto`, and `swift-asn1`.

## Testing
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `swift test --filter WITransportNativeInspectorSymbolResolverTests`
- `swift test --filter WIImageCacheSPITests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorUITests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`