### PR TITLE
[codex] Show V2 network bodies in syntax editor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "89064ad4b03a574088b540948d92236a045c26dadc43d5b3a36e5bfd14973a15",
+  "originHash" : "d29e18ae9c6177920acedfea7ea6e2e4ad89016408302d1ac9d911397e6fc836",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "8b9b2807f573cf82b156aabb4534dfd4e7f0b02e",
-        "version" : "0.4.2"
+        "revision" : "e8130e3a3ff7d91577a9619f8ba288689cd2bf0e",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.4.2"
+            exact: "0.5.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorEngine/Network/NetworkBody.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkBody.swift
@@ -84,6 +84,15 @@ package struct NetworkBodyPayload: Decodable {
     }
 }
 
+package enum NetworkBodySyntaxKind: Hashable, Sendable {
+    case plainText
+    case json
+    case html
+    case xml
+    case css
+    case javascript
+}
+
 @Observable
 public final class NetworkBody {
     public enum Kind: String, Sendable {
@@ -145,13 +154,33 @@ public final class NetworkBody {
         }
     }
 
-    public var kind: Kind
-    public var preview: String?
-    public var full: String?
+    public var kind: Kind {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
+    public var preview: String? {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
+    public var full: String? {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
     public var size: Int?
-    public var isBase64Encoded: Bool
+    public var isBase64Encoded: Bool {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
     public var isTruncated: Bool
-    public var summary: String?
+    public var summary: String? {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
     public var reference: String? {
         didSet {
             refreshDeferredLocatorFromExposedFields()
@@ -162,10 +191,18 @@ public final class NetworkBody {
             refreshDeferredLocatorFromExposedFields()
         }
     }
-    public var formEntries: [FormEntry]
+    public var formEntries: [FormEntry] {
+        didSet {
+            refreshTextRepresentation()
+        }
+    }
     public var fetchState: FetchState
     public var role: Role
     package private(set) var deferredLocator: NetworkDeferredBodyLocator?
+    package private(set) var textRepresentation: String?
+    package private(set) var textRepresentationSyntaxKind: NetworkBodySyntaxKind
+    package private(set) var treatsRawTextAsURLEncodedForm: Bool
+    package private(set) var sourceSyntaxKind: NetworkBodySyntaxKind
 
     @ObservationIgnored
     private var isSynchronizingDeferredLocatorFields = false
@@ -226,6 +263,10 @@ public final class NetworkBody {
         self.deferredLocator = deferredLocator
         self.formEntries = formEntries
         self.role = role
+        self.textRepresentation = nil
+        self.textRepresentationSyntaxKind = .plainText
+        self.treatsRawTextAsURLEncodedForm = false
+        self.sourceSyntaxKind = .plainText
         if let fetchState {
             self.fetchState = fetchState
         } else if resolvedFull == nil && deferredLocator != nil {
@@ -234,6 +275,7 @@ public final class NetworkBody {
             self.fetchState = .full
         }
         syncExposedFieldsFromDeferredLocator()
+        refreshTextRepresentation()
     }
 
     convenience init?(dictionary: NSDictionary) {
@@ -375,6 +417,21 @@ public final class NetworkBody {
         fetchState = .full
     }
 
+    package func applyTextRepresentationHints(
+        syntaxKind: NetworkBodySyntaxKind,
+        treatsRawTextAsURLEncodedForm: Bool
+    ) {
+        guard
+            sourceSyntaxKind != syntaxKind
+                || self.treatsRawTextAsURLEncodedForm != treatsRawTextAsURLEncodedForm
+        else {
+            return
+        }
+        sourceSyntaxKind = syntaxKind
+        self.treatsRawTextAsURLEncodedForm = treatsRawTextAsURLEncodedForm
+        refreshTextRepresentation()
+    }
+
     package func currentDeferredLocator() -> NetworkDeferredBodyLocator? {
         deferredLocator
     }
@@ -435,6 +492,125 @@ public final class NetworkBody {
 }
 
 private extension NetworkBody {
+    func refreshTextRepresentation() {
+        let rawContentText = full ?? preview
+        let contentText = decodedContentText() ?? (kind == .binary ? nil : rawContentText)
+        let formText = formattedFormText(contentText: contentText)
+        let prettyJSON = formText == nil ? Self.prettyPrintedJSON(from: contentText) : nil
+        let displayText = formText ?? prettyJSON ?? contentText ?? summary
+
+        let syntaxKind: NetworkBodySyntaxKind
+        if kind == .binary || kind == .form || treatsRawTextAsURLEncodedForm {
+            syntaxKind = .plainText
+        } else if prettyJSON != nil {
+            syntaxKind = .json
+        } else {
+            syntaxKind = sourceSyntaxKind
+        }
+
+        if textRepresentation != displayText {
+            textRepresentation = displayText
+        }
+        if textRepresentationSyntaxKind != syntaxKind {
+            textRepresentationSyntaxKind = syntaxKind
+        }
+    }
+
+    func decodedContentText() -> String? {
+        guard kind != .binary else {
+            return nil
+        }
+        guard let candidate = full ?? preview else {
+            return nil
+        }
+        guard isBase64Encoded else {
+            return candidate
+        }
+        guard let data = Data(base64Encoded: candidate) else {
+            return nil
+        }
+        if let decoded = String(data: data, encoding: .utf8) {
+            return decoded
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func formattedFormText(contentText: String?) -> String? {
+        guard kind == .form || treatsRawTextAsURLEncodedForm else {
+            return nil
+        }
+        if formEntries.isEmpty == false {
+            return formEntries.map(Self.formEntryLine).joined(separator: "\n")
+        }
+        guard let contentText else {
+            return nil
+        }
+        return Self.formattedURLEncodedFormText(from: contentText)
+    }
+
+    static func formEntryLine(_ entry: FormEntry) -> String {
+        let value: String
+        if entry.isFile, let fileName = entry.fileName, fileName.isEmpty == false {
+            value = "<file \(fileName)>"
+        } else {
+            value = entry.value
+        }
+        return "\(entry.name)=\(value)"
+    }
+
+    static func formattedURLEncodedFormText(from text: String) -> String? {
+        guard text.isEmpty == false, text.contains("=") else {
+            return nil
+        }
+
+        var lines: [String] = []
+        for pair in text.split(separator: "&", omittingEmptySubsequences: false) {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.isEmpty == false else {
+                continue
+            }
+            guard let name = decodeFormComponent(String(parts[0])) else {
+                return nil
+            }
+            let value: String
+            if parts.count > 1 {
+                guard let decodedValue = decodeFormComponent(String(parts[1])) else {
+                    return nil
+                }
+                value = decodedValue
+            } else {
+                value = ""
+            }
+            lines.append("\(name)=\(value)")
+        }
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
+    }
+
+    static func decodeFormComponent(_ component: String) -> String? {
+        component
+            .replacingOccurrences(of: "+", with: " ")
+            .removingPercentEncoding
+    }
+
+    static func prettyPrintedJSON(from text: String?) -> String? {
+        guard let text, let data = text.data(using: .utf8) else {
+            return nil
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return nil
+        }
+        guard JSONSerialization.isValidJSONObject(object) else {
+            return nil
+        }
+        guard
+            let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+            let pretty = String(data: prettyData, encoding: .utf8)
+        else {
+            return nil
+        }
+        return pretty
+    }
+
     func refreshDeferredLocatorFromExposedFields() {
         guard isSynchronizingDeferredLocatorFields == false else {
             return

--- a/Sources/WebInspectorEngine/Network/NetworkEntry.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkEntry.swift
@@ -111,15 +111,6 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         }
     }
 
-    package enum BodySyntaxKind: Hashable, Sendable {
-        case plainText
-        case json
-        case html
-        case xml
-        case css
-        case javascript
-    }
-
     public struct WebSocket: Hashable, Sendable {
         public enum ReadyState: String, Sendable {
             case connecting
@@ -426,15 +417,31 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
     nonisolated public let requestID: Int
     nonisolated public let createdAt: Date
 
-    public internal(set) var url: String
+    public internal(set) var url: String {
+        didSet {
+            refreshBodyTextRepresentationHints()
+        }
+    }
     public internal(set) var method: String
     public internal(set) var statusCode: Int?
     public internal(set) var statusText: String
-    public internal(set) var mimeType: String?
+    public internal(set) var mimeType: String? {
+        didSet {
+            refreshResponseBodyTextRepresentationHints()
+        }
+    }
     public internal(set) var fileTypeLabel: String
     public internal(set) var resourceFilter: NetworkResourceFilter
-    public internal(set) var requestHeaders: NetworkHeaders
-    public internal(set) var responseHeaders: NetworkHeaders
+    public internal(set) var requestHeaders: NetworkHeaders {
+        didSet {
+            refreshRequestBodyTextRepresentationHints()
+        }
+    }
+    public internal(set) var responseHeaders: NetworkHeaders {
+        didSet {
+            refreshResponseBodyTextRepresentationHints()
+        }
+    }
     public internal(set) var startTimestamp: TimeInterval
     public internal(set) var endTimestamp: TimeInterval?
     public internal(set) var duration: TimeInterval?
@@ -445,8 +452,16 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
     public internal(set) var requestBodyBytesSent: Int?
     public internal(set) var wallTime: TimeInterval?
     public internal(set) var phase: Phase
-    public internal(set) var requestBody: NetworkBody?
-    public internal(set) var responseBody: NetworkBody?
+    public internal(set) var requestBody: NetworkBody? {
+        didSet {
+            configureBody(requestBody, role: .request)
+        }
+    }
+    public internal(set) var responseBody: NetworkBody? {
+        didSet {
+            configureBody(responseBody, role: .response)
+        }
+    }
     public internal(set) var webSocket: WebSocket?
 
     public var kind: Kind {
@@ -551,9 +566,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         requestType = snapshot.request.type
         requestBodyBytesSent = snapshot.request.bodyBytesSent ?? snapshot.request.body?.size
         requestBody = snapshot.request.body
-        requestBody?.role = .request
         responseBody = snapshot.response.body
-        responseBody?.role = .response
         phase = snapshot.transfer.phase
         endTimestamp = snapshot.transfer.endTimestamp
         duration = snapshot.transfer.duration
@@ -644,7 +657,6 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         )
         self.requestType = requestType
         self.requestBody = requestBody
-        self.requestBody?.role = .request
         self.requestBodyBytesSent = requestBodyBytesSent ?? requestBody?.size
         refreshFileTypeLabel()
     }
@@ -675,11 +687,10 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
             if let existingRequestBody = self.requestBody,
                existingRequestBody.hasDeferredContent,
                requestBody.hasDeferredContent {
-                existingRequestBody.role = .request
+                configureBody(existingRequestBody, role: .request)
                 existingRequestBody.adoptDeferredNetworkRequestTarget(from: requestBody)
             } else {
                 self.requestBody = requestBody
-                self.requestBody?.role = .request
             }
         }
         if let requestBodyBytesSent = requestBodyBytesSent ?? requestBody?.size {
@@ -767,7 +778,6 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         }
         if let responseBody {
             self.responseBody = responseBody
-            self.responseBody?.role = .response
         } else if failed {
             self.responseBody = nil
         }
@@ -1042,7 +1052,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         Self.isURLEncodedFormContentType(bodyContentType(for: role))
     }
 
-    package func bodySyntaxKind(for role: NetworkBody.Role) -> BodySyntaxKind {
+    package func bodySyntaxKind(for role: NetworkBody.Role) -> NetworkBodySyntaxKind {
         Self.bodySyntaxKind(
             contentType: bodyContentType(for: role),
             url: url
@@ -1052,7 +1062,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
     package static func bodySyntaxKind(
         contentType: String?,
         url: String
-    ) -> BodySyntaxKind {
+    ) -> NetworkBodySyntaxKind {
         let normalizedContentType = normalizedMimeType(contentType)
         let pathExtension = normalizedPathExtension(url)
 
@@ -1078,6 +1088,36 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
 
     package static func isURLEncodedFormContentType(_ contentType: String?) -> Bool {
         normalizedMimeType(contentType) == "application/x-www-form-urlencoded"
+    }
+
+    private func configureBody(_ body: NetworkBody?, role: NetworkBody.Role) {
+        guard let body else {
+            return
+        }
+        body.role = role
+        body.applyTextRepresentationHints(
+            syntaxKind: bodySyntaxKind(for: role),
+            treatsRawTextAsURLEncodedForm: isURLEncodedFormBody(for: role)
+        )
+    }
+
+    private func refreshBodyTextRepresentationHints() {
+        refreshRequestBodyTextRepresentationHints()
+        refreshResponseBodyTextRepresentationHints()
+    }
+
+    private func refreshRequestBodyTextRepresentationHints() {
+        requestBody?.applyTextRepresentationHints(
+            syntaxKind: bodySyntaxKind(for: .request),
+            treatsRawTextAsURLEncodedForm: isURLEncodedFormBody(for: .request)
+        )
+    }
+
+    private func refreshResponseBodyTextRepresentationHints() {
+        responseBody?.applyTextRepresentationHints(
+            syntaxKind: bodySyntaxKind(for: .response),
+            treatsRawTextAsURLEncodedForm: isURLEncodedFormBody(for: .response)
+        )
     }
 
     func applyWebSocketHandshakeRequest(headers: NetworkHeaders) {

--- a/Sources/WebInspectorEngine/Network/NetworkEntry.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkEntry.swift
@@ -111,6 +111,15 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         }
     }
 
+    package enum BodySyntaxKind: Hashable, Sendable {
+        case plainText
+        case json
+        case html
+        case xml
+        case css
+        case javascript
+    }
+
     public struct WebSocket: Hashable, Sendable {
         public enum ReadyState: String, Sendable {
             case connecting
@@ -1020,6 +1029,57 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         return .other
     }
 
+    package func bodyContentType(for role: NetworkBody.Role) -> String? {
+        switch role {
+        case .request:
+            requestHeaders["content-type"]
+        case .response:
+            responseHeaders["content-type"] ?? mimeType
+        }
+    }
+
+    package func isURLEncodedFormBody(for role: NetworkBody.Role) -> Bool {
+        Self.isURLEncodedFormContentType(bodyContentType(for: role))
+    }
+
+    package func bodySyntaxKind(for role: NetworkBody.Role) -> BodySyntaxKind {
+        Self.bodySyntaxKind(
+            contentType: bodyContentType(for: role),
+            url: url
+        )
+    }
+
+    package static func bodySyntaxKind(
+        contentType: String?,
+        url: String
+    ) -> BodySyntaxKind {
+        let normalizedContentType = normalizedMimeType(contentType)
+        let pathExtension = normalizedPathExtension(url)
+
+        if isJSONContentType(normalizedContentType) || pathExtension == "json" {
+            return .json
+        }
+        if documentMimeTypes.contains(normalizedContentType)
+            || documentExtensions.contains(pathExtension) {
+            return .html
+        }
+        if isXMLContentType(normalizedContentType) || pathExtension == "xml" {
+            return .xml
+        }
+        if normalizedContentType == "text/css" || pathExtension == "css" {
+            return .css
+        }
+        if scriptMimeTokens.contains(where: { normalizedContentType.contains($0) })
+            || scriptExtensions.contains(pathExtension) {
+            return .javascript
+        }
+        return .plainText
+    }
+
+    package static func isURLEncodedFormContentType(_ contentType: String?) -> Bool {
+        normalizedMimeType(contentType) == "application/x-www-form-urlencoded"
+    }
+
     func applyWebSocketHandshakeRequest(headers: NetworkHeaders) {
         if !headers.isEmpty {
             requestHeaders = headers
@@ -1119,11 +1179,19 @@ extension NetworkEntry {
     ]
     fileprivate static let fontExtensions: Set<String> = ["woff", "woff2", "ttf", "otf", "eot"]
 
+    fileprivate static func isJSONContentType(_ contentType: String) -> Bool {
+        contentType == "application/json" || contentType.hasSuffix("+json")
+    }
+
+    fileprivate static func isXMLContentType(_ contentType: String) -> Bool {
+        contentType == "application/xml" || contentType == "text/xml" || contentType.hasSuffix("+xml")
+    }
+
     fileprivate static func normalizedMimeType(_ mimeType: String?) -> String {
         guard let mimeType, mimeType.isEmpty == false else { return "" }
         let trimmed = mimeType.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
             .first ?? ""
-        return trimmed.lowercased()
+        return trimmed.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     fileprivate static func normalizedPathExtension(_ url: String) -> String {

--- a/Sources/WebInspectorUI/V2/DOM/ElementCell/V2_DOMElementPreviewCell.swift
+++ b/Sources/WebInspectorUI/V2/DOM/ElementCell/V2_DOMElementPreviewCell.swift
@@ -9,7 +9,7 @@ final class V2_DOMElementPreviewCell: V2_DOMElementBaseCell {
 
     private let previewModel = SyntaxEditorModel(
         text: "",
-        language: BuiltinSyntaxLanguages.html,
+        language: .html,
         isEditable: false,
         lineWrappingEnabled: true
     )
@@ -90,7 +90,6 @@ final class V2_DOMElementPreviewCell: V2_DOMElementBaseCell {
         previewEditorView.isScrollEnabled = false
         previewEditorView.alwaysBounceVertical = false
         previewEditorView.backgroundColor = .clear
-        previewEditorView.textContainer.lineFragmentPadding = 0
         previewEditorView.textContainerInset = .zero
         previewEditorView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         previewEditorView.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -120,18 +119,25 @@ final class V2_DOMElementPreviewCell: V2_DOMElementBaseCell {
             return 0
         }
 
-        let originalInsets = previewEditorView.textContainerInset
-        let sizingInsets = UIEdgeInsets(top: 0, left: originalInsets.left, bottom: 0, right: originalInsets.right)
-        if originalInsets != sizingInsets {
-            previewEditorView.textContainerInset = sizingInsets
+        guard previewModel.text.isEmpty == false else {
+            return ceil(previewEditorView.font.lineHeight)
         }
-        let size = previewEditorView.sizeThatFits(
-            CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+
+        let lineFragmentPadding = CGFloat(10)
+        let textInsets = previewEditorView.textContainerInset
+        let textWidth = max(1, width - textInsets.left - textInsets.right - lineFragmentPadding)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byCharWrapping
+        let textBounds = (previewModel.text as NSString).boundingRect(
+            with: CGSize(width: textWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [
+                .font: previewEditorView.font,
+                .paragraphStyle: paragraphStyle,
+            ],
+            context: nil
         )
-        if previewEditorView.textContainerInset != originalInsets {
-            previewEditorView.textContainerInset = originalInsets
-        }
-        return ceil(size.height)
+        return max(ceil(previewEditorView.font.lineHeight), ceil(textBounds.height))
     }
 
     private func updateVerticalTextInsets() {

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyRenderModel.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyRenderModel.swift
@@ -1,0 +1,283 @@
+#if canImport(UIKit)
+import Foundation
+import SyntaxEditorUI
+import UIKit
+import WebInspectorEngine
+import WebInspectorRuntime
+
+struct V2_NetworkBodyRenderModel: Sendable {
+    enum SyntaxStyle: Equatable, Sendable {
+        case highlighted(SyntaxLanguage)
+        case plainText
+    }
+
+    enum FetchDisplayState: Sendable {
+        case normal
+        case fetching
+        case failed(String)
+    }
+
+    struct FormEntry: Sendable {
+        let name: String
+        let value: String
+        let isFile: Bool
+        let fileName: String?
+
+        init(_ entry: NetworkBody.FormEntry) {
+            name = entry.name
+            value = entry.value
+            isFile = entry.isFile
+            fileName = entry.fileName
+        }
+    }
+
+    struct Input: Sendable {
+        let kind: NetworkBody.Kind?
+        let full: String?
+        let preview: String?
+        let summary: String?
+        let isBase64Encoded: Bool
+        let formEntries: [FormEntry]
+        let fetchDisplayState: FetchDisplayState
+        let isURLEncodedForm: Bool
+        let syntaxKind: NetworkEntry.BodySyntaxKind
+        let unavailableText: String
+        let fetchingText: String
+
+        @MainActor
+        init(
+            entry: NetworkEntry?,
+            body: NetworkBody?,
+            role: NetworkBody.Role,
+            unavailableText: String,
+            fetchingText: String
+        ) {
+            kind = body?.kind
+            full = body?.full
+            preview = body?.preview
+            summary = body?.summary
+            isBase64Encoded = body?.isBase64Encoded ?? false
+            formEntries = body?.formEntries.map(FormEntry.init) ?? []
+            isURLEncodedForm = entry?.isURLEncodedFormBody(for: role) ?? false
+            syntaxKind = entry?.bodySyntaxKind(for: role) ?? .plainText
+            self.unavailableText = unavailableText
+            self.fetchingText = fetchingText
+
+            switch body?.fetchState {
+            case .fetching:
+                fetchDisplayState = .fetching
+            case .failed(let error):
+                fetchDisplayState = .failed(error.localizedDescriptionText)
+            default:
+                fetchDisplayState = .normal
+            }
+        }
+    }
+
+    let text: String
+    let syntaxStyle: SyntaxStyle
+
+    static func make(from input: Input) -> V2_NetworkBodyRenderModel {
+        if case .fetching = input.fetchDisplayState {
+            return V2_NetworkBodyRenderModel(
+                text: input.fetchingText,
+                syntaxStyle: .plainText
+            )
+        }
+
+        let decoded = decodedText(from: input)
+        let contentText = decoded ?? input.full ?? input.preview
+        let formText = formattedFormText(from: input, contentText: contentText)
+        let prettyJSON = formText == nil ? prettyPrintedJSON(from: contentText) : nil
+        let displayText = formText
+            ?? prettyJSON
+            ?? contentText
+            ?? input.summary
+            ?? input.unavailableText
+
+        let text: String
+        if case .failed(let errorText) = input.fetchDisplayState {
+            text = displayText + "\n\n" + errorText
+        } else {
+            text = displayText
+        }
+
+        return V2_NetworkBodyRenderModel(
+            text: text,
+            syntaxStyle: syntaxStyle(from: input, contentText: contentText, didPrettyPrintJSON: prettyJSON != nil)
+        )
+    }
+}
+
+extension V2_NetworkBodyRenderModel.SyntaxStyle {
+    @MainActor
+    var language: SyntaxLanguage {
+        switch self {
+        case .highlighted(let language):
+            language
+        case .plainText:
+            .json
+        }
+    }
+
+    @MainActor
+    var colorTheme: SyntaxEditorColorTheme {
+        switch self {
+        case .highlighted:
+            .xcode
+        case .plainText:
+            .webInspectorPlainText
+        }
+    }
+}
+
+@MainActor
+extension SyntaxEditorColorTheme {
+    static let webInspectorPlainText = SyntaxEditorColorTheme(
+        baseForeground: .label,
+        bracketBackground: .clear,
+        comment: .label,
+        string: .label,
+        keyword: .label,
+        number: .label,
+        function: .label,
+        type: .label,
+        constant: .label,
+        variable: .label,
+        punctuation: .label
+    )
+}
+
+private extension V2_NetworkBodyRenderModel {
+    static func decodedText(from input: Input) -> String? {
+        guard input.kind != .binary else {
+            return nil
+        }
+        guard let candidate = input.full ?? input.preview else {
+            return nil
+        }
+        guard input.isBase64Encoded else {
+            return candidate
+        }
+        guard let data = Data(base64Encoded: candidate) else {
+            return nil
+        }
+        if let decoded = String(data: data, encoding: .utf8) {
+            return decoded
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    static func formattedFormText(from input: Input, contentText: String?) -> String? {
+        guard input.kind == .form || input.isURLEncodedForm else {
+            return nil
+        }
+        if input.formEntries.isEmpty == false {
+            return input.formEntries.map(formEntryLine).joined(separator: "\n")
+        }
+        guard let contentText else {
+            return nil
+        }
+        return formattedURLEncodedFormText(from: contentText)
+    }
+
+    static func formEntryLine(_ entry: FormEntry) -> String {
+        let value: String
+        if entry.isFile, let fileName = entry.fileName, fileName.isEmpty == false {
+            value = "<file \(fileName)>"
+        } else {
+            value = entry.value
+        }
+        return "\(entry.name)=\(value)"
+    }
+
+    static func formattedURLEncodedFormText(from text: String) -> String? {
+        guard text.isEmpty == false, text.contains("=") else {
+            return nil
+        }
+
+        var lines: [String] = []
+        for pair in text.split(separator: "&", omittingEmptySubsequences: false) {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.isEmpty == false else {
+                continue
+            }
+            guard let name = decodedFormComponent(String(parts[0])) else {
+                return nil
+            }
+            let value: String
+            if parts.count > 1 {
+                guard let decodedValue = decodedFormComponent(String(parts[1])) else {
+                    return nil
+                }
+                value = decodedValue
+            } else {
+                value = ""
+            }
+            lines.append("\(name)=\(value)")
+        }
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
+    }
+
+    static func decodedFormComponent(_ component: String) -> String? {
+        component
+            .replacingOccurrences(of: "+", with: " ")
+            .removingPercentEncoding
+    }
+
+    static func prettyPrintedJSON(from text: String?) -> String? {
+        guard let text, let data = text.data(using: .utf8) else {
+            return nil
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return nil
+        }
+        guard JSONSerialization.isValidJSONObject(object) else {
+            return nil
+        }
+        guard
+            let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+            let pretty = String(data: prettyData, encoding: .utf8)
+        else {
+            return nil
+        }
+        return pretty
+    }
+
+    static func syntaxStyle(
+        from input: Input,
+        contentText: String?,
+        didPrettyPrintJSON: Bool
+    ) -> V2_NetworkBodyRenderModel.SyntaxStyle {
+        if input.kind == .form || input.isURLEncodedForm {
+            return .plainText
+        }
+        if didPrettyPrintJSON {
+            return .highlighted(.json)
+        }
+        if contentText.flatMap(prettyPrintedJSON(from:)) != nil {
+            return .highlighted(.json)
+        }
+        return input.syntaxKind.syntaxStyle
+    }
+}
+
+private extension NetworkEntry.BodySyntaxKind {
+    var syntaxStyle: V2_NetworkBodyRenderModel.SyntaxStyle {
+        switch self {
+        case .plainText:
+            .plainText
+        case .json:
+            .highlighted(.json)
+        case .html:
+            .highlighted(.html)
+        case .xml:
+            .highlighted(.xml)
+        case .css:
+            .highlighted(.css)
+        case .javascript:
+            .highlighted(.javascript)
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
@@ -1,0 +1,154 @@
+#if canImport(UIKit)
+import ObservationBridge
+import SyntaxEditorUI
+import UIKit
+import WebInspectorEngine
+import WebInspectorRuntime
+
+@MainActor
+final class V2_NetworkBodyViewController: UIViewController {
+    private let syntaxModel = SyntaxEditorModel(
+        text: "",
+        language: .json,
+        isEditable: false,
+        lineWrappingEnabled: true,
+        colorTheme: .webInspectorPlainText
+    )
+    private lazy var syntaxView = SyntaxEditorView(model: syntaxModel)
+    private let observationScope = ObservationScope()
+    private var renderTask: Task<Void, Never>?
+    private var renderGeneration: UInt64 = 0
+    private weak var entry: NetworkEntry?
+    private weak var body: NetworkBody?
+    private var role: NetworkBody.Role = .response
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        configureSyntaxView()
+    }
+
+    isolated deinit {
+        renderTask?.cancel()
+        observationScope.cancelAll()
+    }
+
+    func display(entry: NetworkEntry?, body: NetworkBody?, role: NetworkBody.Role) {
+        self.entry = entry
+        self.body = body
+        self.role = role
+        startObserving(entry: entry, body: body)
+        requestRenderModelUpdate()
+    }
+
+    private func configureSyntaxView() {
+        syntaxView.translatesAutoresizingMaskIntoConstraints = false
+        syntaxView.isEditable = false
+        syntaxView.isSelectable = true
+        syntaxView.isScrollEnabled = true
+        syntaxView.alwaysBounceVertical = true
+        syntaxView.backgroundColor = .clear
+        syntaxView.contentInsetAdjustmentBehavior = .automatic
+        syntaxView.keyboardDismissMode = .onDrag
+        syntaxView.accessibilityIdentifier = "V2.Network.BodyView"
+        view.addSubview(syntaxView)
+
+        NSLayoutConstraint.activate([
+            syntaxView.topAnchor.constraint(equalTo: view.topAnchor),
+            syntaxView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            syntaxView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            syntaxView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func startObserving(entry: NetworkEntry?, body: NetworkBody?) {
+        observationScope.update {
+            if let entry {
+                entry.observe([\.url, \.mimeType, \.requestHeaders, \.responseHeaders]) { [weak self, weak entry] in
+                    guard let self, entry === self.entry else {
+                        return
+                    }
+                    self.requestRenderModelUpdate()
+                }
+                .store(in: observationScope)
+            }
+
+            if let body {
+                body.observe(
+                    [
+                        \.kind,
+                        \.preview,
+                        \.full,
+                        \.summary,
+                        \.isBase64Encoded,
+                        \.formEntries,
+                        \.fetchState,
+                    ]
+                ) { [weak self, weak body] in
+                    guard let self, body === self.body else {
+                        return
+                    }
+                    self.requestRenderModelUpdate()
+                }
+                .store(in: observationScope)
+            }
+        }
+    }
+
+    private func requestRenderModelUpdate() {
+        renderTask?.cancel()
+        renderGeneration &+= 1
+        let generation = renderGeneration
+        let input = V2_NetworkBodyRenderModel.Input(
+            entry: entry,
+            body: body,
+            role: role,
+            unavailableText: wiLocalized("network.body.unavailable", default: "Body unavailable"),
+            fetchingText: wiLocalized("network.body.fetching", default: "Fetching body...")
+        )
+
+        renderTask = Task(priority: .userInitiated) { [weak self, generation, input] in
+            let workerTask = Task.detached(priority: .userInitiated) {
+                V2_NetworkBodyRenderModel.make(from: input)
+            }
+            let model = await withTaskCancellationHandler {
+                await workerTask.value
+            } onCancel: {
+                workerTask.cancel()
+            }
+
+            guard
+                Task.isCancelled == false,
+                let self,
+                self.renderGeneration == generation
+            else {
+                return
+            }
+            self.applyRenderModel(model)
+        }
+    }
+
+    private func applyRenderModel(_ renderModel: V2_NetworkBodyRenderModel) {
+        let language = renderModel.syntaxStyle.language
+        if syntaxModel.language != language {
+            syntaxModel.language = language
+        }
+        let colorTheme = renderModel.syntaxStyle.colorTheme
+        if syntaxModel.colorTheme != colorTheme {
+            syntaxModel.colorTheme = colorTheme
+        }
+        if syntaxModel.text != renderModel.text {
+            syntaxModel.text = renderModel.text
+        }
+    }
+}
+
+#if DEBUG
+extension V2_NetworkBodyViewController {
+    var syntaxViewForTesting: SyntaxEditorView {
+        loadViewIfNeeded()
+        return syntaxView
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
@@ -16,11 +16,7 @@ final class V2_NetworkBodyViewController: UIViewController {
     )
     private lazy var syntaxView = SyntaxEditorView(model: syntaxModel)
     private let observationScope = ObservationScope()
-    private var displayTask: Task<Void, Never>?
-    private var displayGeneration: UInt64 = 0
     private weak var body: NetworkBody?
-    private var syntaxKind: NetworkEntry.BodySyntaxKind = .plainText
-    private var isURLEncodedForm = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,20 +25,13 @@ final class V2_NetworkBodyViewController: UIViewController {
     }
 
     isolated deinit {
-        displayTask?.cancel()
         observationScope.cancelAll()
     }
 
-    func display(
-        body: NetworkBody?,
-        syntaxKind: NetworkEntry.BodySyntaxKind,
-        isURLEncodedForm: Bool
-    ) {
+    func display(body: NetworkBody?) {
         self.body = body
-        self.syntaxKind = syntaxKind
-        self.isURLEncodedForm = isURLEncodedForm
         startObserving(body: body)
-        requestBodyDisplayUpdate()
+        renderBody()
     }
 
     private func configureSyntaxView() {
@@ -70,139 +59,58 @@ final class V2_NetworkBodyViewController: UIViewController {
             if let body {
                 body.observe(
                     [
-                        \.kind,
-                        \.preview,
-                        \.full,
-                        \.summary,
-                        \.isBase64Encoded,
-                        \.formEntries,
+                        \.textRepresentation,
+                        \.textRepresentationSyntaxKind,
                         \.fetchState,
                     ]
                 ) { [weak self, weak body] in
                     guard let self, body === self.body else {
                         return
                     }
-                    self.requestBodyDisplayUpdate()
+                    self.renderBody()
                 }
                 .store(in: observationScope)
             }
         }
     }
 
-    private func requestBodyDisplayUpdate() {
-        displayTask?.cancel()
-        displayGeneration &+= 1
-        let generation = displayGeneration
-        let body = body
-        let bodyKind = body?.kind
-        let fullText = body?.full
-        let previewText = body?.preview
-        let summaryText = body?.summary
-        let isBase64Encoded = body?.isBase64Encoded ?? false
-        let formEntries = body?.formEntries ?? []
-        let syntaxKind = syntaxKind
-        let isURLEncodedForm = isURLEncodedForm
+    private func renderBody() {
         let unavailableText = wiLocalized("network.body.unavailable", default: "Body unavailable")
         let fetchingText = wiLocalized("network.body.fetching", default: "Fetching body...")
-        let isFetching: Bool
-        let fetchErrorText: String?
-        switch body?.fetchState {
+        let displayText: String
+        let syntaxKind: NetworkBodySyntaxKind
+        guard let body else {
+            applyBodyDisplay(text: unavailableText, syntaxKind: .plainText)
+            return
+        }
+
+        switch body.fetchState {
         case .fetching:
-            isFetching = true
-            fetchErrorText = nil
+            displayText = fetchingText
+            syntaxKind = .plainText
         case .failed(let error):
-            isFetching = false
-            fetchErrorText = error.localizedDescriptionText
+            displayText = (body.textRepresentation ?? unavailableText)
+                + "\n\n"
+                + error.localizedDescriptionText
+            syntaxKind = body.textRepresentationSyntaxKind
         default:
-            isFetching = false
-            fetchErrorText = nil
+            displayText = body.textRepresentation ?? unavailableText
+            syntaxKind = body.textRepresentationSyntaxKind
         }
 
-        displayTask = Task(priority: .userInitiated) {
-            [
-                weak self,
-                generation,
-                bodyKind,
-                fullText,
-                previewText,
-                summaryText,
-                isBase64Encoded,
-                formEntries,
-                isFetching,
-                fetchErrorText,
-                syntaxKind,
-                isURLEncodedForm,
-                unavailableText,
-                fetchingText,
-            ] in
-            let workerTask = Task.detached(priority: .userInitiated) {
-                if isFetching {
-                    return (text: fetchingText, language: SyntaxLanguage.json, usesPlainTextTheme: true)
-                }
-
-                let decoded = decodedV2NetworkBodyText(
-                    kind: bodyKind,
-                    fullText: fullText,
-                    previewText: previewText,
-                    isBase64Encoded: isBase64Encoded
-                )
-                let contentText = decoded ?? fullText ?? previewText
-                let formText = formattedV2NetworkBodyFormText(
-                    kind: bodyKind,
-                    isURLEncodedForm: isURLEncodedForm,
-                    formEntries: formEntries,
-                    contentText: contentText
-                )
-                let prettyJSON = formText == nil ? prettyPrintedV2NetworkBodyJSON(from: contentText) : nil
-                let displayText = formText
-                    ?? prettyJSON
-                    ?? contentText
-                    ?? summaryText
-                    ?? unavailableText
-                let text = if let fetchErrorText {
-                    displayText + "\n\n" + fetchErrorText
-                } else {
-                    displayText
-                }
-                let syntax = v2NetworkBodySyntax(
-                    kind: bodyKind,
-                    syntaxKind: syntaxKind,
-                    isURLEncodedForm: isURLEncodedForm,
-                    contentText: contentText,
-                    didPrettyPrintJSON: prettyJSON != nil
-                )
-                return (text: text, language: syntax.language, usesPlainTextTheme: syntax.usesPlainTextTheme)
-            }
-            let display = await withTaskCancellationHandler {
-                await workerTask.value
-            } onCancel: {
-                workerTask.cancel()
-            }
-
-            guard
-                Task.isCancelled == false,
-                let self,
-                self.displayGeneration == generation
-            else {
-                return
-            }
-            self.applyBodyDisplay(
-                text: display.text,
-                language: display.language,
-                usesPlainTextTheme: display.usesPlainTextTheme
-            )
-        }
+        applyBodyDisplay(text: displayText, syntaxKind: syntaxKind)
     }
 
     private func applyBodyDisplay(
         text: String,
-        language: SyntaxLanguage,
-        usesPlainTextTheme: Bool
+        syntaxKind: NetworkBodySyntaxKind
     ) {
+        let syntax = syntaxKind.syntax
+        let language = syntax.language
         if syntaxModel.language != language {
             syntaxModel.language = language
         }
-        let colorTheme: SyntaxEditorColorTheme = usesPlainTextTheme ? .webInspectorPlainText : .xcode
+        let colorTheme: SyntaxEditorColorTheme = syntax.usesPlainTextTheme ? .webInspectorPlainText : .xcode
         if syntaxModel.colorTheme != colorTheme {
             syntaxModel.colorTheme = colorTheme
         }
@@ -210,130 +118,6 @@ final class V2_NetworkBodyViewController: UIViewController {
             syntaxModel.text = text
         }
     }
-}
-
-private func decodedV2NetworkBodyText(
-    kind: NetworkBody.Kind?,
-    fullText: String?,
-    previewText: String?,
-    isBase64Encoded: Bool
-) -> String? {
-    guard kind != .binary else {
-        return nil
-    }
-    guard let candidate = fullText ?? previewText else {
-        return nil
-    }
-    guard isBase64Encoded else {
-        return candidate
-    }
-    guard let data = Data(base64Encoded: candidate) else {
-        return nil
-    }
-    if let decoded = String(data: data, encoding: .utf8) {
-        return decoded
-    }
-    return String(decoding: data, as: UTF8.self)
-}
-
-private func formattedV2NetworkBodyFormText(
-    kind: NetworkBody.Kind?,
-    isURLEncodedForm: Bool,
-    formEntries: [NetworkBody.FormEntry],
-    contentText: String?
-) -> String? {
-    guard kind == .form || isURLEncodedForm else {
-        return nil
-    }
-    if formEntries.isEmpty == false {
-        return formEntries.map(v2NetworkBodyFormEntryLine).joined(separator: "\n")
-    }
-    guard let contentText else {
-        return nil
-    }
-    return formattedV2NetworkURLEncodedFormText(from: contentText)
-}
-
-private func v2NetworkBodyFormEntryLine(_ entry: NetworkBody.FormEntry) -> String {
-    let value: String
-    if entry.isFile, let fileName = entry.fileName, fileName.isEmpty == false {
-        value = "<file \(fileName)>"
-    } else {
-        value = entry.value
-    }
-    return "\(entry.name)=\(value)"
-}
-
-private func formattedV2NetworkURLEncodedFormText(from text: String) -> String? {
-    guard text.isEmpty == false, text.contains("=") else {
-        return nil
-    }
-
-    var lines: [String] = []
-    for pair in text.split(separator: "&", omittingEmptySubsequences: false) {
-        let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-        guard parts.isEmpty == false else {
-            continue
-        }
-        guard let name = decodedV2NetworkFormComponent(String(parts[0])) else {
-            return nil
-        }
-        let value: String
-        if parts.count > 1 {
-            guard let decodedValue = decodedV2NetworkFormComponent(String(parts[1])) else {
-                return nil
-            }
-            value = decodedValue
-        } else {
-            value = ""
-        }
-        lines.append("\(name)=\(value)")
-    }
-    return lines.isEmpty ? nil : lines.joined(separator: "\n")
-}
-
-private func decodedV2NetworkFormComponent(_ component: String) -> String? {
-    component
-        .replacingOccurrences(of: "+", with: " ")
-        .removingPercentEncoding
-}
-
-private func prettyPrintedV2NetworkBodyJSON(from text: String?) -> String? {
-    guard let text, let data = text.data(using: .utf8) else {
-        return nil
-    }
-    guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
-        return nil
-    }
-    guard JSONSerialization.isValidJSONObject(object) else {
-        return nil
-    }
-    guard
-        let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
-        let pretty = String(data: prettyData, encoding: .utf8)
-    else {
-        return nil
-    }
-    return pretty
-}
-
-private func v2NetworkBodySyntax(
-    kind: NetworkBody.Kind?,
-    syntaxKind: NetworkEntry.BodySyntaxKind,
-    isURLEncodedForm: Bool,
-    contentText: String?,
-    didPrettyPrintJSON: Bool
-) -> (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
-    if kind == .form || isURLEncodedForm {
-        return (.json, true)
-    }
-    if didPrettyPrintJSON {
-        return (.json, false)
-    }
-    if contentText.flatMap(prettyPrintedV2NetworkBodyJSON(from:)) != nil {
-        return (.json, false)
-    }
-    return syntaxKind.syntax
 }
 
 @MainActor
@@ -353,7 +137,7 @@ extension SyntaxEditorColorTheme {
     )
 }
 
-private extension NetworkEntry.BodySyntaxKind {
+private extension NetworkBodySyntaxKind {
     var syntax: (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
         switch self {
         case .plainText:

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkBodyViewController.swift
@@ -1,0 +1,383 @@
+#if canImport(UIKit)
+import ObservationBridge
+import SyntaxEditorUI
+import UIKit
+import WebInspectorEngine
+import WebInspectorRuntime
+
+@MainActor
+final class V2_NetworkBodyViewController: UIViewController {
+    private let syntaxModel = SyntaxEditorModel(
+        text: "",
+        language: .json,
+        isEditable: false,
+        lineWrappingEnabled: true,
+        colorTheme: .webInspectorPlainText
+    )
+    private lazy var syntaxView = SyntaxEditorView(model: syntaxModel)
+    private let observationScope = ObservationScope()
+    private var displayTask: Task<Void, Never>?
+    private var displayGeneration: UInt64 = 0
+    private weak var body: NetworkBody?
+    private var syntaxKind: NetworkEntry.BodySyntaxKind = .plainText
+    private var isURLEncodedForm = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        configureSyntaxView()
+    }
+
+    isolated deinit {
+        displayTask?.cancel()
+        observationScope.cancelAll()
+    }
+
+    func display(
+        body: NetworkBody?,
+        syntaxKind: NetworkEntry.BodySyntaxKind,
+        isURLEncodedForm: Bool
+    ) {
+        self.body = body
+        self.syntaxKind = syntaxKind
+        self.isURLEncodedForm = isURLEncodedForm
+        startObserving(body: body)
+        requestBodyDisplayUpdate()
+    }
+
+    private func configureSyntaxView() {
+        syntaxView.translatesAutoresizingMaskIntoConstraints = false
+        syntaxView.isEditable = false
+        syntaxView.isSelectable = true
+        syntaxView.isScrollEnabled = true
+        syntaxView.alwaysBounceVertical = true
+        syntaxView.backgroundColor = .clear
+        syntaxView.contentInsetAdjustmentBehavior = .automatic
+        syntaxView.keyboardDismissMode = .onDrag
+        syntaxView.accessibilityIdentifier = "V2.Network.BodyView"
+        view.addSubview(syntaxView)
+
+        NSLayoutConstraint.activate([
+            syntaxView.topAnchor.constraint(equalTo: view.topAnchor),
+            syntaxView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            syntaxView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            syntaxView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func startObserving(body: NetworkBody?) {
+        observationScope.update {
+            if let body {
+                body.observe(
+                    [
+                        \.kind,
+                        \.preview,
+                        \.full,
+                        \.summary,
+                        \.isBase64Encoded,
+                        \.formEntries,
+                        \.fetchState,
+                    ]
+                ) { [weak self, weak body] in
+                    guard let self, body === self.body else {
+                        return
+                    }
+                    self.requestBodyDisplayUpdate()
+                }
+                .store(in: observationScope)
+            }
+        }
+    }
+
+    private func requestBodyDisplayUpdate() {
+        displayTask?.cancel()
+        displayGeneration &+= 1
+        let generation = displayGeneration
+        let body = body
+        let bodyKind = body?.kind
+        let fullText = body?.full
+        let previewText = body?.preview
+        let summaryText = body?.summary
+        let isBase64Encoded = body?.isBase64Encoded ?? false
+        let formEntries = body?.formEntries ?? []
+        let syntaxKind = syntaxKind
+        let isURLEncodedForm = isURLEncodedForm
+        let unavailableText = wiLocalized("network.body.unavailable", default: "Body unavailable")
+        let fetchingText = wiLocalized("network.body.fetching", default: "Fetching body...")
+        let isFetching: Bool
+        let fetchErrorText: String?
+        switch body?.fetchState {
+        case .fetching:
+            isFetching = true
+            fetchErrorText = nil
+        case .failed(let error):
+            isFetching = false
+            fetchErrorText = error.localizedDescriptionText
+        default:
+            isFetching = false
+            fetchErrorText = nil
+        }
+
+        displayTask = Task(priority: .userInitiated) {
+            [
+                weak self,
+                generation,
+                bodyKind,
+                fullText,
+                previewText,
+                summaryText,
+                isBase64Encoded,
+                formEntries,
+                isFetching,
+                fetchErrorText,
+                syntaxKind,
+                isURLEncodedForm,
+                unavailableText,
+                fetchingText,
+            ] in
+            let workerTask = Task.detached(priority: .userInitiated) {
+                if isFetching {
+                    return (text: fetchingText, language: SyntaxLanguage.json, usesPlainTextTheme: true)
+                }
+
+                let decoded = decodedV2NetworkBodyText(
+                    kind: bodyKind,
+                    fullText: fullText,
+                    previewText: previewText,
+                    isBase64Encoded: isBase64Encoded
+                )
+                let contentText = decoded ?? fullText ?? previewText
+                let formText = formattedV2NetworkBodyFormText(
+                    kind: bodyKind,
+                    isURLEncodedForm: isURLEncodedForm,
+                    formEntries: formEntries,
+                    contentText: contentText
+                )
+                let prettyJSON = formText == nil ? prettyPrintedV2NetworkBodyJSON(from: contentText) : nil
+                let displayText = formText
+                    ?? prettyJSON
+                    ?? contentText
+                    ?? summaryText
+                    ?? unavailableText
+                let text = if let fetchErrorText {
+                    displayText + "\n\n" + fetchErrorText
+                } else {
+                    displayText
+                }
+                let syntax = v2NetworkBodySyntax(
+                    kind: bodyKind,
+                    syntaxKind: syntaxKind,
+                    isURLEncodedForm: isURLEncodedForm,
+                    contentText: contentText,
+                    didPrettyPrintJSON: prettyJSON != nil
+                )
+                return (text: text, language: syntax.language, usesPlainTextTheme: syntax.usesPlainTextTheme)
+            }
+            let display = await withTaskCancellationHandler {
+                await workerTask.value
+            } onCancel: {
+                workerTask.cancel()
+            }
+
+            guard
+                Task.isCancelled == false,
+                let self,
+                self.displayGeneration == generation
+            else {
+                return
+            }
+            self.applyBodyDisplay(
+                text: display.text,
+                language: display.language,
+                usesPlainTextTheme: display.usesPlainTextTheme
+            )
+        }
+    }
+
+    private func applyBodyDisplay(
+        text: String,
+        language: SyntaxLanguage,
+        usesPlainTextTheme: Bool
+    ) {
+        if syntaxModel.language != language {
+            syntaxModel.language = language
+        }
+        let colorTheme: SyntaxEditorColorTheme = usesPlainTextTheme ? .webInspectorPlainText : .xcode
+        if syntaxModel.colorTheme != colorTheme {
+            syntaxModel.colorTheme = colorTheme
+        }
+        if syntaxModel.text != text {
+            syntaxModel.text = text
+        }
+    }
+}
+
+private func decodedV2NetworkBodyText(
+    kind: NetworkBody.Kind?,
+    fullText: String?,
+    previewText: String?,
+    isBase64Encoded: Bool
+) -> String? {
+    guard kind != .binary else {
+        return nil
+    }
+    guard let candidate = fullText ?? previewText else {
+        return nil
+    }
+    guard isBase64Encoded else {
+        return candidate
+    }
+    guard let data = Data(base64Encoded: candidate) else {
+        return nil
+    }
+    if let decoded = String(data: data, encoding: .utf8) {
+        return decoded
+    }
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func formattedV2NetworkBodyFormText(
+    kind: NetworkBody.Kind?,
+    isURLEncodedForm: Bool,
+    formEntries: [NetworkBody.FormEntry],
+    contentText: String?
+) -> String? {
+    guard kind == .form || isURLEncodedForm else {
+        return nil
+    }
+    if formEntries.isEmpty == false {
+        return formEntries.map(v2NetworkBodyFormEntryLine).joined(separator: "\n")
+    }
+    guard let contentText else {
+        return nil
+    }
+    return formattedV2NetworkURLEncodedFormText(from: contentText)
+}
+
+private func v2NetworkBodyFormEntryLine(_ entry: NetworkBody.FormEntry) -> String {
+    let value: String
+    if entry.isFile, let fileName = entry.fileName, fileName.isEmpty == false {
+        value = "<file \(fileName)>"
+    } else {
+        value = entry.value
+    }
+    return "\(entry.name)=\(value)"
+}
+
+private func formattedV2NetworkURLEncodedFormText(from text: String) -> String? {
+    guard text.isEmpty == false, text.contains("=") else {
+        return nil
+    }
+
+    var lines: [String] = []
+    for pair in text.split(separator: "&", omittingEmptySubsequences: false) {
+        let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.isEmpty == false else {
+            continue
+        }
+        guard let name = decodedV2NetworkFormComponent(String(parts[0])) else {
+            return nil
+        }
+        let value: String
+        if parts.count > 1 {
+            guard let decodedValue = decodedV2NetworkFormComponent(String(parts[1])) else {
+                return nil
+            }
+            value = decodedValue
+        } else {
+            value = ""
+        }
+        lines.append("\(name)=\(value)")
+    }
+    return lines.isEmpty ? nil : lines.joined(separator: "\n")
+}
+
+private func decodedV2NetworkFormComponent(_ component: String) -> String? {
+    component
+        .replacingOccurrences(of: "+", with: " ")
+        .removingPercentEncoding
+}
+
+private func prettyPrintedV2NetworkBodyJSON(from text: String?) -> String? {
+    guard let text, let data = text.data(using: .utf8) else {
+        return nil
+    }
+    guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+        return nil
+    }
+    guard JSONSerialization.isValidJSONObject(object) else {
+        return nil
+    }
+    guard
+        let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+        let pretty = String(data: prettyData, encoding: .utf8)
+    else {
+        return nil
+    }
+    return pretty
+}
+
+private func v2NetworkBodySyntax(
+    kind: NetworkBody.Kind?,
+    syntaxKind: NetworkEntry.BodySyntaxKind,
+    isURLEncodedForm: Bool,
+    contentText: String?,
+    didPrettyPrintJSON: Bool
+) -> (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
+    if kind == .form || isURLEncodedForm {
+        return (.json, true)
+    }
+    if didPrettyPrintJSON {
+        return (.json, false)
+    }
+    if contentText.flatMap(prettyPrintedV2NetworkBodyJSON(from:)) != nil {
+        return (.json, false)
+    }
+    return syntaxKind.syntax
+}
+
+@MainActor
+extension SyntaxEditorColorTheme {
+    static let webInspectorPlainText = SyntaxEditorColorTheme(
+        baseForeground: .label,
+        bracketBackground: .clear,
+        comment: .label,
+        string: .label,
+        keyword: .label,
+        number: .label,
+        function: .label,
+        type: .label,
+        constant: .label,
+        variable: .label,
+        punctuation: .label
+    )
+}
+
+private extension NetworkEntry.BodySyntaxKind {
+    var syntax: (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
+        switch self {
+        case .plainText:
+            (.json, true)
+        case .json:
+            (.json, false)
+        case .html:
+            (.html, false)
+        case .xml:
+            (.xml, false)
+        case .css:
+            (.css, false)
+        case .javascript:
+            (.javascript, false)
+        }
+    }
+}
+
+#if DEBUG
+extension V2_NetworkBodyViewController {
+    var syntaxViewForTesting: SyntaxEditorView {
+        loadViewIfNeeded()
+        return syntaxView
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailMode.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailMode.swift
@@ -1,0 +1,43 @@
+#if canImport(UIKit)
+import WebInspectorEngine
+
+@MainActor
+enum V2_NetworkEntryDetailMode: CaseIterable, Hashable {
+    case overview
+    case requestBody
+    case responseBody
+
+    var title: String {
+        switch self {
+        case .overview:
+            wiLocalized("network.detail.section.overview", default: "Overview")
+        case .requestBody:
+            wiLocalized("network.section.body.request", default: "Request Body")
+        case .responseBody:
+            wiLocalized("network.section.body.response", default: "Response Body")
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .overview:
+            "list.bullet.rectangle"
+        case .requestBody:
+            "arrow.up.doc"
+        case .responseBody:
+            "arrow.down.doc"
+        }
+    }
+
+    var bodyRole: NetworkBody.Role? {
+        switch self {
+        case .overview:
+            nil
+        case .requestBody:
+            .request
+        case .responseBody:
+            .response
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
@@ -1,11 +1,12 @@
 #if canImport(UIKit)
 import ObservationBridge
+import SyntaxEditorUI
 import UIKit
 import WebInspectorEngine
 import WebInspectorRuntime
 
 @MainActor
-final class V2_NetworkEntryDetailViewController: UICollectionViewController {
+final class V2_NetworkEntryDetailViewController: UIViewController, UICollectionViewDelegate {
     private enum SectionIdentifier: Int, CaseIterable, Hashable {
         case overview
         case request
@@ -34,7 +35,31 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     private let inspector: WINetworkModel
     private let observationScope = ObservationScope()
     private let selectedEntryObservationScope = ObservationScope()
+    private let bodyViewController = V2_NetworkBodyViewController()
+    private lazy var modeMenu = V2_NetworkEntryDetailModeMenu(
+        detailViewController: self,
+        inspector: inspector
+    )
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: Self.makeListLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.backgroundColor = .clear
+        collectionView.alwaysBounceVertical = true
+        collectionView.accessibilityIdentifier = "V2.Network.Detail"
+        collectionView.delegate = self
+        collectionView.isHidden = true
+        return collectionView
+    }()
     private lazy var dataSource = makeDataSource()
+    fileprivate var mode: V2_NetworkEntryDetailMode = .overview {
+        didSet {
+            guard mode != oldValue else {
+                return
+            }
+            renderCurrentMode(reloadData: mode == .overview)
+            modeMenu.render()
+        }
+    }
 
     private var selectedEntry: NetworkEntry? {
         inspector.selectedEntry
@@ -42,7 +67,7 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
 
     init(inspector: WINetworkModel) {
         self.inspector = inspector
-        super.init(collectionViewLayout: Self.makeListLayout())
+        super.init(nibName: nil, bundle: nil)
 
         inspector.observe(\.selectedEntry) { [weak self] selectedEntry in
             self?.display(selectedEntry, reloadData: true)
@@ -63,14 +88,48 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
-        collectionView.backgroundColor = .clear
-        collectionView.alwaysBounceVertical = true
-        collectionView.accessibilityIdentifier = "V2.Network.Detail"
+        configureNavigationItem()
+        installCollectionView()
+        installBodyViewController()
         display(inspector.selectedEntry, reloadData: true)
     }
 
-    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         false
+    }
+
+    private func configureNavigationItem() {
+        navigationItem.trailingItemGroups = [
+            UIBarButtonItemGroup(
+                barButtonItems: [modeMenu.makeCompactItem()],
+                representativeItem: nil
+            )
+        ]
+    }
+
+    private func installCollectionView() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func installBodyViewController() {
+        addChild(bodyViewController)
+        bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bodyViewController.view)
+        let safeArea = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            bodyViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            bodyViewController.view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            bodyViewController.view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            bodyViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        bodyViewController.didMove(toParent: self)
+        bodyViewController.view.isHidden = true
     }
 
     private static func makeListLayout() -> UICollectionViewLayout {
@@ -155,10 +214,11 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
         guard isViewLoaded else {
             return
         }
-
         guard let entry else {
             selectedEntryObservationScope.update {}
             collectionView.isHidden = true
+            bodyViewController.view.isHidden = true
+            bodyViewController.display(entry: nil, body: nil, role: .response)
             var configuration = UIContentUnavailableConfiguration.empty()
             configuration.text = wiLocalized("network.empty.selection.title", default: "No request selected")
             configuration.secondaryText = wiLocalized(
@@ -171,23 +231,18 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
             return
         }
 
-        collectionView.isHidden = false
         contentUnavailableConfiguration = nil
-        if reloadData {
-            applySnapshotUsingReloadData()
-        } else {
-            applySnapshot()
-        }
         startObserving(entry)
+        renderCurrentMode(reloadData: reloadData)
     }
 
     private func startObserving(_ entry: NetworkEntry) {
         selectedEntryObservationScope.update {
-            entry.observe([\.requestHeaders, \.responseHeaders]) { [weak self, weak entry] in
+            entry.observe([\.requestHeaders, \.responseHeaders, \.requestBody, \.responseBody]) { [weak self, weak entry] in
                 guard let self, let entry, self.selectedEntry?.id == entry.id else {
                     return
                 }
-                self.applySnapshot()
+                self.renderCurrentMode(reloadData: false)
             }
             .store(in: selectedEntryObservationScope)
 
@@ -198,6 +253,51 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
                 self.title = entry.displayName
             }
             .store(in: selectedEntryObservationScope)
+        }
+    }
+
+    private func renderCurrentMode(reloadData: Bool) {
+        guard isViewLoaded else {
+            return
+        }
+        guard let selectedEntry else {
+            return
+        }
+
+        switch mode {
+        case .overview:
+            bodyViewController.display(entry: nil, body: nil, role: .response)
+            bodyViewController.view.isHidden = true
+            collectionView.isHidden = false
+            if reloadData {
+                applySnapshotUsingReloadData()
+            } else {
+                applySnapshot()
+            }
+        case .requestBody, .responseBody:
+            collectionView.isHidden = true
+            bodyViewController.view.isHidden = false
+            guard let role = mode.bodyRole else {
+                return
+            }
+            bodyViewController.display(
+                entry: selectedEntry,
+                body: body(in: selectedEntry, for: role),
+                role: role
+            )
+        }
+    }
+
+    func makeRegularModeItem() -> UIBarButtonItem {
+        modeMenu.makeRegularItem()
+    }
+
+    private func body(in entry: NetworkEntry, for role: NetworkBody.Role) -> NetworkBody? {
+        switch role {
+        case .request:
+            entry.requestBody
+        case .response:
+            entry.responseBody
         }
     }
 
@@ -271,10 +371,186 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     }
 }
 
+@MainActor
+private final class V2_NetworkEntryDetailModeMenu {
+    private weak var detailViewController: V2_NetworkEntryDetailViewController?
+    private let inspector: WINetworkModel
+    private let observationScope = ObservationScope()
+    private let selectedEntryObservationScope = ObservationScope()
+    private var compactItem: UIBarButtonItem?
+    private var regularItem: UIBarButtonItem?
+
+    init(detailViewController: V2_NetworkEntryDetailViewController, inspector: WINetworkModel) {
+        self.detailViewController = detailViewController
+        self.inspector = inspector
+
+        inspector.observe(\.selectedEntry) { [weak self] entry in
+            self?.observeBodyAvailability(in: entry)
+            self?.render()
+        }
+        .store(in: observationScope)
+    }
+
+    isolated deinit {
+        observationScope.cancelAll()
+        selectedEntryObservationScope.cancelAll()
+    }
+
+    private func observeBodyAvailability(in entry: NetworkEntry?) {
+        selectedEntryObservationScope.update {
+            guard let entry else {
+                return
+            }
+            entry.observe([\.requestBody, \.responseBody]) { [weak self, weak entry] in
+                guard let self, let entry, self.inspector.selectedEntry?.id == entry.id else {
+                    return
+                }
+                self.render()
+            }
+            .store(in: selectedEntryObservationScope)
+        }
+    }
+
+    fileprivate func render() {
+        let mode = detailViewController?.mode ?? .overview
+        let selectedEntry = inspector.selectedEntry
+        let isEnabled = selectedEntry != nil
+
+        if let compactItem {
+            compactItem.image = UIImage(systemName: mode.systemImageName)
+            compactItem.title = nil
+            compactItem.isEnabled = isEnabled
+            compactItem.menu = makeMenu(includesImages: true)
+            compactItem.accessibilityLabel = mode.title
+            compactItem.preferredMenuElementOrder = .fixed
+        }
+
+        if let regularItem {
+            regularItem.isEnabled = isEnabled
+            regularItem.accessibilityLabel = mode.title
+            regularItem.preferredMenuElementOrder = .fixed
+
+            if let button = regularItem.customView as? UIButton {
+                var configuration = button.configuration ?? .bordered()
+                configuration.title = mode.title
+                button.configuration = configuration
+                button.menu = makeMenu(includesImages: false)
+                button.isEnabled = isEnabled
+                button.accessibilityLabel = mode.title
+                button.preferredMenuElementOrder = .fixed
+            }
+        }
+    }
+
+    func makeCompactItem() -> UIBarButtonItem {
+        if let compactItem {
+            return compactItem
+        }
+
+        let compactItem = makeCompactBarButtonItem()
+        self.compactItem = compactItem
+        render()
+        return compactItem
+    }
+
+    func makeRegularItem() -> UIBarButtonItem {
+        if let regularItem {
+            return regularItem
+        }
+
+        let regularItem = makeRegularBarButtonItem()
+        self.regularItem = regularItem
+        render()
+        return regularItem
+    }
+
+    func makeMenuForTesting() -> UIMenu {
+        makeMenu(includesImages: true)
+    }
+
+    private func makeCompactBarButtonItem() -> UIBarButtonItem {
+        let item = UIBarButtonItem(
+            image: UIImage(systemName: (detailViewController?.mode ?? .overview).systemImageName),
+            menu: makeMenu(includesImages: true)
+        )
+        item.accessibilityIdentifier = "V2.Network.DetailModeButton"
+        item.preferredMenuElementOrder = .fixed
+        return item
+    }
+
+    private func makeRegularBarButtonItem() -> UIBarButtonItem {
+        let item = UIBarButtonItem(customView: makeRegularModeButton())
+        item.accessibilityIdentifier = "V2.Network.DetailModeButton.Regular"
+        item.preferredMenuElementOrder = .fixed
+        return item
+    }
+
+    private func makeRegularModeButton() -> UIButton {
+        let button = UIButton(type: .system)
+        var configuration = UIButton.Configuration.bordered()
+        configuration.title = (detailViewController?.mode ?? .overview).title
+        button.configuration = configuration
+        button.showsMenuAsPrimaryAction = true
+        button.changesSelectionAsPrimaryAction = true
+        button.preferredMenuElementOrder = .fixed
+        button.menu = makeMenu(includesImages: false)
+        button.accessibilityIdentifier = "V2.Network.DetailModeButton.Regular.Button"
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
+    }
+
+    private func makeMenu(includesImages: Bool) -> UIMenu {
+        UIMenu(
+            title: "",
+            options: .singleSelection,
+            children: V2_NetworkEntryDetailMode.allCases.map { mode in
+                UIAction(
+                    title: mode.title,
+                    image: includesImages ? UIImage(systemName: mode.systemImageName) : nil,
+                    attributes: isModeEnabled(mode) ? [] : [.disabled],
+                    state: detailViewController?.mode == mode ? .on : .off
+                ) { [weak detailViewController] _ in
+                    detailViewController?.mode = mode
+                }
+            }
+        )
+    }
+
+    private func isModeEnabled(_ mode: V2_NetworkEntryDetailMode) -> Bool {
+        guard let selectedEntry = inspector.selectedEntry else {
+            return mode == .overview
+        }
+        switch mode {
+        case .overview:
+            return true
+        case .requestBody:
+            return selectedEntry.requestBody != nil
+        case .responseBody:
+            return selectedEntry.responseBody != nil
+        }
+    }
+}
+
 #if DEBUG
 extension V2_NetworkEntryDetailViewController {
     var collectionViewForTesting: UICollectionView {
         collectionView
+    }
+
+    var currentModeForTesting: V2_NetworkEntryDetailMode {
+        mode
+    }
+
+    var modeMenuForTesting: UIMenu {
+        modeMenu.makeMenuForTesting()
+    }
+
+    var bodyTextViewForTesting: SyntaxEditorView {
+        bodyViewController.syntaxViewForTesting
+    }
+
+    func setModeForTesting(_ mode: V2_NetworkEntryDetailMode) {
+        self.mode = mode
     }
 }
 #endif

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
@@ -218,11 +218,7 @@ final class V2_NetworkEntryDetailViewController: UIViewController, UICollectionV
             selectedEntryObservationScope.update {}
             collectionView.isHidden = true
             bodyViewController.view.isHidden = true
-            bodyViewController.display(
-                body: nil,
-                syntaxKind: .plainText,
-                isURLEncodedForm: false
-            )
+            bodyViewController.display(body: nil)
             var configuration = UIContentUnavailableConfiguration.empty()
             configuration.text = wiLocalized("network.empty.selection.title", default: "No request selected")
             configuration.secondaryText = wiLocalized(
@@ -270,11 +266,7 @@ final class V2_NetworkEntryDetailViewController: UIViewController, UICollectionV
 
         switch mode {
         case .overview:
-            bodyViewController.display(
-                body: nil,
-                syntaxKind: .plainText,
-                isURLEncodedForm: false
-            )
+            bodyViewController.display(body: nil)
             bodyViewController.view.isHidden = true
             collectionView.isHidden = false
             if reloadData {
@@ -288,11 +280,7 @@ final class V2_NetworkEntryDetailViewController: UIViewController, UICollectionV
             guard let role = mode.bodyRole else {
                 return
             }
-            bodyViewController.display(
-                body: body(in: selectedEntry, for: role),
-                syntaxKind: selectedEntry.bodySyntaxKind(for: role),
-                isURLEncodedForm: selectedEntry.isURLEncodedFormBody(for: role)
-            )
+            bodyViewController.display(body: body(in: selectedEntry, for: role))
         }
     }
 

--- a/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/Detail/V2_NetworkEntryDetailViewController.swift
@@ -1,11 +1,12 @@
 #if canImport(UIKit)
 import ObservationBridge
+import SyntaxEditorUI
 import UIKit
 import WebInspectorEngine
 import WebInspectorRuntime
 
 @MainActor
-final class V2_NetworkEntryDetailViewController: UICollectionViewController {
+final class V2_NetworkEntryDetailViewController: UIViewController, UICollectionViewDelegate {
     private enum SectionIdentifier: Int, CaseIterable, Hashable {
         case overview
         case request
@@ -34,7 +35,31 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     private let inspector: WINetworkModel
     private let observationScope = ObservationScope()
     private let selectedEntryObservationScope = ObservationScope()
+    private let bodyViewController = V2_NetworkBodyViewController()
+    private lazy var modeMenu = V2_NetworkEntryDetailModeMenu(
+        detailViewController: self,
+        inspector: inspector
+    )
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: Self.makeListLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.backgroundColor = .clear
+        collectionView.alwaysBounceVertical = true
+        collectionView.accessibilityIdentifier = "V2.Network.Detail"
+        collectionView.delegate = self
+        collectionView.isHidden = true
+        return collectionView
+    }()
     private lazy var dataSource = makeDataSource()
+    fileprivate var mode: V2_NetworkEntryDetailMode = .overview {
+        didSet {
+            guard mode != oldValue else {
+                return
+            }
+            renderCurrentMode(reloadData: mode == .overview)
+            modeMenu.render()
+        }
+    }
 
     private var selectedEntry: NetworkEntry? {
         inspector.selectedEntry
@@ -42,7 +67,7 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
 
     init(inspector: WINetworkModel) {
         self.inspector = inspector
-        super.init(collectionViewLayout: Self.makeListLayout())
+        super.init(nibName: nil, bundle: nil)
 
         inspector.observe(\.selectedEntry) { [weak self] selectedEntry in
             self?.display(selectedEntry, reloadData: true)
@@ -63,14 +88,48 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
-        collectionView.backgroundColor = .clear
-        collectionView.alwaysBounceVertical = true
-        collectionView.accessibilityIdentifier = "V2.Network.Detail"
+        configureNavigationItem()
+        installCollectionView()
+        installBodyViewController()
         display(inspector.selectedEntry, reloadData: true)
     }
 
-    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         false
+    }
+
+    private func configureNavigationItem() {
+        navigationItem.trailingItemGroups = [
+            UIBarButtonItemGroup(
+                barButtonItems: [modeMenu.makeCompactItem()],
+                representativeItem: nil
+            )
+        ]
+    }
+
+    private func installCollectionView() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func installBodyViewController() {
+        addChild(bodyViewController)
+        bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bodyViewController.view)
+        let safeArea = view.safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            bodyViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            bodyViewController.view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            bodyViewController.view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            bodyViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        bodyViewController.didMove(toParent: self)
+        bodyViewController.view.isHidden = true
     }
 
     private static func makeListLayout() -> UICollectionViewLayout {
@@ -155,10 +214,15 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
         guard isViewLoaded else {
             return
         }
-
         guard let entry else {
             selectedEntryObservationScope.update {}
             collectionView.isHidden = true
+            bodyViewController.view.isHidden = true
+            bodyViewController.display(
+                body: nil,
+                syntaxKind: .plainText,
+                isURLEncodedForm: false
+            )
             var configuration = UIContentUnavailableConfiguration.empty()
             configuration.text = wiLocalized("network.empty.selection.title", default: "No request selected")
             configuration.secondaryText = wiLocalized(
@@ -171,23 +235,18 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
             return
         }
 
-        collectionView.isHidden = false
         contentUnavailableConfiguration = nil
-        if reloadData {
-            applySnapshotUsingReloadData()
-        } else {
-            applySnapshot()
-        }
         startObserving(entry)
+        renderCurrentMode(reloadData: reloadData)
     }
 
     private func startObserving(_ entry: NetworkEntry) {
         selectedEntryObservationScope.update {
-            entry.observe([\.requestHeaders, \.responseHeaders]) { [weak self, weak entry] in
+            entry.observe([\.requestHeaders, \.responseHeaders, \.requestBody, \.responseBody]) { [weak self, weak entry] in
                 guard let self, let entry, self.selectedEntry?.id == entry.id else {
                     return
                 }
-                self.applySnapshot()
+                self.renderCurrentMode(reloadData: false)
             }
             .store(in: selectedEntryObservationScope)
 
@@ -198,6 +257,55 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
                 self.title = entry.displayName
             }
             .store(in: selectedEntryObservationScope)
+        }
+    }
+
+    private func renderCurrentMode(reloadData: Bool) {
+        guard isViewLoaded else {
+            return
+        }
+        guard let selectedEntry else {
+            return
+        }
+
+        switch mode {
+        case .overview:
+            bodyViewController.display(
+                body: nil,
+                syntaxKind: .plainText,
+                isURLEncodedForm: false
+            )
+            bodyViewController.view.isHidden = true
+            collectionView.isHidden = false
+            if reloadData {
+                applySnapshotUsingReloadData()
+            } else {
+                applySnapshot()
+            }
+        case .requestBody, .responseBody:
+            collectionView.isHidden = true
+            bodyViewController.view.isHidden = false
+            guard let role = mode.bodyRole else {
+                return
+            }
+            bodyViewController.display(
+                body: body(in: selectedEntry, for: role),
+                syntaxKind: selectedEntry.bodySyntaxKind(for: role),
+                isURLEncodedForm: selectedEntry.isURLEncodedFormBody(for: role)
+            )
+        }
+    }
+
+    func makeRegularModeItem() -> UIBarButtonItem {
+        modeMenu.makeRegularItem()
+    }
+
+    private func body(in entry: NetworkEntry, for role: NetworkBody.Role) -> NetworkBody? {
+        switch role {
+        case .request:
+            entry.requestBody
+        case .response:
+            entry.responseBody
         }
     }
 
@@ -271,10 +379,186 @@ final class V2_NetworkEntryDetailViewController: UICollectionViewController {
     }
 }
 
+@MainActor
+private final class V2_NetworkEntryDetailModeMenu {
+    private weak var detailViewController: V2_NetworkEntryDetailViewController?
+    private let inspector: WINetworkModel
+    private let observationScope = ObservationScope()
+    private let selectedEntryObservationScope = ObservationScope()
+    private var compactItem: UIBarButtonItem?
+    private var regularItem: UIBarButtonItem?
+
+    init(detailViewController: V2_NetworkEntryDetailViewController, inspector: WINetworkModel) {
+        self.detailViewController = detailViewController
+        self.inspector = inspector
+
+        inspector.observe(\.selectedEntry) { [weak self] entry in
+            self?.observeBodyAvailability(in: entry)
+            self?.render()
+        }
+        .store(in: observationScope)
+    }
+
+    isolated deinit {
+        observationScope.cancelAll()
+        selectedEntryObservationScope.cancelAll()
+    }
+
+    private func observeBodyAvailability(in entry: NetworkEntry?) {
+        selectedEntryObservationScope.update {
+            guard let entry else {
+                return
+            }
+            entry.observe([\.requestBody, \.responseBody]) { [weak self, weak entry] in
+                guard let self, let entry, self.inspector.selectedEntry?.id == entry.id else {
+                    return
+                }
+                self.render()
+            }
+            .store(in: selectedEntryObservationScope)
+        }
+    }
+
+    fileprivate func render() {
+        let mode = detailViewController?.mode ?? .overview
+        let selectedEntry = inspector.selectedEntry
+        let isEnabled = selectedEntry != nil
+
+        if let compactItem {
+            compactItem.image = UIImage(systemName: mode.systemImageName)
+            compactItem.title = nil
+            compactItem.isEnabled = isEnabled
+            compactItem.menu = makeMenu(includesImages: true)
+            compactItem.accessibilityLabel = mode.title
+            compactItem.preferredMenuElementOrder = .fixed
+        }
+
+        if let regularItem {
+            regularItem.isEnabled = isEnabled
+            regularItem.accessibilityLabel = mode.title
+            regularItem.preferredMenuElementOrder = .fixed
+
+            if let button = regularItem.customView as? UIButton {
+                var configuration = button.configuration ?? .bordered()
+                configuration.title = mode.title
+                button.configuration = configuration
+                button.menu = makeMenu(includesImages: false)
+                button.isEnabled = isEnabled
+                button.accessibilityLabel = mode.title
+                button.preferredMenuElementOrder = .fixed
+            }
+        }
+    }
+
+    func makeCompactItem() -> UIBarButtonItem {
+        if let compactItem {
+            return compactItem
+        }
+
+        let compactItem = makeCompactBarButtonItem()
+        self.compactItem = compactItem
+        render()
+        return compactItem
+    }
+
+    func makeRegularItem() -> UIBarButtonItem {
+        if let regularItem {
+            return regularItem
+        }
+
+        let regularItem = makeRegularBarButtonItem()
+        self.regularItem = regularItem
+        render()
+        return regularItem
+    }
+
+    func makeMenuForTesting() -> UIMenu {
+        makeMenu(includesImages: true)
+    }
+
+    private func makeCompactBarButtonItem() -> UIBarButtonItem {
+        let item = UIBarButtonItem(
+            image: UIImage(systemName: (detailViewController?.mode ?? .overview).systemImageName),
+            menu: makeMenu(includesImages: true)
+        )
+        item.accessibilityIdentifier = "V2.Network.DetailModeButton"
+        item.preferredMenuElementOrder = .fixed
+        return item
+    }
+
+    private func makeRegularBarButtonItem() -> UIBarButtonItem {
+        let item = UIBarButtonItem(customView: makeRegularModeButton())
+        item.accessibilityIdentifier = "V2.Network.DetailModeButton.Regular"
+        item.preferredMenuElementOrder = .fixed
+        return item
+    }
+
+    private func makeRegularModeButton() -> UIButton {
+        let button = UIButton(type: .system)
+        var configuration = UIButton.Configuration.bordered()
+        configuration.title = (detailViewController?.mode ?? .overview).title
+        button.configuration = configuration
+        button.showsMenuAsPrimaryAction = true
+        button.changesSelectionAsPrimaryAction = true
+        button.preferredMenuElementOrder = .fixed
+        button.menu = makeMenu(includesImages: false)
+        button.accessibilityIdentifier = "V2.Network.DetailModeButton.Regular.Button"
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
+    }
+
+    private func makeMenu(includesImages: Bool) -> UIMenu {
+        UIMenu(
+            title: "",
+            options: .singleSelection,
+            children: V2_NetworkEntryDetailMode.allCases.map { mode in
+                UIAction(
+                    title: mode.title,
+                    image: includesImages ? UIImage(systemName: mode.systemImageName) : nil,
+                    attributes: isModeEnabled(mode) ? [] : [.disabled],
+                    state: detailViewController?.mode == mode ? .on : .off
+                ) { [weak detailViewController] _ in
+                    detailViewController?.mode = mode
+                }
+            }
+        )
+    }
+
+    private func isModeEnabled(_ mode: V2_NetworkEntryDetailMode) -> Bool {
+        guard let selectedEntry = inspector.selectedEntry else {
+            return mode == .overview
+        }
+        switch mode {
+        case .overview:
+            return true
+        case .requestBody:
+            return selectedEntry.requestBody != nil
+        case .responseBody:
+            return selectedEntry.responseBody != nil
+        }
+    }
+}
+
 #if DEBUG
 extension V2_NetworkEntryDetailViewController {
     var collectionViewForTesting: UICollectionView {
         collectionView
+    }
+
+    var currentModeForTesting: V2_NetworkEntryDetailMode {
+        mode
+    }
+
+    var modeMenuForTesting: UIMenu {
+        modeMenu.makeMenuForTesting()
+    }
+
+    var bodyTextViewForTesting: SyntaxEditorView {
+        bodyViewController.syntaxViewForTesting
+    }
+
+    func setModeForTesting(_ mode: V2_NetworkEntryDetailMode) {
+        self.mode = mode
     }
 }
 #endif

--- a/Sources/WebInspectorUI/V2/Network/V2_NetworkSplitViewController.swift
+++ b/Sources/WebInspectorUI/V2/Network/V2_NetworkSplitViewController.swift
@@ -39,6 +39,7 @@ final class V2_NetworkSplitViewController: UISplitViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
+        configureNavigationItem()
     }
 
     private func configureSplitViewLayout() {
@@ -46,6 +47,7 @@ final class V2_NetworkSplitViewController: UISplitViewController {
         presentsWithGesture = false
         displayModeButtonVisibility = .never
         preferredDisplayMode = .oneBesideSecondary
+        preferredPrimaryColumnWidthFraction = 0.33
 
         setViewController(primaryViewController, for: .primary)
         setViewController(secondaryViewController, for: .secondary)
@@ -53,6 +55,20 @@ final class V2_NetworkSplitViewController: UISplitViewController {
 
     private func showEntryDetail(_ entry: NetworkEntry?) {
         inspector.selectEntry(entry)
+    }
+
+    private func configureNavigationItem() {
+        let item = detailViewController.makeRegularModeItem()
+        if #available(iOS 26.0, *) {
+            item.hidesSharedBackground = true
+        }
+        let group = UIBarButtonItemGroup(
+            barButtonItems: [item],
+            representativeItem: nil
+        )
+        navigationItem.trailingItemGroups = [
+            group
+        ]
     }
 }
 
@@ -87,6 +103,15 @@ import WebInspectorRuntime
         inspector: network.model,
         listViewController: V2_NetworkListViewController(inspector: network.model),
         detailViewController: V2_NetworkEntryDetailViewController(inspector: network.model)
+    )
+}
+
+#Preview("V2 Network Split Entries") {
+    let inspector = WINetworkPreviewFixtures.makeInspector(mode: .detail)
+    V2_NetworkSplitViewController(
+        inspector: inspector,
+        listViewController: V2_NetworkListViewController(inspector: inspector),
+        detailViewController: V2_NetworkEntryDetailViewController(inspector: inspector)
     )
 }
 #endif

--- a/Sources/WebInspectorUI/V2/Network/V2_NetworkTabController.swift
+++ b/Sources/WebInspectorUI/V2/Network/V2_NetworkTabController.swift
@@ -40,13 +40,12 @@ struct V2_NetworkTabController: V2_BuiltInTabController {
                 detailViewController: detailViewController
             )
         case .regular:
-            return V2_WIRegularSplitRootViewController(
-                contentViewController: V2_NetworkSplitViewController(
-                    inspector: session.runtime.network.model,
-                    listViewController: listViewController,
-                    detailViewController: detailViewController
-                )
+            let splitViewController = V2_NetworkSplitViewController(
+                inspector: session.runtime.network.model,
+                listViewController: listViewController,
+                detailViewController: detailViewController
             )
+            return V2_WIRegularSplitRootViewController(contentViewController: splitViewController)
         }
     }
 

--- a/Tests/WebInspectorEngineTests/NetworkStoreTests.swift
+++ b/Tests/WebInspectorEngineTests/NetworkStoreTests.swift
@@ -5,6 +5,35 @@ import WebInspectorTestSupport
 @MainActor
 struct NetworkStoreTests {
     @Test
+    func bodySyntaxKindUsesContentTypeAndURL() {
+        #expect(
+            NetworkEntry.bodySyntaxKind(
+                contentType: "application/problem+json; charset=utf-8",
+                url: "https://example.com/error"
+            ) == .json
+        )
+        #expect(
+            NetworkEntry.bodySyntaxKind(
+                contentType: nil,
+                url: "https://example.com/assets/app.mjs"
+            ) == .javascript
+        )
+        #expect(
+            NetworkEntry.bodySyntaxKind(
+                contentType: "application/xhtml+xml",
+                url: "https://example.com/page"
+            ) == .html
+        )
+        #expect(
+            NetworkEntry.bodySyntaxKind(
+                contentType: "application/atom+xml",
+                url: "https://example.com/feed"
+            ) == .xml
+        )
+        #expect(NetworkEntry.isURLEncodedFormContentType("application/x-www-form-urlencoded; charset=UTF-8"))
+    }
+
+    @Test
     func keepsEntriesScopedBySessionAndRequestId() throws {
         let store = NetworkStore()
 

--- a/Tests/WebInspectorEngineTests/NetworkStoreTests.swift
+++ b/Tests/WebInspectorEngineTests/NetworkStoreTests.swift
@@ -34,6 +34,251 @@ struct NetworkStoreTests {
     }
 
     @Test
+    func networkBodyTextRepresentationUsesRawTextAndSummaryFallback() {
+        let rawBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: "plain payload",
+            summary: "summary"
+        )
+        #expect(rawBody.displayText == "plain payload")
+        #expect(rawBody.textRepresentation == "plain payload")
+        #expect(rawBody.textRepresentationSyntaxKind == .plainText)
+
+        let summaryBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: nil,
+            summary: "No content"
+        )
+        #expect(summaryBody.displayText == "No content")
+        #expect(summaryBody.textRepresentation == "No content")
+    }
+
+    @Test
+    func networkBodyTextRepresentationDecodesBase64Text() {
+        let body = NetworkBody(
+            kind: .text,
+            preview: "aGVsbG8gd29ybGQ=",
+            full: nil,
+            isBase64Encoded: true,
+            isTruncated: false
+        )
+
+        #expect(body.displayText == "aGVsbG8gd29ybGQ=")
+        #expect(body.textRepresentation == "hello world")
+    }
+
+    @Test
+    func networkBodyTextRepresentationFormatsFormEntries() {
+        let body = NetworkBody(
+            kind: .form,
+            preview: nil,
+            full: nil,
+            summary: "FormData",
+            formEntries: [
+                NetworkBody.FormEntry(name: "token", value: "abc", isFile: false, fileName: nil),
+                NetworkBody.FormEntry(name: "upload", value: "", isFile: true, fileName: "payload.txt"),
+            ]
+        )
+
+        #expect(body.textRepresentation == "token=abc\nupload=<file payload.txt>")
+        #expect(body.textRepresentationSyntaxKind == .plainText)
+    }
+
+    @Test
+    func networkBodyTextRepresentationFormatsURLEncodedRawBody() {
+        let body = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: "name=Jane+Doe&city=Tokyo%20East"
+        )
+
+        body.applyTextRepresentationHints(
+            syntaxKind: .plainText,
+            treatsRawTextAsURLEncodedForm: true
+        )
+
+        #expect(body.treatsRawTextAsURLEncodedForm)
+        #expect(body.textRepresentation == "name=Jane Doe\ncity=Tokyo East")
+        #expect(body.textRepresentationSyntaxKind == .plainText)
+    }
+
+    @Test
+    func networkBodyTextRepresentationPrettyPrintsJSON() {
+        let body = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: #"{"name":"Ada","items":[1,2]}"#
+        )
+
+        #expect(body.textRepresentation?.contains("\n") == true)
+        #expect(body.textRepresentation?.contains(#""name""#) == true)
+        #expect(body.textRepresentationSyntaxKind == .json)
+    }
+
+    @Test
+    func networkBodyTextRepresentationDoesNotDecodeBinaryBody() {
+        let body = NetworkBody(
+            kind: .binary,
+            preview: "raw-bytes",
+            full: "raw-bytes",
+            summary: "Binary content"
+        )
+
+        #expect(body.displayText == "raw-bytes")
+        #expect(body.textRepresentation == "Binary content")
+        #expect(body.textRepresentationSyntaxKind == .plainText)
+    }
+
+    @Test
+    func networkEntryConfiguresBodyRolesAndSyntaxHintsWhenBodiesAreAssigned() throws {
+        let requestBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: #"{"ok":true}"#,
+            role: .response
+        )
+        let responseBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: "body {}",
+            role: .request
+        )
+        let store = NetworkStore()
+
+        let entry = try #require(
+            store.applySnapshots([
+                Self.makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/styles/main.css",
+                    requestHeaders: NetworkHeaders(dictionary: [
+                        "content-type": "application/json",
+                    ]),
+                    responseMimeType: "text/css",
+                    requestBody: requestBody,
+                    responseBody: responseBody
+                )
+            ]).first
+        )
+
+        #expect(entry.requestBody === requestBody)
+        #expect(requestBody.role == .request)
+        #expect(requestBody.sourceSyntaxKind == .json)
+        #expect(responseBody.role == .response)
+        #expect(responseBody.sourceSyntaxKind == .css)
+    }
+
+    @Test
+    func networkEntryRefreshesExistingBodySyntaxHintsWhenMetadataChanges() throws {
+        let requestBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: "name=Jane+Doe"
+        )
+        let responseBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: "body {}"
+        )
+        let store = NetworkStore()
+        let entry = try #require(
+            store.applySnapshots([
+                Self.makeSnapshot(
+                    requestID: 2,
+                    url: "https://example.com/body",
+                    requestBody: requestBody,
+                    responseBody: responseBody
+                )
+            ]).first
+        )
+
+        #expect(requestBody.sourceSyntaxKind == .plainText)
+        #expect(requestBody.treatsRawTextAsURLEncodedForm == false)
+        #expect(responseBody.sourceSyntaxKind == .plainText)
+
+        entry.applyRequestStart(
+            url: "https://example.com/app.js",
+            method: nil,
+            requestHeaders: NetworkHeaders(dictionary: [
+                "content-type": "application/x-www-form-urlencoded",
+            ]),
+            requestType: nil,
+            requestBody: nil,
+            requestBodyBytesSent: nil,
+            startTimestamp: 0,
+            wallTime: nil
+        )
+        #expect(requestBody.treatsRawTextAsURLEncodedForm)
+        #expect(requestBody.textRepresentation == "name=Jane Doe")
+        #expect(responseBody.sourceSyntaxKind == .javascript)
+
+        entry.applyResponse(
+            statusCode: 200,
+            statusText: "OK",
+            mimeType: "text/css",
+            responseHeaders: NetworkHeaders(),
+            requestType: nil,
+            timestamp: 1
+        )
+        #expect(responseBody.sourceSyntaxKind == .css)
+
+        entry.applyResponse(
+            statusCode: 200,
+            statusText: "OK",
+            mimeType: nil,
+            responseHeaders: NetworkHeaders(dictionary: [
+                "content-type": "application/json",
+            ]),
+            requestType: nil,
+            timestamp: 2
+        )
+        #expect(responseBody.sourceSyntaxKind == .json)
+    }
+
+    @Test
+    func networkEntryFetchedBodyUpdatesTextRepresentation() throws {
+        let targetBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: nil,
+            isTruncated: true,
+            reference: "response-ref",
+            fetchState: .inline,
+            role: .response
+        )
+        let fetchedBody = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: #"{"updated":true}"#,
+            isTruncated: false,
+            reference: "response-ref",
+            fetchState: .full,
+            role: .response
+        )
+        let store = NetworkStore()
+        let entry = try #require(
+            store.applySnapshots([
+                Self.makeSnapshot(
+                    requestID: 3,
+                    url: "https://example.com/fetch",
+                    responseHeaders: NetworkHeaders(dictionary: [
+                        "content-type": "application/json",
+                    ]),
+                    responseBody: targetBody
+                )
+            ]).first
+        )
+
+        entry.applyFetchedBody(fetchedBody, to: targetBody)
+
+        #expect(targetBody.fetchState == .full)
+        #expect(targetBody.textRepresentation?.contains("\n") == true)
+        #expect(targetBody.textRepresentation?.contains(#""updated""#) == true)
+        #expect(targetBody.textRepresentationSyntaxKind == .json)
+    }
+
+    @Test
     func keepsEntriesScopedBySessionAndRequestId() throws {
         let store = NetworkStore()
 
@@ -792,5 +1037,47 @@ private extension NetworkStoreTests {
         sessionID: String = ""
     ) {
         store.apply(payload, sessionID: sessionID)
+    }
+
+    static func makeSnapshot(
+        requestID: Int,
+        url: String,
+        method: String = "GET",
+        requestHeaders: NetworkHeaders = NetworkHeaders(),
+        responseMimeType: String? = nil,
+        responseHeaders: NetworkHeaders = NetworkHeaders(),
+        requestBody: NetworkBody? = nil,
+        responseBody: NetworkBody? = nil
+    ) -> NetworkEntry.Snapshot {
+        NetworkEntry.Snapshot(
+            sessionID: "test-session",
+            requestID: requestID,
+            request: NetworkEntry.Request(
+                url: url,
+                method: method,
+                headers: requestHeaders,
+                body: requestBody,
+                bodyBytesSent: nil,
+                type: nil,
+                wallTime: nil
+            ),
+            response: NetworkEntry.Response(
+                statusCode: 200,
+                statusText: "OK",
+                mimeType: responseMimeType,
+                headers: responseHeaders,
+                body: responseBody,
+                blockedCookies: [],
+                errorDescription: nil
+            ),
+            transfer: NetworkEntry.Transfer(
+                startTimestamp: 0,
+                endTimestamp: 1,
+                duration: 1,
+                encodedBodyLength: nil,
+                decodedBodyLength: nil,
+                phase: .completed
+            )
+        )
     }
 }

--- a/Tests/WebInspectorUITests/V2DOMElementViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/V2DOMElementViewControllerTests.swift
@@ -52,12 +52,15 @@ struct V2DOMElementViewControllerTests {
             visibleListCellText(in: viewController.collectionView, at: IndexPath(item: 0, section: 0))
                 == "<div id=\"selected\" class=\"hero\">"
         )
-        let previewTextView = visibleTextView(in: viewController.collectionView, at: IndexPath(item: 0, section: 0))
-        #expect(previewTextView is SyntaxEditorView)
-        #expect(previewTextView?.isSelectable == true)
-        #expect(previewTextView?.isEditable == false)
-        #expect(previewTextView?.isScrollEnabled == false)
-        #expect(hasCenteredTextContainerInsets(previewTextView))
+        let previewEditorView = visibleSyntaxEditorView(
+            in: viewController.collectionView,
+            at: IndexPath(item: 0, section: 0)
+        )
+        #expect(previewEditorView != nil)
+        #expect(previewEditorView?.isSelectable == true)
+        #expect(previewEditorView?.isEditable == false)
+        #expect(previewEditorView?.isScrollEnabled == false)
+        #expect(hasCenteredTextContainerInsets(previewEditorView))
         #expect(visibleCellHeight(in: viewController.collectionView, at: IndexPath(item: 0, section: 0)) ?? 0 >= 44)
         #expect(visibleListCellText(in: viewController.collectionView, at: IndexPath(item: 0, section: 1)) == "#selected")
         let selectorTextView = visibleTextView(in: viewController.collectionView, at: IndexPath(item: 0, section: 1))
@@ -92,10 +95,10 @@ struct V2DOMElementViewControllerTests {
             let indexPath = IndexPath(item: 0, section: 0)
             guard visibleListCellText(in: viewController.collectionView, at: indexPath) == expectedPreview,
                   let cell = viewController.collectionView.cellForItem(at: indexPath),
-                  let textView = visibleTextView(in: cell.contentView),
-                  let lineHeight = textView.font?.lineHeight else {
+                  let editorView = visibleSyntaxEditorView(in: cell.contentView) else {
                 return false
             }
+            let lineHeight = editorView.font.lineHeight
             return cell.bounds.height > lineHeight * 2
         }
         #expect(previewExpanded)
@@ -238,9 +241,36 @@ struct V2DOMElementViewControllerTests {
         }
         guard let cell = collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell,
               let configuration = cell.contentConfiguration as? UIListContentConfiguration else {
-            return visibleTextView(in: collectionView.cellForItem(at: indexPath)?.contentView)?.text
+            return visibleDisplayText(in: collectionView.cellForItem(at: indexPath)?.contentView)
         }
         return configuration.text
+    }
+
+    private func visibleSyntaxEditorView(
+        in collectionView: UICollectionView,
+        at indexPath: IndexPath
+    ) -> SyntaxEditorView? {
+        collectionView.layoutIfNeeded()
+        guard collectionView.numberOfSections > indexPath.section,
+              collectionView.numberOfItems(inSection: indexPath.section) > indexPath.item else {
+            return nil
+        }
+        return visibleSyntaxEditorView(in: collectionView.cellForItem(at: indexPath)?.contentView)
+    }
+
+    private func visibleSyntaxEditorView(in view: UIView?) -> SyntaxEditorView? {
+        guard let view else {
+            return nil
+        }
+        if let editorView = view as? SyntaxEditorView {
+            return editorView
+        }
+        for subview in view.subviews {
+            if let editorView = visibleSyntaxEditorView(in: subview) {
+                return editorView
+            }
+        }
+        return nil
     }
 
     private func visibleTextView(in collectionView: UICollectionView, at indexPath: IndexPath) -> UITextView? {
@@ -274,6 +304,24 @@ struct V2DOMElementViewControllerTests {
         return textViews
     }
 
+    private func visibleDisplayText(in view: UIView?) -> String? {
+        guard let view else {
+            return nil
+        }
+        if let textView = view as? UITextView {
+            return textView.text
+        }
+        if let editorView = view as? SyntaxEditorView {
+            return editorView.text
+        }
+        for subview in view.subviews {
+            if let text = visibleDisplayText(in: subview) {
+                return text
+            }
+        }
+        return nil
+    }
+
     private func visibleCellHeight(in collectionView: UICollectionView, at indexPath: IndexPath) -> CGFloat? {
         collectionView.layoutIfNeeded()
         guard collectionView.numberOfSections > indexPath.section,
@@ -290,6 +338,15 @@ struct V2DOMElementViewControllerTests {
         textView.layoutIfNeeded()
         return textView.textContainerInset.top > 0
             && abs(textView.textContainerInset.top - textView.textContainerInset.bottom) <= 1
+    }
+
+    private func hasCenteredTextContainerInsets(_ editorView: SyntaxEditorView?) -> Bool {
+        guard let editorView else {
+            return false
+        }
+        editorView.layoutIfNeeded()
+        return editorView.textContainerInset.top > 0
+            && abs(editorView.textContainerInset.top - editorView.textContainerInset.bottom) <= 1
     }
 
     private func visibleListCellSecondaryText(in collectionView: UICollectionView, at indexPath: IndexPath) -> String? {

--- a/Tests/WebInspectorUITests/V2NetworkEntryDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/V2NetworkEntryDetailViewControllerTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import SyntaxEditorUI
 import Testing
 import UIKit
 @testable import WebInspectorEngine
@@ -156,6 +157,295 @@ struct V2NetworkEntryDetailViewControllerTests {
 
         #expect(didRenderOnlyHeaderSections)
         #expect(fetcher.fetchCount == 0)
+    }
+
+    @Test
+    func detailModeMenuReflectsBodyAvailability() async throws {
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/body",
+                    requestBody: makeBody(
+                        full: "request-body",
+                        role: .request
+                    ),
+                    responseBody: nil
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRender = await waitUntil {
+            viewController.collectionViewForTesting.numberOfSections == 3
+        }
+        #expect(didRender)
+
+        let overviewAction = try action(for: .overview, in: viewController.modeMenuForTesting)
+        let requestAction = try action(for: .requestBody, in: viewController.modeMenuForTesting)
+        let responseAction = try action(for: .responseBody, in: viewController.modeMenuForTesting)
+
+        #expect(overviewAction.state == .on)
+        #expect(overviewAction.attributes.contains(.disabled) == false)
+        #expect(requestAction.attributes.contains(.disabled) == false)
+        #expect(responseAction.attributes.contains(.disabled))
+        #expect(menuActionTitles(in: viewController.modeMenuForTesting) == V2_NetworkEntryDetailMode.allCases.map(\.title))
+
+        requestAction.performWithSender(nil, target: nil)
+
+        let didSwitch = await waitUntil {
+            viewController.currentModeForTesting == .requestBody
+                && viewController.bodyTextViewForTesting.text == "request-body"
+        }
+        #expect(didSwitch)
+        #expect(try action(for: .requestBody, in: viewController.modeMenuForTesting).state == .on)
+        #expect(menuActionTitles(in: viewController.modeMenuForTesting) == V2_NetworkEntryDetailMode.allCases.map(\.title))
+    }
+
+    @Test
+    func responseBodyModeRendersPrettyPrintedJSONInReadOnlySyntaxEditor() async throws {
+        let compactJSON = "{\"name\":\"codex\",\"value\":42}"
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/api/data.json",
+                    responseHeaders: NetworkHeaders([
+                        NetworkHeaderField(name: "content-type", value: "application/json")
+                    ]),
+                    responseBody: makeBody(full: compactJSON, role: .response)
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+
+        let didRender = await waitUntil {
+            viewController.bodyTextViewForTesting.text.contains("\n")
+                && viewController.bodyTextViewForTesting.text.contains("\"name\"")
+        }
+        #expect(didRender)
+
+        let syntaxView = viewController.bodyTextViewForTesting
+        #expect(syntaxView.isEditable == false)
+        #expect(syntaxView.isSelectable)
+        #expect(syntaxView.model.lineWrappingEnabled)
+        #expect(syntaxView.model.language == .json)
+        #expect(syntaxView.model.colorTheme == .xcode)
+    }
+
+    @Test
+    func requestBodyModeFormatsFormEntriesAsPlainText() async throws {
+        let inspector = WINetworkModel(session: NetworkSession())
+        let body = NetworkBody(
+            kind: .form,
+            preview: nil,
+            full: nil,
+            size: nil,
+            isBase64Encoded: false,
+            isTruncated: false,
+            summary: "FormData",
+            reference: nil,
+            formEntries: [
+                NetworkBody.FormEntry(name: "token", value: "abc", isFile: false, fileName: nil),
+                NetworkBody.FormEntry(name: "upload", value: "<file payload.txt>", isFile: true, fileName: "payload.txt"),
+            ],
+            fetchState: .full,
+            role: .request
+        )
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/upload",
+                    method: "POST",
+                    requestBody: body
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.requestBody)
+
+        let didRender = await waitUntil {
+            viewController.bodyTextViewForTesting.text == "token=abc\nupload=<file payload.txt>"
+        }
+        #expect(didRender)
+        let syntaxView = viewController.bodyTextViewForTesting
+        #expect(syntaxView.model.colorTheme == .webInspectorPlainText)
+    }
+
+    @Test
+    func requestBodyModeFormatsURLEncodedFormText() async throws {
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/form",
+                    method: "POST",
+                    requestHeaders: NetworkHeaders([
+                        NetworkHeaderField(name: "content-type", value: "application/x-www-form-urlencoded")
+                    ]),
+                    requestBody: makeBody(
+                        full: "name=Jane+Doe&city=Tokyo%20East",
+                        role: .request
+                    )
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.requestBody)
+
+        let didRender = await waitUntil {
+            viewController.bodyTextViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
+        }
+        #expect(didRender)
+        #expect(viewController.bodyTextViewForTesting.model.colorTheme == .webInspectorPlainText)
+    }
+
+    @Test
+    func responseBodyModeUsesNoHighlightThemeForPlainText() async throws {
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/download.bin",
+                    responseHeaders: NetworkHeaders([
+                        NetworkHeaderField(name: "content-type", value: "application/octet-stream")
+                    ]),
+                    responseBody: makeBody(full: "plain payload", role: .response)
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+
+        let didRender = await waitUntil {
+            viewController.bodyTextViewForTesting.text == "plain payload"
+        }
+        #expect(didRender)
+        #expect(viewController.bodyTextViewForTesting.model.colorTheme == .webInspectorPlainText)
+    }
+
+    @Test
+    func bodyModePersistsAcrossSelectedEntryChanges() async throws {
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entries = inspector.store.applySnapshots([
+            makeSnapshot(
+                requestID: 1,
+                url: "https://example.com/first.json",
+                responseBody: makeBody(full: "{\"first\":true}", role: .response)
+            ),
+            makeSnapshot(
+                requestID: 2,
+                url: "https://example.com/second.json",
+                responseBody: nil
+            ),
+        ])
+        let firstEntry = try #require(entries.first)
+        let secondEntry = try #require(entries.dropFirst().first)
+        inspector.selectEntry(firstEntry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+        let didRenderFirst = await waitUntil {
+            viewController.bodyTextViewForTesting.text.contains("\"first\"")
+        }
+        #expect(didRenderFirst)
+
+        inspector.selectEntry(secondEntry)
+
+        let didKeepMode = await waitUntil {
+            viewController.currentModeForTesting == .responseBody
+                && viewController.title == "second.json"
+                && viewController.bodyTextViewForTesting.text == wiLocalized(
+                    "network.body.unavailable",
+                    default: "Body unavailable"
+                )
+        }
+        #expect(didKeepMode)
+    }
+
+    @Test
+    func bodyViewUpdatesWhenBodyFetchStateAndTextChange() async throws {
+        let body = NetworkBody(
+            kind: .text,
+            preview: nil,
+            full: nil,
+            size: nil,
+            isBase64Encoded: false,
+            isTruncated: true,
+            summary: nil,
+            reference: "response-ref",
+            formEntries: [],
+            fetchState: .inline,
+            role: .response
+        )
+        let inspector = WINetworkModel(session: NetworkSession())
+        let entry = try #require(
+            inspector.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/fetch.json",
+                    responseHeaders: NetworkHeaders([
+                        NetworkHeaderField(name: "content-type", value: "application/json")
+                    ]),
+                    responseBody: body
+                )
+            ]).first
+        )
+        inspector.selectEntry(entry)
+        let viewController = V2_NetworkEntryDetailViewController(inspector: inspector)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+        body.fetchState = .fetching
+
+        let didShowFetching = await waitUntil {
+            viewController.bodyTextViewForTesting.text == wiLocalized(
+                "network.body.fetching",
+                default: "Fetching body..."
+            )
+        }
+        #expect(didShowFetching)
+
+        body.applyFullBody(
+            "{\"updated\":true}",
+            isBase64Encoded: false,
+            isTruncated: false,
+            size: nil
+        )
+
+        let didShowUpdatedText = await waitUntil {
+            viewController.bodyTextViewForTesting.text.contains("\"updated\"")
+                && viewController.bodyTextViewForTesting.text.contains("\n")
+        }
+        #expect(didShowUpdatedText)
     }
 
     @Test
@@ -329,20 +619,48 @@ struct V2NetworkEntryDetailViewControllerTests {
         )
     }
 
-    private func makeBody(reference: String, role: NetworkBody.Role) -> NetworkBody {
+    private func makeBody(
+        reference: String? = nil,
+        full: String? = nil,
+        preview: String? = "preview",
+        role: NetworkBody.Role
+    ) -> NetworkBody {
         NetworkBody(
             kind: .text,
-            preview: "preview",
-            full: nil,
+            preview: preview,
+            full: full,
             size: nil,
             isBase64Encoded: false,
-            isTruncated: true,
+            isTruncated: full == nil,
             summary: nil,
             reference: reference,
             formEntries: [],
-            fetchState: .inline,
+            fetchState: full == nil ? .inline : .full,
             role: role
         )
+    }
+
+    private func action(
+        for mode: V2_NetworkEntryDetailMode,
+        in menu: UIMenu
+    ) throws -> UIAction {
+        try #require(action(title: mode.title, in: menu))
+    }
+
+    private func action(title: String, in menu: UIMenu) -> UIAction? {
+        for child in menu.children {
+            if let action = child as? UIAction, action.title == title {
+                return action
+            }
+            if let submenu = child as? UIMenu, let nested = action(title: title, in: submenu) {
+                return nested
+            }
+        }
+        return nil
+    }
+
+    private func menuActionTitles(in menu: UIMenu) -> [String] {
+        menu.children.compactMap { ($0 as? UIAction)?.title }
     }
 
     private func listCellText(

--- a/Tests/WebInspectorUITests/V2RegularTabHostViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/V2RegularTabHostViewControllerTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import SyntaxEditorUI
 import Testing
 import UIKit
 @testable import WebInspectorEngine
@@ -110,6 +111,81 @@ struct V2RegularTabHostViewControllerTests {
     }
 
     @Test
+    func regularNetworkRootExposesDetailModeMenuAsTrailingText() async throws {
+        let session = V2_WISession(tabs: [.dom, .network])
+        session.interface.selectTab(V2_WITab.network)
+        let entry = try #require(
+            session.runtime.network.model.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/body.json",
+                    responseBody: makeBody(full: "{\"ok\":true}", role: .response)
+                )
+            ]).first
+        )
+        let host = V2_WIRegularTabContentViewController(session: session)
+        let window = showInWindow(host)
+        defer { window.isHidden = true }
+        let rootViewController = try #require(host.viewControllers.first)
+        rootViewController.loadViewIfNeeded()
+
+        #expect(rootViewController.navigationItem.centerItemGroups.isEmpty == false)
+        let initialModeItem = try #require(regularDetailModeItem(in: rootViewController))
+        #expect(initialModeItem.isEnabled == false)
+        let initialModeButton = try #require(initialModeItem.customView as? UIButton)
+        #expect(initialModeButton.configuration?.title == V2_NetworkEntryDetailMode.overview.title)
+        #expect(initialModeButton.showsMenuAsPrimaryAction)
+        #expect(initialModeButton.changesSelectionAsPrimaryAction)
+        #expect(initialModeButton.preferredMenuElementOrder == .fixed)
+        #expect(initialModeButton.isEnabled == false)
+
+        session.runtime.network.model.selectEntry(entry)
+
+        let didEnableModeItem = await waitUntil {
+            guard
+                let modeItem = regularDetailModeItem(in: rootViewController),
+                let modeButton = modeItem.customView as? UIButton,
+                modeItem.isEnabled,
+                modeButton.isEnabled,
+                let menu = modeButton.menu,
+                let responseAction = action(title: V2_NetworkEntryDetailMode.responseBody.title, in: menu)
+            else {
+                return false
+            }
+            return responseAction.attributes.contains(.disabled) == false
+        }
+        #expect(didEnableModeItem)
+
+        let enabledModeItem = try #require(regularDetailModeItem(in: rootViewController))
+        let enabledModeButton = try #require(enabledModeItem.customView as? UIButton)
+        #expect(enabledModeItem === initialModeItem)
+        #expect(enabledModeButton === initialModeButton)
+        #expect(enabledModeButton.preferredMenuElementOrder == .fixed)
+        #expect(enabledModeItem.preferredMenuElementOrder == .fixed)
+        #expect(menuActionTitles(in: try #require(enabledModeButton.menu)) == V2_NetworkEntryDetailMode.allCases.map(\.title))
+        let responseAction = try action(for: .responseBody, in: try #require(enabledModeButton.menu))
+        responseAction.performWithSender(nil, target: nil)
+
+        let didSwitchModeTitle = await waitUntil {
+            guard
+                let modeItem = regularDetailModeItem(in: rootViewController),
+                let modeButton = modeItem.customView as? UIButton,
+                let menu = modeButton.menu
+            else {
+                return false
+            }
+            return modeButton.configuration?.title == V2_NetworkEntryDetailMode.responseBody.title
+                && modeButton.preferredMenuElementOrder == .fixed
+                && menuActionTitles(in: menu) == V2_NetworkEntryDetailMode.allCases.map(\.title)
+        }
+        #expect(didSwitchModeTitle)
+        let switchedModeItem = try #require(regularDetailModeItem(in: rootViewController))
+        let switchedModeButton = try #require(switchedModeItem.customView as? UIButton)
+        #expect(switchedModeItem === enabledModeItem)
+        #expect(switchedModeButton === enabledModeButton)
+    }
+
+    @Test
     func regularNetworkSplitContainsDetailSecondary() throws {
         let session = V2_WISession(tabs: [.dom, .network])
         session.interface.selectTab(V2_WITab.network)
@@ -167,6 +243,65 @@ struct V2RegularTabHostViewControllerTests {
         }
 
         #expect(didUpdateDetail)
+    }
+
+    @Test
+    func regularNetworkBodyViewUsesDetailSafeArea() async throws {
+        let session = V2_WISession(tabs: [.dom, .network])
+        session.interface.selectTab(V2_WITab.network)
+        let entry = try #require(
+            session.runtime.network.model.store.applySnapshots([
+                makeSnapshot(
+                    requestID: 1,
+                    url: "https://example.com/body.json",
+                    responseBody: makeBody(
+                        full: String(repeating: "{\"ok\":true}", count: 64),
+                        role: .response
+                    )
+                )
+            ]).first
+        )
+        let rootViewController = V2_TabContentFactory.makeViewController(
+            for: .network,
+            session: session,
+            hostLayout: .regular
+        )
+        let window = showInWindow(
+            rootViewController,
+            frame: CGRect(x: 0, y: 0, width: 724, height: 560)
+        )
+        defer { window.isHidden = true }
+        let splitViewController = try childSplitViewController(in: rootViewController)
+        let detailViewController: V2_NetworkEntryDetailViewController = try splitRootViewController(
+            in: splitViewController,
+            column: .secondary
+        )
+        detailViewController.loadViewIfNeeded()
+        detailViewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 240, bottom: 0, right: 0)
+        detailViewController.view.setNeedsLayout()
+        detailViewController.view.layoutIfNeeded()
+
+        session.runtime.network.model.selectEntry(entry)
+        let collectionView = detailViewController.collectionViewForTesting
+        let didRenderOverview = await waitUntil {
+            collectionView.isHidden == false
+                && collectionView.numberOfSections == 3
+        }
+        #expect(didRenderOverview)
+
+        detailViewController.setModeForTesting(.responseBody)
+
+        let didRenderBody = await waitUntil {
+            detailViewController.bodyTextViewForTesting.text.contains("\"ok\"")
+        }
+        #expect(didRenderBody)
+
+        let syntaxView = detailViewController.bodyTextViewForTesting
+        let syntaxFrame = syntaxView.convert(syntaxView.bounds, to: detailViewController.view)
+        let safeAreaFrame = detailViewController.view.safeAreaLayoutGuide.layoutFrame
+
+        #expect(abs(syntaxFrame.minX - safeAreaFrame.minX) <= 1)
+        #expect(abs(syntaxFrame.maxX - safeAreaFrame.maxX) <= 1)
     }
 
     @Test
@@ -628,7 +763,9 @@ struct V2RegularTabHostViewControllerTests {
 
     private func makeSnapshot(
         requestID: Int,
-        url: String
+        url: String,
+        requestBody: NetworkBody? = nil,
+        responseBody: NetworkBody? = nil
     ) -> NetworkEntry.Snapshot {
         NetworkEntry.Snapshot(
             sessionID: "test-session",
@@ -637,7 +774,7 @@ struct V2RegularTabHostViewControllerTests {
                 url: url,
                 method: "GET",
                 headers: NetworkHeaders(),
-                body: nil,
+                body: requestBody,
                 bodyBytesSent: nil,
                 type: nil,
                 wallTime: nil
@@ -647,7 +784,7 @@ struct V2RegularTabHostViewControllerTests {
                 statusText: "OK",
                 mimeType: "application/json",
                 headers: NetworkHeaders(),
-                body: nil,
+                body: responseBody,
                 blockedCookies: [],
                 errorDescription: nil
             ),
@@ -662,8 +799,59 @@ struct V2RegularTabHostViewControllerTests {
         )
     }
 
-    private func showInWindow(_ viewController: UIViewController) -> UIWindow {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 1024, height: 768))
+    private func makeBody(
+        full: String,
+        role: NetworkBody.Role
+    ) -> NetworkBody {
+        NetworkBody(
+            kind: .text,
+            preview: full,
+            full: full,
+            size: nil,
+            isBase64Encoded: false,
+            isTruncated: false,
+            summary: nil,
+            reference: nil,
+            formEntries: [],
+            fetchState: .full,
+            role: role
+        )
+    }
+
+    private func regularDetailModeItem(in viewController: UIViewController) -> UIBarButtonItem? {
+        viewController.navigationItem.trailingItemGroups
+            .flatMap(\.barButtonItems)
+            .first { $0.accessibilityIdentifier == "V2.Network.DetailModeButton.Regular" }
+    }
+
+    private func action(
+        for mode: V2_NetworkEntryDetailMode,
+        in menu: UIMenu
+    ) throws -> UIAction {
+        try #require(action(title: mode.title, in: menu))
+    }
+
+    private func action(title: String, in menu: UIMenu) -> UIAction? {
+        for child in menu.children {
+            if let action = child as? UIAction, action.title == title {
+                return action
+            }
+            if let submenu = child as? UIMenu, let nested = action(title: title, in: submenu) {
+                return nested
+            }
+        }
+        return nil
+    }
+
+    private func menuActionTitles(in menu: UIMenu) -> [String] {
+        menu.children.compactMap { ($0 as? UIAction)?.title }
+    }
+
+    private func showInWindow(
+        _ viewController: UIViewController,
+        frame: CGRect = CGRect(x: 0, y: 0, width: 1024, height: 768)
+    ) -> UIWindow {
+        let window = UIWindow(frame: frame)
         window.rootViewController = viewController
         window.makeKeyAndVisible()
         viewController.view.frame = window.bounds

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "180e1e45d16353711551549495e92723f254c417f5ebdd5646283e86d939e22c",
+  "originHash" : "44d6e171304a7c20cafe1da521dfe37792221d4d30ae311be967f9f99237fdbb",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "8b9b2807f573cf82b156aabb4534dfd4e7f0b02e",
-        "version" : "0.4.2"
+        "revision" : "e8130e3a3ff7d91577a9619f8ba288689cd2bf0e",
+        "version" : "0.5.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose

Show V2 network request/response bodies in SyntaxEditorUI, with the existing detail view treated as Overview and body rendering owned by the network model rather than UIKit formatting code.

## Changes

- Update SyntaxEditorUI to v0.5.0 and use the new public SyntaxLanguage API.
- Add Overview / Request Body / Response Body detail modes with a trailing menu item and body unavailable handling.
- Move body text representation, syntax kind, JSON pretty printing, form formatting, and raw body decoding into NetworkBody stored state.
- Have NetworkEntry propagate request/response body syntax hints from content type, MIME type, and URL at owner boundaries.
- Simplify V2_NetworkBodyViewController so it observes NetworkBody and mirrors text/language/theme into SyntaxEditorModel.
- Add Engine and UI coverage for JSON, form, plain text, fetch state updates, mode persistence, and regular split body geometry.

## Testing

- git diff --check
- Xcode navigator issues: error 0
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorEngineTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorUITests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1

## Screenshots

- Not included; behavior is covered by focused tests.
