### PR TITLE
chore(deps): update syntaxeditorui to 0.5.1

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "8b9b2807f573cf82b156aabb4534dfd4e7f0b02e",
-        "version" : "0.4.2"
+        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Monocly/Monocly/Info.plist
+++ b/Monocly/Monocly/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d29e18ae9c6177920acedfea7ea6e2e4ad89016408302d1ac9d911397e6fc836",
+  "originHash" : "904549e4966658820801bbe0d5fc19577f635aa10a535e69f3c8f3236310c8a1",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "e8130e3a3ff7d91577a9619f8ba288689cd2bf0e",
-        "version" : "0.5.0"
+        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.5.0"
+            exact: "0.5.1"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "44d6e171304a7c20cafe1da521dfe37792221d4d30ae311be967f9f99237fdbb",
+  "originHash" : "354e71237289c65de87b7414f23ea553bf99a3626719534df513ad066a2529eb",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "e8130e3a3ff7d91577a9619f8ba288689cd2bf0e",
-        "version" : "0.5.0"
+        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
+        "version" : "0.5.1"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin `SyntaxEditorUI` to `0.5.1` in the package manifest.
- Refresh root, workspace, and Monocly SwiftPM resolved files to the `v0.5.1` revision.
- Enable `UIApplicationSupportsIndirectInputEvents` for Monocly so iPad pointer drags work with the updated editor behavior.

## Testing
- `plutil -lint Monocly/Monocly/Info.plist`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorUITests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`