### PR TITLE
fix(warnings): resolve xcode warnings

### DIFF
--- a/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
+++ b/Sources/WebInspectorEngine/DOM/DOMPageAgent.swift
@@ -198,7 +198,7 @@ extension DOMPageAgent: WKScriptMessageHandler {
         guard message.frameInfo.isMainFrame else {
             return
         }
-        guard let handlerName = HandlerName(rawValue: message.name) else {
+        guard HandlerName(rawValue: message.name) != nil else {
             return
         }
         guard let payload = message.body as? NSDictionary,
@@ -212,13 +212,6 @@ extension DOMPageAgent: WKScriptMessageHandler {
         let payloadDocumentScopeID = (payload["documentScopeID"] as? NSNumber)?.uint64Value
             ?? (payload["documentScopeID"] as? UInt64)
             ?? documentScopeID
-        let payloadKind = if let dictionary = bundle as? NSDictionary {
-            dictionary["kind"] as? String ?? "unknown"
-        } else if let dictionary = bundle as? [String: Any] {
-            dictionary["kind"] as? String ?? "unknown"
-        } else {
-            "raw"
-        }
 
         if let rawJSON = bundle as? String, !rawJSON.isEmpty {
             sink?.domDidEmit(
@@ -469,7 +462,7 @@ extension DOMPageAgent {
                 in: nil,
                 contentWorld: bridgeWorld
             )
-            return parseMutationExecutionResult(rawValue)
+            return parseMutationExecutionResult(rawValue as Any)
         } catch {
             domLogger.error("undo remove node failed: \(error.localizedDescription, privacy: .public)")
             return .failed
@@ -497,7 +490,7 @@ extension DOMPageAgent {
                 in: nil,
                 contentWorld: bridgeWorld
             )
-            let result = parseMutationExecutionResult(rawValue)
+            let result = parseMutationExecutionResult(rawValue as Any)
             if case .applied = result, let nodeId {
                 handleCache.removeHandle(for: nodeId)
             }
@@ -542,7 +535,7 @@ extension DOMPageAgent {
                     in: nil,
                     contentWorld: self.bridgeWorld
                 )
-                return self.parseMutationExecutionResult(rawValue)
+                return self.parseMutationExecutionResult(rawValue as Any)
             } catch {
                 domLogger.error("set attribute failed: \(error.localizedDescription, privacy: .public)")
                 return .failed
@@ -588,7 +581,7 @@ extension DOMPageAgent {
                 in: nil,
                 contentWorld: bridgeWorld
             )
-            return parseMutationExecutionResult(rawValue)
+            return parseMutationExecutionResult(rawValue as Any)
         } catch {
             domLogger.error("remove attribute failed: \(error.localizedDescription, privacy: .public)")
             return .failed
@@ -880,30 +873,29 @@ extension DOMPageAgent {
 private extension DOMPageAgent {
     func observePageNavigationState(on webView: WKWebView) {
         pageNavigationObservations.removeAll()
-        let urlObservation = webView.observe(\.url, options: [.new]) { [weak self, weak webView] observedWebView, _ in
-            guard let self, let webView, self.webView === webView else {
-                return
-            }
-            guard !observedWebView.isLoading else {
-                return
-            }
-            guard self.shouldScheduleNavigationRefresh(for: observedWebView.url) else {
-                return
-            }
-            self.scheduleNavigationRefreshIfNeeded(on: webView)
-        }
-        let loadingObservation = webView.observe(\.isLoading, options: [.new]) { [weak self, weak webView] observedWebView, _ in
-            guard let self, let webView else {
-                return
-            }
-            guard observedWebView.isLoading == false else {
-                return
-            }
+        let urlObservation = webView.observe(\.url, options: [.new]) { [weak self, weak webView] _, _ in
             Task { @MainActor [weak self, weak webView] in
                 guard let self, let webView, self.webView === webView else {
                     return
                 }
-                if self.shouldScheduleNavigationRefresh(for: observedWebView.url) {
+                guard webView.isLoading == false else {
+                    return
+                }
+                guard self.shouldScheduleNavigationRefresh(for: webView.url) else {
+                    return
+                }
+                self.scheduleNavigationRefreshIfNeeded(on: webView)
+            }
+        }
+        let loadingObservation = webView.observe(\.isLoading, options: [.new]) { [weak self, weak webView] _, _ in
+            Task { @MainActor [weak self, weak webView] in
+                guard let self, let webView, self.webView === webView else {
+                    return
+                }
+                guard webView.isLoading == false else {
+                    return
+                }
+                if self.shouldScheduleNavigationRefresh(for: webView.url) {
                     self.scheduleNavigationRefreshIfNeeded(on: webView)
                     return
                 }

--- a/Sources/WebInspectorUI/Network/Detail/WINetworkBodyPreviewViewController+AppKit.swift
+++ b/Sources/WebInspectorUI/Network/Detail/WINetworkBodyPreviewViewController+AppKit.swift
@@ -153,8 +153,8 @@ final class WINetworkBodyPreviewViewController: NSViewController, NSOutlineViewD
         outlineScrollView.hasVerticalScroller = true
         outlineScrollView.autohidesScrollers = true
 
-        unsafe outlineView.addTableColumn(outlineColumn)
-        outlineView.outlineTableColumn = outlineColumn
+        outlineView.addTableColumn(outlineColumn)
+        unsafe outlineView.outlineTableColumn = outlineColumn
         outlineView.headerView = nil
         outlineView.rowHeight = 28
         outlineView.selectionHighlightStyle = .regular

--- a/Tests/WebInspectorRuntimeTests/DOMInspectorRuntimeTests.swift
+++ b/Tests/WebInspectorRuntimeTests/DOMInspectorRuntimeTests.swift
@@ -543,10 +543,11 @@ struct DOMInspectorRuntimeTests {
 
         await store.updateConfiguration(configuration)
         await store.setPreferredDepth(9)
-        await store.requestDocument(depth: 9, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 9, mode: .fresh)
 
         #expect(events.isEmpty)
         #expect(documentRequests.isEmpty)
+        #expect(didRequestDocument == true)
 
         store.testSetReady(true)
         await store.testWaitForBootstrapForTesting()
@@ -679,7 +680,12 @@ struct DOMInspectorRuntimeTests {
         }
 
         await store.performPageTransition { nextPageEpoch in
-            await store.requestDocument(depth: 9, mode: .preserveUIState, expectedPageEpoch: nextPageEpoch)
+            let didRequestDocument = await store.requestDocument(
+                depth: 9,
+                mode: .preserveUIState,
+                expectedPageEpoch: nextPageEpoch
+            )
+            #expect(didRequestDocument == true)
             #expect(documentRequests.isEmpty)
         }
         await store.testWaitForBootstrapForTesting()
@@ -694,9 +700,10 @@ struct DOMInspectorRuntimeTests {
         let store = makeStore(autoUpdateDebounce: 0.4)
 
         await store.setPreferredDepth(9)
-        await store.requestDocument(depth: 9, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 9, mode: .fresh)
 
         let payload = store.currentBootstrapPayload
+        #expect(didRequestDocument == true)
         #expect(payload["preferredDepth"] as? Int == 9)
         let request = payload["pendingDocumentRequest"] as? [String: Any]
         #expect(request?["depth"] as? Int == 9)
@@ -879,7 +886,7 @@ struct DOMInspectorRuntimeTests {
         #expect(store.currentDocumentModel.rootNode?.attributes.first?.value == "before")
 
         await harness.resume()
-        await requestTask.value
+        #expect(await requestTask.value == true)
         await store.testWaitForBootstrapForTesting()
 
         #expect(store.currentDocumentModel.rootNode?.attributes.first?.value == "mutation")
@@ -1182,8 +1189,9 @@ struct DOMInspectorRuntimeTests {
             isLoading: false
         )
 
-        await store.requestDocument(depth: 4, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
+        #expect(didRequestDocument == true)
         #expect(store.currentDocumentModel.selectedNode == nil)
     }
 
@@ -1229,7 +1237,7 @@ struct DOMInspectorRuntimeTests {
         #expect(store.currentDocumentScopeID == initialProjectedScopeID)
 
         await harness.resume()
-        await requestTask.value
+        #expect(await requestTask.value == true)
 
         #expect(store.currentDocumentModel.selectedNode == nil)
         #expect(store.currentPageEpoch == initialProjectedPageEpoch)
@@ -1298,7 +1306,7 @@ struct DOMInspectorRuntimeTests {
         #expect(store.currentDocumentModel.selectedNode == nil)
 
         await harness.resume()
-        await requestTask.value
+        #expect(await requestTask.value == false)
 
         #expect(resetRequestCount == 1)
         #expect(store.currentPageEpoch == transitionedPageEpoch)
@@ -1337,7 +1345,12 @@ struct DOMInspectorRuntimeTests {
             let expectedPageEpoch = store.currentPageEpoch
             await store.updateConfiguration(configuration, expectedPageEpoch: expectedPageEpoch)
             await store.setPreferredDepth(9, expectedPageEpoch: expectedPageEpoch)
-            await store.requestDocument(depth: 9, mode: .fresh, expectedPageEpoch: expectedPageEpoch)
+            let didRequestDocument = await store.requestDocument(
+                depth: 9,
+                mode: .fresh,
+                expectedPageEpoch: expectedPageEpoch
+            )
+            #expect(didRequestDocument == false)
         }
 
         await harness.waitUntilStarted()
@@ -1409,8 +1422,9 @@ struct DOMInspectorRuntimeTests {
             isLoading: false
         )
 
-        await store.requestDocument(depth: 4, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
+        #expect(didRequestDocument == true)
         #expect(store.currentDocumentModel.selectedNode == nil)
     }
 
@@ -1419,8 +1433,9 @@ struct DOMInspectorRuntimeTests {
         let store = makeStore(autoUpdateDebounce: 0.4)
         store.enqueueMutationBundle("{\"kind\":\"mutation\"}", preservingInspectorState: true)
 
-        await store.requestDocument(depth: 4, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
+        #expect(didRequestDocument == true)
         #expect(store.pendingMutationBundleCount == 0)
     }
 
@@ -1437,8 +1452,9 @@ struct DOMInspectorRuntimeTests {
             return true
         }
 
-        await store.requestDocument(depth: 4, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
+        #expect(didRequestDocument == true)
         #expect(resetPayloads.count == 1)
         #expect(resetPayloads.first?["documentScopeID"] as? UInt64 == currentDocumentScopeID)
     }
@@ -1489,8 +1505,9 @@ struct DOMInspectorRuntimeTests {
         }
         store.enqueueMutationBundle("{\"kind\":\"mutation\"}", preservingInspectorState: true)
 
-        await store.requestDocument(depth: 4, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
+        #expect(didRequestDocument == false)
         #expect(store.pendingMutationBundleCount == 1)
     }
 
@@ -1498,17 +1515,13 @@ struct DOMInspectorRuntimeTests {
     func freshRequestDocumentResetFailurePreservesDeferredBootstrapDOMBundles() async {
         let store = makeStore(autoUpdateDebounce: 0.4)
         let initialScopeID = store.currentDocumentScopeID
-        var didStartConfigurationPass = false
-        var allowConfigurationPassToFinish = false
+        let configurationHarness = BootstrapHarness()
 
         replaceDocument(in: store, root: makeNode(localID: 1))
 
         store.testSetReady(true)
         store.testConfigurationApplyOverride = { _ in
-            didStartConfigurationPass = true
-            while allowConfigurationPassToFinish == false, Task.isCancelled == false {
-                try? await Task.sleep(nanoseconds: 1_000_000)
-            }
+            await configurationHarness.blockUntilResumed()
         }
         store.testFrontendDispatchOverride = { payload in
             let body = (payload as? [String: Any]) ?? [:]
@@ -1521,10 +1534,7 @@ struct DOMInspectorRuntimeTests {
             )
         }
 
-        let didStartBootstrap = await waitForCondition {
-            didStartConfigurationPass
-        }
-        #expect(didStartBootstrap == true)
+        await configurationHarness.waitUntilStarted()
         store.domDidEmit(
             bundle: .init(
                 objectEnvelope: [
@@ -1555,7 +1565,7 @@ struct DOMInspectorRuntimeTests {
 
         let didRequestDocument = await store.requestDocument(depth: 4, mode: .fresh)
 
-        allowConfigurationPassToFinish = true
+        await configurationHarness.resume()
         await bootstrapTask.value
         await store.testWaitForBootstrapForTesting()
 
@@ -3488,18 +3498,14 @@ struct DOMInspectorRuntimeTests {
         let syncHarness = BootstrapHarness()
         let initialScopeID = store.currentDocumentScopeID
         var syncedScopeID: UInt64?
-        var didStartConfigurationPass = false
-        var allowConfigurationPassToFinish = false
+        let configurationHarness = BootstrapHarness()
         var flushedBundles: [Any] = []
 
         replaceDocument(in: store, root: makeNode(localID: 1))
 
         store.testSetReady(true)
         store.testConfigurationApplyOverride = { _ in
-            didStartConfigurationPass = true
-            while allowConfigurationPassToFinish == false, Task.isCancelled == false {
-                try? await Task.sleep(nanoseconds: 1_000_000)
-            }
+            await configurationHarness.blockUntilResumed()
         }
         store.testFrontendDispatchOverride = { _ in true }
         store.testDocumentScopeSyncOverride = { scopeID in
@@ -3516,10 +3522,7 @@ struct DOMInspectorRuntimeTests {
             )
         }
 
-        let didStartBootstrap = await waitForCondition {
-            didStartConfigurationPass
-        }
-        #expect(didStartBootstrap == true)
+        await configurationHarness.waitUntilStarted()
         store.domDidEmit(
             bundle: .init(
                 objectEnvelope: [
@@ -3558,7 +3561,7 @@ struct DOMInspectorRuntimeTests {
         await syncHarness.resume()
         _ = await requestTask.value
 
-        allowConfigurationPassToFinish = true
+        await configurationHarness.resume()
         await bootstrapTask.value
 
         store.testSetReady(true)
@@ -3608,11 +3611,12 @@ struct DOMInspectorRuntimeTests {
         }
 
         await store.setPreferredDepth(9)
-        await store.requestDocument(depth: 9, mode: .fresh)
+        let didRequestDocument = await store.requestDocument(depth: 9, mode: .fresh)
         store.testResetInspectorStateForTesting()
         store.testSetReady(true)
         await store.testWaitForBootstrapForTesting()
 
+        #expect(didRequestDocument == true)
         #expect(documentRequests.isEmpty)
     }
 


### PR DESCRIPTION
Summary:
- resolve the AppKit `unsafe` annotation warnings in the network body preview setup
- remove `DOMPageAgent` compile warnings around unused values, `Any?` coercion, and `@MainActor` navigation observers
- update `DOMInspectorRuntimeTests` to consume `requestDocument` results explicitly and replace sendable-unsafe wait flags with `BootstrapHarness`

Testing:
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorRuntimeTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1` (fails: existing Runtime test failures / interrupted run)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1` (passed)