### PR TITLE
Refactor V2 inspector dependencies and stabilize DOM selection

### DIFF
--- a/Docs/MIGRATION.md
+++ b/Docs/MIGRATION.md
@@ -8,33 +8,37 @@ Internal refactors, transport rewrites, module splits, and cache changes are int
 
 `WebInspectorView` was removed.
 
-Use `WITabViewController` with a `WIInspectorController` instead.
+On UIKit, use the V2 entry point: `V2_WIViewController` or `V2_WISession`.
+The older `WIInspectorController` / `WITabViewController` path remains for compatibility,
+but it is no longer the recommended architecture and is scheduled for removal after V2
+stabilizes.
 
 ```swift
-private let inspector = WIInspectorController()
-
 @objc private func presentInspector() {
-    let controller = WITabViewController(
-        inspector,
-        webView: pageWebView,
-        tabs: [.dom(), .network()]
-    )
-    present(controller, animated: true)
+    let inspector = V2_WIViewController()
+    Task { @MainActor in
+        await inspector.attach(to: pageWebView)
+        present(inspector, animated: true)
+    }
 }
 ```
 
 If your app used the default inspector UI, this is the main migration.
 
+AppKit should stay on `WIInspectorController` / `WITabViewController` until a V2 AppKit
+surface is available.
+
 ## 2. Rename the model and lifecycle API
 
 | `v0.1.x` | Current |
 | --- | --- |
-| `WebInspectorModel` | `WIInspectorController` |
+| `WebInspectorModel` | `V2_WISession` / `V2_WIViewController` on UIKit |
 | `WebInspectorConfiguration` | `WIModelConfiguration` |
-| `attach(webView:)` | `connect(to:)` |
-| `detach()` | `disconnect()` |
+| `attach(webView:)` | `attach(to:)` |
+| `detach()` | `detach()` |
 
-`suspend()` is still available.
+`WIInspectorController.connect(to:)`, `suspend()`, and `disconnect()` remain only on the
+legacy compatibility path.
 
 The DOM-related configuration fields keep the same meaning, but they now live under `WIModelConfiguration.dom`.
 
@@ -52,7 +56,7 @@ let inspector = WebInspectorModel(
 inspector.attach(webView: webView)
 ```
 
-After:
+Legacy compatibility:
 
 ```swift
 let inspector = WIInspectorController(
@@ -68,37 +72,71 @@ let inspector = WIInspectorController(
 inspector.connect(to: webView)
 ```
 
-## 3. Update custom tab definitions
-
-The important source-level changes are:
-
-- `WITab` changed from a value type to a reference type.
-- `WITabRole` became `WITab.Role`.
-- `value:` became `id:` / `identifier:`.
-- Tab titles are now plain `String`.
-- The old `WITabBuilder`-based `WebInspectorView { ... }` API is gone.
-- Custom tabs now provide a platform view controller (`UIViewController` / `NSViewController`).
+V2 UIKit:
 
 ```swift
-let customTab = WITab(
-    id: "custom",
-    title: "Custom",
-    systemImage: "folder",
-    role: .other
-) { _ in
-    MyCustomViewController()
+let inspector = V2_WIViewController(
+    configuration: WIModelConfiguration(
+        dom: DOMConfiguration(
+            snapshotDepth: 6,
+            subtreeDepth: 4,
+            autoUpdateDebounce: 0.3
+        )
+    )
+)
+
+await inspector.attach(to: webView)
+```
+
+## 3. Inject side effects through `WIInspectorDependencies`
+
+`WIModelConfiguration` now stays focused on value-only configuration. Runtime factories,
+scripts, WebKit SPI, transport, sleep/timeout behavior, and UIKit scene activation can be
+injected through `WIInspectorDependencies`.
+
+```swift
+let dependencies = WIInspectorDependencies.testing {
+    $0.network = WIInspectorNetworkClient(
+        networkAgentScript: { "" }
+    )
 }
 
-let controller = WITabViewController(
-    inspector,
-    webView: pageWebView,
-    tabs: [.dom(), .network(), customTab]
+let inspector = V2_WIViewController(
+    configuration: WIModelConfiguration(),
+    dependencies: dependencies,
+    tabs: [.dom, .network]
 )
 ```
 
-If you only use the built-in tabs, keep using `.dom()`, `.network()`, and on UIKit `.element()`.
+Use `WIInspectorDependencies.liveValue` for production defaults and
+`WIInspectorDependencies.testing { ... }` for tests.
 
-## 4. Use intent-based DOM APIs
+## 4. Update custom tab definitions
+
+The important source-level changes are:
+
+- UIKit custom tabs should use `V2_WITab`.
+- The old `WITabBuilder`-based `WebInspectorView { ... }` API is gone.
+- V2 custom tabs provide a `UIViewController`.
+
+```swift
+let customTab = V2_WITab.custom(
+    id: "custom",
+    title: "Custom",
+    systemImage: "folder"
+) { context in
+    _ = context.runtime
+    MyCustomViewController()
+}
+
+let controller = V2_WIViewController(
+    tabs: [.dom, .network, customTab]
+)
+```
+
+If you only use the built-in V2 tabs, keep using `.dom` and `.network`.
+
+## 5. Use intent-based DOM APIs
 
 The DOM model no longer exposes low-level `nodeId`-driven editing and reload APIs.
 

--- a/Monocly/MonoclyUITests/BrowserInspectorNavigationUITests.swift
+++ b/Monocly/MonoclyUITests/BrowserInspectorNavigationUITests.swift
@@ -413,6 +413,54 @@ final class BrowserInspectorNavigationUITests: XCTestCase {
     }
 
     @MainActor
+    func testDOMInspectorNativeDragSelectionResolvesAfterPageNavigation() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["MONOCLY_UI_TEST_SCENARIO"] = "domNavigationBackForward"
+        app.launch()
+
+        XCTAssertTrue(app.buttons[AccessibilityID.loadPage1].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons[AccessibilityID.loadPage2].waitForExistence(timeout: 10))
+
+        _ = try waitForHarnessState(
+            in: app,
+            pageFilename: "dom-page-1.html",
+            canGoBack: false,
+            canGoForward: false
+        )
+
+        app.buttons[AccessibilityID.loadPage2].tap()
+
+        _ = try waitForHarnessState(
+            in: app,
+            pageFilename: "dom-page-2.html",
+            canGoBack: true,
+            canGoForward: false
+        )
+
+        let selection = try performNativeSelection(
+            in: app,
+            dragFrom: CGVector(dx: 0.42, dy: 0.22),
+            to: CGVector(dx: 0.58, dy: 0.24),
+            timeout: 20
+        )
+
+        XCTAssertTrue(
+            selection.selectedPreview.contains("<")
+                && selection.treeSelectedPreview != "domTreeSelectedPreview=n/a"
+                && selection.treeSelectedVisible
+                && selection.error == "domError=n/a",
+            """
+            Native drag selection did not resolve after page navigation.
+            selectedPreview=\(selection.selectedPreview)
+            treeSelectedPreview=\(selection.treeSelectedPreview)
+            treeSelectedVisible=\(selection.treeSelectedVisible)
+            domSelectionDebug=\(selection.selectionDebug)
+            domError=\(selection.error)
+            """
+        )
+    }
+
+    @MainActor
     func testDOMInspectorNativeSelectionRemainsStableAcrossRepeatedSelections() throws {
         let app = XCUIApplication()
         app.launchEnvironment["MONOCLY_UI_TEST_SCENARIO"] = "domOpenInspectorAfterInitialLoad"
@@ -623,6 +671,31 @@ final class BrowserInspectorNavigationUITests: XCTestCase {
         tap: CGVector,
         timeout: TimeInterval = 15
     ) throws -> (selectedPreview: String, treeSelectedPreview: String, treeSelectedLineage: String, treeSelectedVisible: Bool, selectionDebug: String, error: String) {
+        try performNativeSelection(in: app, timeout: timeout) {
+            app.coordinate(withNormalizedOffset: tap).tap()
+        }
+    }
+
+    @MainActor
+    private func performNativeSelection(
+        in app: XCUIApplication,
+        dragFrom start: CGVector,
+        to end: CGVector,
+        timeout: TimeInterval = 15
+    ) throws -> (selectedPreview: String, treeSelectedPreview: String, treeSelectedLineage: String, treeSelectedVisible: Bool, selectionDebug: String, error: String) {
+        try performNativeSelection(in: app, timeout: timeout) {
+            let startCoordinate = app.coordinate(withNormalizedOffset: start)
+            let endCoordinate = app.coordinate(withNormalizedOffset: end)
+            startCoordinate.press(forDuration: 0.1, thenDragTo: endCoordinate)
+        }
+    }
+
+    @MainActor
+    private func performNativeSelection(
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        gesture: () -> Void
+    ) throws -> (selectedPreview: String, treeSelectedPreview: String, treeSelectedLineage: String, treeSelectedVisible: Bool, selectionDebug: String, error: String) {
         let beginNativeSelectionButton = app.buttons[AccessibilityID.beginNativeSelection]
         XCTAssertTrue(beginNativeSelectionButton.waitForExistence(timeout: 10))
         beginNativeSelectionButton.tap()
@@ -635,7 +708,7 @@ final class BrowserInspectorNavigationUITests: XCTestCase {
             "DOM selection mode did not start: \(selectingLabel.label)"
         )
 
-        app.coordinate(withNormalizedOffset: tap).tap()
+        gesture()
 
         let domSelectedPreviewLabel = app.staticTexts[AccessibilityID.domSelectedPreview]
         let domTreeSelectedPreviewLabel = app.staticTexts[AccessibilityID.domTreeSelectedPreview]

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 ## 製品
 
-- `WebInspectorKit`: コンテナ UI、`WITab` ベースのタブ構成、Observation ベースの状態管理
+- `WebInspectorKit`: V2 UIKit コンテナ UI、`V2_WITab` ベースのタブ構成、Observation ベースの状態管理
 - `WebInspectorEngine`: DOM/Network エンジン、ランタイム actor、同梱 inspector script
 
 `WebInspectorKit` は `WebInspectorEngine` に依存します。
@@ -17,8 +17,9 @@
 
 - DOM ツリーの参照（要素ピック、ハイライト、削除、属性編集）
 - Network リクエストログ（fetch/XHR/WebSocket）と、buffering/active モード切り替え
-- `WITab` によるタブ構成のカスタマイズ（custom tab は `viewControllerProvider` を利用）
-- `WIInspectorController` による明示的ライフサイクル（`connect(to:)`, `suspend()`, `disconnect()`）
+- `V2_WITab` による V2 タブ構成のカスタマイズ
+- `V2_WISession` / `V2_WIViewController` による明示的ライフサイクル（`attach(to:)`, `detach()`）
+- `WIInspectorDependencies` による依存性注入
 
 ## 要件
 
@@ -37,26 +38,27 @@ import WebInspectorKit
 
 final class BrowserViewController: UIViewController {
     private let pageWebView = WKWebView(frame: .zero)
-    private let inspector = WIInspectorController()
 
     @objc private func presentInspector() {
-        let container = WITabViewController(
-            inspector,
-            webView: pageWebView,
-            tabs: [.dom(), .network()]
-        )
-        container.modalPresentationStyle = .pageSheet
-        if let sheet = container.sheetPresentationController {
+        let inspector = V2_WIViewController()
+        inspector.modalPresentationStyle = .pageSheet
+        if let sheet = inspector.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
             sheet.selectedDetentIdentifier = .medium
             sheet.prefersGrabberVisible = true
         }
-        present(container, animated: true)
+        Task { @MainActor in
+            await inspector.attach(to: pageWebView)
+            present(inspector, animated: true)
+        }
     }
 }
 ```
 
 ### AppKit
+
+V2 UI は現時点では UIKit のみです。AppKit の `WIInspectorController` / `WITabViewController`
+入口は互換用に残っていますが、推奨アーキテクチャではなく、V2 安定後に削除予定です。
 
 ```swift
 import AppKit
@@ -85,24 +87,36 @@ final class BrowserWindowController: NSWindowController {
 ## カスタムタブ
 
 ```swift
-let customTab = WITab(
+let customTab = V2_WITab.custom(
+    id: "my_custom_tab",
     title: "Custom",
-    image: nil,
-    identifier: "my_custom_tab",
-    role: .other
-) { tab in
-    _ = tab
-    #if canImport(UIKit)
+    systemImage: "folder"
+) { context in
+    _ = context.runtime
     return UIViewController()
-    #else
-    return NSViewController()
-    #endif
 }
 
-let container = WITabViewController(
-    inspector,
-    webView: pageWebView,
-    tabs: [.dom(), .network(), customTab]
+let inspector = V2_WIViewController(
+    tabs: [.dom, .network, customTab]
+)
+```
+
+## 依存性注入
+
+値だけの設定は `WIModelConfiguration` に残し、副作用を持つ runtime 境界は
+`WIInspectorDependencies` で注入します。
+
+```swift
+let dependencies = WIInspectorDependencies.testing {
+    $0.network = WIInspectorNetworkClient(
+        networkAgentScript: { "" }
+    )
+}
+
+let inspector = V2_WIViewController(
+    configuration: WIModelConfiguration(),
+    dependencies: dependencies,
+    tabs: [.dom, .network]
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Web Inspector for `WKWebView` (iOS / macOS).
 
 ## Products
 
-- `WebInspectorKit`: Container UI, `WITab`-based tab composition, Observation state
+- `WebInspectorKit`: V2 UIKit container UI, `V2_WITab`-based tab composition, Observation state
 - `WebInspectorEngine`: DOM/Network engines, runtime actors, bundled inspector scripts
 
 `WebInspectorKit` depends on `WebInspectorEngine`.
@@ -17,8 +17,9 @@ Web Inspector for `WKWebView` (iOS / macOS).
 
 - DOM tree browsing (element picking, highlights, deletion, attribute editing)
 - Network request logging (fetch/XHR/WebSocket) with buffering/active mode switching
-- Configurable tabs via `WITab` (`viewControllerProvider` for custom tabs)
-- Explicit lifecycle via `WIInspectorController` (`connect(to:)`, `suspend()`, `disconnect()`)
+- Configurable V2 tabs via `V2_WITab`
+- Explicit V2 lifecycle via `V2_WISession` / `V2_WIViewController` (`attach(to:)`, `detach()`)
+- Dependency injection via `WIInspectorDependencies`
 
 ## Requirements
 
@@ -37,25 +38,27 @@ import WebInspectorKit
 
 final class BrowserViewController: UIViewController {
     private let pageWebView = WKWebView(frame: .zero)
-    private let inspector = WIInspectorController()
 
     @objc private func presentInspector() {
-        let container = WITabViewController(
-            inspector,
-            webView: pageWebView,
-            tabs: [.dom(), .network()]
-        )
-        container.modalPresentationStyle = .pageSheet
-        if let sheet = container.sheetPresentationController {
+        let inspector = V2_WIViewController()
+        inspector.modalPresentationStyle = .pageSheet
+        if let sheet = inspector.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
             sheet.selectedDetentIdentifier = .medium
         }
-        present(container, animated: true)
+        Task { @MainActor in
+            await inspector.attach(to: pageWebView)
+            present(inspector, animated: true)
+        }
     }
 }
 ```
 
 ### AppKit
+
+V2 UI is currently UIKit-only. The AppKit `WIInspectorController` / `WITabViewController`
+entry point remains for compatibility, but is not the recommended architecture path and is
+scheduled to be removed after V2 stabilization.
 
 ```swift
 import AppKit
@@ -84,24 +87,36 @@ final class BrowserWindowController: NSWindowController {
 ## Custom Tab
 
 ```swift
-let customTab = WITab(
+let customTab = V2_WITab.custom(
+    id: "my_custom_tab",
     title: "Custom",
-    image: nil,
-    identifier: "my_custom_tab",
-    role: .other
-) { tab in
-    _ = tab
-    #if canImport(UIKit)
+    systemImage: "folder"
+) { context in
+    _ = context.runtime
     return UIViewController()
-    #else
-    return NSViewController()
-    #endif
 }
 
-let container = WITabViewController(
-    inspector,
-    webView: pageWebView,
-    tabs: [.dom(), .network(), customTab]
+let inspector = V2_WIViewController(
+    tabs: [.dom, .network, customTab]
+)
+```
+
+## Dependency Injection
+
+Keep value-only settings in `WIModelConfiguration`, and inject side-effectful runtime
+boundaries through `WIInspectorDependencies`.
+
+```swift
+let dependencies = WIInspectorDependencies.testing {
+    $0.network = WIInspectorNetworkClient(
+        networkAgentScript: { "" }
+    )
+}
+
+let inspector = V2_WIViewController(
+    configuration: WIModelConfiguration(),
+    dependencies: dependencies,
+    tabs: [.dom, .network]
 )
 ```
 

--- a/Sources/WebInspectorBridge/ObjCShim/WIKPrivateWebKitInspector.h
+++ b/Sources/WebInspectorBridge/ObjCShim/WIKPrivateWebKitInspector.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIView (WIKPrivateInspectorNodeSearch)
 - (void)_enableInspectorNodeSearch;
 - (void)_disableInspectorNodeSearch;
+- (void)_inspectorNodeSearchRecognized:(id)recognizer;
 - (BOOL)isShowingInspectorIndication;
 - (void)setShowingInspectorIndication:(BOOL)showingInspectorIndication;
 @end

--- a/Sources/WebInspectorBridge/ObjCShim/WIKRuntimeBridge.m
+++ b/Sources/WebInspectorBridge/ObjCShim/WIKRuntimeBridge.m
@@ -11,6 +11,113 @@ typedef const struct OpaqueWKPage *WKPageRef;
 
 NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntimeBridge";
 
+#if TARGET_OS_IPHONE
+@interface WIKInspectorNodeSearchCommitGestureRecognizer : UIGestureRecognizer
+- (instancetype)initWithContentView:(UIView *)contentView;
+@end
+
+@interface WIKInspectorNodeSearchCommitGestureRecognizer ()
+@property (nonatomic, weak) UIView *contentView;
+@property (nonatomic) CGPoint initialLocation;
+@property (nonatomic) BOOL hasInitialLocation;
+@property (nonatomic) BOOL didMoveBeyondTapTolerance;
+- (void)wi_commitInspectorNodeSearchIfPossible;
+@end
+
+@implementation WIKInspectorNodeSearchCommitGestureRecognizer
+
+static const CGFloat WIKInspectorNodeSearchCommitMovementThreshold = 3.0;
+
+- (instancetype)initWithContentView:(UIView *)contentView
+{
+    self = [super initWithTarget:nil action:nil];
+    if (!self)
+        return nil;
+
+    _contentView = contentView;
+    self.cancelsTouchesInView = NO;
+    self.delaysTouchesBegan = NO;
+    self.delaysTouchesEnded = NO;
+    return self;
+}
+
+- (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer
+{
+    return NO;
+}
+
+- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer
+{
+    return NO;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    if (touches.count != 1) {
+        self.state = UIGestureRecognizerStateFailed;
+        return;
+    }
+
+    UIView *contentView = self.contentView ?: self.view;
+    self.initialLocation = [[touches anyObject] locationInView:contentView];
+    self.hasInitialLocation = YES;
+    self.didMoveBeyondTapTolerance = NO;
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    if (!self.hasInitialLocation || self.state != UIGestureRecognizerStatePossible)
+        return;
+
+    UIView *contentView = self.contentView ?: self.view;
+    CGPoint location = [[touches anyObject] locationInView:contentView];
+    CGFloat deltaX = location.x - self.initialLocation.x;
+    CGFloat deltaY = location.y - self.initialLocation.y;
+    CGFloat squaredDistance = deltaX * deltaX + deltaY * deltaY;
+    CGFloat threshold = WIKInspectorNodeSearchCommitMovementThreshold;
+    if (squaredDistance >= threshold * threshold)
+        self.didMoveBeyondTapTolerance = YES;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    if (self.state != UIGestureRecognizerStatePossible)
+        return;
+
+    if (!self.didMoveBeyondTapTolerance) {
+        self.state = UIGestureRecognizerStateFailed;
+        return;
+    }
+
+    self.state = UIGestureRecognizerStateRecognized;
+    [self wi_commitInspectorNodeSearchIfPossible];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    self.state = UIGestureRecognizerStateCancelled;
+}
+
+- (void)reset
+{
+    [super reset];
+    self.hasInitialLocation = NO;
+    self.didMoveBeyondTapTolerance = NO;
+    self.initialLocation = CGPointZero;
+}
+
+- (void)wi_commitInspectorNodeSearchIfPossible
+{
+    UIView *contentView = self.contentView ?: self.view;
+    if (!contentView || ![contentView respondsToSelector:@selector(_inspectorNodeSearchRecognized:)])
+        return;
+
+    [contentView _inspectorNodeSearchRecognized:self];
+}
+
+@end
+#endif
+
 @implementation WIKRuntimeBridge
 
 #if TARGET_OS_IPHONE
@@ -34,6 +141,11 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
     return recognizerClass;
 }
 
++ (Class)wi_inspectorNodeSearchCommitRecognizerClass
+{
+    return [WIKInspectorNodeSearchCommitGestureRecognizer class];
+}
+
 + (BOOL)wi_contentViewHasInspectorNodeSearchRecognizer:(UIView *)contentView
 {
     Class recognizerClass = [self wi_inspectorNodeSearchRecognizerClass];
@@ -46,6 +158,42 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
     }
 
     return NO;
+}
+
++ (BOOL)wi_contentViewHasInspectorNodeSearchCommitRecognizer:(UIView *)contentView
+{
+    Class recognizerClass = [self wi_inspectorNodeSearchCommitRecognizerClass];
+    for (UIGestureRecognizer *recognizer in contentView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:recognizerClass])
+            return YES;
+    }
+
+    return NO;
+}
+
++ (BOOL)wi_installInspectorNodeSearchCommitRecognizerInContentView:(UIView *)contentView
+{
+    if ([self wi_contentViewHasInspectorNodeSearchCommitRecognizer:contentView])
+        return NO;
+
+    WIKInspectorNodeSearchCommitGestureRecognizer *recognizer =
+        [[WIKInspectorNodeSearchCommitGestureRecognizer alloc] initWithContentView:contentView];
+    [contentView addGestureRecognizer:recognizer];
+    return YES;
+}
+
++ (BOOL)wi_removeInspectorNodeSearchCommitRecognizersInContentView:(UIView *)contentView
+{
+    BOOL didRemoveRecognizer = NO;
+    Class recognizerClass = [self wi_inspectorNodeSearchCommitRecognizerClass];
+    for (UIGestureRecognizer *recognizer in [contentView.gestureRecognizers copy]) {
+        if (![recognizer isKindOfClass:recognizerClass])
+            continue;
+        recognizer.enabled = NO;
+        [contentView removeGestureRecognizer:recognizer];
+        didRemoveRecognizer = YES;
+    }
+    return didRemoveRecognizer;
 }
 
 + (nullable UIView *)wi_firstContentViewInView:(UIView *)view
@@ -229,12 +377,16 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
             continue;
         if ([contentView respondsToSelector:@selector(_disableInspectorNodeSearch)])
             [contentView _disableInspectorNodeSearch];
+        [self wi_removeInspectorNodeSearchCommitRecognizersInContentView:contentView];
     }
 
-    if ([self wi_contentViewHasInspectorNodeSearchRecognizer:activeContentView])
+    if ([self wi_contentViewHasInspectorNodeSearchRecognizer:activeContentView]) {
+        [self wi_installInspectorNodeSearchCommitRecognizerInContentView:activeContentView];
         return YES;
+    }
 
     [activeContentView _enableInspectorNodeSearch];
+    [self wi_installInspectorNodeSearchCommitRecognizerInContentView:activeContentView];
     return YES;
 }
 
@@ -242,10 +394,11 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
 {
     BOOL didDisable = NO;
     for (UIView *contentView in [self wi_contentViewsForWebView:webView]) {
-        if (![contentView respondsToSelector:@selector(_disableInspectorNodeSearch)])
-            continue;
-        [contentView _disableInspectorNodeSearch];
-        didDisable = YES;
+        if ([contentView respondsToSelector:@selector(_disableInspectorNodeSearch)]) {
+            [contentView _disableInspectorNodeSearch];
+            didDisable = YES;
+        }
+        didDisable = [self wi_removeInspectorNodeSearchCommitRecognizersInContentView:contentView] || didDisable;
     }
     return didDisable;
 }
@@ -262,13 +415,13 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
 + (BOOL)removeInspectorNodeSearchRecognizersFromWebView:(WKWebView *)webView
 {
     Class recognizerClass = [self wi_inspectorNodeSearchRecognizerClass];
-    if (!recognizerClass)
-        return NO;
 
     BOOL didRemoveRecognizer = NO;
     for (UIView *contentView in [self wi_contentViewsForWebView:webView]) {
         for (UIGestureRecognizer *recognizer in [contentView.gestureRecognizers copy]) {
-            if (![recognizer isKindOfClass:recognizerClass])
+            BOOL isNodeSearchRecognizer = recognizerClass && [recognizer isKindOfClass:recognizerClass];
+            BOOL isCommitRecognizer = [recognizer isKindOfClass:[self wi_inspectorNodeSearchCommitRecognizerClass]];
+            if (!isNodeSearchRecognizer && !isCommitRecognizer)
                 continue;
             recognizer.enabled = NO;
             [contentView removeGestureRecognizer:recognizer];
@@ -285,21 +438,27 @@ NSErrorDomain const WIKRuntimeBridgeErrorDomain = @"WebInspectorBridge.WIKRuntim
     UIView *activeContentView = [self wi_activeContentViewForWebView:webView];
 
     NSUInteger recognizerViewCount = 0;
+    NSUInteger commitRecognizerViewCount = 0;
     for (UIView *contentView in contentViews) {
         if ([self wi_contentViewHasInspectorNodeSearchRecognizer:contentView])
             recognizerViewCount += 1;
+        if ([self wi_contentViewHasInspectorNodeSearchCommitRecognizer:contentView])
+            commitRecognizerViewCount += 1;
     }
 
     BOOL activeHasNodeSearch = activeContentView && [self wi_contentViewHasInspectorNodeSearchRecognizer:activeContentView];
+    BOOL activeHasCommit = activeContentView && [self wi_contentViewHasInspectorNodeSearchCommitRecognizer:activeContentView];
     BOOL anyHasNodeSearch = recognizerViewCount > 0;
     NSString *activeSource = currentContentView ? @"current" : @"fallback";
 
     return [NSString stringWithFormat:
-        @"activeSource=%@ contentViews=%lu recognizerViews=%lu activeHasNodeSearch=%d anyHasNodeSearch=%d",
+        @"activeSource=%@ contentViews=%lu recognizerViews=%lu commitRecognizerViews=%lu activeHasNodeSearch=%d activeHasCommit=%d anyHasNodeSearch=%d",
         activeSource,
         (unsigned long)contentViews.count,
         (unsigned long)recognizerViewCount,
+        (unsigned long)commitRecognizerViewCount,
         activeHasNodeSearch ? 1 : 0,
+        activeHasCommit ? 1 : 0,
         anyHasNodeSearch ? 1 : 0
     ];
 }

--- a/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkPageAgent.swift
@@ -54,7 +54,7 @@ public final class NetworkPageAgent: NSObject, PageAgent {
     // XHR/fetch remain page-hooked to preserve reliable body capture.
     private let nativeObserverIncludesFetchAndXHR = false
 
-    private let runtime: WISPIRuntime
+    private let dependencies: NetworkPageAgentDependencies
     private let controllerStateRegistry: WIUserContentControllerStateRegistry
     private var bridgeMode: WIBridgeMode
     private var bridgeModeLocked = false
@@ -65,11 +65,19 @@ public final class NetworkPageAgent: NSObject, PageAgent {
         bridgeMode
     }
 
-    package init(controllerStateRegistry: WIUserContentControllerStateRegistry = .shared) {
-        runtime = .shared
-        self.controllerStateRegistry = controllerStateRegistry
-        bridgeMode = runtime.startupMode()
+    package init(dependencies: NetworkPageAgentDependencies = .liveValue) {
+        self.dependencies = dependencies
+        self.controllerStateRegistry = dependencies.controllerStateRegistry
+        bridgeMode = dependencies.startupMode()
         super.init()
+    }
+
+    package convenience init(controllerStateRegistry: WIUserContentControllerStateRegistry) {
+        self.init(
+            dependencies: NetworkPageAgentDependencies(
+                controllerStateRegistry: controllerStateRegistry
+            )
+        )
     }
 
     isolated deinit {
@@ -390,7 +398,7 @@ private extension NetworkPageAgent {
         guard !bridgeModeLocked else {
             return
         }
-        bridgeMode = runtime.modeForAttachment(webView: webView)
+        bridgeMode = dependencies.modeForAttachment(webView)
         bridgeModeLocked = true
         networkLogger.notice("bridge_mode=\(self.bridgeMode.rawValue, privacy: .public)")
     }
@@ -535,7 +543,7 @@ private extension NetworkPageAgent {
 
     func loadNetworkAgentScriptSource() -> String? {
         do {
-            return try WebInspectorScripts.networkAgent()
+            return try dependencies.loadNetworkAgentScriptSource()
         } catch {
             networkLogger.error("failed to prepare network inspector script: \(error.localizedDescription, privacy: .public)")
             return nil
@@ -873,7 +881,9 @@ private extension NetworkPageAgent {
                     return false
                 }
                 return self.loggingMode == .active
-            }
+            },
+            supportsResourceLoadDelegate: dependencies.supportsResourceLoadDelegate,
+            setResourceLoadDelegate: dependencies.setResourceLoadDelegate
         )
         let attached = observer.attach(to: webView)
         nativeObserverEnabled = attached

--- a/Sources/WebInspectorEngine/Network/NetworkPageAgentDependencies.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkPageAgentDependencies.swift
@@ -1,0 +1,53 @@
+import WebKit
+import WebInspectorBridge
+import WebInspectorScripts
+
+@MainActor
+package struct NetworkPageAgentDependencies {
+    package var controllerStateRegistry: WIUserContentControllerStateRegistry
+    package var startupMode: @MainActor @Sendable () -> WIBridgeMode
+    package var modeForAttachment: @MainActor @Sendable (WKWebView?) -> WIBridgeMode
+    package var loadNetworkAgentScriptSource: @MainActor @Sendable () throws -> String
+    package var supportsResourceLoadDelegate: @MainActor @Sendable (WKWebView) -> Bool
+    package var setResourceLoadDelegate: @MainActor @Sendable (WKWebView, AnyObject?) -> Bool
+
+    package init(
+        controllerStateRegistry: WIUserContentControllerStateRegistry = .shared,
+        startupMode: @escaping @MainActor @Sendable () -> WIBridgeMode = {
+            WISPIRuntime.shared.startupMode()
+        },
+        modeForAttachment: @escaping @MainActor @Sendable (WKWebView?) -> WIBridgeMode = { webView in
+            WISPIRuntime.shared.modeForAttachment(webView: webView)
+        },
+        loadNetworkAgentScriptSource: @escaping @MainActor @Sendable () throws -> String = {
+            try WebInspectorScripts.networkAgent()
+        },
+        supportsResourceLoadDelegate: @escaping @MainActor @Sendable (WKWebView) -> Bool = { webView in
+            WISPIRuntime.shared.canSetResourceLoadDelegate(on: webView)
+        },
+        setResourceLoadDelegate: @escaping @MainActor @Sendable (WKWebView, AnyObject?) -> Bool = { webView, delegate in
+            WISPIRuntime.shared.setResourceLoadDelegate(on: webView, delegate: delegate)
+        }
+    ) {
+        self.controllerStateRegistry = controllerStateRegistry
+        self.startupMode = startupMode
+        self.modeForAttachment = modeForAttachment
+        self.loadNetworkAgentScriptSource = loadNetworkAgentScriptSource
+        self.supportsResourceLoadDelegate = supportsResourceLoadDelegate
+        self.setResourceLoadDelegate = setResourceLoadDelegate
+    }
+
+    package static var liveValue: Self {
+        Self()
+    }
+
+    package static var testValue: Self {
+        Self(
+            startupMode: { .legacyJSON },
+            modeForAttachment: { _ in .legacyJSON },
+            loadNetworkAgentScriptSource: { "" },
+            supportsResourceLoadDelegate: { _ in false },
+            setResourceLoadDelegate: { _, _ in false }
+        )
+    }
+}

--- a/Sources/WebInspectorRuntime/DOM/DOMInspectorBridge.swift
+++ b/Sources/WebInspectorRuntime/DOM/DOMInspectorBridge.swift
@@ -35,6 +35,12 @@ final class DOMInspectorBridge: NSObject {
     private(set) var inspectorWebView: InspectorWebView?
     private(set) var generation: UInt64 = 0
     private var bootstrapPayload: [String: Any] = DOMInspectorBridge.defaultBootstrapPayload()
+    private let dependencies: WIInspectorDOMFrontendClient
+
+    init(dependencies: WIInspectorDOMFrontendClient = .liveValue) {
+        self.dependencies = dependencies
+        super.init()
+    }
 
     func makeInspectorWebView(bootstrapPayload: [String: Any]) -> InspectorWebView {
         self.bootstrapPayload = bootstrapPayload
@@ -42,7 +48,7 @@ final class DOMInspectorBridge: NSObject {
             return inspectorWebView
         }
 
-        let inspectorWebView = InspectorWebView()
+        let inspectorWebView = dependencies.makeInspectorWebView()
         installInitialBootstrap(on: inspectorWebView)
         attachInspectorWebView(to: inspectorWebView)
         loadInspector(in: inspectorWebView)
@@ -229,8 +235,8 @@ private extension DOMInspectorBridge {
     }
 
     func loadInspector(in inspectorWebView: InspectorWebView) {
-        guard let mainURL = WIAssets.mainFileURL,
-              let baseURL = WIAssets.resourcesDirectory
+        guard let mainURL = dependencies.mainFileURL(),
+              let baseURL = dependencies.resourcesDirectoryURL()
         else {
             domInspectorBridgeLogger.error("missing inspector resources")
             return

--- a/Sources/WebInspectorRuntime/DOM/InspectorWebView.swift
+++ b/Sources/WebInspectorRuntime/DOM/InspectorWebView.swift
@@ -16,14 +16,27 @@ final class InspectorWebView: WKWebView {
 #if canImport(AppKit)
     var domContextMenuProvider: ((Int?) -> NSMenu?)?
 #endif
+    private let dependencies: WIInspectorDOMFrontendClient
 
-    convenience init() {
-        self.init(frame: .zero, configuration: Self.makeDefaultConfiguration())
+    convenience init(dependencies: WIInspectorDOMFrontendClient = .liveValue) {
+        self.init(
+            frame: .zero,
+            configuration: Self.makeDefaultConfiguration(dependencies: dependencies),
+            dependencies: dependencies
+        )
     }
-    
-    override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+
+    init(
+        frame: CGRect,
+        configuration: WKWebViewConfiguration,
+        dependencies: WIInspectorDOMFrontendClient = .liveValue
+    ) {
+        self.dependencies = dependencies
         super.init(frame: frame, configuration: configuration)
-        Self.installDOMTreeViewScriptsIfNeeded(on: configuration.userContentController)
+        Self.installDOMTreeViewScriptsIfNeeded(
+            on: configuration.userContentController,
+            dependencies: dependencies
+        )
         applyInspectorDefaults()
     }
     
@@ -32,24 +45,34 @@ final class InspectorWebView: WKWebView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private static func makeDefaultConfiguration() -> WKWebViewConfiguration {
+    private static func makeDefaultConfiguration(
+        dependencies: WIInspectorDOMFrontendClient
+    ) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.writingToolsBehavior = .none
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
-        configuration.userContentController = makeInspectorContentController()
+        configuration.userContentController = makeInspectorContentController(dependencies: dependencies)
         return configuration
     }
 
-    private static func makeInspectorContentController() -> WKUserContentController {
+    private static func makeInspectorContentController(
+        dependencies: WIInspectorDOMFrontendClient
+    ) -> WKUserContentController {
         let controller = WKUserContentController()
-        installDOMTreeViewScriptsIfNeeded(on: controller)
+        installDOMTreeViewScriptsIfNeeded(on: controller, dependencies: dependencies)
         return controller
     }
 
-    private static func installDOMTreeViewScriptsIfNeeded(on controller: WKUserContentController) {
+    private static func installDOMTreeViewScriptsIfNeeded(
+        on controller: WKUserContentController,
+        dependencies: WIInspectorDOMFrontendClient
+    ) {
         let existingSources = Set(controller.userScripts.map(\.source))
         do {
-            let scriptSource = try WebInspectorScripts.domTreeView()
+            let scriptSource = try dependencies.domTreeViewScript()
+            guard !scriptSource.isEmpty else {
+                return
+            }
             if existingSources.contains(scriptSource) {
                 return
             }

--- a/Sources/WebInspectorRuntime/DOM/V2_WIDOMRuntime.swift
+++ b/Sources/WebInspectorRuntime/DOM/V2_WIDOMRuntime.swift
@@ -13,19 +13,25 @@ public final class V2_WIDOMRuntime {
 
     public let document: DOMDocumentModel
 
-    public convenience init(configuration: DOMConfiguration = .init()) {
+    public convenience init(
+        configuration: DOMConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue
+    ) {
         self.init(
             configuration: configuration,
-            sharedTransport: WISharedInspectorTransport()
+            dependencies: dependencies,
+            sharedTransport: dependencies.makeSharedTransport()
         )
     }
 
     package init(
         configuration: DOMConfiguration,
+        dependencies: WIInspectorDependencies = .liveValue,
         sharedTransport: WISharedInspectorTransport
     ) {
         let inspector = WIDOMInspector(
             configuration: configuration,
+            dependencies: dependencies,
             sharedTransport: sharedTransport
         )
         self.inspector = inspector

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
@@ -269,7 +269,9 @@ extension WIDOMInspector {
         let selectionWasActive = isNativeInspectorElementSelectionActive(on: webView) == true
         let nodeSearchWasActive = hasActiveNativeInspectorNodeSearch(in: webView)
         if selectionWasActive || nodeSearchWasActive {
-            if nodeSearchWasActive == false {
+            if nodeSearchWasActive {
+                _ = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
+            } else {
                 let didEnableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
                 nativeInspectorNodeSearchNeedsDirectDeactivation = didEnableNodeSearch
             }

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
@@ -328,7 +328,14 @@ extension WIDOMInspector {
         dependencies.webKitSPI.dismissPageEditing(webView)
     }
 
+    private func nativeInspectorSelectionNeedsProtocolInspectModeReset(on webView: WKWebView) -> Bool {
+        isNativeInspectorElementSelectionActive(on: webView) == true
+            || hasActiveNativeInspectorNodeSearch(in: webView)
+    }
+
     private func enableProtocolInspectModeForNativeInspectorSelection(
+        on webView: WKWebView,
+        contextID: DOMContextID,
         targetIdentifier: String
     ) async -> Bool {
         do {
@@ -343,11 +350,103 @@ extension WIDOMInspector {
             )
             return true
         } catch {
+            let didRecover = await recoverProtocolInspectModeEnableAfterNativeInspectorWakeup(
+                on: webView,
+                contextID: contextID,
+                targetIdentifier: targetIdentifier,
+                initialError: error
+            )
+            if didRecover {
+                return true
+            }
+
             nativeInspectorProtocolInspectModeNeedsDeactivation = false
             logInspectorLifecycleDiagnostics(
                 "beginSelectionMode failed to enable protocol inspect mode for native inspector backend",
                 extra: "target=\(targetIdentifier) error=\(error.localizedDescription)",
                 level: .error
+            )
+            return false
+        }
+    }
+
+    private func recoverProtocolInspectModeEnableAfterNativeInspectorWakeup(
+        on webView: WKWebView,
+        contextID: DOMContextID,
+        targetIdentifier: String,
+        initialError: any Error
+    ) async -> Bool {
+        guard selectionLifecycleStateMatches(
+            contextID: contextID,
+            targetIdentifier: targetIdentifier
+        ) else {
+            return false
+        }
+
+        let didActivateNativeSelection = activateNativeInspectorElementSelection(on: webView)
+        guard didActivateNativeSelection,
+              selectionLifecycleStateMatches(
+                contextID: contextID,
+                targetIdentifier: targetIdentifier
+              ) else {
+            cleanUpNativeInspectorActivationAttempt(on: webView)
+            return false
+        }
+
+        do {
+            try await ContinuousClock().sleep(for: .milliseconds(20))
+        } catch {
+            return false
+        }
+
+        guard selectionLifecycleStateMatches(
+            contextID: contextID,
+            targetIdentifier: targetIdentifier
+        ) else {
+            cleanUpNativeInspectorActivationAttempt(on: webView)
+            return false
+        }
+
+        do {
+            try await setProtocolInspectModeEnabledForInspectorLifecycle(
+                true,
+                targetIdentifier: targetIdentifier
+            )
+            nativeInspectorProtocolInspectModeNeedsDeactivation = true
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode enabled protocol inspect mode after native inspector wakeup",
+                extra: "target=\(targetIdentifier) initialError=\(initialError.localizedDescription)"
+            )
+            return true
+        } catch {
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode failed protocol inspect mode retry after native inspector wakeup",
+                extra: "target=\(targetIdentifier) initialError=\(initialError.localizedDescription) retryError=\(error.localizedDescription)",
+                level: .error
+            )
+            return false
+        }
+    }
+
+    @discardableResult
+    private func resetProtocolInspectModeForNativeInspectorSelection(
+        targetIdentifier: String
+    ) async -> Bool {
+        do {
+            try await setProtocolInspectModeEnabledForInspectorLifecycle(
+                false,
+                targetIdentifier: targetIdentifier
+            )
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode reset protocol inspect mode before native inspector backend",
+                extra: "target=\(targetIdentifier)"
+            )
+            return true
+        } catch {
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode failed to reset protocol inspect mode before native inspector backend",
+                extra: "target=\(targetIdentifier) error=\(error.localizedDescription)",
+                level: .debug
             )
             return false
         }
@@ -430,18 +529,46 @@ extension WIDOMInspector {
         if nativeInspectorSelectionBackend(for: pageWebView) == .nativeInspector {
             nativeInspectorProtocolInspectModeNeedsDeactivation = false
             let didConnect = connectNativeInspectorIfNeeded(on: pageWebView)
+            let shouldResetProtocolInspectMode = nativeInspectorSelectionNeedsProtocolInspectModeReset(
+                on: pageWebView
+            )
+            if shouldResetProtocolInspectMode {
+                await resetProtocolInspectModeForNativeInspectorSelection(
+                    targetIdentifier: targetIdentifier
+                )
+            }
             let didEnableProtocolInspectMode = await enableProtocolInspectModeForNativeInspectorSelection(
+                on: pageWebView,
+                contextID: contextID,
                 targetIdentifier: targetIdentifier
             )
+            guard didEnableProtocolInspectMode else {
+                guard selectionLifecycleStateMatches(
+                    contextID: contextID,
+                    targetIdentifier: targetIdentifier
+                ) else {
+                    cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                    throw DOMOperationError.contextInvalidated
+                }
+                logInspectorLifecycleDiagnostics(
+                    "beginSelectionMode skipped native inspector backend because protocol inspect mode did not enable",
+                    extra: "contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
+                    level: .error
+                )
+                cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                return try await enableTransportProtocolInspectorSelectionMode(
+                    on: pageWebView,
+                    contextID: contextID,
+                    targetIdentifier: targetIdentifier
+                )
+            }
             guard selectionLifecycleStateMatches(
                 contextID: contextID,
                 targetIdentifier: targetIdentifier
             ) else {
-                if didEnableProtocolInspectMode {
-                    _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
-                        targetIdentifier: targetIdentifier
-                    )
-                }
+                _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                    targetIdentifier: targetIdentifier
+                )
                 cleanUpNativeInspectorActivationAttempt(on: pageWebView)
                 throw DOMOperationError.contextInvalidated
             }
@@ -454,11 +581,9 @@ extension WIDOMInspector {
                 contextID: contextID,
                 targetIdentifier: targetIdentifier
             ) else {
-                if didEnableProtocolInspectMode {
-                    _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
-                        targetIdentifier: targetIdentifier
-                    )
-                }
+                _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                    targetIdentifier: targetIdentifier
+                )
                 cleanUpNativeInspectorActivationAttempt(on: pageWebView)
                 throw DOMOperationError.contextInvalidated
             }
@@ -471,22 +596,21 @@ extension WIDOMInspector {
                 extra: "contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
                 level: .error
             )
-            if didEnableProtocolInspectMode {
-                if await waitForTransportInspectModeActivation(on: pageWebView) {
-                    guard selectionLifecycleStateMatches(
-                        contextID: contextID,
+            if await waitForTransportInspectModeActivation(on: pageWebView) {
+                guard selectionLifecycleStateMatches(
+                    contextID: contextID,
+                    targetIdentifier: targetIdentifier
+                ) else {
+                    _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
                         targetIdentifier: targetIdentifier
-                    ) else {
-                        _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
-                            targetIdentifier: targetIdentifier
-                        )
-                        cleanUpNativeInspectorActivationAttempt(on: pageWebView)
-                        throw DOMOperationError.contextInvalidated
-                    }
+                    )
                     cleanUpNativeInspectorActivationAttempt(on: pageWebView)
-                    nativeInspectorProtocolInspectModeNeedsDeactivation = false
-                    return .transportProtocol
+                    throw DOMOperationError.contextInvalidated
                 }
+                cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                nativeInspectorProtocolInspectModeNeedsDeactivation = false
+                return .transportProtocol
+            } else {
                 _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
                     targetIdentifier: targetIdentifier
                 )
@@ -494,6 +618,18 @@ extension WIDOMInspector {
             cleanUpNativeInspectorActivationAttempt(on: pageWebView)
         }
 
+        return try await enableTransportProtocolInspectorSelectionMode(
+            on: pageWebView,
+            contextID: contextID,
+            targetIdentifier: targetIdentifier
+        )
+    }
+
+    private func enableTransportProtocolInspectorSelectionMode(
+        on pageWebView: WKWebView,
+        contextID: DOMContextID,
+        targetIdentifier: String
+    ) async throws -> InspectModeControlBackend {
         do {
             logInspectorLifecycleDiagnostics(
                 "beginSelectionMode using transport protocol backend",

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
@@ -265,11 +265,13 @@ extension WIDOMInspector {
 
     private func activateNativeInspectorElementSelection(on webView: WKWebView) -> Bool {
         nativeInspectorSelectionToggleNeedsDeactivation = false
+        nativeInspectorNodeSearchNeedsDirectDeactivation = false
         let selectionWasActive = isNativeInspectorElementSelectionActive(on: webView) == true
         let nodeSearchWasActive = hasActiveNativeInspectorNodeSearch(in: webView)
         if selectionWasActive || nodeSearchWasActive {
             if nodeSearchWasActive == false {
-                _ = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
+                let didEnableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
+                nativeInspectorNodeSearchNeedsDirectDeactivation = didEnableNodeSearch
             }
             if isNativeInspectorConnected(on: webView) == false {
                 _ = connectNativeInspectorIfNeeded(on: webView)
@@ -279,6 +281,7 @@ extension WIDOMInspector {
         }
 
         let didEnableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
+        nativeInspectorNodeSearchNeedsDirectDeactivation = didEnableNodeSearch
         if isNativeInspectorConnected(on: webView) == false {
             _ = connectNativeInspectorIfNeeded(on: webView)
         }
@@ -310,8 +313,76 @@ extension WIDOMInspector {
         return dependencies.webKitSPI.toggleElementSelection(webView)
     }
 
+    private func cleanUpNativeInspectorActivationAttempt(on webView: WKWebView) {
+        _ = deactivateNativeInspectorElementSelectionIfNeeded(on: webView)
+        let shouldDisableNodeSearch =
+            nativeInspectorNodeSearchNeedsDirectDeactivation
+                || hasActiveNativeInspectorNodeSearch(in: webView)
+        nativeInspectorNodeSearchNeedsDirectDeactivation = false
+        if shouldDisableNodeSearch {
+            _ = dependencies.webKitSPI.setNodeSearchEnabled(webView, false)
+        }
+    }
+
     private func dismissPageEditingForInspectorSelection(on webView: WKWebView) {
         dependencies.webKitSPI.dismissPageEditing(webView)
+    }
+
+    private func enableProtocolInspectModeForNativeInspectorSelection(
+        targetIdentifier: String
+    ) async -> Bool {
+        do {
+            try await setProtocolInspectModeEnabledForInspectorLifecycle(
+                true,
+                targetIdentifier: targetIdentifier
+            )
+            nativeInspectorProtocolInspectModeNeedsDeactivation = true
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode enabled protocol inspect mode for native inspector backend",
+                extra: "target=\(targetIdentifier)"
+            )
+            return true
+        } catch {
+            nativeInspectorProtocolInspectModeNeedsDeactivation = false
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode failed to enable protocol inspect mode for native inspector backend",
+                extra: "target=\(targetIdentifier) error=\(error.localizedDescription)",
+                level: .error
+            )
+            return false
+        }
+    }
+
+    private func disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+        targetIdentifier: String?
+    ) async -> Bool {
+        guard nativeInspectorProtocolInspectModeNeedsDeactivation else {
+            return false
+        }
+        nativeInspectorProtocolInspectModeNeedsDeactivation = false
+        guard let targetIdentifier else {
+            logInspectorLifecycleDiagnostics(
+                "disableInspectorSelectionModeIfNeeded skipped protocol inspect mode disable",
+                extra: "missing target identifier",
+                level: .error
+            )
+            return false
+        }
+
+        do {
+            try await setProtocolInspectModeEnabledForInspectorLifecycle(
+                false,
+                targetIdentifier: targetIdentifier
+            )
+            return true
+        } catch {
+            logInspectorLifecycleDiagnostics(
+                "disableInspectorSelectionModeIfNeeded failed to disable protocol inspect mode for native inspector backend",
+                extra: "target=\(targetIdentifier) error=\(error.localizedDescription)",
+                level: .error
+            )
+            return false
+        }
     }
 
     private func waitForTransportInspectModeActivation(on webView: WKWebView) async -> Bool {
@@ -357,12 +428,40 @@ extension WIDOMInspector {
         dismissPageEditingForInspectorSelection(on: pageWebView)
 
         if nativeInspectorSelectionBackend(for: pageWebView) == .nativeInspector {
+            nativeInspectorProtocolInspectModeNeedsDeactivation = false
             let didConnect = connectNativeInspectorIfNeeded(on: pageWebView)
+            let didEnableProtocolInspectMode = await enableProtocolInspectModeForNativeInspectorSelection(
+                targetIdentifier: targetIdentifier
+            )
+            guard selectionLifecycleStateMatches(
+                contextID: contextID,
+                targetIdentifier: targetIdentifier
+            ) else {
+                if didEnableProtocolInspectMode {
+                    _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                        targetIdentifier: targetIdentifier
+                    )
+                }
+                cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                throw DOMOperationError.contextInvalidated
+            }
             let didEnable = activateNativeInspectorElementSelection(on: pageWebView)
             logInspectorLifecycleDiagnostics(
                 "beginSelectionMode using native inspector backend",
-                extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) contextID=\(contextID) target=\(targetIdentifier) connected=\(didConnect) enabled=\(didEnable) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
+                extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) contextID=\(contextID) target=\(targetIdentifier) connected=\(didConnect) protocolInspectMode=\(didEnableProtocolInspectMode) enabled=\(didEnable) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
             )
+            guard selectionLifecycleStateMatches(
+                contextID: contextID,
+                targetIdentifier: targetIdentifier
+            ) else {
+                if didEnableProtocolInspectMode {
+                    _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                        targetIdentifier: targetIdentifier
+                    )
+                }
+                cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                throw DOMOperationError.contextInvalidated
+            }
             if didEnable {
                 return .nativeInspector
             }
@@ -372,6 +471,27 @@ extension WIDOMInspector {
                 extra: "contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
                 level: .error
             )
+            if didEnableProtocolInspectMode {
+                if await waitForTransportInspectModeActivation(on: pageWebView) {
+                    guard selectionLifecycleStateMatches(
+                        contextID: contextID,
+                        targetIdentifier: targetIdentifier
+                    ) else {
+                        _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                            targetIdentifier: targetIdentifier
+                        )
+                        cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                        throw DOMOperationError.contextInvalidated
+                    }
+                    cleanUpNativeInspectorActivationAttempt(on: pageWebView)
+                    nativeInspectorProtocolInspectModeNeedsDeactivation = false
+                    return .transportProtocol
+                }
+                _ = await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                    targetIdentifier: targetIdentifier
+                )
+            }
+            cleanUpNativeInspectorActivationAttempt(on: pageWebView)
         }
 
         do {
@@ -380,7 +500,21 @@ extension WIDOMInspector {
                 extra: "backend=\(InspectModeControlBackend.transportProtocol.rawValue) contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
             )
             try await setProtocolInspectModeEnabledForInspectorLifecycle(true, targetIdentifier: targetIdentifier)
+            guard selectionLifecycleStateMatches(
+                contextID: contextID,
+                targetIdentifier: targetIdentifier
+            ) else {
+                try? await setProtocolInspectModeEnabledForInspectorLifecycle(false, targetIdentifier: targetIdentifier)
+                throw DOMOperationError.contextInvalidated
+            }
             if await waitForTransportInspectModeActivation(on: pageWebView) {
+                guard selectionLifecycleStateMatches(
+                    contextID: contextID,
+                    targetIdentifier: targetIdentifier
+                ) else {
+                    try? await setProtocolInspectModeEnabledForInspectorLifecycle(false, targetIdentifier: targetIdentifier)
+                    throw DOMOperationError.contextInvalidated
+                }
                 return .transportProtocol
             }
             logInspectorLifecycleDiagnostics(
@@ -411,10 +545,21 @@ extension WIDOMInspector {
         switch backend ?? inspectModeControlBackend ?? nativeInspectorSelectionBackend(for: pageWebView) {
         case .nativeInspector:
             let didToggleOff = deactivateNativeInspectorElementSelectionIfNeeded(on: pageWebView)
-            let didDisableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(pageWebView, false)
+            let didDisableProtocolInspectMode =
+                await disableProtocolInspectModeForNativeInspectorSelectionIfNeeded(
+                    targetIdentifier: targetIdentifier
+                )
+            let shouldDisableNodeSearchDirectly =
+                nativeInspectorNodeSearchNeedsDirectDeactivation
+                    || didDisableProtocolInspectMode == false
+                    || hasActiveNativeInspectorNodeSearch(in: pageWebView)
+            nativeInspectorNodeSearchNeedsDirectDeactivation = false
+            let didDisableNodeSearch = shouldDisableNodeSearchDirectly
+                ? dependencies.webKitSPI.setNodeSearchEnabled(pageWebView, false)
+                : false
             logInspectorLifecycleDiagnostics(
                 "disableInspectorSelectionModeIfNeeded used native inspector backend",
-                extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) target=\(targetIdentifier ?? "nil") toggledOff=\(didToggleOff) disabledNodeSearch=\(didDisableNodeSearch) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
+                extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) target=\(targetIdentifier ?? "nil") toggledOff=\(didToggleOff) disabledProtocolInspectMode=\(didDisableProtocolInspectMode) disabledNodeSearch=\(didDisableNodeSearch) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
             )
         case .transportProtocol:
             guard let targetIdentifier else {

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector+UIKit.swift
@@ -47,15 +47,6 @@ private final class WIDOMUIKitSceneActivationWaitState {
 }
 
 @MainActor
-private final class WIDOMUIKitSceneActivationRequestErrorState {
-    private(set) var error: Error?
-
-    func signal(_ error: Error) {
-        self.error = error
-    }
-}
-
-@MainActor
 package protocol WIDOMUIKitSceneActivationTarget: AnyObject {
     var activationState: UIScene.ActivationState { get }
     var sceneSession: UISceneSession? { get }
@@ -124,6 +115,11 @@ package enum WIDOMUIKitInspectorSelectionEnvironment {
     package static var selectionActiveProvider: @MainActor (WKWebView) -> Bool? = {
         WIInspectorSelectionPrivateBridge.isElementSelectionActive(in: $0)
     }
+    package static var pageEditingDismissalHandler: @MainActor (WKWebView) -> Void = {
+        $0.endEditing(true)
+    }
+    package static var transportInspectActivationProvider: @MainActor (WKWebView) -> Bool = { _ in true }
+    package static var transportInspectActivationTimeoutNanoseconds: UInt64 = 50_000_000
 }
 
 @MainActor
@@ -138,7 +134,7 @@ package enum WIDOMUIKitSceneActivationEnvironment {
         try await waitForSceneActivation(target, timeout: timeout)
     }
 
-    private static func waitForSceneActivation(
+    package static func waitForSceneActivation(
         _ target: any WIDOMUIKitSceneActivationTarget,
         timeout: Duration
     ) async throws {
@@ -201,46 +197,12 @@ extension WIDOMInspector {
         guard let pageWindow = pageWebView?.window else {
             return
         }
-        guard let pageScene = WIDOMUIKitSceneActivationEnvironment.sceneProvider(pageWindow) else {
-            return
-        }
-        guard pageScene.activationState != .foregroundActive else {
-            return
-        }
-
-        let requestingScene = sceneActivationRequestingScene
-            ?? WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider(pageScene)
-        let requestErrorState = WIDOMUIKitSceneActivationRequestErrorState()
-        let activationTask = Task { @MainActor in
-            try await WIDOMUIKitSceneActivationEnvironment.activationWaiter(
-                pageScene,
-                WIDOMUIKitSceneActivationEnvironment.activationTimeout
-            )
-        }
-
-        defer {
-            activationTask.cancel()
-        }
-
-        WIDOMUIKitSceneActivationEnvironment.requester.requestActivation(
-            of: pageScene,
-            requestingScene: requestingScene
-        ) { error in
-            Task { @MainActor in
-                domWindowActivationLogger.error("page scene activation failed: \(error.localizedDescription, privacy: .public)")
-                requestErrorState.signal(error)
-                activationTask.cancel()
-            }
-        }
-
-        do {
-            try await activationTask.value
-        } catch is CancellationError {
-            if let error = requestErrorState.error {
-                throw DOMOperationError.scriptFailure(error.localizedDescription)
-            }
-            throw CancellationError()
-        }
+        let sceneActivation = dependencies.platform.uiKitSceneActivation
+        try await sceneActivation.activateWindowSceneIfNeeded(
+            pageWindow,
+            sceneActivationRequestingScene,
+            sceneActivation.activationTimeout
+        )
     }
 
     func awaitInspectModeInactive() async {
@@ -257,7 +219,7 @@ extension WIDOMInspector {
         if selectionActive {
             _ = deactivateNativeInspectorElementSelectionIfNeeded(on: pageWebView)
         }
-        _ = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter(pageWebView, false)
+        _ = dependencies.webKitSPI.setNodeSearchEnabled(pageWebView, false)
         if hasActiveNativeInspectorNodeSearch(in: pageWebView) == false {
             return
         }
@@ -271,42 +233,43 @@ extension WIDOMInspector {
     }
 
     private func removeLingeringNativeInspectorNodeSearchRecognizers(in webView: WKWebView) {
-        _ = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover(webView)
+        _ = dependencies.webKitSPI.removeNodeSearchRecognizers(webView)
     }
 
     private func hasActiveNativeInspectorNodeSearch(in webView: WKWebView) -> Bool {
-        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider(webView)
+        dependencies.webKitSPI.hasNodeSearchRecognizer(webView)
     }
 
     private func nativeInspectorSelectionBackend(for webView: WKWebView) -> InspectModeControlBackend {
-        if WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider(webView) {
+        if dependencies.webKitSPI.hasPrivateInspectorAccess(webView) {
             return .nativeInspector
         }
         return .transportProtocol
     }
 
     private func isNativeInspectorConnected(on webView: WKWebView) -> Bool? {
-        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider(webView)
+        dependencies.webKitSPI.isInspectorConnected(webView)
     }
 
     private func isNativeInspectorElementSelectionActive(on webView: WKWebView) -> Bool? {
-        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider(webView)
+        dependencies.webKitSPI.isElementSelectionActive(webView)
     }
 
     private func connectNativeInspectorIfNeeded(on webView: WKWebView) -> Bool {
         if isNativeInspectorConnected(on: webView) == true {
             return true
         }
-        let didRequestConnect = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector(webView)
+        let didRequestConnect = dependencies.webKitSPI.connectInspector(webView)
         return isNativeInspectorConnected(on: webView) ?? didRequestConnect
     }
 
     private func activateNativeInspectorElementSelection(on webView: WKWebView) -> Bool {
+        nativeInspectorSelectionToggleNeedsDeactivation = false
         let selectionWasActive = isNativeInspectorElementSelectionActive(on: webView) == true
         let nodeSearchWasActive = hasActiveNativeInspectorNodeSearch(in: webView)
         if selectionWasActive || nodeSearchWasActive {
             if nodeSearchWasActive == false {
-                _ = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter(webView, true)
+                _ = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
             }
             if isNativeInspectorConnected(on: webView) == false {
                 _ = connectNativeInspectorIfNeeded(on: webView)
@@ -315,7 +278,7 @@ extension WIDOMInspector {
                 || hasActiveNativeInspectorNodeSearch(in: webView)
         }
 
-        let didEnableNodeSearch = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter(webView, true)
+        let didEnableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(webView, true)
         if isNativeInspectorConnected(on: webView) == false {
             _ = connectNativeInspectorIfNeeded(on: webView)
         }
@@ -323,21 +286,59 @@ extension WIDOMInspector {
             return true
         }
 
-        let didToggleSelection = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler(webView)
+        let didToggleSelection = dependencies.webKitSPI.toggleElementSelection(webView)
         if isNativeInspectorConnected(on: webView) == false {
             _ = connectNativeInspectorIfNeeded(on: webView)
         }
-        return isNativeInspectorElementSelectionActive(on: webView) == true
-            || hasActiveNativeInspectorNodeSearch(in: webView)
-            || didEnableNodeSearch
-            || didToggleSelection
+        let selectionActive = isNativeInspectorElementSelectionActive(on: webView)
+        if didToggleSelection && selectionActive == nil {
+            nativeInspectorSelectionToggleNeedsDeactivation = true
+        }
+        if selectionActive == true || hasActiveNativeInspectorNodeSearch(in: webView) {
+            return true
+        }
+        return selectionActive == nil && (didEnableNodeSearch || didToggleSelection)
     }
 
     private func deactivateNativeInspectorElementSelectionIfNeeded(on webView: WKWebView) -> Bool {
-        guard isNativeInspectorElementSelectionActive(on: webView) == true else {
+        let shouldToggleOff = isNativeInspectorElementSelectionActive(on: webView) == true
+            || nativeInspectorSelectionToggleNeedsDeactivation
+        nativeInspectorSelectionToggleNeedsDeactivation = false
+        guard shouldToggleOff else {
             return false
         }
-        return WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler(webView)
+        return dependencies.webKitSPI.toggleElementSelection(webView)
+    }
+
+    private func dismissPageEditingForInspectorSelection(on webView: WKWebView) {
+        dependencies.webKitSPI.dismissPageEditing(webView)
+    }
+
+    private func waitForTransportInspectModeActivation(on webView: WKWebView) async -> Bool {
+        if dependencies.webKitSPI.transportInspectActivationProvider(webView) {
+            return true
+        }
+
+        let timeoutNanoseconds = dependencies.webKitSPI.transportInspectActivationTimeoutNanoseconds
+        guard timeoutNanoseconds > 0 else {
+            return false
+        }
+
+        let clock = ContinuousClock()
+        let clampedTimeout = min(timeoutNanoseconds, UInt64(Int64.max))
+        let deadline = clock.now.advanced(by: .nanoseconds(Int64(clampedTimeout)))
+        while clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(10))
+            } catch {
+                return dependencies.webKitSPI.transportInspectActivationProvider(webView)
+            }
+            if dependencies.webKitSPI.transportInspectActivationProvider(webView) {
+                return true
+            }
+        }
+
+        return dependencies.webKitSPI.transportInspectActivationProvider(webView)
     }
 
     func enableInspectorSelectionMode(
@@ -353,28 +354,13 @@ extension WIDOMInspector {
             try? await hideHighlightForInspectorLifecycle()
         }
 
-        do {
-            logInspectorLifecycleDiagnostics(
-                "beginSelectionMode using transport protocol backend",
-                extra: "backend=\(InspectModeControlBackend.transportProtocol.rawValue) contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
-            )
-            try await setProtocolInspectModeEnabledForInspectorLifecycle(true, targetIdentifier: targetIdentifier)
-            return .transportProtocol
-        } catch {
-            logInspectorLifecycleDiagnostics(
-                "beginSelectionMode transport protocol failed; evaluating native fallback",
-                extra: "contextID=\(contextID) target=\(targetIdentifier) error=\(error.localizedDescription) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
-                level: .error
-            )
+        dismissPageEditingForInspectorSelection(on: pageWebView)
 
-            guard nativeInspectorSelectionBackend(for: pageWebView) == .nativeInspector else {
-                throw error
-            }
-
+        if nativeInspectorSelectionBackend(for: pageWebView) == .nativeInspector {
             let didConnect = connectNativeInspectorIfNeeded(on: pageWebView)
             let didEnable = activateNativeInspectorElementSelection(on: pageWebView)
             logInspectorLifecycleDiagnostics(
-                "beginSelectionMode using native inspector fallback backend",
+                "beginSelectionMode using native inspector backend",
                 extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) contextID=\(contextID) target=\(targetIdentifier) connected=\(didConnect) enabled=\(didEnable) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
             )
             if didEnable {
@@ -382,8 +368,32 @@ extension WIDOMInspector {
             }
 
             logInspectorLifecycleDiagnostics(
-                "beginSelectionMode native inspector fallback failed",
+                "beginSelectionMode native inspector failed; falling back to transport protocol",
                 extra: "contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
+                level: .error
+            )
+        }
+
+        do {
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode using transport protocol backend",
+                extra: "backend=\(InspectModeControlBackend.transportProtocol.rawValue) contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
+            )
+            try await setProtocolInspectModeEnabledForInspectorLifecycle(true, targetIdentifier: targetIdentifier)
+            if await waitForTransportInspectModeActivation(on: pageWebView) {
+                return .transportProtocol
+            }
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode transport protocol did not activate",
+                extra: "contextID=\(contextID) target=\(targetIdentifier) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
+                level: .error
+            )
+            try? await setProtocolInspectModeEnabledForInspectorLifecycle(false, targetIdentifier: targetIdentifier)
+            throw DOMOperationError.scriptFailure("Transport inspect mode did not activate.")
+        } catch {
+            logInspectorLifecycleDiagnostics(
+                "beginSelectionMode transport protocol failed",
+                extra: "contextID=\(contextID) target=\(targetIdentifier) error=\(error.localizedDescription) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")",
                 level: .error
             )
             throw error
@@ -401,7 +411,7 @@ extension WIDOMInspector {
         switch backend ?? inspectModeControlBackend ?? nativeInspectorSelectionBackend(for: pageWebView) {
         case .nativeInspector:
             let didToggleOff = deactivateNativeInspectorElementSelectionIfNeeded(on: pageWebView)
-            let didDisableNodeSearch = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter(pageWebView, false)
+            let didDisableNodeSearch = dependencies.webKitSPI.setNodeSearchEnabled(pageWebView, false)
             logInspectorLifecycleDiagnostics(
                 "disableInspectorSelectionModeIfNeeded used native inspector backend",
                 extra: "backend=\(InspectModeControlBackend.nativeInspector.rawValue) target=\(targetIdentifier ?? "nil") toggledOff=\(didToggleOff) disabledNodeSearch=\(didDisableNodeSearch) nativeState=\(nativeInspectorInteractionStateSummaryForDiagnostics() ?? "nil")"
@@ -473,7 +483,7 @@ extension WIDOMInspector {
             return nil
         }
 
-        let hasPrivateInspectorAccess = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider(pageWebView)
+        let hasPrivateInspectorAccess = dependencies.webKitSPI.hasPrivateInspectorAccess(pageWebView)
         let connected = isNativeInspectorConnected(on: pageWebView)
         let selectionActive = isNativeInspectorElementSelectionActive(on: pageWebView)
         let contentViewActive = hasActiveNativeInspectorNodeSearch(in: pageWebView)

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
@@ -17,6 +17,8 @@ nonisolated(unsafe) private let pageWebViewLifetimeObserverAssociationKey = unsa
 private enum WIDOMConsoleDiagnostics {
     private static let milestoneMessages: Set<String> = [
         "beginFreshContext requested",
+        "beginSelectionMode using native inspector backend",
+        "beginSelectionMode enabled protocol inspect mode for native inspector backend",
         "requestSelectionModeToggle enabled inspect mode",
         "beginSelectionMode armed inspect selection",
         "applyPendingInspectSelectionIfPossible resolved transport node",
@@ -215,6 +217,12 @@ public final class WIDOMInspector {
         var progressRevision: UInt64 = 0
     }
 
+    private struct InspectorInspectNodeResolution {
+        let nodeID: Int
+        let targetIdentifier: String
+        let attemptedTargetIdentifiers: [String]
+    }
+
     private struct PendingChildRequestKey: Hashable {
         let nodeID: Int
         let contextID: DOMContextID
@@ -371,6 +379,8 @@ public final class WIDOMInspector {
 #if canImport(UIKit)
     @ObservationIgnored package weak var sceneActivationRequestingScene: UIScene?
     @ObservationIgnored package var nativeInspectorSelectionToggleNeedsDeactivation = false
+    @ObservationIgnored package var nativeInspectorNodeSearchNeedsDirectDeactivation = false
+    @ObservationIgnored package var nativeInspectorProtocolInspectModeNeedsDeactivation = false
 #endif
 
     public convenience init(
@@ -627,6 +637,18 @@ public final class WIDOMInspector {
         )
     }
 
+    package func selectionLifecycleStateMatches(
+        contextID: DOMContextID,
+        targetIdentifier: String
+    ) -> Bool {
+        guard case let .ready(context, currentTargetIdentifier) = phase else {
+            return false
+        }
+        return context.contextID == contextID
+            && currentTargetIdentifier == targetIdentifier
+            && currentContext?.contextID == contextID
+    }
+
     public func beginSelectionMode() async throws {
         let _ = try requirePageWebView()
         applyRecoverableError(nil)
@@ -634,14 +656,20 @@ public final class WIDOMInspector {
         let hadSelectedNode = document.selectedNode != nil
 
         do {
-            let context = try requireCurrentContext()
+            let initialState = try requireReadySelectionState()
             activatePageWindowForSelectionIfPossible()
 #if canImport(UIKit)
             try await requestPageWindowActivationIfNeeded()
             await awaitInspectModeInactive()
 #endif
 
-            let targetIdentifier = try requireCurrentTargetIdentifier()
+            let readyState = try requireReadySelectionState()
+            guard readyState.context.contextID == initialState.context.contextID,
+                  readyState.targetIdentifier == initialState.targetIdentifier else {
+                throw DOMOperationError.contextInvalidated
+            }
+            let context = readyState.context
+            let targetIdentifier = readyState.targetIdentifier
 #if canImport(UIKit)
             let inspectModeControlBackend = try await enableInspectorSelectionMode(
                 hadSelectedNode: hadSelectedNode,
@@ -655,7 +683,10 @@ public final class WIDOMInspector {
             try await setInspectModeEnabled(true, targetIdentifier: targetIdentifier)
             let inspectModeControlBackend = InspectModeControlBackend.transportProtocol
 #endif
-            guard currentContext?.contextID == context.contextID else {
+            guard selectionLifecycleStateMatches(
+                contextID: context.contextID,
+                targetIdentifier: targetIdentifier
+            ) else {
 #if canImport(UIKit)
                 await disableInspectorSelectionModeIfNeeded(
                     targetIdentifier: targetIdentifier,
@@ -1495,6 +1526,14 @@ private extension WIDOMInspector {
             throw DOMOperationError.contextInvalidated
         }
         return currentContext
+    }
+
+    func requireReadySelectionState() throws -> (context: DOMContext, targetIdentifier: String) {
+        guard case let .ready(context, targetIdentifier) = phase,
+              currentContext?.contextID == context.contextID else {
+            throw DOMOperationError.contextInvalidated
+        }
+        return (context, targetIdentifier)
     }
 
     func requireCurrentTargetIdentifier() throws -> String {
@@ -3014,6 +3053,11 @@ private extension WIDOMInspector {
 #else
         isSelectingElement = false
 #endif
+
+        if let contextID = currentContext?.contextID,
+           document.selectedNode != nil {
+            await syncSelectedNodeHighlight(contextID: contextID)
+        }
     }
 
     func setInspectModeEnabled(
@@ -3135,37 +3179,39 @@ private extension WIDOMInspector {
                 "handleInspectorInspectEvent received transport inspect",
                 extra: "contextID=\(contextID) objectID=\(objectID) injectedScriptId=\(injectedScriptIdentifier(from: objectID) ?? "nil") sourceTarget=\(eventTargetIdentifier ?? "nil") requestNodeTarget=\(resolutionTargetIdentifier) generation=\(transaction.generation)"
             )
-            let nodeID = try await transportNodeID(
+            let resolution = try await resolveInspectorInspectNodeID(
                 forRemoteObjectID: objectID,
-                targetIdentifier: resolutionTargetIdentifier
+                initialTargetIdentifier: resolutionTargetIdentifier
             )
             logSelectionDiagnostics(
                 "handleInspectorInspectEvent resolved requestNode",
                 extra: inspectResolutionDiagnosticSummary(
-                    nodeID: nodeID,
-                    targetIdentifier: resolutionTargetIdentifier,
+                    nodeID: resolution.nodeID,
+                    targetIdentifier: resolution.targetIdentifier,
                     contextID: contextID
-                ),
+                ) + " attempts=\(resolution.attemptedTargetIdentifiers.joined(separator: ","))",
                 level: .debug
             )
-            if resolvedAttachedInspectedNodeFromCurrentDocument(nodeID: nodeID) == nil {
+            if resolvedAttachedInspectedNodeFromCurrentDocument(nodeID: resolution.nodeID) == nil {
                 _ = upsertPendingInspectSelection(
-                    nodeID: nodeID,
+                    nodeID: resolution.nodeID,
                     contextID: contextID,
                     selectorPath: nil,
-                    resolutionTargetIdentifier: resolutionTargetIdentifier,
+                    resolutionTargetIdentifier: resolution.targetIdentifier,
                     transaction: transaction
                 )
             }
             scheduleInspectSelectionResolutionAfterTransportDrain(
                 objectID: objectID,
-                nodeID: nodeID,
+                nodeID: resolution.nodeID,
                 contextID: contextID,
                 selectorPath: nil,
-                targetIdentifier: resolutionTargetIdentifier,
+                targetIdentifier: resolution.targetIdentifier,
                 transaction: transaction,
                 showErrorOnFailure: true,
-                allowMaterialization: sharedTransport.targetKind(for: resolutionTargetIdentifier) != .frame
+                allowMaterialization: allowsInspectSelectionMaterialization(
+                    targetIdentifier: resolution.targetIdentifier
+                )
             )
         } catch {
             await completeInspectModeAfterBackendSelection()
@@ -3257,7 +3303,7 @@ private extension WIDOMInspector {
             return
         }
 
-        if sharedTransport.targetKind(for: targetIdentifier) == .frame {
+        if shouldMergeTargetDocumentForInspectSelection(targetIdentifier: targetIdentifier) {
             _ = await mergeFrameTargetDocumentIfNeeded(
                 targetIdentifier: targetIdentifier,
                 contextID: contextID,
@@ -3341,6 +3387,70 @@ private extension WIDOMInspector {
         return nodeID
     }
 
+    private func resolveInspectorInspectNodeID(
+        forRemoteObjectID objectID: String,
+        initialTargetIdentifier: String
+    ) async throws -> InspectorInspectNodeResolution {
+        let candidateTargetIdentifiers = inspectorInspectRequestNodeCandidateTargets(
+            initialTargetIdentifier: initialTargetIdentifier
+        )
+        var attemptedTargetIdentifiers: [String] = []
+        var lastError: (any Error)?
+
+        for targetIdentifier in candidateTargetIdentifiers {
+            attemptedTargetIdentifiers.append(targetIdentifier)
+            do {
+                let nodeID = try await transportNodeID(
+                    forRemoteObjectID: objectID,
+                    targetIdentifier: targetIdentifier
+                )
+                if targetIdentifier != initialTargetIdentifier {
+                    logSelectionDiagnostics(
+                        "Inspector.inspect resolved node on fallback target",
+                        extra: "initialTarget=\(initialTargetIdentifier) resolvedTarget=\(targetIdentifier) attempts=\(attemptedTargetIdentifiers.joined(separator: ","))",
+                        level: .debug
+                    )
+                }
+                return InspectorInspectNodeResolution(
+                    nodeID: nodeID,
+                    targetIdentifier: targetIdentifier,
+                    attemptedTargetIdentifiers: attemptedTargetIdentifiers
+                )
+            } catch {
+                lastError = error
+            }
+        }
+
+        throw lastError ?? DOMOperationError.invalidSelection
+    }
+
+    private func inspectorInspectRequestNodeCandidateTargets(
+        initialTargetIdentifier: String
+    ) -> [String] {
+        var targetIdentifiers: [String] = []
+        func appendTarget(_ targetIdentifier: String?) {
+            guard let targetIdentifier,
+                  targetIdentifiers.contains(targetIdentifier) == false else {
+                return
+            }
+            targetIdentifiers.append(targetIdentifier)
+        }
+
+        appendTarget(initialTargetIdentifier)
+
+        guard sharedTransport.targetKind(for: initialTargetIdentifier) != .frame else {
+            return targetIdentifiers
+        }
+
+        for targetIdentifier in sharedTransport.pageTargetIdentifiers() {
+            appendTarget(targetIdentifier)
+        }
+        for targetIdentifier in sharedTransport.frameTargetIdentifiers() {
+            appendTarget(targetIdentifier)
+        }
+        return targetIdentifiers
+    }
+
     private func upsertPendingInspectSelection(
         nodeID: Int,
         contextID: DOMContextID,
@@ -3407,7 +3517,7 @@ private extension WIDOMInspector {
             return
         }
 
-        if sharedTransport.targetKind(for: targetIdentifier) == .frame,
+        if shouldMergeTargetDocumentForInspectSelection(targetIdentifier: targetIdentifier),
            await mergeFrameTargetDocumentIfNeeded(
                 targetIdentifier: targetIdentifier,
                 contextID: contextID,
@@ -4485,6 +4595,20 @@ private extension WIDOMInspector {
         return roots
     }
 
+    private func shouldMergeTargetDocumentForInspectSelection(
+        targetIdentifier: String
+    ) -> Bool {
+        sharedTransport.targetKind(for: targetIdentifier) == .frame
+            || targetIdentifier != phase.targetIdentifier
+    }
+
+    private func allowsInspectSelectionMaterialization(
+        targetIdentifier: String
+    ) -> Bool {
+        sharedTransport.targetKind(for: targetIdentifier) != .frame
+            && targetIdentifier == phase.targetIdentifier
+    }
+
     private func mergeFrameTargetDocumentIfNeeded(
         targetIdentifier: String,
         contextID: DOMContextID,
@@ -4492,7 +4616,7 @@ private extension WIDOMInspector {
     ) async -> Bool {
         guard currentContext?.contextID == contextID,
               selectionTransactionIsCurrent(transaction),
-              sharedTransport.targetKind(for: targetIdentifier) == .frame else {
+              shouldMergeTargetDocumentForInspectSelection(targetIdentifier: targetIdentifier) else {
             return false
         }
 
@@ -4652,7 +4776,7 @@ private extension WIDOMInspector {
             return false
         }
 
-        if sharedTransport.targetKind(for: targetIdentifier) == .frame {
+        if shouldMergeTargetDocumentForInspectSelection(targetIdentifier: targetIdentifier) {
             guard await mergeFrameTargetDocumentIfNeeded(
                 targetIdentifier: targetIdentifier,
                 contextID: contextID,
@@ -6233,28 +6357,29 @@ private extension WIDOMInspector {
     }
 }
 
-private struct DOMSetInspectModeEnabledParameters: Encodable {
-    struct RGBAColor: Encodable {
-        let r: Int
-        let g: Int
-        let b: Int
-        let a: Double
-    }
+private struct DOMHighlightColor: Encodable {
+    let r: Int
+    let g: Int
+    let b: Int
+    let a: Double
+}
 
-    struct HighlightConfig: Encodable {
-        let showInfo: Bool
-        let contentColor = RGBAColor(r: 111, g: 168, b: 220, a: 0.66)
-        let paddingColor = RGBAColor(r: 147, g: 196, b: 125, a: 0.66)
-        let borderColor = RGBAColor(r: 255, g: 229, b: 153, a: 0.66)
-        let marginColor = RGBAColor(r: 246, g: 178, b: 107, a: 0.66)
-    }
+private struct DOMHighlightConfig: Encodable {
+    let showInfo: Bool
+    let contentColor = DOMHighlightColor(r: 111, g: 168, b: 220, a: 0.66)
+    let paddingColor = DOMHighlightColor(r: 147, g: 196, b: 125, a: 0.66)
+    let borderColor = DOMHighlightColor(r: 255, g: 229, b: 153, a: 0.66)
+    let marginColor = DOMHighlightColor(r: 246, g: 178, b: 107, a: 0.66)
+}
+
+private struct DOMSetInspectModeEnabledParameters: Encodable {
 
     let enabled: Bool
-    let highlightConfig: HighlightConfig?
+    let highlightConfig: DOMHighlightConfig?
 
     static let enabled = DOMSetInspectModeEnabledParameters(
         enabled: true,
-        highlightConfig: .init(showInfo: false)
+        highlightConfig: DOMHighlightConfig(showInfo: false)
     )
 
     static let disabled = DOMSetInspectModeEnabledParameters(
@@ -6315,13 +6440,9 @@ private struct DOMRemoveAttributeParameters: Encodable {
 }
 
 private struct DOMHighlightNodeParameters: Encodable {
-    struct HighlightConfig: Encodable {
-        let showInfo = false
-    }
-
     let nodeId: Int
     let reveal: Bool
-    let highlightConfig = HighlightConfig()
+    let highlightConfig = DOMHighlightConfig(showInfo: false)
 }
 
 private extension String {

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
@@ -324,6 +324,7 @@ public final class WIDOMInspector {
         }
     }
 
+    @ObservationIgnored package let dependencies: WIInspectorDependencies
     @ObservationIgnored private let sharedTransport: WISharedInspectorTransport
     @ObservationIgnored let inspectorBridge: DOMInspectorBridge
     @ObservationIgnored private let frontendCoordinator = DOMFrontendCoordinator()
@@ -369,27 +370,32 @@ public final class WIDOMInspector {
 
 #if canImport(UIKit)
     @ObservationIgnored package weak var sceneActivationRequestingScene: UIScene?
+    @ObservationIgnored package var nativeInspectorSelectionToggleNeedsDeactivation = false
 #endif
 
     public convenience init(
         configuration: DOMConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue,
         onRecoverableError: (@MainActor (String?) -> Void)? = nil
     ) {
         self.init(
             configuration: configuration,
-            sharedTransport: WISharedInspectorTransport(),
+            dependencies: dependencies,
+            sharedTransport: dependencies.makeSharedTransport(),
             onRecoverableError: onRecoverableError
         )
     }
 
     package init(
         configuration: DOMConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue,
         sharedTransport: WISharedInspectorTransport,
         onRecoverableError: (@MainActor (String?) -> Void)? = nil
     ) {
+        self.dependencies = dependencies
         self.configuration = configuration
         self.sharedTransport = sharedTransport
-        self.inspectorBridge = DOMInspectorBridge()
+        self.inspectorBridge = DOMInspectorBridge(dependencies: dependencies.domFrontend)
         self.document = DOMDocumentModel()
         self.externalRecoverableErrorHandler = onRecoverableError
 

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
@@ -1568,14 +1568,18 @@ private extension WIDOMInspector {
     }
 
     func cancelStaleInspectModeBeforeBeginningSelectionIfNeeded() async {
-        let shouldCancelStaleInspectMode =
+        var shouldCancelStaleInspectMode =
             isSelectingElement
                 || acceptsInspectEvents
                 || inspectModeControlBackend != nil
                 || inspectModeTargetIdentifier != nil
+#if canImport(UIKit)
+        shouldCancelStaleInspectMode =
+            shouldCancelStaleInspectMode
                 || nativeInspectorSelectionToggleNeedsDeactivation
                 || nativeInspectorNodeSearchNeedsDirectDeactivation
                 || nativeInspectorProtocolInspectModeNeedsDeactivation
+#endif
         guard shouldCancelStaleInspectMode else {
             return
         }

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
@@ -651,6 +651,8 @@ public final class WIDOMInspector {
 
     public func beginSelectionMode() async throws {
         let _ = try requirePageWebView()
+        try await refreshReadyContextIfTransportTargetAdvanced(reason: "beginSelectionMode")
+        await cancelStaleInspectModeBeforeBeginningSelectionIfNeeded()
         applyRecoverableError(nil)
         let selectedContextID = currentContext?.contextID
         let hadSelectedNode = document.selectedNode != nil
@@ -1541,6 +1543,52 @@ private extension WIDOMInspector {
             throw DOMOperationError.contextInvalidated
         }
         return targetIdentifier
+    }
+
+    func refreshReadyContextIfTransportTargetAdvanced(reason: String) async throws {
+        guard case let .ready(_, activeTargetIdentifier) = phase,
+              let committedTargetIdentifier = sharedTransport.currentCommittedPageTargetIdentifier(),
+              committedTargetIdentifier != activeTargetIdentifier else {
+            return
+        }
+
+        logSelectionDiagnostics(
+            "selection requested with stale target; refreshing current document",
+            extra: "reason=\(reason) activeTarget=\(activeTargetIdentifier) committedTarget=\(committedTargetIdentifier)",
+            level: .error
+        )
+        await beginFreshContext(
+            documentURL: normalizedDocumentURL(pageWebView?.url?.absoluteString),
+            targetIdentifier: committedTargetIdentifier,
+            loadImmediately: true,
+            isFreshDocument: true,
+            reason: "\(reason).targetAdvanced"
+        )
+        throw DOMOperationError.contextInvalidated
+    }
+
+    func cancelStaleInspectModeBeforeBeginningSelectionIfNeeded() async {
+        let shouldCancelStaleInspectMode =
+            isSelectingElement
+                || acceptsInspectEvents
+                || inspectModeControlBackend != nil
+                || inspectModeTargetIdentifier != nil
+                || nativeInspectorSelectionToggleNeedsDeactivation
+                || nativeInspectorNodeSearchNeedsDirectDeactivation
+                || nativeInspectorProtocolInspectModeNeedsDeactivation
+        guard shouldCancelStaleInspectMode else {
+            return
+        }
+
+        let targetIdentifier = inspectModeTargetIdentifier ?? phase.targetIdentifier
+        logSelectionDiagnostics(
+            "beginSelectionMode cancelling stale inspect mode before rearming",
+            extra: "target=\(targetIdentifier ?? "nil") selecting=\(isSelectingElement) acceptsInspectEvents=\(acceptsInspectEvents) backend=\(inspectModeControlBackend?.rawValue ?? "nil")"
+        )
+        await cancelInspectMode(
+            targetIdentifier: targetIdentifier,
+            invalidatePendingSelection: true
+        )
     }
 
     func nodeForBackendAction(backendNodeID: Int) -> DOMNodeModel? {
@@ -3138,7 +3186,9 @@ private extension WIDOMInspector {
             targetIdentifier: resolutionTargetIdentifier,
             transaction: transaction,
             showErrorOnFailure: false,
-            allowMaterialization: false
+            allowMaterialization: allowsInspectSelectionMaterialization(
+                targetIdentifier: resolutionTargetIdentifier
+            )
         )
     }
 
@@ -3545,14 +3595,11 @@ private extension WIDOMInspector {
             return
         }
 
-        let shouldMaterializeCurrentInspectSelection: Bool
-        if transaction != nil {
-            shouldMaterializeCurrentInspectSelection = selectionMaterializationCandidates(
-                for: pendingInspectSelection
-            ).strategy == .genericIncomplete
-        } else {
-            shouldMaterializeCurrentInspectSelection = true
-        }
+        let shouldMaterializeCurrentInspectSelection = shouldMaterializeInspectSelection(
+            transaction: transaction,
+            pendingSelection: pendingInspectSelection,
+            showErrorOnFailure: showErrorOnFailure
+        )
 
         if allowMaterialization, shouldMaterializeCurrentInspectSelection {
             let outcome = await materializePendingInspectSelection(
@@ -3587,6 +3634,25 @@ private extension WIDOMInspector {
             errorMessage: "Failed to resolve selected element."
         )
         throw DOMOperationError.invalidSelection
+    }
+
+    private func shouldMaterializeInspectSelection(
+        transaction: SelectionTransaction?,
+        pendingSelection: PendingInspectSelection?,
+        showErrorOnFailure: Bool
+    ) -> Bool {
+        guard transaction != nil else {
+            return true
+        }
+
+        switch selectionMaterializationCandidates(for: pendingSelection).strategy {
+        case .genericIncomplete:
+            return true
+        case .frameRelated, .nestedDocumentRoots:
+            return showErrorOnFailure == false
+        case .body, .html, .structuredChild, .root, .none:
+            return false
+        }
     }
 
     @discardableResult

--- a/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
+++ b/Sources/WebInspectorRuntime/DOM/WIDOMInspector.swift
@@ -361,6 +361,7 @@ public final class WIDOMInspector {
     @ObservationIgnored private var lastSelectionDiagnosticMessage: String?
     @ObservationIgnored private var lastEmittedSelectionDiagnosticMessage: String?
     @ObservationIgnored private var selectionGeneration: UInt64 = 0
+    @ObservationIgnored private var selectionActivationGeneration: UInt64 = 0
     @ObservationIgnored private var acceptsInspectEvents = false
     @ObservationIgnored private var pendingInspectSelection: PendingInspectSelection?
     @ObservationIgnored private var pendingInspectMaterializationTimeoutTask: Task<Void, Never>?
@@ -656,15 +657,36 @@ public final class WIDOMInspector {
         applyRecoverableError(nil)
         let selectedContextID = currentContext?.contextID
         let hadSelectedNode = document.selectedNode != nil
+        var selectionActivation: (
+            generation: UInt64,
+            contextID: DOMContextID,
+            targetIdentifier: String
+        )?
 
         do {
             let initialState = try requireReadySelectionState()
+            let activationGeneration = beginSelectionActivation(
+                contextID: initialState.context.contextID,
+                targetIdentifier: initialState.targetIdentifier
+            )
+            selectionActivation = (
+                generation: activationGeneration,
+                contextID: initialState.context.contextID,
+                targetIdentifier: initialState.targetIdentifier
+            )
             activatePageWindowForSelectionIfPossible()
 #if canImport(UIKit)
             try await requestPageWindowActivationIfNeeded()
             await awaitInspectModeInactive()
 #endif
 
+            guard selectionActivationIsCurrent(
+                generation: activationGeneration,
+                contextID: initialState.context.contextID,
+                targetIdentifier: initialState.targetIdentifier
+            ) else {
+                throw DOMOperationError.contextInvalidated
+            }
             let readyState = try requireReadySelectionState()
             guard readyState.context.contextID == initialState.context.contextID,
                   readyState.targetIdentifier == initialState.targetIdentifier else {
@@ -685,7 +707,8 @@ public final class WIDOMInspector {
             try await setInspectModeEnabled(true, targetIdentifier: targetIdentifier)
             let inspectModeControlBackend = InspectModeControlBackend.transportProtocol
 #endif
-            guard selectionLifecycleStateMatches(
+            guard selectionActivationIsCurrent(
+                generation: activationGeneration,
                 contextID: context.contextID,
                 targetIdentifier: targetIdentifier
             ) else {
@@ -709,6 +732,13 @@ public final class WIDOMInspector {
                 backend: inspectModeControlBackend
             )
         } catch {
+            if let selectionActivation,
+               selectionActivationGeneration == selectionActivation.generation {
+                clearInspectModeState(
+                    invalidatePendingSelection: true,
+                    clearSelectionArm: true
+                )
+            }
             if hadSelectedNode, let selectedContextID {
                 await syncSelectedNodeHighlight(contextID: selectedContextID)
             }
@@ -1665,6 +1695,7 @@ private extension WIDOMInspector {
         frontendCoordinator.reset()
         isSelectingElement = false
         selectionGeneration &+= 1
+        selectionActivationGeneration &+= 1
         cancelPendingChildRequestRecords()
         payloadNormalizer.resetForDocumentUpdate()
         document.clearDocument(isFreshDocument: true)
@@ -2995,6 +3026,33 @@ private extension WIDOMInspector {
         isSelectingElement = true
     }
 
+    func beginSelectionActivation(
+        contextID: DOMContextID,
+        targetIdentifier: String
+    ) -> UInt64 {
+        selectionActivationGeneration &+= 1
+        pendingInspectSelection = nil
+        inspectModeTargetIdentifier = targetIdentifier
+        inspectModeControlBackend = nil
+        acceptsInspectEvents = false
+        inspectSelectionArm = nil
+        isSelectingElement = true
+        return selectionActivationGeneration
+    }
+
+    func selectionActivationIsCurrent(
+        generation: UInt64,
+        contextID: DOMContextID,
+        targetIdentifier: String
+    ) -> Bool {
+        selectionActivationGeneration == generation
+            && isSelectingElement
+            && selectionLifecycleStateMatches(
+                contextID: contextID,
+                targetIdentifier: targetIdentifier
+            )
+    }
+
     func clearInspectModeState(
         invalidatePendingSelection: Bool = false,
         markSelectionInactive: Bool = true,
@@ -3015,6 +3073,7 @@ private extension WIDOMInspector {
         if invalidatePendingSelection {
             pendingInspectSelection = nil
             selectionGeneration &+= 1
+            selectionActivationGeneration &+= 1
         }
     }
 
@@ -3030,6 +3089,7 @@ private extension WIDOMInspector {
             deactivateInspectEvents: true,
             clearSelectionArm: true
         )
+        let cancellationActivationGeneration = selectionActivationGeneration
 
 #if canImport(UIKit)
         await disableInspectorSelectionModeIfNeeded(
@@ -3056,12 +3116,17 @@ private extension WIDOMInspector {
 
 #if canImport(UIKit)
         await awaitInspectModeInactive()
-        isSelectingElement = false
+        if selectionActivationGeneration == cancellationActivationGeneration {
+            isSelectingElement = false
+        }
 #else
-        isSelectingElement = false
+        if selectionActivationGeneration == cancellationActivationGeneration {
+            isSelectingElement = false
+        }
 #endif
 
-        if restoreSelectedHighlight,
+        if selectionActivationGeneration == cancellationActivationGeneration,
+           restoreSelectedHighlight,
            let contextID = currentContext?.contextID,
            document.selectedNode != nil {
             await syncSelectedNodeHighlight(contextID: contextID)
@@ -3069,8 +3134,16 @@ private extension WIDOMInspector {
     }
 
     private func completeInspectModeAfterBackendSelection(
+        transaction: SelectionTransaction? = nil,
         invalidatePendingSelection: Bool = false
     ) async {
+        guard selectionTransactionIsCurrent(transaction) else {
+            logSelectionDiagnostics(
+                "completeInspectModeAfterBackendSelection ignored stale transaction",
+                extra: "generation=\(transaction.map { String($0.generation) } ?? "nil")"
+            )
+            return
+        }
         let activeTargetIdentifier = inspectModeTargetIdentifier ?? phase.targetIdentifier
         let activeInspectModeControlBackend = inspectModeControlBackend
         clearInspectModeState(
@@ -3099,6 +3172,13 @@ private extension WIDOMInspector {
         }
 #endif
 
+        guard selectionTransactionIsCurrent(transaction) else {
+            logSelectionDiagnostics(
+                "completeInspectModeAfterBackendSelection skipped stale completion",
+                extra: "generation=\(transaction.map { String($0.generation) } ?? "nil")"
+            )
+            return
+        }
 #if canImport(UIKit)
         await awaitInspectModeInactive()
         isSelectingElement = false
@@ -3218,7 +3298,7 @@ private extension WIDOMInspector {
             return
         }
         guard let resolutionTargetIdentifier else {
-            await completeInspectModeAfterBackendSelection()
+            await completeInspectModeAfterBackendSelection(transaction: transaction)
             await clearSelectionForFailedResolution(
                 contextID: contextID,
                 transaction: transaction,
@@ -3268,7 +3348,7 @@ private extension WIDOMInspector {
                 )
             )
         } catch {
-            await completeInspectModeAfterBackendSelection()
+            await completeInspectModeAfterBackendSelection(transaction: transaction)
             logSelectionDiagnostics(
                 "Inspector.inspect failed to resolve node",
                 extra: "sourceTarget=\(eventTargetIdentifier ?? "nil") requestNodeTarget=\(resolutionTargetIdentifier) error=\(error.localizedDescription)",
@@ -3565,7 +3645,7 @@ private extension WIDOMInspector {
                 contextID: contextID,
                 targetIdentifierForMaterialization: targetIdentifier
             )
-            await completeInspectModeAfterBackendSelection()
+            await completeInspectModeAfterBackendSelection(transaction: transaction)
             finishInspectSelectionResolution(transaction: transaction)
             applyRecoverableError(nil)
             return
@@ -3589,7 +3669,7 @@ private extension WIDOMInspector {
                 contextID: contextID,
                 targetIdentifierForMaterialization: targetIdentifier
             )
-            await completeInspectModeAfterBackendSelection()
+            await completeInspectModeAfterBackendSelection(transaction: transaction)
             finishInspectSelectionResolution(transaction: transaction)
             applyRecoverableError(nil)
             return
@@ -3776,6 +3856,17 @@ private extension WIDOMInspector {
             pendingInspectSelection.observedMaterializationStrategy = selectionMaterialization.strategy
             pendingInspectSelection.observedMaterializationCandidateNodeIDs = selectionMaterialization.candidateNodeIDs
             self.pendingInspectSelection = pendingInspectSelection
+            if selectionMaterialization.strategy == .genericIncomplete,
+               pendingInspectSelection.outstandingMaterializationNodeIDs.isEmpty {
+                logSelectionDiagnostics(
+                    "materializePendingInspectSelection waiting after generic candidate completion",
+                    selector: selectorPath,
+                    extra: "nodeID=\(nodeID) target=\(targetIdentifier) plan=\(selectionMaterializationPlanSummary(selectionMaterialization)) pendingInspect=\(pendingInspectSelectionDiagnosticSummary(pendingInspectSelection))",
+                    level: .debug
+                )
+                schedulePendingInspectMaterializationTimeout(for: pendingInspectSelection)
+                return .waitingForMutation
+            }
             return pendingInspectSelection.outstandingMaterializationNodeIDs.isEmpty ? .exhausted : .requested
         }
 
@@ -5021,7 +5112,7 @@ private extension WIDOMInspector {
             preferredSubtreeRootNodeIDs: pendingInspectSelection.materializedAncestorNodeIDs,
             targetIdentifierForMaterialization: pendingInspectSelection.resolutionTargetIdentifier
         )
-        await completeInspectModeAfterBackendSelection()
+        await completeInspectModeAfterBackendSelection(transaction: pendingInspectSelection.transaction)
         finishInspectSelectionResolution(transaction: pendingInspectSelection.transaction)
         applyRecoverableError(nil)
     }
@@ -5235,7 +5326,7 @@ private extension WIDOMInspector {
         )
         if transaction != nil,
            inspectModeControlBackend != nil || isSelectingElement {
-            await completeInspectModeAfterBackendSelection()
+            await completeInspectModeAfterBackendSelection(transaction: transaction)
         }
         if transaction != nil {
             cancelPendingInspectMaterializationTimeout()

--- a/Sources/WebInspectorRuntime/Network/V2_WINetworkRuntime.swift
+++ b/Sources/WebInspectorRuntime/Network/V2_WINetworkRuntime.swift
@@ -12,21 +12,29 @@ public final class V2_WINetworkRuntime {
         model.store.entries
     }
 
-    public convenience init(configuration: NetworkConfiguration = .init()) {
+    public convenience init(
+        configuration: NetworkConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue
+    ) {
         self.init(
             configuration: configuration,
-            sharedTransport: WISharedInspectorTransport()
+            dependencies: dependencies,
+            sharedTransport: dependencies.makeSharedTransport()
         )
     }
 
     package init(
         configuration: NetworkConfiguration,
+        dependencies: WIInspectorDependencies = .liveValue,
         sharedTransport: WISharedInspectorTransport
     ) {
         let backend = WIBackendFactory.makeNetworkBackend(
             configuration: configuration,
+            supportSnapshot: dependencies.transport.supportSnapshot(),
             sharedTransport: sharedTransport
-        )
+        ) {
+            NetworkPageAgent(dependencies: dependencies.makeNetworkPageAgentDependencies())
+        }
         let session = NetworkSession(
             configuration: configuration,
             backend: backend

--- a/Sources/WebInspectorRuntime/Session/V2_WIRuntimeSession.swift
+++ b/Sources/WebInspectorRuntime/Session/V2_WIRuntimeSession.swift
@@ -8,15 +8,20 @@ public final class V2_WIRuntimeSession {
     public let dom: V2_WIDOMRuntime
     public let network: V2_WINetworkRuntime
 
-    public convenience init(configuration: WIModelConfiguration = .init()) {
-        let sharedTransport = WISharedInspectorTransport()
+    public convenience init(
+        configuration: WIModelConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue
+    ) {
+        let sharedTransport = dependencies.makeSharedTransport()
         self.init(
             dom: V2_WIDOMRuntime(
                 configuration: configuration.dom,
+                dependencies: dependencies,
                 sharedTransport: sharedTransport
             ),
             network: V2_WINetworkRuntime(
                 configuration: configuration.network,
+                dependencies: dependencies,
                 sharedTransport: sharedTransport
             )
         )

--- a/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
+++ b/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
@@ -262,26 +262,21 @@ public struct WIInspectorWebKitSPIClient: WIInspectorDependencyClient {
         self.removeNodeSearchRecognizers = removeNodeSearchRecognizers
         self.isElementSelectionActive = isElementSelectionActive
         self.startupBridgeMode = {
-            WISPIRuntime.shared.startupMode()
+            .legacyJSON
         }
-        self.bridgeModeForAttachment = { webView in
-            WISPIRuntime.shared.modeForAttachment(webView: webView)
+        self.bridgeModeForAttachment = { _ in
+            .legacyJSON
         }
-        self.supportsResourceLoadDelegate = { webView in
-            WISPIRuntime.shared.canSetResourceLoadDelegate(on: webView)
+        self.supportsResourceLoadDelegate = { _ in
+            false
         }
-        self.setResourceLoadDelegate = { webView, delegate in
-            WISPIRuntime.shared.setResourceLoadDelegate(on: webView, delegate: delegate)
+        self.setResourceLoadDelegate = { _, _ in
+            false
         }
-        self.dismissPageEditing = { webView in
-            #if canImport(UIKit)
-            webView.endEditing(true)
-            #else
-            _ = webView
-            #endif
+        self.dismissPageEditing = { _ in
         }
         self.transportInspectActivationProvider = { _ in true }
-        self.transportInspectActivationTimeoutNanoseconds = 50_000_000
+        self.transportInspectActivationTimeoutNanoseconds = 0
     }
 
     package init(
@@ -367,7 +362,31 @@ public struct WIInspectorWebKitSPIClient: WIInspectorDependencyClient {
                 WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
         )
         #else
-        Self()
+        Self(
+            hasPrivateInspectorAccess: { _ in false },
+            isInspectorConnected: { _ in nil },
+            connectInspector: { _ in false },
+            toggleElementSelection: { _ in false },
+            setNodeSearchEnabled: { _, _ in false },
+            hasNodeSearchRecognizer: { _ in false },
+            removeNodeSearchRecognizers: { _ in true },
+            isElementSelectionActive: { _ in false },
+            startupBridgeMode: {
+                WISPIRuntime.shared.startupMode()
+            },
+            bridgeModeForAttachment: { webView in
+                WISPIRuntime.shared.modeForAttachment(webView: webView)
+            },
+            supportsResourceLoadDelegate: { webView in
+                WISPIRuntime.shared.canSetResourceLoadDelegate(on: webView)
+            },
+            setResourceLoadDelegate: { webView, delegate in
+                WISPIRuntime.shared.setResourceLoadDelegate(on: webView, delegate: delegate)
+            },
+            dismissPageEditing: { _ in },
+            transportInspectActivationProvider: { _ in true },
+            transportInspectActivationTimeoutNanoseconds: 50_000_000
+        )
         #endif
     }
 

--- a/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
+++ b/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
@@ -1,0 +1,600 @@
+import Foundation
+import WebKit
+import WebInspectorBridge
+import WebInspectorEngine
+import WebInspectorScripts
+import WebInspectorTransport
+
+@MainActor
+public protocol WIInspectorDependencyClient {
+    static var liveValue: Self { get }
+    static var testValue: Self { get }
+}
+
+@MainActor
+public struct WIInspectorDependencies: WIInspectorDependencyClient {
+    public var transport: WIInspectorTransportClient
+    public var domFrontend: WIInspectorDOMFrontendClient
+    public var network: WIInspectorNetworkClient
+    public var webKitSPI: WIInspectorWebKitSPIClient
+    public var platform: WIInspectorPlatformClient
+
+    public init(
+        transport: WIInspectorTransportClient = .liveValue,
+        domFrontend: WIInspectorDOMFrontendClient = .liveValue,
+        network: WIInspectorNetworkClient = .liveValue,
+        webKitSPI: WIInspectorWebKitSPIClient = .liveValue,
+        platform: WIInspectorPlatformClient = .liveValue
+    ) {
+        self.transport = transport
+        self.domFrontend = domFrontend
+        self.network = network
+        self.webKitSPI = webKitSPI
+        self.platform = platform
+    }
+
+    public static var liveValue: Self {
+        Self()
+    }
+
+    public static var testValue: Self {
+        Self(
+            transport: .testValue,
+            domFrontend: .testValue,
+            network: .testValue,
+            webKitSPI: .testValue,
+            platform: .testValue
+        )
+    }
+
+    public static func testing(_ update: (inout Self) -> Void = { _ in }) -> Self {
+        var dependencies = Self.testValue
+        update(&dependencies)
+        return dependencies
+    }
+
+    package func makeSharedTransport() -> WISharedInspectorTransport {
+        transport.makeSharedTransport()
+    }
+
+    package func makeNetworkPageAgentDependencies() -> NetworkPageAgentDependencies {
+        NetworkPageAgentDependencies(
+            controllerStateRegistry: network.controllerStateRegistry,
+            startupMode: webKitSPI.startupBridgeMode,
+            modeForAttachment: webKitSPI.bridgeModeForAttachment,
+            loadNetworkAgentScriptSource: network.networkAgentScript,
+            supportsResourceLoadDelegate: webKitSPI.supportsResourceLoadDelegate,
+            setResourceLoadDelegate: webKitSPI.setResourceLoadDelegate
+        )
+    }
+}
+
+@MainActor
+public struct WIInspectorTransportClient: WIInspectorDependencyClient {
+    public var configuration: WITransportConfiguration
+    public var supportSnapshot: @MainActor @Sendable () -> WITransportSupportSnapshot
+    package var makeSessionWithConfiguration: @MainActor @Sendable (WITransportConfiguration) -> WITransportSession
+
+    public init(
+        configuration: WITransportConfiguration = .init(),
+        supportSnapshot: @escaping @MainActor @Sendable () -> WITransportSupportSnapshot = {
+            WITransportSession().supportSnapshot
+        }
+    ) {
+        self.configuration = configuration
+        self.supportSnapshot = supportSnapshot
+        self.makeSessionWithConfiguration = { configuration in
+            WITransportSession(configuration: configuration)
+        }
+    }
+
+    package init(
+        configuration: WITransportConfiguration = .init(),
+        supportSnapshot: @escaping @MainActor @Sendable () -> WITransportSupportSnapshot,
+        makeSessionWithConfiguration: @escaping @MainActor @Sendable (WITransportConfiguration) -> WITransportSession
+    ) {
+        self.configuration = configuration
+        self.supportSnapshot = supportSnapshot
+        self.makeSessionWithConfiguration = makeSessionWithConfiguration
+    }
+
+    public static var liveValue: Self {
+        Self()
+    }
+
+    public static var testValue: Self {
+        let snapshot = WITransportSupportSnapshot.unsupported(reason: "Test transport is unsupported.")
+        return Self(
+            configuration: .init(responseTimeout: .milliseconds(100)),
+            supportSnapshot: { snapshot },
+            makeSessionWithConfiguration: { configuration in
+                WITransportSession.unsupported(
+                    configuration: configuration,
+                    reason: snapshot.failureReason ?? "Test transport is unsupported."
+                )
+            }
+        )
+    }
+
+    package func makeSharedTransport() -> WISharedInspectorTransport {
+        WISharedInspectorTransport(sessionFactory: {
+            makeSessionWithConfiguration(configuration)
+        })
+    }
+}
+
+@MainActor
+public struct WIInspectorDOMFrontendClient: WIInspectorDependencyClient {
+    public var domTreeViewScript: @MainActor @Sendable () throws -> String
+    public var mainFileURL: @MainActor @Sendable () -> URL?
+    public var resourcesDirectoryURL: @MainActor @Sendable () -> URL?
+
+    public init(
+        domTreeViewScript: @escaping @MainActor @Sendable () throws -> String = {
+            try WebInspectorScripts.domTreeView()
+        },
+        mainFileURL: @escaping @MainActor @Sendable () -> URL? = {
+            WebInspectorScripts.resourceBundle.url(
+                forResource: "dom-tree-view",
+                withExtension: "html",
+                subdirectory: WebInspectorScripts.domTreeViewResourceSubdirectory
+            ) ?? Bundle.main.url(
+                forResource: "dom-tree-view",
+                withExtension: "html",
+                subdirectory: WebInspectorScripts.domTreeViewResourceSubdirectory
+            )
+        },
+        resourcesDirectoryURL: @escaping @MainActor @Sendable () -> URL? = {
+            let packageURL = WebInspectorScripts.resourceBundle.url(
+                forResource: "dom-tree-view",
+                withExtension: "html",
+                subdirectory: WebInspectorScripts.domTreeViewResourceSubdirectory
+            )
+            let mainURL = Bundle.main.url(
+                forResource: "dom-tree-view",
+                withExtension: "html",
+                subdirectory: WebInspectorScripts.domTreeViewResourceSubdirectory
+            )
+            return (packageURL ?? mainURL)?.deletingLastPathComponent()
+        }
+    ) {
+        self.domTreeViewScript = domTreeViewScript
+        self.mainFileURL = mainFileURL
+        self.resourcesDirectoryURL = resourcesDirectoryURL
+    }
+
+    public static var liveValue: Self {
+        Self(
+            domTreeViewScript: {
+                try WebInspectorScripts.domTreeView()
+            },
+            mainFileURL: {
+                WIAssets.mainFileURL
+            },
+            resourcesDirectoryURL: {
+                WIAssets.resourcesDirectory
+            }
+        )
+    }
+
+    public static var testValue: Self {
+        Self(
+            domTreeViewScript: { "" },
+            mainFileURL: { nil },
+            resourcesDirectoryURL: { nil }
+        )
+    }
+
+    func makeInspectorWebView() -> InspectorWebView {
+        InspectorWebView(dependencies: self)
+    }
+}
+
+@MainActor
+public struct WIInspectorNetworkClient: WIInspectorDependencyClient {
+    public var networkAgentScript: @MainActor @Sendable () throws -> String
+    package var controllerStateRegistry: WIUserContentControllerStateRegistry
+
+    public init(
+        networkAgentScript: @escaping @MainActor @Sendable () throws -> String = {
+            try WebInspectorScripts.networkAgent()
+        }
+    ) {
+        self.networkAgentScript = networkAgentScript
+        self.controllerStateRegistry = .shared
+    }
+
+    package init(
+        networkAgentScript: @escaping @MainActor @Sendable () throws -> String,
+        controllerStateRegistry: WIUserContentControllerStateRegistry
+    ) {
+        self.networkAgentScript = networkAgentScript
+        self.controllerStateRegistry = controllerStateRegistry
+    }
+
+    public static var liveValue: Self {
+        Self()
+    }
+
+    public static var testValue: Self {
+        Self(
+            networkAgentScript: { "" },
+            controllerStateRegistry: .shared
+        )
+    }
+}
+
+@MainActor
+public struct WIInspectorWebKitSPIClient: WIInspectorDependencyClient {
+    public var hasPrivateInspectorAccess: @MainActor @Sendable (WKWebView) -> Bool
+    public var isInspectorConnected: @MainActor @Sendable (WKWebView) -> Bool?
+    public var connectInspector: @MainActor @Sendable (WKWebView) -> Bool
+    public var toggleElementSelection: @MainActor @Sendable (WKWebView) -> Bool
+    public var setNodeSearchEnabled: @MainActor @Sendable (WKWebView, Bool) -> Bool
+    public var hasNodeSearchRecognizer: @MainActor @Sendable (WKWebView) -> Bool
+    public var removeNodeSearchRecognizers: @MainActor @Sendable (WKWebView) -> Bool
+    public var isElementSelectionActive: @MainActor @Sendable (WKWebView) -> Bool?
+
+    package var startupBridgeMode: @MainActor @Sendable () -> WIBridgeMode
+    package var bridgeModeForAttachment: @MainActor @Sendable (WKWebView?) -> WIBridgeMode
+    package var supportsResourceLoadDelegate: @MainActor @Sendable (WKWebView) -> Bool
+    package var setResourceLoadDelegate: @MainActor @Sendable (WKWebView, AnyObject?) -> Bool
+    package var dismissPageEditing: @MainActor @Sendable (WKWebView) -> Void
+    package var transportInspectActivationProvider: @MainActor @Sendable (WKWebView) -> Bool
+    package var transportInspectActivationTimeoutNanoseconds: UInt64
+
+    public init(
+        hasPrivateInspectorAccess: @escaping @MainActor @Sendable (WKWebView) -> Bool = { _ in false },
+        isInspectorConnected: @escaping @MainActor @Sendable (WKWebView) -> Bool? = { _ in nil },
+        connectInspector: @escaping @MainActor @Sendable (WKWebView) -> Bool = { _ in false },
+        toggleElementSelection: @escaping @MainActor @Sendable (WKWebView) -> Bool = { _ in false },
+        setNodeSearchEnabled: @escaping @MainActor @Sendable (WKWebView, Bool) -> Bool = { _, _ in false },
+        hasNodeSearchRecognizer: @escaping @MainActor @Sendable (WKWebView) -> Bool = { _ in false },
+        removeNodeSearchRecognizers: @escaping @MainActor @Sendable (WKWebView) -> Bool = { _ in true },
+        isElementSelectionActive: @escaping @MainActor @Sendable (WKWebView) -> Bool? = { _ in false }
+    ) {
+        self.hasPrivateInspectorAccess = hasPrivateInspectorAccess
+        self.isInspectorConnected = isInspectorConnected
+        self.connectInspector = connectInspector
+        self.toggleElementSelection = toggleElementSelection
+        self.setNodeSearchEnabled = setNodeSearchEnabled
+        self.hasNodeSearchRecognizer = hasNodeSearchRecognizer
+        self.removeNodeSearchRecognizers = removeNodeSearchRecognizers
+        self.isElementSelectionActive = isElementSelectionActive
+        self.startupBridgeMode = {
+            WISPIRuntime.shared.startupMode()
+        }
+        self.bridgeModeForAttachment = { webView in
+            WISPIRuntime.shared.modeForAttachment(webView: webView)
+        }
+        self.supportsResourceLoadDelegate = { webView in
+            WISPIRuntime.shared.canSetResourceLoadDelegate(on: webView)
+        }
+        self.setResourceLoadDelegate = { webView, delegate in
+            WISPIRuntime.shared.setResourceLoadDelegate(on: webView, delegate: delegate)
+        }
+        self.dismissPageEditing = { webView in
+            #if canImport(UIKit)
+            webView.endEditing(true)
+            #else
+            _ = webView
+            #endif
+        }
+        self.transportInspectActivationProvider = { _ in true }
+        self.transportInspectActivationTimeoutNanoseconds = 50_000_000
+    }
+
+    package init(
+        hasPrivateInspectorAccess: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        isInspectorConnected: @escaping @MainActor @Sendable (WKWebView) -> Bool?,
+        connectInspector: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        toggleElementSelection: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        setNodeSearchEnabled: @escaping @MainActor @Sendable (WKWebView, Bool) -> Bool,
+        hasNodeSearchRecognizer: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        removeNodeSearchRecognizers: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        isElementSelectionActive: @escaping @MainActor @Sendable (WKWebView) -> Bool?,
+        startupBridgeMode: @escaping @MainActor @Sendable () -> WIBridgeMode,
+        bridgeModeForAttachment: @escaping @MainActor @Sendable (WKWebView?) -> WIBridgeMode,
+        supportsResourceLoadDelegate: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        setResourceLoadDelegate: @escaping @MainActor @Sendable (WKWebView, AnyObject?) -> Bool,
+        dismissPageEditing: @escaping @MainActor @Sendable (WKWebView) -> Void,
+        transportInspectActivationProvider: @escaping @MainActor @Sendable (WKWebView) -> Bool,
+        transportInspectActivationTimeoutNanoseconds: UInt64
+    ) {
+        self.hasPrivateInspectorAccess = hasPrivateInspectorAccess
+        self.isInspectorConnected = isInspectorConnected
+        self.connectInspector = connectInspector
+        self.toggleElementSelection = toggleElementSelection
+        self.setNodeSearchEnabled = setNodeSearchEnabled
+        self.hasNodeSearchRecognizer = hasNodeSearchRecognizer
+        self.removeNodeSearchRecognizers = removeNodeSearchRecognizers
+        self.isElementSelectionActive = isElementSelectionActive
+        self.startupBridgeMode = startupBridgeMode
+        self.bridgeModeForAttachment = bridgeModeForAttachment
+        self.supportsResourceLoadDelegate = supportsResourceLoadDelegate
+        self.setResourceLoadDelegate = setResourceLoadDelegate
+        self.dismissPageEditing = dismissPageEditing
+        self.transportInspectActivationProvider = transportInspectActivationProvider
+        self.transportInspectActivationTimeoutNanoseconds = transportInspectActivationTimeoutNanoseconds
+    }
+
+    public static var liveValue: Self {
+        #if canImport(UIKit)
+        Self(
+            hasPrivateInspectorAccess: {
+                WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider($0)
+            },
+            isInspectorConnected: {
+                WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider($0)
+            },
+            connectInspector: {
+                WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector($0)
+            },
+            toggleElementSelection: {
+                WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler($0)
+            },
+            setNodeSearchEnabled: { webView, enabled in
+                WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter(webView, enabled)
+            },
+            hasNodeSearchRecognizer: {
+                WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider($0)
+            },
+            removeNodeSearchRecognizers: {
+                WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover($0)
+            },
+            isElementSelectionActive: {
+                WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider($0)
+            },
+            startupBridgeMode: {
+                WISPIRuntime.shared.startupMode()
+            },
+            bridgeModeForAttachment: { webView in
+                WISPIRuntime.shared.modeForAttachment(webView: webView)
+            },
+            supportsResourceLoadDelegate: { webView in
+                WISPIRuntime.shared.canSetResourceLoadDelegate(on: webView)
+            },
+            setResourceLoadDelegate: { webView, delegate in
+                WISPIRuntime.shared.setResourceLoadDelegate(on: webView, delegate: delegate)
+            },
+            dismissPageEditing: {
+                WIDOMUIKitInspectorSelectionEnvironment.pageEditingDismissalHandler($0)
+            },
+            transportInspectActivationProvider: {
+                WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider($0)
+            },
+            transportInspectActivationTimeoutNanoseconds:
+                WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        )
+        #else
+        Self()
+        #endif
+    }
+
+    public static var testValue: Self {
+        Self(
+            hasPrivateInspectorAccess: { _ in false },
+            isInspectorConnected: { _ in nil },
+            connectInspector: { _ in false },
+            toggleElementSelection: { _ in false },
+            setNodeSearchEnabled: { _, _ in false },
+            hasNodeSearchRecognizer: { _ in false },
+            removeNodeSearchRecognizers: { _ in true },
+            isElementSelectionActive: { _ in false },
+            startupBridgeMode: { .legacyJSON },
+            bridgeModeForAttachment: { _ in .legacyJSON },
+            supportsResourceLoadDelegate: { _ in false },
+            setResourceLoadDelegate: { _, _ in false },
+            dismissPageEditing: { _ in },
+            transportInspectActivationProvider: { _ in true },
+            transportInspectActivationTimeoutNanoseconds: 0
+        )
+    }
+}
+
+@MainActor
+public struct WIInspectorPlatformClient: WIInspectorDependencyClient {
+    public var environment: @MainActor @Sendable () -> [String: String]
+    public var sleep: @MainActor @Sendable (Duration) async throws -> Void
+
+    #if canImport(UIKit)
+    public var uiKitSceneActivation: WIInspectorUIKitSceneActivationClient
+    #endif
+
+    public init(
+        environment: @escaping @MainActor @Sendable () -> [String: String] = {
+            ProcessInfo.processInfo.environment
+        },
+        sleep: @escaping @MainActor @Sendable (Duration) async throws -> Void = { duration in
+            try await ContinuousClock().sleep(for: duration)
+        }
+    ) {
+        self.environment = environment
+        self.sleep = sleep
+        #if canImport(UIKit)
+        self.uiKitSceneActivation = .liveValue
+        #endif
+    }
+
+    #if canImport(UIKit)
+    public init(
+        environment: @escaping @MainActor @Sendable () -> [String: String] = {
+            ProcessInfo.processInfo.environment
+        },
+        sleep: @escaping @MainActor @Sendable (Duration) async throws -> Void = { duration in
+            try await ContinuousClock().sleep(for: duration)
+        },
+        uiKitSceneActivation: WIInspectorUIKitSceneActivationClient
+    ) {
+        self.environment = environment
+        self.sleep = sleep
+        self.uiKitSceneActivation = uiKitSceneActivation
+    }
+    #endif
+
+    public static var liveValue: Self {
+        Self()
+    }
+
+    public static var testValue: Self {
+        #if canImport(UIKit)
+        Self(
+            environment: { [:] },
+            sleep: { _ in },
+            uiKitSceneActivation: .testValue
+        )
+        #else
+        Self(
+            environment: { [:] },
+            sleep: { _ in }
+        )
+        #endif
+    }
+}
+
+#if canImport(UIKit)
+import UIKit
+import OSLog
+
+private let sceneActivationLogger = Logger(
+    subsystem: "WebInspectorKit",
+    category: "WIInspectorUIKitSceneActivation"
+)
+
+@MainActor
+public struct WIInspectorUIKitSceneActivationClient: WIInspectorDependencyClient {
+    package var requester: any WIDOMUIKitSceneActivationRequesting
+    package var sceneProvider: @MainActor @Sendable (UIWindow) -> (any WIDOMUIKitSceneActivationTarget)?
+    package var requestingSceneProvider: @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget) -> UIScene?
+    public var activationTimeout: Duration
+    package var activationWaiter: @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget, Duration) async throws -> Void
+    public var activateWindowSceneIfNeeded: @MainActor @Sendable (UIWindow, UIScene?, Duration) async throws -> Void
+
+    public init(
+        activationTimeout: Duration = .seconds(5),
+        activateWindowSceneIfNeeded: @escaping @MainActor @Sendable (UIWindow, UIScene?, Duration) async throws -> Void
+    ) {
+        self.requester = WIInspectorNoopSceneActivationRequester()
+        self.sceneProvider = { _ in nil }
+        self.requestingSceneProvider = { _ in nil }
+        self.activationTimeout = activationTimeout
+        self.activationWaiter = { _, _ in }
+        self.activateWindowSceneIfNeeded = activateWindowSceneIfNeeded
+    }
+
+    package init(
+        requester: any WIDOMUIKitSceneActivationRequesting,
+        sceneProvider: @escaping @MainActor @Sendable (UIWindow) -> (any WIDOMUIKitSceneActivationTarget)?,
+        requestingSceneProvider: @escaping @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget) -> UIScene?,
+        activationTimeout: Duration,
+        activationWaiter: @escaping @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget, Duration) async throws -> Void
+    ) {
+        self.requester = requester
+        self.sceneProvider = sceneProvider
+        self.requestingSceneProvider = requestingSceneProvider
+        self.activationTimeout = activationTimeout
+        self.activationWaiter = activationWaiter
+        self.activateWindowSceneIfNeeded = { pageWindow, requestingScene, timeout in
+            try await Self.activateWindowSceneIfNeeded(
+                pageWindow,
+                requestingScene: requestingScene,
+                timeout: timeout,
+                requester: requester,
+                sceneProvider: sceneProvider,
+                requestingSceneProvider: requestingSceneProvider,
+                activationWaiter: activationWaiter
+            )
+        }
+    }
+
+    public static var liveValue: Self {
+        Self(
+            requester: WIDOMUIKitSceneActivationEnvironment.requester,
+            sceneProvider: {
+                WIDOMUIKitSceneActivationEnvironment.sceneProvider($0)
+            },
+            requestingSceneProvider: {
+                WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider($0)
+            },
+            activationTimeout: WIDOMUIKitSceneActivationEnvironment.activationTimeout,
+            activationWaiter: { target, timeout in
+                try await WIDOMUIKitSceneActivationEnvironment.activationWaiter(target, timeout)
+            }
+        )
+    }
+
+    public static var testValue: Self {
+        Self(activationTimeout: .milliseconds(100)) { _, _, _ in }
+    }
+
+    private static func activateWindowSceneIfNeeded(
+        _ pageWindow: UIWindow,
+        requestingScene preferredRequestingScene: UIScene?,
+        timeout: Duration,
+        requester: any WIDOMUIKitSceneActivationRequesting,
+        sceneProvider: @escaping @MainActor @Sendable (UIWindow) -> (any WIDOMUIKitSceneActivationTarget)?,
+        requestingSceneProvider: @escaping @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget) -> UIScene?,
+        activationWaiter: @escaping @MainActor @Sendable (any WIDOMUIKitSceneActivationTarget, Duration) async throws -> Void
+    ) async throws {
+        guard let pageScene = sceneProvider(pageWindow) else {
+            return
+        }
+        guard pageScene.activationState != .foregroundActive else {
+            return
+        }
+
+        let requestingScene = preferredRequestingScene
+            ?? requestingSceneProvider(pageScene)
+        let requestErrorState = WIInspectorUIKitSceneActivationRequestErrorState()
+        let activationTask = Task { @MainActor in
+            try await activationWaiter(pageScene, timeout)
+        }
+
+        defer {
+            activationTask.cancel()
+        }
+
+        requester.requestActivation(
+            of: pageScene,
+            requestingScene: requestingScene
+        ) { error in
+            Task { @MainActor in
+                sceneActivationLogger.error("page scene activation failed: \(error.localizedDescription, privacy: .public)")
+                requestErrorState.signal(error)
+                activationTask.cancel()
+            }
+        }
+
+        do {
+            try await activationTask.value
+        } catch is CancellationError {
+            if let error = requestErrorState.error {
+                throw DOMOperationError.scriptFailure(error.localizedDescription)
+            }
+            throw CancellationError()
+        }
+    }
+}
+
+@MainActor
+private final class WIInspectorUIKitSceneActivationRequestErrorState {
+    private(set) var error: Error?
+
+    func signal(_ error: Error) {
+        self.error = error
+    }
+}
+
+@MainActor
+private final class WIInspectorNoopSceneActivationRequester: WIDOMUIKitSceneActivationRequesting {
+    func requestActivation(
+        of target: any WIDOMUIKitSceneActivationTarget,
+        requestingScene: UIScene?,
+        errorHandler: ((any Error) -> Void)?
+    ) {
+        _ = target
+        _ = requestingScene
+        _ = errorHandler
+    }
+}
+#endif

--- a/Sources/WebInspectorTransport/WIBackendFactory.swift
+++ b/Sources/WebInspectorTransport/WIBackendFactory.swift
@@ -5,14 +5,17 @@ package enum WIBackendFactory {
     package static func makeNetworkBackend(
         configuration: NetworkConfiguration,
         supportSnapshot: WITransportSupportSnapshot? = nil,
-        sharedTransport: WISharedInspectorTransport? = nil
+        sharedTransport: WISharedInspectorTransport? = nil,
+        pageAgentFactory: @escaping @MainActor () -> any WINetworkBackend = {
+            NetworkPageAgent()
+        }
     ) -> any WINetworkBackend {
         let resolvedSupport = WIBackendFactoryTesting.networkSupportSnapshotOverride
             ?? supportSnapshot
             ?? WITransportSession().supportSnapshot
         _ = configuration
         guard resolvedSupport.isSupported else {
-            return NetworkPageAgent()
+            return pageAgentFactory()
         }
         return NetworkTransportDriver(
             sharedTransport: sharedTransport,

--- a/Sources/WebInspectorTransport/WITransportPlatformBackend.swift
+++ b/Sources/WebInspectorTransport/WITransportPlatformBackend.swift
@@ -57,6 +57,17 @@ enum WITransportPlatformBackendFactory {
         )
         #endif
     }
+
+    @MainActor
+    static func makeUnsupportedBackend(
+        configuration: WITransportConfiguration,
+        reason: String
+    ) -> any WITransportPlatformBackend {
+        WITransportUnsupportedPlatformBackend(
+            configuration: configuration,
+            reason: reason
+        )
+    }
 }
 
 @MainActor

--- a/Sources/WebInspectorTransport/WITransportSession.swift
+++ b/Sources/WebInspectorTransport/WITransportSession.swift
@@ -727,7 +727,16 @@ extension WITransportSession {
             log("received root event method=\(method)")
         }
 
-        if method.hasPrefix("DOM.") || method == "Inspector.inspect" {
+        if method == "Inspector.inspect" {
+            enqueuePageEvent(
+                method: method,
+                targetIdentifier: inspectEventTargetIdentifier(from: parsed.params),
+                paramsObject: parsed.params
+            )
+            return
+        }
+
+        if method.hasPrefix("DOM.") {
             enqueuePageEvent(
                 method: method,
                 targetIdentifier: inspectEventTargetIdentifier(from: parsed.params)

--- a/Sources/WebInspectorTransport/WITransportSession.swift
+++ b/Sources/WebInspectorTransport/WITransportSession.swift
@@ -227,6 +227,10 @@ public final class WITransportSession {
         pageTargetTracker.observedCurrentIdentifier
     }
 
+    package func currentCommittedPageTargetIdentifier() -> String? {
+        pageTargetTracker.committedIdentifier
+    }
+
     package func targetKind(for identifier: String?) -> WITransportTargetKind? {
         pageTargetTracker.targetKind(for: identifier)
     }
@@ -515,6 +519,10 @@ package final class WISharedInspectorTransport {
 
     package func currentObservedPageTargetIdentifier() -> String? {
         session?.currentObservedPageTargetIdentifier()
+    }
+
+    package func currentCommittedPageTargetIdentifier() -> String? {
+        session?.currentCommittedPageTargetIdentifier()
     }
 
     package func pageTargetIdentifiers() -> [String] {
@@ -1348,6 +1356,10 @@ private final class WITransportPageTargetTracker {
             return nil
         }
         return currentIdentifierStorage
+    }
+
+    var committedIdentifier: String? {
+        committedIdentifierStorage
     }
 
     var allowsDerivedCommittedSeed: Bool {

--- a/Sources/WebInspectorTransport/WITransportSession.swift
+++ b/Sources/WebInspectorTransport/WITransportSession.swift
@@ -47,6 +47,21 @@ public final class WITransportSession {
         self.init(configuration: configuration, backendFactory: WITransportPlatformBackendFactory.makeDefaultBackend)
     }
 
+    package static func unsupported(
+        configuration: WITransportConfiguration = .init(),
+        reason: String = "Test transport is unsupported."
+    ) -> WITransportSession {
+        WITransportSession(
+            configuration: configuration,
+            backendFactory: { configuration in
+                WITransportPlatformBackendFactory.makeUnsupportedBackend(
+                    configuration: configuration,
+                    reason: reason
+                )
+            }
+        )
+    }
+
     init(
         configuration: WITransportConfiguration = .init(),
         backendFactory: @escaping @MainActor (WITransportConfiguration) -> any WITransportPlatformBackend,

--- a/Sources/WebInspectorTransport/WITransportSession.swift
+++ b/Sources/WebInspectorTransport/WITransportSession.swift
@@ -242,6 +242,10 @@ public final class WITransportSession {
         return pageTargetTracker.orderedIdentifiers
     }
 
+    package func frameTargetIdentifiers() -> [String] {
+        pageTargetTracker.frameTargetIdentifiers
+    }
+
     package func sendRootData(
         method: String,
         parametersData: Data? = nil
@@ -511,6 +515,14 @@ package final class WISharedInspectorTransport {
 
     package func currentObservedPageTargetIdentifier() -> String? {
         session?.currentObservedPageTargetIdentifier()
+    }
+
+    package func pageTargetIdentifiers() -> [String] {
+        session?.pageTargetIdentifiers() ?? []
+    }
+
+    package func frameTargetIdentifiers() -> [String] {
+        session?.frameTargetIdentifiers() ?? []
     }
 
     package func targetKind(for identifier: String?) -> WITransportTargetKind? {
@@ -1350,6 +1362,18 @@ private final class WITransportPageTargetTracker {
                 }
                 if rhs.identifier == currentIdentifierStorage {
                     return false
+                }
+                return lhs.creationOrder > rhs.creationOrder
+            }
+            .map(\.identifier)
+    }
+
+    var frameTargetIdentifiers: [String] {
+        knownTargetsByIdentifier.values
+            .filter { $0.kind == .frame }
+            .sorted { lhs, rhs in
+                if lhs.isProvisional != rhs.isProvisional {
+                    return lhs.isProvisional == false
                 }
                 return lhs.creationOrder > rhs.creationOrder
             }

--- a/Sources/WebInspectorUI/V2/V2_WISession.swift
+++ b/Sources/WebInspectorUI/V2/V2_WISession.swift
@@ -19,7 +19,7 @@ public final class V2_WISession {
     }
 
     public convenience init(
-        configuration: WIModelConfiguration = .init(),
+        configuration: WIModelConfiguration,
         dependencies: WIInspectorDependencies = .liveValue,
         tabs: [V2_WITab] = [.dom, .network]
     ) {
@@ -28,6 +28,17 @@ public final class V2_WISession {
                 configuration: configuration,
                 dependencies: dependencies
             ),
+            tabs: tabs
+        )
+    }
+
+    public convenience init(
+        dependencies: WIInspectorDependencies,
+        tabs: [V2_WITab] = [.dom, .network]
+    ) {
+        self.init(
+            configuration: .init(),
+            dependencies: dependencies,
             tabs: tabs
         )
     }

--- a/Sources/WebInspectorUI/V2/V2_WISession.swift
+++ b/Sources/WebInspectorUI/V2/V2_WISession.swift
@@ -18,6 +18,20 @@ public final class V2_WISession {
         self.interface = V2_WIInterfaceModel(tabs: tabs)
     }
 
+    public convenience init(
+        configuration: WIModelConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue,
+        tabs: [V2_WITab] = [.dom, .network]
+    ) {
+        self.init(
+            runtime: V2_WIRuntimeSession(
+                configuration: configuration,
+                dependencies: dependencies
+            ),
+            tabs: tabs
+        )
+    }
+
     isolated deinit {
         interface.removeContentCache()
     }

--- a/Sources/WebInspectorUI/V2/V2_WIViewController.swift
+++ b/Sources/WebInspectorUI/V2/V2_WIViewController.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit)
 import UIKit
 import WebKit
+import WebInspectorRuntime
 
 @MainActor
 public final class V2_WIViewController: UIViewController {
@@ -19,8 +20,26 @@ public final class V2_WIViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    public convenience init(
+        configuration: WIModelConfiguration = .init(),
+        dependencies: WIInspectorDependencies = .liveValue,
+        tabs: [V2_WITab] = [.dom, .network]
+    ) {
+        self.init(
+            session: V2_WISession(
+                configuration: configuration,
+                dependencies: dependencies,
+                tabs: tabs
+            )
+        )
+    }
+
     public convenience init(tabs: [V2_WITab]) {
-        self.init(session: V2_WISession(tabs: tabs))
+        self.init(
+            configuration: .init(),
+            dependencies: .liveValue,
+            tabs: tabs
+        )
     }
 
     @available(*, unavailable)

--- a/Sources/WebInspectorUI/V2/V2_WIViewController.swift
+++ b/Sources/WebInspectorUI/V2/V2_WIViewController.swift
@@ -21,7 +21,7 @@ public final class V2_WIViewController: UIViewController {
     }
 
     public convenience init(
-        configuration: WIModelConfiguration = .init(),
+        configuration: WIModelConfiguration,
         dependencies: WIInspectorDependencies = .liveValue,
         tabs: [V2_WITab] = [.dom, .network]
     ) {
@@ -34,11 +34,20 @@ public final class V2_WIViewController: UIViewController {
         )
     }
 
-    public convenience init(tabs: [V2_WITab]) {
+    public convenience init(
+        dependencies: WIInspectorDependencies,
+        tabs: [V2_WITab] = [.dom, .network]
+    ) {
         self.init(
             configuration: .init(),
-            dependencies: .liveValue,
+            dependencies: dependencies,
             tabs: tabs
+        )
+    }
+
+    public convenience init(tabs: [V2_WITab]) {
+        self.init(
+            session: V2_WISession(tabs: tabs)
         )
     }
 

--- a/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
@@ -1498,6 +1498,97 @@ struct WIDOMInspectorTests {
     }
 
     @Test
+    func selectionModeToggleCancelsPendingActivationBeforeInspectModeEnables() async throws {
+#if canImport(UIKit)
+        let requester = FakeSceneActivationRequester()
+        let targetScene = FakeSceneActivationTarget(activationState: .foregroundInactive)
+        let requestGate = AsyncGate()
+        let activationGate = AsyncGate()
+        var inspectModeEnabledValues: [Bool] = []
+
+        let previousRequester = WIDOMUIKitSceneActivationEnvironment.requester
+        let previousSceneProvider = WIDOMUIKitSceneActivationEnvironment.sceneProvider
+        let previousRequestingSceneProvider = WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider
+        let previousActivationTimeout = WIDOMUIKitSceneActivationEnvironment.activationTimeout
+        let previousActivationWaiter = WIDOMUIKitSceneActivationEnvironment.activationWaiter
+        defer {
+            WIDOMUIKitSceneActivationEnvironment.requester = previousRequester
+            WIDOMUIKitSceneActivationEnvironment.sceneProvider = previousSceneProvider
+            WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = previousRequestingSceneProvider
+            WIDOMUIKitSceneActivationEnvironment.activationTimeout = previousActivationTimeout
+            WIDOMUIKitSceneActivationEnvironment.activationWaiter = previousActivationWaiter
+        }
+
+        WIDOMUIKitSceneActivationEnvironment.requester = requester
+        WIDOMUIKitSceneActivationEnvironment.sceneProvider = { _ in targetScene }
+        WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = { _ in nil }
+        WIDOMUIKitSceneActivationEnvironment.activationTimeout = .milliseconds(200)
+        WIDOMUIKitSceneActivationEnvironment.activationWaiter = { target, timeout in
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while target.activationState != .foregroundActive {
+                if clock.now >= deadline {
+                    throw DOMOperationError.scriptFailure("Page scene activation timed out.")
+                }
+                try await clock.sleep(for: .milliseconds(1))
+            }
+        }
+
+        requester.onRequest = { _ in
+            await requestGate.open()
+            await activationGate.wait()
+            targetScene.activationState = .foregroundActive
+        }
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let enabled = params?["enabled"] as? Bool {
+                        inspectModeEnabledValues.append(enabled)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+        let window = hostWebViewInWindow(webView)
+        defer { window.isHidden = true }
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        inspector.requestSelectionModeToggle()
+        await requestGate.wait()
+        #expect(inspector.isSelectingElement)
+        #expect(inspectModeEnabledValues.isEmpty)
+
+        inspector.requestSelectionModeToggle()
+        let cancelled = await waitForCondition {
+            inspector.isSelectingElement == false
+        }
+        #expect(cancelled)
+
+        await activationGate.open()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(requester.requestCount == 1)
+        #expect(inspectModeEnabledValues.contains(true) == false)
+        #expect(inspector.isSelectingElement == false)
+#endif
+    }
+
+    @Test
     func beginSelectionModeDoesNotEnableInspectModeWhenNavigationStartsDuringSceneActivation() async {
         let requester = FakeSceneActivationRequester()
         let targetScene = FakeSceneActivationTarget(activationState: .foregroundInactive)
@@ -2223,18 +2314,18 @@ struct WIDOMInspectorTests {
         #expect(inspectModeEnableAttempts == 2)
         #expect(connectCallCount == 1)
         #expect(toggleCallCount == 0)
-        #expect(nodeSearchEnabledValues == [true])
+        #expect(nodeSearchEnabledValues == [true, true])
         #expect(inspectModeEnabledValues == [true])
 
         await inspector.cancelSelectionMode()
         #expect(inspector.isSelectingElement == false)
         #expect(toggleCallCount == 0)
-        #expect(nodeSearchEnabledValues == [true, false])
+        #expect(nodeSearchEnabledValues == [true, true, false])
         #expect(inspectModeEnabledValues == [true, false])
     }
 
     @Test
-    func beginSelectionModeDoesNotRecreateActiveNativeNodeSearchAfterProtocolEnableOnUIKit() async throws {
+    func beginSelectionModeRefreshesActiveNativeNodeSearchAfterProtocolEnableOnUIKit() async throws {
         var inspectModeEnabledValues: [Bool] = []
         var connectCallCount = 0
         var toggleCallCount = 0
@@ -2330,13 +2421,13 @@ struct WIDOMInspectorTests {
         #expect(inspector.isSelectingElement)
         #expect(connectCallCount == 1)
         #expect(toggleCallCount == 0)
-        #expect(nodeSearchEnabledValues == [false])
+        #expect(nodeSearchEnabledValues == [false, true])
         #expect(inspectModeEnabledValues == [true])
 
         await inspector.cancelSelectionMode()
         #expect(inspector.isSelectingElement == false)
         #expect(toggleCallCount == 1)
-        #expect(nodeSearchEnabledValues == [false])
+        #expect(nodeSearchEnabledValues == [false, true])
         #expect(inspectModeEnabledValues == [true, false])
     }
 
@@ -3059,6 +3150,88 @@ struct WIDOMInspectorTests {
 
         #expect(outcome == "waitingForMutation")
         #expect(requestedNodeIDs.isEmpty)
+    }
+
+    @Test
+    func genericPendingInspectMaterializationWaitsAfterCompletedCandidateStillMissesNode() async throws {
+        var requestedNodeIDs: [Int] = []
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    return [:]
+                case WITransportMethod.DOM.requestChildNodes:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let nodeID = params.flatMap({ runtimeTestIntValue($0["nodeId"]) }) {
+                        requestedNodeIDs.append(nodeID)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+        inspector.document.replaceDocument(
+            with: makeMainDocumentSnapshot(
+                mainChildren: [
+                    DOMGraphNodeDescriptor(
+                        localID: 500,
+                        backendNodeID: 500,
+                        nodeType: 1,
+                        nodeName: "section",
+                        localName: "section",
+                        nodeValue: "",
+                        attributes: [.init(name: "id", value: "dynamic")],
+                        childCount: 2,
+                        layoutFlags: [],
+                        isRendered: true,
+                        children: []
+                    ),
+                ]
+            ),
+            isFreshDocument: true
+        )
+
+        try await inspector.beginSelectionMode()
+        backend.emitPageEvent(method: "DOM.inspect", params: ["nodeId": 502])
+        let requestedGenericCandidate = await waitForCondition {
+            requestedNodeIDs == [500]
+        }
+        #expect(requestedGenericCandidate)
+
+        backend.emitPageEvent(
+            method: "DOM.setChildNodes",
+            params: [
+                "parentId": 500,
+                "nodes": [[
+                    "nodeId": 501,
+                    "backendNodeId": 501,
+                    "nodeType": 1,
+                    "nodeName": "SPAN",
+                    "localName": "span",
+                    "nodeValue": "",
+                    "attributes": ["id", "placeholder"],
+                    "childNodeCount": 0,
+                    "children": [],
+                ]],
+            ]
+        )
+        await backend.waitForPendingMessages()
+
+        #expect(inspector.document.selectedNode == nil)
+        #expect(inspector.testHasPendingInspectSelection)
+        #expect(inspector.document.errorMessage == nil)
     }
 
     @Test

--- a/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
@@ -1587,7 +1587,10 @@ struct WIDOMInspectorTests {
                 }
             }
         )
-        let inspector = makeInspector(using: backend)
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
         _ = inspector.makeInspectorWebView()
         let webView = makeTestWebView()
 
@@ -1682,7 +1685,10 @@ struct WIDOMInspectorTests {
                 }
             }
         )
-        let inspector = makeInspector(using: backend)
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
         _ = inspector.makeInspectorWebView()
         let webView = makeTestWebView()
 
@@ -1705,6 +1711,102 @@ struct WIDOMInspectorTests {
         #expect(toggleCallCount == 0)
         #expect(nativeSelectionActive == false)
         #expect(nodeSearchEnabledValues.last == false)
+        #expect(inspectModeEnabledValues.isEmpty)
+    }
+
+    @Test
+    func beginSelectionModeKeepsNativeInspectorWhenActivationProbeIsUnavailableOnUIKit() async throws {
+        var inspectModeEnabledValues: [Bool] = []
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nodeSearchEnabledValues: [Bool] = []
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in false }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in nil }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in
+            inspectModeEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let enabled = params?["enabled"] as? Bool {
+                        inspectModeEnabledValues.append(enabled)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        try await inspector.beginSelectionMode()
+        #expect(inspector.isSelectingElement)
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 1)
+        #expect(nodeSearchEnabledValues == [true])
+        #expect(inspectModeEnabledValues.isEmpty)
+
+        await inspector.cancelSelectionMode()
+        #expect(inspector.isSelectingElement == false)
+        #expect(toggleCallCount == 2)
+        #expect(nodeSearchEnabledValues == [true, false])
         #expect(inspectModeEnabledValues.isEmpty)
     }
 
@@ -1780,7 +1882,10 @@ struct WIDOMInspectorTests {
                 }
             }
         )
-        let inspector = makeInspector(using: backend)
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
         _ = inspector.makeInspectorWebView()
         let webView = makeTestWebView()
 
@@ -1878,7 +1983,10 @@ struct WIDOMInspectorTests {
                 }
             }
         )
-        let inspector = makeInspector(using: backend)
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
         _ = inspector.makeInspectorWebView()
         let webView = makeTestWebView()
 
@@ -5763,8 +5871,10 @@ struct WIDOMInspectorTests {
 private func makeInspector(
     configuration: DOMConfiguration = .init(),
     using backend: FakeDOMTransportBackend,
-    derivedPageTargetIdentifier: String? = nil
+    derivedPageTargetIdentifier: String? = nil,
+    dependencies: WIInspectorDependencies? = nil
 ) -> WIDOMInspector {
+    let dependencies = dependencies ?? makeDOMInspectorTestDependencies()
     let sharedTransport = WISharedInspectorTransport(sessionFactory: {
         let session = WITransportSession(
             configuration: .init(responseTimeout: .seconds(1)),
@@ -5781,8 +5891,16 @@ private func makeInspector(
     })
     return WIDOMInspector(
         configuration: configuration,
+        dependencies: dependencies,
         sharedTransport: sharedTransport
     )
+}
+
+@MainActor
+private func makeDOMInspectorTestDependencies() -> WIInspectorDependencies {
+    var dependencies = WIInspectorDependencies.liveValue
+    dependencies.webKitSPI = .testValue
+    return dependencies
 }
 
 @MainActor

--- a/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
@@ -915,6 +915,104 @@ struct WIDOMInspectorTests {
     }
 
     @Test
+    func selectionModeRefreshesFreshContextWhenTransportTargetAdvancedBeforeLifecycleDelivery() async throws {
+        var inspectModeEnabledValues: [Bool] = []
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, targetIdentifier in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    if targetIdentifier == "page-B" {
+                        return makeDocumentResult(
+                            url: "https://example.com/b",
+                            mainChildren: [[
+                                "nodeId": 16,
+                                "backendNodeId": 16,
+                                "nodeType": 1,
+                                "nodeName": "SECTION",
+                                "localName": "section",
+                                "nodeValue": "",
+                                "attributes": ["id", "second"],
+                                "childNodeCount": 0,
+                                "children": [],
+                            ]]
+                        )
+                    }
+                    return makeDocumentResult(
+                        url: "https://example.com/a",
+                        mainChildren: [[
+                            "nodeId": 6,
+                            "backendNodeId": 6,
+                            "nodeType": 1,
+                            "nodeName": "A",
+                            "localName": "a",
+                            "nodeValue": "",
+                            "attributes": ["id", "first"],
+                            "childNodeCount": 0,
+                            "children": [],
+                        ]]
+                    )
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let enabled = params?["enabled"] as? Bool {
+                        inspectModeEnabledValues.append(enabled)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        let firstContextID = try #require(inspector.testCurrentContextID)
+        backend.emitRootEvent(
+            method: "Target.didCommitProvisionalTarget",
+            params: [
+                "oldTargetId": "page-A",
+                "newTargetId": "page-B",
+            ]
+        )
+
+        do {
+            try await inspector.beginSelectionMode()
+            Issue.record("Expected stale target selection mode activation to refresh instead")
+        } catch {}
+
+        let committedReady = await waitForCondition {
+            inspector.testIsReady
+                && inspector.document.rootNode != nil
+                && inspector.testCurrentContextID != firstContextID
+                && inspector.testCurrentDocumentURL == "https://example.com/b"
+                && inspector.document.selectedNode == nil
+        }
+        #expect(committedReady)
+        #expect(inspectModeEnabledValues.isEmpty)
+
+        try await inspector.beginSelectionMode()
+        backend.emitPageEvent(
+            method: "DOM.inspect",
+            params: ["nodeId": 16],
+            targetIdentifier: "page-B"
+        )
+
+        let reselectionReady = await waitForCondition {
+            inspector.document.selectedNode?.localID == 16
+                && inspector.document.selectedNode?.nodeName == "SECTION"
+                && inspector.isSelectingElement == false
+        }
+        #expect(reselectionReady)
+        #expect(inspectModeEnabledValues == [true, false])
+    }
+
+    @Test
     func freshContextDoesNotMarkFrontendCurrentBeforeInitialHydration() async throws {
         var documentVersion = 0
         let backend = FakeDOMTransportBackend(
@@ -1802,7 +1900,7 @@ struct WIDOMInspectorTests {
         #expect(nativeSelectionActive == false)
         #expect(nodeSearchEnabledValues.contains(true))
         #expect(inspectModeEnabledValues == [true])
-        #expect(runtimeTestHasVisibleHighlightConfig(inspectModeHighlightConfigs.first ?? nil))
+        #expect(runtimeTestHasVisibleHighlightConfig(inspectModeHighlightConfigs.last ?? nil))
 
         await inspector.cancelSelectionMode()
         #expect(inspector.isSelectingElement == false)
@@ -1917,6 +2015,438 @@ struct WIDOMInspectorTests {
     }
 
     @Test
+    func beginSelectionModeDoesNotArmSelectionWhenProtocolEnableFailsWithStaleNativeNodeSearch() async throws {
+        var inspectModeEnableAttempts = 0
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nodeSearchActive = true
+        var nodeSearchEnabledValues: [Bool] = []
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            return false
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            nodeSearchActive = enabled
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in
+            nodeSearchActive
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in false }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in false }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if params?["enabled"] as? Bool == true {
+                        inspectModeEnableAttempts += 1
+                        throw DOMOperationError.scriptFailure("protocol unavailable")
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        do {
+            try await inspector.beginSelectionMode()
+            Issue.record("Expected selection mode activation to fail")
+        } catch {}
+
+        #expect(inspectModeEnableAttempts == 3)
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 0)
+        #expect(nodeSearchEnabledValues == [false, true, false])
+        #expect(nodeSearchActive == false)
+        #expect(inspector.isSelectingElement == false)
+        #expect(
+            inspector.inspectSelectionDiagnosticsForTesting.contains {
+                if case .armed = $0 {
+                    return true
+                }
+                return false
+            } == false
+        )
+    }
+
+    @Test
+    func beginSelectionModeRetriesProtocolEnableAfterNativeInspectorWakeupOnUIKit() async throws {
+        var inspectModeEnableAttempts = 0
+        var inspectModeEnabledValues: [Bool] = []
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nativeSelectionActive = false
+        var nodeSearchActive = false
+        var nodeSearchEnabledValues: [Bool] = []
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            nativeSelectionActive.toggle()
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            nodeSearchActive = enabled
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in
+            nodeSearchActive
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in
+            nodeSearchActive = false
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in nativeSelectionActive }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in
+            inspectModeEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if params?["enabled"] as? Bool == true {
+                        inspectModeEnableAttempts += 1
+                        guard inspectModeEnableAttempts > 1, nodeSearchActive else {
+                            throw DOMOperationError.scriptFailure("protocol unavailable")
+                        }
+                        inspectModeEnabledValues.append(true)
+                    } else if params?["enabled"] as? Bool == false {
+                        inspectModeEnabledValues.append(false)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        try await inspector.beginSelectionMode()
+        #expect(inspector.isSelectingElement)
+        #expect(inspectModeEnableAttempts == 2)
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 0)
+        #expect(nodeSearchEnabledValues == [true])
+        #expect(inspectModeEnabledValues == [true])
+
+        await inspector.cancelSelectionMode()
+        #expect(inspector.isSelectingElement == false)
+        #expect(toggleCallCount == 0)
+        #expect(nodeSearchEnabledValues == [true, false])
+        #expect(inspectModeEnabledValues == [true, false])
+    }
+
+    @Test
+    func beginSelectionModeDoesNotRecreateActiveNativeNodeSearchAfterProtocolEnableOnUIKit() async throws {
+        var inspectModeEnabledValues: [Bool] = []
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nativeSelectionActive = false
+        var nodeSearchActive = true
+        var nodeSearchEnabledValues: [Bool] = []
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            nativeSelectionActive.toggle()
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            nodeSearchActive = enabled
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in
+            nodeSearchActive
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in
+            nodeSearchActive = false
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in nativeSelectionActive }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in
+            inspectModeEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let enabled = params?["enabled"] as? Bool {
+                        inspectModeEnabledValues.append(enabled)
+                        nativeSelectionActive = enabled
+                        nodeSearchActive = enabled
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        try await inspector.beginSelectionMode()
+        #expect(inspector.isSelectingElement)
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 0)
+        #expect(nodeSearchEnabledValues == [false])
+        #expect(inspectModeEnabledValues == [true])
+
+        await inspector.cancelSelectionMode()
+        #expect(inspector.isSelectingElement == false)
+        #expect(toggleCallCount == 1)
+        #expect(nodeSearchEnabledValues == [false])
+        #expect(inspectModeEnabledValues == [true, false])
+    }
+
+    @Test
+    func beginSelectionModeCancelsStaleNativeInspectModeBeforeRearmingOnUIKit() async throws {
+        var inspectModeEnabledValues: [Bool] = []
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nativeSelectionActive = false
+        var nodeSearchActive = false
+        var nodeSearchEnabledValues: [Bool] = []
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            nativeSelectionActive.toggle()
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            nodeSearchActive = enabled
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in
+            nodeSearchActive
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in
+            nodeSearchActive = false
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in nativeSelectionActive }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in
+            inspectModeEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    if let enabled = params?["enabled"] as? Bool {
+                        inspectModeEnabledValues.append(enabled)
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        try await inspector.beginSelectionMode()
+        try await inspector.beginSelectionMode()
+
+        #expect(inspector.isSelectingElement)
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 0)
+        #expect(nodeSearchEnabledValues == [true, false, true])
+        #expect(inspectModeEnabledValues == [true, false, true])
+
+        await inspector.cancelSelectionMode()
+        #expect(inspector.isSelectingElement == false)
+        #expect(nodeSearchEnabledValues == [true, false, true, false])
+        #expect(inspectModeEnabledValues == [true, false, true, false])
+    }
+
+    @Test
     func beginSelectionModeKeepsNativeInspectorWhenActivationProbeIsUnavailableOnUIKit() async throws {
         var inspectModeEnabledValues: [Bool] = []
         var connectCallCount = 0
@@ -2017,7 +2547,7 @@ struct WIDOMInspectorTests {
         var inspectModeEnabledValues: [Bool] = []
         var connectCallCount = 0
         var toggleCallCount = 0
-        var nativeSelectionActive = false
+        let nativeSelectionActive = false
         var nodeSearchEnabledValues: [Bool] = []
         let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
         let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
@@ -3249,6 +3779,107 @@ struct WIDOMInspectorTests {
         let selected = await waitForCondition {
             inspector.document.selectedNode?.localID == 26
                 && inspector.document.selectedNode?.attributes.contains(where: { $0.name == "id" && $0.value == "frame-target" }) == true
+                && inspector.isSelectingElement == false
+        }
+        #expect(selected)
+    }
+
+    @Test
+    func domInspectMaterializesFrameDocumentBeforeResolvingSelectedNode() async throws {
+        var requestedChildNodeIDs: [Int] = []
+        var backend: FakeDOMTransportBackend!
+        backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, targetIdentifier in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    return [:]
+                case WITransportMethod.DOM.requestChildNodes:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    let requestedNodeID = params.flatMap {
+                        runtimeTestIntValue($0["nodeId"]) ?? ($0["nodeId"] as? NSNumber)?.intValue
+                    }
+                    if let requestedNodeID {
+                        requestedChildNodeIDs.append(requestedNodeID)
+                        if requestedNodeID == 24 {
+                            backend.emitPageEvent(
+                                method: "DOM.setChildNodes",
+                                params: [
+                                    "parentId": 24,
+                                    "nodes": [[
+                                        "nodeId": 25,
+                                        "backendNodeId": 25,
+                                        "nodeType": 1,
+                                        "nodeName": "HTML",
+                                        "localName": "html",
+                                        "nodeValue": "",
+                                        "childNodeCount": 1,
+                                        "children": [[
+                                            "nodeId": 26,
+                                            "backendNodeId": 26,
+                                            "nodeType": 1,
+                                            "nodeName": "BUTTON",
+                                            "localName": "button",
+                                            "nodeValue": "",
+                                            "attributes": ["id", "frame-target"],
+                                            "childNodeCount": 0,
+                                            "children": [],
+                                        ]],
+                                    ]],
+                                ],
+                                targetIdentifier: targetIdentifier
+                            )
+                        }
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        inspector.document.replaceDocument(
+            with: makeMainDocumentSnapshot(
+                mainChildren: [
+                    makeFrameOwnerDescriptor(
+                        localID: 20,
+                        backendNodeID: 20,
+                        frameID: "frame-child",
+                        idAttribute: "frame-owner",
+                        childCount: 1,
+                        children: [
+                            makeFrameDocumentDescriptor(
+                                localID: 24,
+                                backendNodeID: 24,
+                                frameID: "frame-child",
+                                childCount: 1,
+                                children: []
+                            )
+                        ]
+                    )
+                ]
+            ),
+            isFreshDocument: false
+        )
+
+        try await inspector.beginSelectionMode()
+        backend.emitPageEvent(method: "DOM.inspect", params: ["nodeId": 26])
+
+        let selected = await waitForCondition(maxAttempts: 300) {
+            requestedChildNodeIDs == [24]
+                && inspector.document.selectedNode?.localID == 26
+                && inspector.document.selectedNode?.attributes.contains(where: { $0.name == "id" && $0.value == "frame-target" }) == true
+                && inspector.document.errorMessage == nil
                 && inspector.isSelectingElement == false
         }
         #expect(selected)

--- a/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIDOMInspectorTests.swift
@@ -1275,6 +1275,9 @@ struct WIDOMInspectorTests {
         #expect(inspector.isSelectingElement)
         #expect((inspectModePayload?["enabled"] as? Bool) == true)
         #expect(inspectModePayload?["highlightConfig"] != nil)
+        #expect(runtimeTestHasVisibleHighlightConfig(
+            runtimeTestDictionaryValue(inspectModePayload?["highlightConfig"])
+        ))
     }
 
     @Test
@@ -1326,26 +1329,34 @@ struct WIDOMInspectorTests {
         let previousSceneProvider = WIDOMUIKitSceneActivationEnvironment.sceneProvider
         let previousRequestingSceneProvider = WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider
         let previousActivationTimeout = WIDOMUIKitSceneActivationEnvironment.activationTimeout
+        let previousActivationWaiter = WIDOMUIKitSceneActivationEnvironment.activationWaiter
         defer {
             WIDOMUIKitSceneActivationEnvironment.requester = previousRequester
             WIDOMUIKitSceneActivationEnvironment.sceneProvider = previousSceneProvider
             WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = previousRequestingSceneProvider
             WIDOMUIKitSceneActivationEnvironment.activationTimeout = previousActivationTimeout
+            WIDOMUIKitSceneActivationEnvironment.activationWaiter = previousActivationWaiter
         }
 
         WIDOMUIKitSceneActivationEnvironment.requester = requester
         WIDOMUIKitSceneActivationEnvironment.sceneProvider = { _ in targetScene }
         WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = { _ in nil }
         WIDOMUIKitSceneActivationEnvironment.activationTimeout = .milliseconds(200)
+        WIDOMUIKitSceneActivationEnvironment.activationWaiter = { target, timeout in
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while target.activationState != .foregroundActive {
+                if clock.now >= deadline {
+                    throw DOMOperationError.scriptFailure("Page scene activation timed out.")
+                }
+                try await clock.sleep(for: .milliseconds(1))
+            }
+        }
 
-        requester.onRequest = { target in
+        requester.onRequest = { _ in
             await requestGate.open()
             await activationGate.wait()
             targetScene.activationState = .foregroundActive
-            NotificationCenter.default.post(
-                name: UIScene.didActivateNotification,
-                object: target
-            )
         }
 
         let backend = FakeDOMTransportBackend(
@@ -1386,6 +1397,88 @@ struct WIDOMInspectorTests {
         #expect(requester.requestCount == 1)
         #expect((inspectModePayload?["enabled"] as? Bool) == true)
         #expect(inspector.isSelectingElement)
+    }
+
+    @Test
+    func beginSelectionModeDoesNotEnableInspectModeWhenNavigationStartsDuringSceneActivation() async {
+        let requester = FakeSceneActivationRequester()
+        let targetScene = FakeSceneActivationTarget(activationState: .foregroundInactive)
+        let requestGate = AsyncGate()
+        let activationGate = AsyncGate()
+        var inspectModePayload: [String: Any]?
+
+        let previousRequester = WIDOMUIKitSceneActivationEnvironment.requester
+        let previousSceneProvider = WIDOMUIKitSceneActivationEnvironment.sceneProvider
+        let previousRequestingSceneProvider = WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider
+        let previousActivationTimeout = WIDOMUIKitSceneActivationEnvironment.activationTimeout
+        let previousActivationWaiter = WIDOMUIKitSceneActivationEnvironment.activationWaiter
+        defer {
+            WIDOMUIKitSceneActivationEnvironment.requester = previousRequester
+            WIDOMUIKitSceneActivationEnvironment.sceneProvider = previousSceneProvider
+            WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = previousRequestingSceneProvider
+            WIDOMUIKitSceneActivationEnvironment.activationTimeout = previousActivationTimeout
+            WIDOMUIKitSceneActivationEnvironment.activationWaiter = previousActivationWaiter
+        }
+
+        WIDOMUIKitSceneActivationEnvironment.requester = requester
+        WIDOMUIKitSceneActivationEnvironment.sceneProvider = { _ in targetScene }
+        WIDOMUIKitSceneActivationEnvironment.requestingSceneProvider = { _ in nil }
+        WIDOMUIKitSceneActivationEnvironment.activationTimeout = .milliseconds(200)
+        WIDOMUIKitSceneActivationEnvironment.activationWaiter = { target, timeout in
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while target.activationState != .foregroundActive {
+                if clock.now >= deadline {
+                    throw DOMOperationError.scriptFailure("Page scene activation timed out.")
+                }
+                try await clock.sleep(for: .milliseconds(1))
+            }
+        }
+
+        requester.onRequest = { _ in
+            await requestGate.open()
+            await activationGate.wait()
+            targetScene.activationState = .foregroundActive
+        }
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    inspectModePayload = runtimeTestDictionaryValue(payload["params"])
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+        let window = hostWebViewInWindow(webView)
+        defer { window.isHidden = true }
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        let beginSelectionTask = Task {
+            try await inspector.beginSelectionMode()
+        }
+
+        await requestGate.wait()
+        inspector.testSetLoadingPhaseCurrentContext(targetIdentifier: "page-B")
+        await activationGate.open()
+
+        await #expect(throws: DOMOperationError.contextInvalidated) {
+            try await beginSelectionTask.value
+        }
+        #expect(inspectModePayload == nil)
+        #expect(inspector.isSelectingElement == false)
     }
 
     @Test
@@ -1615,6 +1708,7 @@ struct WIDOMInspectorTests {
     @Test
     func beginSelectionModeUsesNativeInspectorOnUIKitWhenPrivateInspectorIsAvailable() async throws {
         var inspectModeEnabledValues: [Bool] = []
+        var inspectModeHighlightConfigs: [[String: Any]?] = []
         var connectCallCount = 0
         var toggleCallCount = 0
         var nativeSelectionActive = false
@@ -1678,6 +1772,9 @@ struct WIDOMInspectorTests {
                     let params = runtimeTestDictionaryValue(payload["params"])
                     if let enabled = params?["enabled"] as? Bool {
                         inspectModeEnabledValues.append(enabled)
+                        inspectModeHighlightConfigs.append(
+                            runtimeTestDictionaryValue(params?["highlightConfig"])
+                        )
                     }
                     return [:]
                 default:
@@ -1704,14 +1801,119 @@ struct WIDOMInspectorTests {
         #expect(toggleCallCount == 0)
         #expect(nativeSelectionActive == false)
         #expect(nodeSearchEnabledValues.contains(true))
-        #expect(inspectModeEnabledValues.isEmpty)
+        #expect(inspectModeEnabledValues == [true])
+        #expect(runtimeTestHasVisibleHighlightConfig(inspectModeHighlightConfigs.first ?? nil))
 
         await inspector.cancelSelectionMode()
         #expect(inspector.isSelectingElement == false)
         #expect(toggleCallCount == 0)
         #expect(nativeSelectionActive == false)
         #expect(nodeSearchEnabledValues.last == false)
-        #expect(inspectModeEnabledValues.isEmpty)
+        #expect(inspectModeEnabledValues == [true, false])
+    }
+
+    @Test
+    func beginSelectionModeDoesNotActivateNativeInspectorWhenNavigationStartsDuringProtocolEnable() async throws {
+        var inspectModeEnabledValues: [Bool] = []
+        var connectCallCount = 0
+        var toggleCallCount = 0
+        var nativeSelectionActive = false
+        var nodeSearchEnabledValues: [Bool] = []
+        var didInvalidateContext = false
+        var inspector: WIDOMInspector!
+        let previousPrivateInspectorAccessProvider = WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider
+        let previousInspectorConnectedProvider = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider
+        let previousInspectorConnector = WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector
+        let previousElementSelectionToggler = WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler
+        let previousNodeSearchSetter = WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter
+        let previousRecognizerPresenceProvider = WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider
+        let previousRecognizerRemover = WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover
+        let previousSelectionActiveProvider = WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider
+        let previousTransportInspectActivationProvider = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider
+        let previousTransportInspectActivationTimeout = WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds
+        defer {
+            WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = previousPrivateInspectorAccessProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = previousInspectorConnectedProvider
+            WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = previousInspectorConnector
+            WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = previousElementSelectionToggler
+            WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = previousNodeSearchSetter
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = previousRecognizerPresenceProvider
+            WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = previousRecognizerRemover
+            WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = previousSelectionActiveProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = previousTransportInspectActivationProvider
+            WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = previousTransportInspectActivationTimeout
+        }
+
+        WIDOMUIKitInspectorSelectionEnvironment.privateInspectorAccessProvider = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnectedProvider = { _ in
+            connectCallCount > 0
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.inspectorConnector = { _ in
+            connectCallCount += 1
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.elementSelectionToggler = { _ in
+            toggleCallCount += 1
+            nativeSelectionActive.toggle()
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.nodeSearchSetter = { _, enabled in
+            nodeSearchEnabledValues.append(enabled)
+            return true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerPresenceProvider = { _ in
+            nodeSearchEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.recognizerRemover = { _ in true }
+        WIDOMUIKitInspectorSelectionEnvironment.selectionActiveProvider = { _ in nativeSelectionActive }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationProvider = { _ in
+            inspectModeEnabledValues.last == true
+        }
+        WIDOMUIKitInspectorSelectionEnvironment.transportInspectActivationTimeoutNanoseconds = 0
+
+        let backend = FakeDOMTransportBackend(
+            pageResultProvider: { method, payload, _ in
+                switch method {
+                case WITransportMethod.DOM.getDocument:
+                    return makeDocumentResult(url: "https://example.com/a")
+                case WITransportMethod.DOM.setInspectModeEnabled:
+                    let params = runtimeTestDictionaryValue(payload["params"])
+                    guard let enabled = params?["enabled"] as? Bool else {
+                        return [:]
+                    }
+                    inspectModeEnabledValues.append(enabled)
+                    if enabled, didInvalidateContext == false {
+                        didInvalidateContext = true
+                        inspector.testSetLoadingPhaseCurrentContext(targetIdentifier: "page-B")
+                    }
+                    return [:]
+                default:
+                    return [:]
+                }
+            }
+        )
+        inspector = makeInspector(
+            using: backend,
+            dependencies: .liveValue
+        )
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        await #expect(throws: DOMOperationError.contextInvalidated) {
+            try await inspector.beginSelectionMode()
+        }
+        #expect(connectCallCount == 1)
+        #expect(toggleCallCount == 0)
+        #expect(nativeSelectionActive == false)
+        #expect(nodeSearchEnabledValues.isEmpty)
+        #expect(inspectModeEnabledValues == [true, false])
+        #expect(inspector.isSelectingElement == false)
     }
 
     @Test
@@ -1801,13 +2003,13 @@ struct WIDOMInspectorTests {
         #expect(connectCallCount == 1)
         #expect(toggleCallCount == 1)
         #expect(nodeSearchEnabledValues == [true])
-        #expect(inspectModeEnabledValues.isEmpty)
+        #expect(inspectModeEnabledValues == [true])
 
         await inspector.cancelSelectionMode()
         #expect(inspector.isSelectingElement == false)
         #expect(toggleCallCount == 2)
         #expect(nodeSearchEnabledValues == [true, false])
-        #expect(inspectModeEnabledValues.isEmpty)
+        #expect(inspectModeEnabledValues == [true, false])
     }
 
     @Test
@@ -2902,6 +3104,113 @@ struct WIDOMInspectorTests {
         }
         #expect(selected)
         #expect(requestNodeTargets == ["frame-target-A"])
+    }
+
+    @Test
+    func inspectorInspectFallsBackToSecondaryPageTargetForRequestNode() async throws {
+        var requestNodeTargets: [String] = []
+        let backend = FakeDOMTransportBackend()
+        backend.pageResultProvider = { method, payload, targetIdentifier in
+            switch method {
+            case WITransportMethod.DOM.getDocument:
+                if targetIdentifier == "page-frame-A" {
+                    return [
+                        "root": [
+                            "nodeId": 240,
+                            "backendNodeId": 240,
+                            "nodeType": 9,
+                            "nodeName": "#document",
+                            "localName": "",
+                            "nodeValue": "",
+                            "documentURL": "https://ads.example.com/frame",
+                            "frameId": "frame-child",
+                            "childNodeCount": 1,
+                            "children": [[
+                                "nodeId": 241,
+                                "backendNodeId": 241,
+                                "nodeType": 1,
+                                "nodeName": "HTML",
+                                "localName": "html",
+                                "nodeValue": "",
+                                "childNodeCount": 1,
+                                "children": [[
+                                    "nodeId": 260,
+                                    "backendNodeId": 260,
+                                    "nodeType": 1,
+                                    "nodeName": "BUTTON",
+                                    "localName": "button",
+                                    "nodeValue": "",
+                                    "attributes": ["id", "frame-target"],
+                                    "childNodeCount": 0,
+                                    "children": [],
+                                ]],
+                            ]],
+                        ],
+                    ]
+                }
+                return makeIFrameDocumentResultWithEmptyNestedDocument(url: "https://example.com/a")
+            case WITransportMethod.DOM.setInspectModeEnabled:
+                return [:]
+            case WITransportMethod.DOM.requestNode:
+                let params = runtimeTestDictionaryValue(payload["params"])
+                if params?["objectId"] as? String == "node-object-frame-target" {
+                    requestNodeTargets.append(targetIdentifier)
+                    if targetIdentifier == "page-frame-A" {
+                        return ["nodeId": 260]
+                    }
+                }
+                return [:]
+            default:
+                return [:]
+            }
+        }
+        let inspector = makeInspector(using: backend)
+        _ = inspector.makeInspectorWebView()
+        let webView = makeTestWebView()
+
+        await inspector.attach(to: webView)
+        let ready = await waitForCondition {
+            inspector.testIsReady && inspector.document.rootNode != nil
+        }
+        #expect(ready)
+
+        backend.emitRootEvent(
+            method: "Target.targetCreated",
+            params: [
+                "targetInfo": [
+                    "targetId": "page-frame-A",
+                    "type": "page",
+                    "isProvisional": false,
+                ],
+            ]
+        )
+        await backend.waitForPendingMessages()
+
+        try await inspector.beginSelectionMode()
+        backend.emitPageEvent(
+            method: "Inspector.inspect",
+            params: [
+                "object": [
+                    "type": "object",
+                    "subtype": "node",
+                    "objectId": "node-object-frame-target",
+                ],
+                "hints": [:],
+            ],
+            targetIdentifier: "page-A"
+        )
+
+        let selected = await waitForCondition {
+            inspector.document.selectedNode?.backendNodeID == 260
+                && inspector.document.selectedNode?.attributes.contains(where: { $0.name == "id" && $0.value == "frame-target" }) == true
+                && inspector.isSelectingElement == false
+        }
+        #expect(selected)
+        #expect(inspector.document.selectedNode?.localID != 20)
+        #expect(requestNodeTargets == ["page-A", "page-frame-A"])
+        let nestedDocument = try #require(inspector.document.node(localID: 24))
+        #expect(nestedDocument.children.first?.localID == 241)
+        #expect(inspector.document.node(localID: 260)?.backendNodeID == 260)
     }
 
     @Test
@@ -5355,10 +5664,27 @@ struct WIDOMInspectorTests {
 
     @Test
     func selectedNodeSendsPersistentHighlightAndHidesItOnDocumentReload() async throws {
-        var pageMethods: [String] = []
+        var pageCalls: [(method: String, inspectModeEnabled: Bool?, highlightConfig: [String: Any]?)] = []
         let backend = FakeDOMTransportBackend(
-            pageResultProvider: { method, _, _ in
-                pageMethods.append(method)
+            pageResultProvider: { method, payload, _ in
+                let params = runtimeTestDictionaryValue(payload["params"])
+                let inspectModeEnabled: Bool?
+                if method == WITransportMethod.DOM.setInspectModeEnabled {
+                    inspectModeEnabled = params?["enabled"] as? Bool
+                } else {
+                    inspectModeEnabled = nil
+                }
+                let highlightConfig: [String: Any]?
+                if method == WITransportMethod.DOM.highlightNode {
+                    highlightConfig = runtimeTestDictionaryValue(params?["highlightConfig"])
+                } else {
+                    highlightConfig = nil
+                }
+                pageCalls.append((
+                    method: method,
+                    inspectModeEnabled: inspectModeEnabled,
+                    highlightConfig: highlightConfig
+                ))
                 switch method {
                 case WITransportMethod.DOM.getDocument:
                     return makeDocumentResult(
@@ -5399,9 +5725,22 @@ struct WIDOMInspectorTests {
         let selected = await waitForCondition {
             inspector.document.selectedNode?.localID == 6
                 && inspector.isSelectingElement == false
-                && pageMethods.contains(WITransportMethod.DOM.highlightNode)
+                && pageCalls.contains(where: { $0.method == WITransportMethod.DOM.highlightNode })
         }
         #expect(selected)
+
+        let inspectModeDisableIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.setInspectModeEnabled && $0.inspectModeEnabled == false
+        })
+        let persistentHighlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.highlightNode
+        })
+        #expect(inspectModeDisableIndex != nil)
+        #expect(persistentHighlightIndex != nil)
+        if let inspectModeDisableIndex, let persistentHighlightIndex {
+            #expect(persistentHighlightIndex > inspectModeDisableIndex)
+            #expect(runtimeTestHasVisibleHighlightConfig(pageCalls[persistentHighlightIndex].highlightConfig))
+        }
 
         try await inspector.reloadDocument()
 
@@ -5409,8 +5748,12 @@ struct WIDOMInspectorTests {
             inspector.document.selectedNode == nil
         }
         #expect(reloaded)
-        let highlightIndex = pageMethods.lastIndex(of: WITransportMethod.DOM.highlightNode)
-        let hideHighlightIndex = pageMethods.lastIndex(of: WITransportMethod.DOM.hideHighlight)
+        let highlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.highlightNode
+        })
+        let hideHighlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.hideHighlight
+        })
         #expect(highlightIndex != nil)
         #expect(hideHighlightIndex != nil)
         if let highlightIndex, let hideHighlightIndex {
@@ -5421,6 +5764,7 @@ struct WIDOMInspectorTests {
     @Test
     func frontendHoverHighlightPreservesRevealFalse() async throws {
         var lastHighlightReveal: Bool?
+        var lastHighlightConfig: [String: Any]?
         let backend = FakeDOMTransportBackend(
             pageResultProvider: { method, payload, _ in
                 switch method {
@@ -5429,6 +5773,7 @@ struct WIDOMInspectorTests {
                 case WITransportMethod.DOM.highlightNode:
                     let params = runtimeTestDictionaryValue(payload["params"])
                     lastHighlightReveal = params?["reveal"] as? Bool
+                    lastHighlightConfig = runtimeTestDictionaryValue(params?["highlightConfig"])
                     return [:]
                 default:
                     return [:]
@@ -5453,6 +5798,7 @@ struct WIDOMInspectorTests {
             lastHighlightReveal == false
         }
         #expect(sentRevealFalse)
+        #expect(runtimeTestHasVisibleHighlightConfig(lastHighlightConfig))
     }
 
     @Test
@@ -5577,17 +5923,27 @@ struct WIDOMInspectorTests {
 
     @Test
     func successfulInspectReappliesPersistentHighlightAfterInspectModeTeardown() async throws {
-        var pageCalls: [(method: String, inspectModeEnabled: Bool?)] = []
+        var pageCalls: [(method: String, inspectModeEnabled: Bool?, highlightConfig: [String: Any]?)] = []
         let backend = FakeDOMTransportBackend(
             pageResultProvider: { method, payload, _ in
+                let params = runtimeTestDictionaryValue(payload["params"])
                 let inspectModeEnabled: Bool?
-                if method == WITransportMethod.DOM.setInspectModeEnabled,
-                   let params = runtimeTestDictionaryValue(payload["params"]) {
-                    inspectModeEnabled = params["enabled"] as? Bool
+                if method == WITransportMethod.DOM.setInspectModeEnabled {
+                    inspectModeEnabled = params?["enabled"] as? Bool
                 } else {
                     inspectModeEnabled = nil
                 }
-                pageCalls.append((method: method, inspectModeEnabled: inspectModeEnabled))
+                let highlightConfig: [String: Any]?
+                if method == WITransportMethod.DOM.highlightNode {
+                    highlightConfig = runtimeTestDictionaryValue(params?["highlightConfig"])
+                } else {
+                    highlightConfig = nil
+                }
+                pageCalls.append((
+                    method: method,
+                    inspectModeEnabled: inspectModeEnabled,
+                    highlightConfig: highlightConfig
+                ))
 
                 switch method {
                 case WITransportMethod.DOM.getDocument:
@@ -5641,21 +5997,38 @@ struct WIDOMInspectorTests {
                 && highlightIndex >= 0
         }
         #expect(selected)
+        let persistentHighlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.highlightNode
+        })
+        #expect(persistentHighlightIndex != nil)
+        if let persistentHighlightIndex {
+            #expect(runtimeTestHasVisibleHighlightConfig(pageCalls[persistentHighlightIndex].highlightConfig))
+        }
     }
 
     @Test
     func unresolvedInspectRestoresExistingPersistentHighlight() async throws {
-        var pageCalls: [(method: String, inspectModeEnabled: Bool?)] = []
+        var pageCalls: [(method: String, inspectModeEnabled: Bool?, highlightConfig: [String: Any]?)] = []
         let backend = FakeDOMTransportBackend(
             pageResultProvider: { method, payload, _ in
+                let params = runtimeTestDictionaryValue(payload["params"])
                 let inspectModeEnabled: Bool?
-                if method == WITransportMethod.DOM.setInspectModeEnabled,
-                   let params = runtimeTestDictionaryValue(payload["params"]) {
-                    inspectModeEnabled = params["enabled"] as? Bool
+                if method == WITransportMethod.DOM.setInspectModeEnabled {
+                    inspectModeEnabled = params?["enabled"] as? Bool
                 } else {
                     inspectModeEnabled = nil
                 }
-                pageCalls.append((method: method, inspectModeEnabled: inspectModeEnabled))
+                let highlightConfig: [String: Any]?
+                if method == WITransportMethod.DOM.highlightNode {
+                    highlightConfig = runtimeTestDictionaryValue(params?["highlightConfig"])
+                } else {
+                    highlightConfig = nil
+                }
+                pageCalls.append((
+                    method: method,
+                    inspectModeEnabled: inspectModeEnabled,
+                    highlightConfig: highlightConfig
+                ))
 
                 switch method {
                 case WITransportMethod.DOM.getDocument:
@@ -5720,21 +6093,38 @@ struct WIDOMInspectorTests {
                 && highlightIndex >= 0
         }
         #expect(preserved)
+        let restoredHighlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.highlightNode
+        })
+        #expect(restoredHighlightIndex != nil)
+        if let restoredHighlightIndex {
+            #expect(runtimeTestHasVisibleHighlightConfig(pageCalls[restoredHighlightIndex].highlightConfig))
+        }
     }
 
     @Test
     func inspectorInspectResolvesNodeBeforeInspectModeTeardown() async throws {
-        var pageCalls: [(method: String, inspectModeEnabled: Bool?)] = []
+        var pageCalls: [(method: String, inspectModeEnabled: Bool?, highlightConfig: [String: Any]?)] = []
         let backend = FakeDOMTransportBackend(
             pageResultProvider: { method, payload, _ in
+                let params = runtimeTestDictionaryValue(payload["params"])
                 let inspectModeEnabled: Bool?
-                if method == WITransportMethod.DOM.setInspectModeEnabled,
-                   let params = runtimeTestDictionaryValue(payload["params"]) {
-                    inspectModeEnabled = params["enabled"] as? Bool
+                if method == WITransportMethod.DOM.setInspectModeEnabled {
+                    inspectModeEnabled = params?["enabled"] as? Bool
                 } else {
                     inspectModeEnabled = nil
                 }
-                pageCalls.append((method: method, inspectModeEnabled: inspectModeEnabled))
+                let highlightConfig: [String: Any]?
+                if method == WITransportMethod.DOM.highlightNode {
+                    highlightConfig = runtimeTestDictionaryValue(params?["highlightConfig"])
+                } else {
+                    highlightConfig = nil
+                }
+                pageCalls.append((
+                    method: method,
+                    inspectModeEnabled: inspectModeEnabled,
+                    highlightConfig: highlightConfig
+                ))
 
                 switch method {
                 case WITransportMethod.DOM.getDocument:
@@ -5797,10 +6187,18 @@ struct WIDOMInspectorTests {
         let disableInspectIndex = pageCalls.lastIndex(where: {
             $0.method == WITransportMethod.DOM.setInspectModeEnabled && $0.inspectModeEnabled == false
         })
+        let persistentHighlightIndex = pageCalls.lastIndex(where: {
+            $0.method == WITransportMethod.DOM.highlightNode
+        })
         #expect(requestNodeIndex != nil)
         #expect(disableInspectIndex != nil)
         if let requestNodeIndex, let disableInspectIndex {
             #expect(requestNodeIndex < disableInspectIndex)
+        }
+        #expect(persistentHighlightIndex != nil)
+        if let disableInspectIndex, let persistentHighlightIndex {
+            #expect(persistentHighlightIndex > disableInspectIndex)
+            #expect(runtimeTestHasVisibleHighlightConfig(pageCalls[persistentHighlightIndex].highlightConfig))
         }
     }
 
@@ -6298,6 +6696,37 @@ private func runtimeTestDictionaryValue(_ value: Any?) -> [String: Any]? {
         return normalized.isEmpty ? nil : normalized
     }
     return nil
+}
+
+private func runtimeTestDoubleValue(_ value: Any?) -> Double? {
+    if let value = value as? Double {
+        return value
+    }
+    if let value = value as? Float {
+        return Double(value)
+    }
+    if let value = value as? Int {
+        return Double(value)
+    }
+    if let value = value as? NSNumber {
+        if CFGetTypeID(value) == CFBooleanGetTypeID() {
+            return nil
+        }
+        return value.doubleValue
+    }
+    return nil
+}
+
+private func runtimeTestHasVisibleHighlightConfig(_ config: [String: Any]?) -> Bool {
+    guard let config else {
+        return false
+    }
+    return ["contentColor", "paddingColor", "borderColor", "marginColor"].allSatisfy { key in
+        guard let color = runtimeTestDictionaryValue(config[key]) else {
+            return false
+        }
+        return runtimeTestDoubleValue(color["a"]).map { $0 > 0 } == true
+    }
 }
 
 @MainActor

--- a/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import WebInspectorBridge
 import WebKit
 #if canImport(UIKit)
 import UIKit
@@ -63,6 +64,13 @@ struct WIInspectorDependenciesTests {
         #expect(dependencies.domFrontend.resourcesDirectoryURL()?.path == "/tmp/dom-tree-view")
         #expect(try dependencies.network.networkAgentScript() == "custom-network-script")
         #expect(dependencies.webKitSPI.setNodeSearchEnabled(WKWebView(frame: .zero), true))
+
+        let webView = WKWebView(frame: .zero)
+        let networkDependencies = dependencies.makeNetworkPageAgentDependencies()
+        #expect(networkDependencies.startupMode() == .legacyJSON)
+        #expect(networkDependencies.modeForAttachment(webView) == .legacyJSON)
+        #expect(networkDependencies.supportsResourceLoadDelegate(webView) == false)
+        #expect(networkDependencies.setResourceLoadDelegate(webView, nil) == false)
     }
 
     @Test

--- a/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
@@ -1,0 +1,130 @@
+import Testing
+import WebKit
+#if canImport(UIKit)
+import UIKit
+#endif
+@testable import WebInspectorEngine
+@testable import WebInspectorRuntime
+@testable import WebInspectorTransport
+
+@MainActor
+struct WIInspectorDependenciesTests {
+    @Test
+    func liveValueUsesCurrentTransportSessionSupport() {
+        let dependencies = WIInspectorDependencies.liveValue
+        let expected = WITransportSession().supportSnapshot
+        let actual = dependencies.transport.supportSnapshot()
+
+        #expect(actual.availability == expected.availability)
+        #expect(actual.capabilities == expected.capabilities)
+        #expect(actual.failureReason == expected.failureReason)
+    }
+
+    @Test
+    func testValueDisablesSideEffectfulClients() throws {
+        let dependencies = WIInspectorDependencies.testValue
+        let support = dependencies.transport.supportSnapshot()
+
+        #expect(support.isSupported == false)
+        #expect(try dependencies.domFrontend.domTreeViewScript() == "")
+        #expect(dependencies.domFrontend.mainFileURL() == nil)
+        #expect(dependencies.domFrontend.resourcesDirectoryURL() == nil)
+        #expect(try dependencies.network.networkAgentScript() == "")
+
+        let webView = WKWebView(frame: .zero)
+        #expect(dependencies.webKitSPI.hasPrivateInspectorAccess(webView) == false)
+        #expect(dependencies.webKitSPI.isInspectorConnected(webView) == nil)
+        #expect(dependencies.webKitSPI.connectInspector(webView) == false)
+        #expect(dependencies.webKitSPI.toggleElementSelection(webView) == false)
+        #expect(dependencies.webKitSPI.setNodeSearchEnabled(webView, true) == false)
+        #expect(dependencies.webKitSPI.hasNodeSearchRecognizer(webView) == false)
+        #expect(dependencies.webKitSPI.removeNodeSearchRecognizers(webView))
+        #expect(dependencies.webKitSPI.isElementSelectionActive(webView) == false)
+    }
+
+    @Test
+    func testingAllowsIndividualClientOverrides() throws {
+        let dependencies = WIInspectorDependencies.testing {
+            $0.domFrontend = WIInspectorDOMFrontendClient(
+                domTreeViewScript: { "custom-dom-script" },
+                mainFileURL: { URL(fileURLWithPath: "/tmp/dom-tree-view.html") },
+                resourcesDirectoryURL: { URL(fileURLWithPath: "/tmp/dom-tree-view") }
+            )
+            $0.network = WIInspectorNetworkClient(
+                networkAgentScript: { "custom-network-script" }
+            )
+            $0.webKitSPI = WIInspectorWebKitSPIClient(
+                setNodeSearchEnabled: { _, enabled in enabled }
+            )
+        }
+
+        #expect(try dependencies.domFrontend.domTreeViewScript() == "custom-dom-script")
+        #expect(dependencies.domFrontend.mainFileURL()?.path == "/tmp/dom-tree-view.html")
+        #expect(dependencies.domFrontend.resourcesDirectoryURL()?.path == "/tmp/dom-tree-view")
+        #expect(try dependencies.network.networkAgentScript() == "custom-network-script")
+        #expect(dependencies.webKitSPI.setNodeSearchEnabled(WKWebView(frame: .zero), true))
+    }
+
+    @Test
+    func v2NetworkRuntimeUsesInjectedTransportSupportForBackendSelection() {
+        let dependencies = WIInspectorDependencies.testing {
+            $0.transport = WIInspectorTransportClient(
+                supportSnapshot: {
+                    .supported(
+                        backendKind: .iOSNativeInspector,
+                        capabilities: [.networkDomain]
+                    )
+                },
+                makeSessionWithConfiguration: { configuration in
+                    .unsupported(
+                        configuration: configuration,
+                        reason: "Injected test session is not attached."
+                    )
+                }
+            )
+        }
+
+        let runtime = V2_WINetworkRuntime(dependencies: dependencies)
+
+        #expect(runtime.model.session.testBackendTypeName() == "NetworkTransportDriver")
+    }
+
+    @Test
+    func v2NetworkRuntimeFallsBackToInjectedPageAgentWhenTransportIsUnsupported() {
+        let runtime = V2_WINetworkRuntime(dependencies: .testValue)
+
+        #expect(runtime.model.session.testBackendTypeName() == "NetworkPageAgent")
+    }
+
+#if canImport(UIKit)
+    @Test
+    func testingInjectsUIKitSceneActivationWithoutGlobalOverrides() async throws {
+        let window = UIWindow()
+        var capturedWindow: UIWindow?
+        var capturedRequestingScene: UIScene?
+        var capturedTimeout: Duration?
+        let dependencies = WIInspectorDependencies.testing {
+            $0.platform = WIInspectorPlatformClient(
+                uiKitSceneActivation: WIInspectorUIKitSceneActivationClient(
+                    activationTimeout: .milliseconds(42)
+                ) { window, requestingScene, timeout in
+                    capturedWindow = window
+                    capturedRequestingScene = requestingScene
+                    capturedTimeout = timeout
+                }
+            )
+        }
+        let sceneActivation = dependencies.platform.uiKitSceneActivation
+
+        try await sceneActivation.activateWindowSceneIfNeeded(
+            window,
+            nil,
+            sceneActivation.activationTimeout
+        )
+
+        #expect(capturedWindow === window)
+        #expect(capturedRequestingScene == nil)
+        #expect(capturedTimeout == .milliseconds(42))
+    }
+#endif
+}

--- a/Tests/WebInspectorTransportTests/WIBackendFactoryTests.swift
+++ b/Tests/WebInspectorTransportTests/WIBackendFactoryTests.swift
@@ -1,6 +1,6 @@
 import Testing
 @testable import WebInspectorEngine
-@testable import WebInspectorTransport
+@_spi(Monocly) @testable import WebInspectorTransport
 
 @MainActor
 struct WIBackendFactoryTests {
@@ -26,5 +26,20 @@ struct WIBackendFactoryTests {
         )
 
         #expect(String(describing: type(of: backend)) == "NetworkTransportDriver")
+    }
+
+    @Test
+    func pageAgentFallbackOverrideWinsOverInjectedSupportedSnapshot() {
+        let backend = WIBackendFactoryTesting.withPageAgentFallback {
+            WIBackendFactory.makeNetworkBackend(
+                configuration: .init(),
+                supportSnapshot: .supported(
+                    backendKind: .iOSNativeInspector,
+                    capabilities: [.networkDomain]
+                )
+            )
+        }
+
+        #expect(String(describing: type(of: backend)) == "NetworkPageAgent")
     }
 }

--- a/Tests/WebInspectorTransportTests/WITransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/WITransportSessionTests.swift
@@ -785,6 +785,7 @@ struct WITransportSessionTests {
             await session.waitForPostActivePageEventsToDrain()
         }
         defer { drainTask.cancel() }
+        await Task.yield()
 
         backend.emitPageMessage(
             #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-1"}}"#,
@@ -797,20 +798,10 @@ struct WITransportSessionTests {
         session.beginPageEventDelivery()
         session.finishPageEventDelivery()
 
-        let drainedAfterCommittedTarget = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await drainTask.value
-                return true
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return false
-            }
-
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+        let drainedAfterCommittedTarget = await Self.task(
+            drainTask,
+            completesWithinNanoseconds: 200_000_000
+        )
 
         #expect(drainedAfterCommittedTarget)
 
@@ -852,6 +843,7 @@ struct WITransportSessionTests {
             await session.waitForPostActivePageEventsToDrain()
         }
         defer { drainTask.cancel() }
+        await Task.yield()
 
         backend.emitPageMessage(
             #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-1"}}"#,
@@ -859,20 +851,10 @@ struct WITransportSessionTests {
         )
         await backend.waitForPendingMessages()
 
-        let drainedAfterDroppedBufferedEvent = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await drainTask.value
-                return true
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return false
-            }
-
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+        let drainedAfterDroppedBufferedEvent = await Self.task(
+            drainTask,
+            completesWithinNanoseconds: 200_000_000
+        )
 
         #expect(drainedAfterDroppedBufferedEvent)
     }
@@ -909,20 +891,14 @@ struct WITransportSessionTests {
         session.beginPageEventDelivery()
         session.finishPageEventDelivery()
 
-        let drainedAfterOverflow = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await session.waitForPostActivePageEventsToDrain()
-                return true
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return false
-            }
-
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
+        let drainTask = Task { @MainActor in
+            await session.waitForPostActivePageEventsToDrain()
         }
+        defer { drainTask.cancel() }
+        let drainedAfterOverflow = await Self.task(
+            drainTask,
+            completesWithinNanoseconds: 200_000_000
+        )
 
         #expect(drainedAfterOverflow)
     }
@@ -958,6 +934,7 @@ struct WITransportSessionTests {
             await session.waitForPostActivePageEventsToDrain()
         }
         defer { drainTask.cancel() }
+        await Task.yield()
 
         backend.emitPageMessage(
             #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-1"}}"#,
@@ -965,39 +942,19 @@ struct WITransportSessionTests {
         )
         await backend.waitForPendingMessages()
 
-        let drainedWhileFirstEventWasStillActive = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await drainTask.value
-                return true
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return false
-            }
-
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+        let drainedWhileFirstEventWasStillActive = await Self.task(
+            drainTask,
+            completesWithinNanoseconds: 200_000_000
+        )
 
         #expect(drainedWhileFirstEventWasStillActive == false)
 
         session.finishPageEventDelivery()
 
-        let drainedAfterFinishingActiveEvent = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                await drainTask.value
-                return true
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                return false
-            }
-
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+        let drainedAfterFinishingActiveEvent = await Self.task(
+            drainTask,
+            completesWithinNanoseconds: 200_000_000
+        )
 
         #expect(drainedAfterFinishingActiveEvent)
     }
@@ -1337,6 +1294,23 @@ private extension WITransportSessionTests {
         }
     }
 
+    static func task(
+        _ task: Task<Void, Never>,
+        completesWithinNanoseconds timeoutNanoseconds: UInt64
+    ) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let box = BoolContinuationBox()
+            Task {
+                await task.value
+                box.resume(true, continuation: continuation)
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                box.resume(false, continuation: continuation)
+            }
+        }
+    }
+
     static func identifier(from message: String) throws -> Int {
         guard
             let object = try JSONSerialization.jsonObject(with: Data(message.utf8)) as? [String: Any],
@@ -1367,6 +1341,23 @@ private extension WITransportSessionTests {
 
     enum TestError: Error {
         case invalidMessage
+    }
+}
+
+private final class BoolContinuationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resume(_ value: Bool, continuation: CheckedContinuation<Bool, Never>) {
+        lock.lock()
+        guard !didResume else {
+            lock.unlock()
+            return
+        }
+        didResume = true
+        lock.unlock()
+
+        continuation.resume(returning: value)
     }
 }
 

--- a/Tests/WebInspectorTransportTests/WITransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/WITransportSessionTests.swift
@@ -379,6 +379,7 @@ struct WITransportSessionTests {
         #expect(frameEvent?.method == "Target.targetCreated")
         #expect(frameEvent?.targetIdentifier == "frame-A")
         #expect(session.targetKind(for: "frame-A") == .frame)
+        #expect(session.frameTargetIdentifiers() == ["frame-A"])
         #expect(session.currentPageTargetIdentifier() == "page-A")
         #expect(session.pageTargetIdentifiers() == ["page-A"])
     }
@@ -414,6 +415,7 @@ struct WITransportSessionTests {
         #expect(destroyedEvent?.method == "Target.targetDestroyed")
         #expect(destroyedEvent?.targetIdentifier == "frame-A")
         #expect(session.targetKind(for: "frame-A") == .frame)
+        #expect(session.frameTargetIdentifiers().isEmpty)
         #expect(session.currentPageTargetIdentifier() == "page-A")
     }
 

--- a/Tests/WebInspectorUITests/V2CompactTabBarControllerTests.swift
+++ b/Tests/WebInspectorUITests/V2CompactTabBarControllerTests.swift
@@ -8,6 +8,28 @@ import UIKit
 @MainActor
 struct V2CompactTabBarControllerTests {
     @Test
+    func publicInitializersKeepDefaultAndTabsEntriesUnambiguous() {
+        let defaultSession = V2_WISession()
+        let tabsSession = V2_WISession(tabs: [.dom])
+        let configurationSession = V2_WISession(configuration: .init())
+        let dependenciesSession = V2_WISession(dependencies: .liveValue)
+
+        let defaultViewController = V2_WIViewController()
+        let tabsViewController = V2_WIViewController(tabs: [.network])
+        let configurationViewController = V2_WIViewController(configuration: .init())
+        let dependenciesViewController = V2_WIViewController(dependencies: .liveValue)
+
+        #expect(defaultSession.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+        #expect(tabsSession.interface.tabs.map(\.id) == [V2_WITab.dom.id])
+        #expect(configurationSession.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+        #expect(dependenciesSession.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+        #expect(defaultViewController.session.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+        #expect(tabsViewController.session.interface.tabs.map(\.id) == [V2_WITab.network.id])
+        #expect(configurationViewController.session.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+        #expect(dependenciesViewController.session.interface.tabs.map(\.id) == [V2_WITab.dom.id, V2_WITab.network.id])
+    }
+
+    @Test
     func providedCompactTabsUseNavigationControllers() throws {
         let session = V2_WISession(tabs: [.dom, .network])
 


### PR DESCRIPTION
## Purpose

Refactor the V2 inspector runtime around explicit dependency injection while keeping V1 compatibility out of scope, then stabilize DOM selection behavior that regressed around native inspector selection, cross-origin frame targets, and page navigation.

## Changes

- Added `WIInspectorDependencies` and client-based live/test dependency values, then threaded them through the V2 session, view controller, runtime session, DOM runtime, and network runtime entry points.
- Updated DOM and Network runtime construction to use injected dependencies instead of global/static hooks on the V2 path.
- Added frame-target tracking and request-node fallback so cross-origin iframe DOM selections can resolve through the correct target.
- Hardened native inspector selection lifecycle by enabling protocol inspect mode with highlight configuration, preserving selected-node highlight, and revalidating context/target across navigation-sensitive async boundaries.
- Updated README and migration docs to recommend the V2 entry points and document V1 as pending removal.
- Added runtime, transport, backend factory, and dependency tests for the new DI and DOM selection behaviors.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorRuntimeTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorRuntimeTests/WIDOMInspectorTests` — passed, 101 tests
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorTransportTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorTransportTests/WITransportSessionTests` — passed, 31 tests
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1` — passed, 37 tests

## Screenshots

Not applicable; behavior/runtime changes only.