### PR TITLE
[codex] Native-only Network Cleanup: Phase 1

### DIFF
--- a/Sources/WebInspectorEngine/Common/WIBackendSupport.swift
+++ b/Sources/WebInspectorEngine/Common/WIBackendSupport.swift
@@ -10,7 +10,6 @@ public enum WIBackendCapability: String, Hashable, Sendable {
     case domDomain
     case networkDomain
     case pageTargetRouting
-    case networkBootstrapSnapshot
 }
 
 public struct WIBackendSupport: Sendable {

--- a/Sources/WebInspectorEngine/Network/NetworkEntry.swift
+++ b/Sources/WebInspectorEngine/Network/NetworkEntry.swift
@@ -243,6 +243,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
             public let response: Response
             public let requestType: String?
             public let timestamp: TimeInterval
+            public let requestBodyBytesSent: Int?
             public let encodedBodyLength: Int?
             public let decodedBodyLength: Int?
 
@@ -251,6 +252,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
                 response: Response,
                 requestType: String?,
                 timestamp: TimeInterval,
+                requestBodyBytesSent: Int? = nil,
                 encodedBodyLength: Int?,
                 decodedBodyLength: Int?
             ) {
@@ -258,6 +260,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
                 self.response = response
                 self.requestType = requestType
                 self.timestamp = timestamp
+                self.requestBodyBytesSent = requestBodyBytesSent
                 self.encodedBodyLength = encodedBodyLength
                 self.decodedBodyLength = decodedBodyLength
             }
@@ -750,6 +753,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         decodedBodySize: Int?,
         errorDescription: String?,
         requestType: String?,
+        requestBodyBytesSent: Int?,
         responseBody: NetworkBody?,
         timestamp: TimeInterval,
         failed: Bool
@@ -778,6 +782,9 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
         duration = max(0, timestamp - startTimestamp)
         if let requestType {
             self.requestType = requestType
+        }
+        if let requestBodyBytesSent {
+            self.requestBodyBytesSent = requestBodyBytesSent
         }
         if let responseBody {
             self.responseBody = responseBody
@@ -824,6 +831,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
                 decodedBodySize: value.decodedBodyLength,
                 errorDescription: value.response.errorDescription,
                 requestType: value.requestType,
+                requestBodyBytesSent: value.requestBodyBytesSent,
                 responseBody: value.response.body,
                 timestamp: value.timestamp,
                 failed: false
@@ -837,6 +845,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
                 decodedBodySize: nil,
                 errorDescription: value.response.errorDescription,
                 requestType: value.requestType,
+                requestBodyBytesSent: nil,
                 responseBody: value.response.body,
                 timestamp: value.timestamp,
                 failed: true
@@ -869,6 +878,7 @@ public final class NetworkEntry: Identifiable, Equatable, Hashable {
                 decodedBodySize: value.decodedBodyLength,
                 errorDescription: value.response.errorDescription,
                 requestType: value.request.type,
+                requestBodyBytesSent: value.request.bodyBytesSent,
                 responseBody: value.response.body,
                 timestamp: value.endTimestamp ?? value.startTimestamp,
                 failed: false

--- a/Sources/WebInspectorTransport/Backend/Network/NetworkBootstrapSource.swift
+++ b/Sources/WebInspectorTransport/Backend/Network/NetworkBootstrapSource.swift
@@ -3,14 +3,9 @@ import WebInspectorEngine
 
 package struct NetworkBootstrapLoad {
     package let snapshots: [NetworkEntry.Snapshot]
-    package let bindings: [NetworkTimelineResolver.Binding]
 
-    package init(
-        snapshots: [NetworkEntry.Snapshot],
-        bindings: [NetworkTimelineResolver.Binding] = []
-    ) {
+    package init(snapshots: [NetworkEntry.Snapshot]) {
         self.snapshots = snapshots
-        self.bindings = bindings
     }
 }
 
@@ -26,166 +21,7 @@ package protocol NetworkBootstrapSource {
 }
 
 @MainActor
-package struct StableBootstrapSource: NetworkBootstrapSource {
-    private let codec = WITransportCodec.shared
-
-    package init() {}
-
-    package func load(
-        using session: WITransportSession,
-        targetIdentifier: String,
-        allocateRequestID: @escaping @MainActor () -> Int,
-        defaultSessionID: @escaping @MainActor (String?) -> String,
-        normalizeScopeID: @escaping @MainActor (String?) -> String?
-    ) async throws -> NetworkBootstrapLoad {
-        let result = try await session.sendPageData(
-            method: WITransportMethod.Network.getBootstrapSnapshot,
-            targetIdentifier: targetIdentifier
-        )
-        let snapshot = try await codec.decode(
-            NetworkGetBootstrapSnapshotResponse.self,
-            from: result
-        )
-        let syntheticDefaultSessionID = defaultSessionID(nil)
-        let now = Date().timeIntervalSince1970
-        let snapshotsAndBindings = snapshot.resources.map { resource -> (NetworkEntry.Snapshot, NetworkTimelineResolver.Binding?) in
-            let normalizedOwnerSessionID = normalizeScopeID(resource.ownerSessionID)
-            let resolvedFrameID = normalizeScopeID(resource.bodyFetchDescriptor?.frameId)
-                ?? normalizeScopeID(resource.frameID)
-            let resolvedOwnerSessionID = normalizedOwnerSessionID
-                ?? normalizeScopeID(resource.targetIdentifier)
-                ?? defaultSessionID(targetIdentifier)
-            let resolvedTargetIdentifier = normalizeScopeID(resource.bodyFetchDescriptor?.targetIdentifier)
-                ?? normalizeScopeID(resource.targetIdentifier)
-                ?? ((resolvedOwnerSessionID == defaultSessionID(targetIdentifier)
-                    || resolvedOwnerSessionID == syntheticDefaultSessionID)
-                    ? normalizeScopeID(targetIdentifier)
-                    : normalizedOwnerSessionID)
-            let resolvedRequestTargetIdentifier = normalizeScopeID(resource.targetIdentifier)
-                ?? ((resolvedOwnerSessionID == defaultSessionID(targetIdentifier)
-                    || resolvedOwnerSessionID == syntheticDefaultSessionID)
-                    ? normalizeScopeID(targetIdentifier)
-                    : normalizedOwnerSessionID)
-            let requestID = allocateRequestID()
-            let responseBodyLocator: NetworkDeferredBodyLocator?
-            if resource.phase != .failed,
-               let resolvedTargetIdentifier,
-               let resolvedFrameID {
-                responseBodyLocator = .pageResource(
-                    targetIdentifier: resolvedTargetIdentifier,
-                    frameID: resolvedFrameID,
-                    url: resource.bodyFetchDescriptor?.url ?? resource.url
-                )
-            } else {
-                responseBodyLocator = nil
-            }
-
-            let phase: NetworkEntry.Phase
-            switch resource.phase {
-            case .completed:
-                phase = .completed
-            case .failed:
-                phase = .failed
-            case .inFlight:
-                phase = .pending
-            }
-
-            var statusCode = resource.statusCode
-            var statusText = resource.statusText ?? ""
-            var errorDescription = resource.errorDescription
-            if phase == .failed {
-                if statusCode == nil {
-                    statusCode = 0
-                }
-                if statusText.isEmpty, resource.canceled == true {
-                    statusText = "Canceled"
-                }
-                if errorDescription == nil, resource.canceled == true {
-                    errorDescription = "Canceled"
-                }
-            }
-
-            let entrySnapshot = NetworkEntry.Snapshot(
-                sessionID: resolvedOwnerSessionID,
-                requestID: requestID,
-                request: .init(
-                    url: resource.url,
-                    method: resource.method.isEmpty ? "UNKNOWN" : resource.method.uppercased(),
-                    headers: NetworkHeaders(dictionary: resource.requestHeaders ?? [:]),
-                    body: makeDeferredRequestBody(
-                        method: resource.method,
-                        rawRequestID: normalizeScopeID(resource.rawRequestID),
-                        targetIdentifier: resolvedRequestTargetIdentifier
-                    ),
-                    bodyBytesSent: nil,
-                    type: resource.requestType,
-                    wallTime: nil
-                ),
-                response: .init(
-                    statusCode: statusCode,
-                    statusText: statusText,
-                    mimeType: resource.mimeType,
-                    headers: NetworkHeaders(dictionary: resource.responseHeaders ?? [:]),
-                    body: responseBodyLocator.map {
-                        NetworkBody(
-                            kind: .other,
-                            preview: nil,
-                            full: nil,
-                            size: nil,
-                            isBase64Encoded: false,
-                            isTruncated: false,
-                            summary: nil,
-                            deferredLocator: $0,
-                            formEntries: [],
-                            fetchState: .inline,
-                            role: .response
-                        )
-                    },
-                    blockedCookies: [],
-                    errorDescription: errorDescription
-                ),
-                transfer: .init(
-                    startTimestamp: now,
-                    endTimestamp: phase == .pending ? nil : now,
-                    duration: phase == .pending ? nil : 0,
-                    encodedBodyLength: nil,
-                    decodedBodyLength: nil,
-                    phase: phase
-                )
-            )
-
-            let binding: NetworkTimelineResolver.Binding?
-            if phase == .pending, let rawRequestID = normalizeScopeID(resource.rawRequestID) {
-                binding = .init(
-                    allowsCrossTargetRebind: true,
-                    canonicalRequestID: requestID,
-                    sessionID: resolvedOwnerSessionID,
-                    requestTargetIdentifier: resolvedRequestTargetIdentifier,
-                    responseTargetIdentifier: resolvedTargetIdentifier,
-                    rawRequestID: rawRequestID,
-                    url: resource.url,
-                    requestType: resource.requestType
-                )
-            } else {
-                binding = nil
-            }
-
-            return (entrySnapshot, binding)
-        }
-
-        return NetworkBootstrapLoad(
-            snapshots: snapshotsAndBindings.map(\.0),
-            bindings: snapshotsAndBindings.compactMap(\.1)
-        )
-    }
-}
-
-private struct NetworkGetBootstrapSnapshotResponse: Decodable, Sendable {
-    let resources: [WITransportNetworkBootstrapResource]
-}
-
-@MainActor
-package struct HistoricalBootstrapSource: NetworkBootstrapSource {
+package struct PageResourceTreeBootstrapSource: NetworkBootstrapSource {
     private let codec = WITransportCodec.shared
 
     package init() {}
@@ -367,37 +203,5 @@ package struct HistoricalBootstrapSource: NetworkBootstrapSource {
             parentTargetIdentifier: defaultTargetIdentifier
         )
         return NetworkBootstrapLoad(snapshots: snapshots)
-    }
-}
-
-private func makeDeferredRequestBody(
-    method: String,
-    rawRequestID: String?,
-    targetIdentifier: String?
-) -> NetworkBody? {
-    guard let rawRequestID, requestMethodMayCarryBody(method) else {
-        return nil
-    }
-    return NetworkBody(
-        kind: .text,
-        preview: nil,
-        full: nil,
-        size: nil,
-        isBase64Encoded: false,
-        isTruncated: true,
-        summary: nil,
-        deferredLocator: .networkRequest(id: rawRequestID, targetIdentifier: targetIdentifier),
-        formEntries: [],
-        fetchState: .inline,
-        role: .request
-    )
-}
-
-private func requestMethodMayCarryBody(_ method: String) -> Bool {
-    switch method.uppercased() {
-    case "GET", "HEAD":
-        false
-    default:
-        true
     }
 }

--- a/Sources/WebInspectorTransport/Backend/Network/NetworkTimelineResolver.swift
+++ b/Sources/WebInspectorTransport/Backend/Network/NetworkTimelineResolver.swift
@@ -89,11 +89,7 @@ package final class NetworkTimelineResolver {
         _ load: NetworkBootstrapLoad,
         into store: NetworkStore
     ) {
-        let insertedEntries = store.applySnapshots(load.snapshots)
-        let survivingRequestIDs = Set(insertedEntries.map(\.requestID))
-        register(
-            bindings: load.bindings.filter { survivingRequestIDs.contains($0.canonicalRequestID) }
-        )
+        store.applySnapshots(load.snapshots)
     }
 
     package func finish(
@@ -291,12 +287,6 @@ package final class NetworkTimelineResolver {
 }
 
 private extension NetworkTimelineResolver {
-    func register(bindings: [Binding]) {
-        for binding in bindings {
-            exactBindings[RequestKey(sessionID: binding.sessionID, rawRequestID: binding.rawRequestID)] = binding
-        }
-    }
-
     func rebindCommittedContinuation(
         sessionID: String,
         rawRequestID: String,

--- a/Sources/WebInspectorTransport/Backend/Network/NetworkTransportClient.swift
+++ b/Sources/WebInspectorTransport/Backend/Network/NetworkTransportClient.swift
@@ -13,67 +13,35 @@ package struct NetworkTransportClient {
         role: NetworkBody.Role
     ) async -> WINetworkBodyFetchResult {
         do {
-            switch locator {
-            case .networkRequest(let requestID, let targetIdentifier):
-                switch role {
-                case .request:
-                    let response = try await codec.decode(
-                        NetworkGetRequestPostDataResponse.self,
-                        from: try await session.sendPageData(
-                            method: WITransportMethod.Network.getRequestPostData,
-                            targetIdentifier: targetIdentifier,
-                            parametersData: try await codec.encode(
-                                NetworkRequestIDParameters(requestId: requestID)
-                            )
+            switch (locator, role) {
+            case (.networkRequest, .request):
+                return .bodyUnavailable
+            case let (.networkRequest(requestID, targetIdentifier), .response):
+                let response = try await codec.decode(
+                    NetworkGetResponseBodyResponse.self,
+                    from: try await session.sendPageData(
+                        method: WITransportMethod.Network.getResponseBody,
+                        targetIdentifier: targetIdentifier,
+                        parametersData: try await codec.encode(
+                            NetworkRequestIDParameters(requestId: requestID)
                         )
                     )
-                    guard !response.postData.isEmpty else {
-                        return .bodyUnavailable
-                    }
-                    return .fetched(
-                        NetworkBody(
-                            kind: .text,
-                            preview: nil,
-                            full: response.postData,
-                            size: response.postData.utf8.count,
-                            isBase64Encoded: false,
-                            isTruncated: false,
-                            summary: nil,
-                            formEntries: [],
-                            fetchState: .full,
-                            role: .request
-                        )
+                )
+                return .fetched(
+                    NetworkBody(
+                        kind: response.base64Encoded ? .binary : .text,
+                        preview: nil,
+                        full: response.body,
+                        size: nil,
+                        isBase64Encoded: response.base64Encoded,
+                        isTruncated: false,
+                        summary: nil,
+                        formEntries: [],
+                        fetchState: .full,
+                        role: .response
                     )
-                case .response:
-                    let response = try await codec.decode(
-                        NetworkGetResponseBodyResponse.self,
-                        from: try await session.sendPageData(
-                            method: WITransportMethod.Network.getResponseBody,
-                            targetIdentifier: targetIdentifier,
-                            parametersData: try await codec.encode(
-                                NetworkRequestIDParameters(requestId: requestID)
-                            )
-                        )
-                    )
-                    return .fetched(
-                        NetworkBody(
-                            kind: response.base64Encoded ? .binary : .text,
-                            preview: nil,
-                            full: response.body,
-                            size: nil,
-                            isBase64Encoded: response.base64Encoded,
-                            isTruncated: false,
-                            summary: nil,
-                            formEntries: [],
-                            fetchState: .full,
-                            role: .response
-                        )
-                    )
-                }
-            case .pageResource(let targetIdentifier, let frameID, let url):
-                guard role == .response else {
-                    return .bodyUnavailable
-                }
+                )
+            case let (.pageResource(targetIdentifier, frameID, url), .response):
                 let response = try await codec.decode(
                     PageGetResourceContentResponse.self,
                     from: try await session.sendPageData(
@@ -98,7 +66,7 @@ package struct NetworkTransportClient {
                         role: .response
                     )
                 )
-            case .opaqueHandle:
+            case (.pageResource, .request), (.opaqueHandle, _):
                 return .bodyUnavailable
             }
         } catch let error as WITransportError {
@@ -121,29 +89,8 @@ package struct NetworkTransportClient {
         normalizeScopeID: @escaping @MainActor (String?) -> String?,
         logFailure: @escaping @MainActor (String) -> Void
     ) async throws -> NetworkBootstrapLoad {
-        if session.shouldAttemptStableNetworkBootstrap() {
-            do {
-                let load = try await StableBootstrapSource().load(
-                    using: session,
-                    targetIdentifier: targetIdentifier,
-                    allocateRequestID: allocateRequestID,
-                    defaultSessionID: defaultSessionID,
-                    normalizeScopeID: normalizeScopeID
-                )
-                session.markStableNetworkBootstrapAvailable()
-                return load
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                if shouldDisableStableBootstrap(after: error),
-                   session.markStableNetworkBootstrapUnavailable() {
-                    logFailure("stable network bootstrap disabled: \(error.localizedDescription)")
-                }
-            }
-        }
-
         do {
-            return try await HistoricalBootstrapSource().load(
+            return try await PageResourceTreeBootstrapSource().load(
                 using: session,
                 targetIdentifier: targetIdentifier,
                 allocateRequestID: allocateRequestID,
@@ -153,26 +100,8 @@ package struct NetworkTransportClient {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            logFailure("historical network bootstrap skipped: \(error.localizedDescription)")
+            logFailure("resource tree network bootstrap skipped: \(error.localizedDescription)")
             return NetworkBootstrapLoad(snapshots: [])
-        }
-    }
-}
-
-private extension NetworkTransportClient {
-    func shouldDisableStableBootstrap(after error: any Error) -> Bool {
-        guard let transportError = error as? WITransportError else {
-            return false
-        }
-        switch transportError {
-        case .unsupported:
-            return true
-        case .remoteError:
-            return true
-        case .invalidResponse:
-            return true
-        default:
-            return false
         }
     }
 }
@@ -189,10 +118,6 @@ private struct PageGetResourceContentParameters: Encodable, Sendable {
 private struct NetworkGetResponseBodyResponse: Decodable, Sendable {
     let body: String
     let base64Encoded: Bool
-}
-
-private struct NetworkGetRequestPostDataResponse: Decodable, Sendable {
-    let postData: String
 }
 
 private struct PageGetResourceContentResponse: Decodable, Sendable {

--- a/Sources/WebInspectorTransport/Backend/Network/NetworkTransportDriver.swift
+++ b/Sources/WebInspectorTransport/Backend/Network/NetworkTransportDriver.swift
@@ -66,7 +66,9 @@ final class NetworkTransportDriver: WINetworkBackend, InspectorTransportCapabili
 
     package func supportsDeferredLoading(for role: NetworkBody.Role) -> Bool {
         switch role {
-        case .request, .response:
+        case .request:
+            false
+        case .response:
             true
         }
     }
@@ -673,10 +675,7 @@ private extension NetworkTransportDriver {
                         method: normalizedMethod,
                         headers: NetworkHeaders(dictionary: params.request.headers),
                         body: makeRequestBody(
-                            postData: params.request.postData,
-                            method: params.request.method,
-                            requestID: params.requestId,
-                            targetIdentifier: normalizedTargetIdentifier
+                            postData: params.request.postData
                         ),
                         bodyBytesSent: params.request.postData?.utf8.count,
                         type: params.type,
@@ -771,11 +770,12 @@ private extension NetworkTransportDriver {
                         blockedCookies: [],
                         errorDescription: nil
                     ),
-                    requestType: nil,
-                    timestamp: params.timestamp,
-                    encodedBodyLength: params.metrics?.responseBodyBytesReceived,
-                    decodedBodyLength: params.metrics?.responseBodyDecodedSize
-                )
+                        requestType: nil,
+                        timestamp: params.timestamp,
+                        requestBodyBytesSent: params.metrics?.requestBodyBytesSent,
+                        encodedBodyLength: params.metrics?.responseBodyBytesReceived,
+                        decodedBodyLength: params.metrics?.responseBodyDecodedSize
+                    )
             ),
             sessionID: sessionID,
         )
@@ -1002,53 +1002,23 @@ private extension NetworkTransportDriver {
         )
     }
 
-    func makeRequestBody(
-        postData: String?,
-        method: String,
-        requestID: String,
-        targetIdentifier: String?
-    ) -> NetworkBody? {
-        if let postData, !postData.isEmpty {
-            return NetworkBody(
-                kind: .text,
-                preview: postData,
-                full: postData,
-                size: postData.utf8.count,
-                isBase64Encoded: false,
-                isTruncated: false,
-                summary: nil,
-                formEntries: [],
-                fetchState: .full,
-                role: .request
-            )
-        }
-
-        guard requestMethodMayCarryBody(method) else {
+    func makeRequestBody(postData: String?) -> NetworkBody? {
+        guard let postData, !postData.isEmpty else {
             return nil
         }
 
         return NetworkBody(
             kind: .text,
-            preview: nil,
-            full: nil,
-            size: nil,
+            preview: postData,
+            full: postData,
+            size: postData.utf8.count,
             isBase64Encoded: false,
-            isTruncated: true,
+            isTruncated: false,
             summary: nil,
-            deferredLocator: .networkRequest(id: requestID, targetIdentifier: targetIdentifier),
             formEntries: [],
-            fetchState: .inline,
+            fetchState: .full,
             role: .request
         )
-    }
-
-    func requestMethodMayCarryBody(_ method: String) -> Bool {
-        switch method.uppercased() {
-        case "GET", "HEAD":
-            false
-        default:
-            true
-        }
     }
 
     func loadBootstrapResources(

--- a/Sources/WebInspectorTransport/Support/InspectorTransportCapability.swift
+++ b/Sources/WebInspectorTransport/Support/InspectorTransportCapability.swift
@@ -15,5 +15,4 @@ package enum InspectorTransportCapability: String, Hashable, Sendable {
     case domDomain
     case networkDomain
     case pageTargetRouting
-    case networkBootstrapSnapshot
 }

--- a/Sources/WebInspectorTransport/WITransportCommands.swift
+++ b/Sources/WebInspectorTransport/WITransportCommands.swift
@@ -18,8 +18,6 @@ package enum WITransportMethod {
     package enum Network {
         package static let enable = "Network.enable"
         package static let getResponseBody = "Network.getResponseBody"
-        package static let getRequestPostData = "Network.getRequestPostData"
-        package static let getBootstrapSnapshot = "Network.getBootstrapSnapshot"
     }
 
     package enum DOM {
@@ -140,44 +138,6 @@ public struct WITransportFrameResourceTree: Decodable, Sendable {
         self.childFrames = childFrames
         self.resources = resources
     }
-}
-
-package enum WITransportNetworkBootstrapPhase: String, Decodable, Sendable {
-    case completed
-    case failed
-    case inFlight
-
-    package init(from decoder: any Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let rawValue = try container.decode(String.self)
-        self = Self(rawValue: rawValue) ?? .completed
-    }
-}
-
-package struct WITransportNetworkBootstrapBodyFetchDescriptor: Decodable, Sendable {
-    package let targetIdentifier: String?
-    package let frameId: String
-    package let url: String
-}
-
-package struct WITransportNetworkBootstrapResource: Decodable, Sendable {
-    package let bootstrapRowID: String
-    package let rawRequestID: String?
-    package let ownerSessionID: String
-    package let frameID: String?
-    package let targetIdentifier: String?
-    package let url: String
-    package let method: String
-    package let requestType: String?
-    package let mimeType: String?
-    package let statusCode: Int?
-    package let statusText: String?
-    package let requestHeaders: [String: String]?
-    package let responseHeaders: [String: String]?
-    package let phase: WITransportNetworkBootstrapPhase
-    package let canceled: Bool?
-    package let errorDescription: String?
-    package let bodyFetchDescriptor: WITransportNetworkBootstrapBodyFetchDescriptor?
 }
 
 public final class WITransportDOMNode: Decodable, Sendable {

--- a/Sources/WebInspectorTransport/WITransportSession.swift
+++ b/Sources/WebInspectorTransport/WITransportSession.swift
@@ -43,7 +43,6 @@ public final class WITransportSession {
     private var outOfOrderSettledPageEventSequences: Set<UInt64> = []
     private var activePageEventDeliveryCount: UInt64 = 0
     private var pageEventDrainWaiters: [PageEventDrainWaiter] = []
-    private var stableNetworkBootstrapAvailability: StableNetworkBootstrapAvailability = .unknown
 
 #if DEBUG
     package var derivedPageTargetIdentifierProviderForTesting: (@MainActor (WKWebView) -> String?)?
@@ -99,7 +98,6 @@ public final class WITransportSession {
         self.webView = webView
         self.backend = backend
         resetTransportStateForAttach()
-        stableNetworkBootstrapAvailability = .unknown
 
         let messageSink = WITransportSessionMessageSink(session: self)
         backendMessageSink = messageSink
@@ -403,34 +401,11 @@ public final class WITransportSession {
         originalInspectability = nil
     }
 
-    package func shouldAttemptStableNetworkBootstrap() -> Bool {
-        supportSnapshot.capabilities.contains(.networkBootstrapSnapshot)
-            && stableNetworkBootstrapAvailability != .unavailable
-    }
-
-    @discardableResult
-    package func markStableNetworkBootstrapUnavailable() -> Bool {
-        let wasUnavailable = stableNetworkBootstrapAvailability == .unavailable
-        stableNetworkBootstrapAvailability = .unavailable
-        return !wasUnavailable
-    }
-
-    package func markStableNetworkBootstrapAvailable() {
-        stableNetworkBootstrapAvailability = .available
-    }
 }
 
 private struct PageEventDrainWaiter {
     let targetSequence: UInt64
     let continuation: CheckedContinuation<Void, Never>
-}
-
-extension WITransportSession {
-    enum StableNetworkBootstrapAvailability {
-        case unknown
-        case available
-        case unavailable
-    }
 }
 
 package enum WISharedInspectorTransportClient: Hashable, Sendable {

--- a/Sources/WebInspectorTransport/WITransportTypes.swift
+++ b/Sources/WebInspectorTransport/WITransportTypes.swift
@@ -24,7 +24,6 @@ public enum WITransportCapability: String, Hashable, Sendable {
     case pageTargetRouting
     case domDomain
     case networkDomain
-    case networkBootstrapSnapshot
 }
 
 public struct WITransportSupportSnapshot: Sendable {

--- a/Tests/WebInspectorTransportTests/NetworkTransportDriverTests.swift
+++ b/Tests/WebInspectorTransportTests/NetworkTransportDriverTests.swift
@@ -27,22 +27,17 @@ struct NetworkTransportDriverTests {
     @Test
     func sameWebViewReattachDoesNotReplayBootstrapRows() async {
         let backend = FakeRegistryBackend(
-            capabilities: [.rootMessaging, .pageMessaging, .pageTargetRouting, .domDomain, .networkDomain, .networkBootstrapSnapshot],
-            pageTargetedResultProvider: { method, _, _ in
-                guard method == WITransportMethod.Network.getBootstrapSnapshot else {
+            pageResultProvider: { method, _ in
+                guard method == WITransportMethod.Page.getResourceTree else {
                     return nil
                 }
-                return makeBootstrapSnapshotResultPayload(
+                return makeResourceTreeResultPayload(
+                    mainURL: "https://example.com/",
                     resources: [
-                        makeBootstrapResourcePayload(
-                            bootstrapRowID: "bootstrap-row",
-                            ownerSessionID: "page-A",
-                            targetIdentifier: "page-A",
+                        makeFrameResourcePayload(
                             url: "https://example.com/bootstrap.js",
-                            method: "UNKNOWN",
-                            requestType: "Script",
-                            mimeType: "text/javascript",
-                            phase: "completed"
+                            type: "Script",
+                            mimeType: "text/javascript"
                         ),
                     ]
                 )
@@ -54,14 +49,14 @@ struct NetworkTransportDriverTests {
         await driver.attachPageWebView(webView)
         await driver.waitForAttachForTesting()
         #expect(await waitForCondition {
-            driver.store.entries.count == 1
+            driver.store.entries.count == 2
         })
 
         await driver.attachPageWebView(webView)
         await driver.waitForAttachForTesting()
 
-        #expect(driver.store.entries.count == 1)
-        #expect(backend.sentPageTargets.filter { $0.method == WITransportMethod.Network.getBootstrapSnapshot }.count == 1)
+        #expect(driver.store.entries.count == 2)
+        #expect(backend.sentPageTargets.filter { $0.method == WITransportMethod.Page.getResourceTree }.count == 1)
 
         await driver.detachPageWebView(preparing: .stopped)
     }
@@ -88,16 +83,8 @@ struct NetworkTransportDriverTests {
     }
 
     @Test
-    func networkTransportDriverFetchesDeferredRequestBodiesFromOwningTarget() async {
-        let backend = FakeRegistryBackend(
-            pageTargetedResultProvider: { method, _, targetIdentifier in
-                guard method == WITransportMethod.Network.getRequestPostData,
-                      targetIdentifier == "page-child" else {
-                    return nil
-                }
-                return ["postData": "targeted=value"]
-            }
-        )
+    func networkTransportDriverDoesNotFetchDeferredRequestBodies() async {
+        let backend = FakeRegistryBackend()
         let driver = NetworkTransportDriver(transportSessionFactory: makeTransportSessionFactory(using: backend))
         let session = WINetworkRuntime(configuration: .init(), backend: driver)
         let webView = makeIsolatedTestWebView()
@@ -113,22 +100,105 @@ struct NetworkTransportDriverTests {
             role: .request
         )
 
-        #expect(body?.role == .request)
-        #expect(body?.full == "targeted=value")
-        #expect(
-            backend.sentPageTargets.contains {
-                $0.method == WITransportMethod.Network.getRequestPostData
-                    && $0.targetIdentifier == "page-child"
-            }
-        )
+        #expect(body == nil)
+        #expect(driver.supportsDeferredLoading(for: .request) == false)
 
         await session.detach()
     }
 
     @Test
-    func stableBootstrapMethodNotFoundDisablesFurtherAttemptsOnSameSession() async throws {
+    func networkTransportDriverStoresInlinePostDataAsRequestBody() async {
+        let backend = FakeRegistryBackend()
+        let driver = NetworkTransportDriver(transportSessionFactory: makeTransportSessionFactory(using: backend))
+        let webView = makeIsolatedTestWebView()
+
+        await driver.attachPageWebView(webView)
+        await driver.waitForAttachForTesting()
+
+        backend.emitPageEvent(
+            method: "Network.requestWillBeSent",
+            params: [
+                "requestId": "request-post-data",
+                "timestamp": 12.0,
+                "walltime": 1_700_000_000.0,
+                "type": "Fetch",
+                "request": [
+                    "url": "https://example.com/post",
+                    "method": "POST",
+                    "headers": [
+                        "Content-Type": "application/json",
+                    ],
+                    "postData": #"{"hello":"world"}"#,
+                ],
+            ],
+            targetIdentifier: "page-A"
+        )
+
+        #expect(await waitForCondition {
+            guard let entry = driver.store.entries.first(where: { $0.url == "https://example.com/post" }) else {
+                return false
+            }
+            return entry.requestBody?.full == #"{"hello":"world"}"#
+                && entry.requestBody?.hasDeferredContent == false
+                && entry.requestBodyBytesSent == #"{"hello":"world"}"#.utf8.count
+        })
+
+        await driver.detachPageWebView(preparing: .stopped)
+    }
+
+    @Test
+    func networkTransportDriverKeepsMissingPostDataUnavailableWhileRecordingSentBytes() async {
+        let backend = FakeRegistryBackend()
+        let driver = NetworkTransportDriver(transportSessionFactory: makeTransportSessionFactory(using: backend))
+        let webView = makeIsolatedTestWebView()
+
+        await driver.attachPageWebView(webView)
+        await driver.waitForAttachForTesting()
+
+        backend.emitPageEvent(
+            method: "Network.requestWillBeSent",
+            params: [
+                "requestId": "request-missing-post-data",
+                "timestamp": 12.0,
+                "type": "Fetch",
+                "request": [
+                    "url": "https://example.com/missing-post-data",
+                    "method": "POST",
+                    "headers": [:],
+                ],
+            ],
+            targetIdentifier: "page-A"
+        )
+        backend.emitPageEvent(
+            method: "Network.loadingFinished",
+            params: [
+                "requestId": "request-missing-post-data",
+                "timestamp": 13.0,
+                "metrics": [
+                    "requestBodyBytesSent": 512,
+                    "responseBodyBytesReceived": 64,
+                    "responseBodyDecodedSize": 64,
+                ],
+            ],
+            targetIdentifier: "page-A"
+        )
+
+        #expect(await waitForCondition {
+            guard let entry = driver.store.entries.first(where: { $0.url == "https://example.com/missing-post-data" }) else {
+                return false
+            }
+            return entry.phase == .completed
+                && entry.requestBody == nil
+                && entry.requestBodyBytesSent == 512
+                && entry.decodedBodyLength == 64
+        })
+
+        await driver.detachPageWebView(preparing: .stopped)
+    }
+
+    @Test
+    func bootstrapLoadsResourceTreeEachTimeWithoutStableNetworkSnapshot() async throws {
         let backend = FakeRegistryBackend(
-            capabilities: [.rootMessaging, .pageMessaging, .pageTargetRouting, .domDomain, .networkDomain, .networkBootstrapSnapshot],
             pageTargetedResultProvider: { method, _, _ in
                 guard method == WITransportMethod.Page.getResourceTree else {
                     return nil
@@ -137,12 +207,6 @@ struct NetworkTransportDriverTests {
                     mainURL: "https://example.com/",
                     resources: []
                 )
-            },
-            pageErrorResponseProvider: { method, _, _ in
-                guard method == WITransportMethod.Network.getBootstrapSnapshot else {
-                    return nil
-                }
-                return "'Network.getBootstrapSnapshot' was not found"
             }
         )
         let session = makeTransportSessionFactory(using: backend)()
@@ -170,7 +234,6 @@ struct NetworkTransportDriverTests {
 
         #expect(firstLoad.snapshots.count == 1)
         #expect(secondLoad.snapshots.count == 1)
-        #expect(backend.sentPageTargets.filter { $0.method == WITransportMethod.Network.getBootstrapSnapshot }.count == 1)
         #expect(backend.sentPageTargets.filter { $0.method == WITransportMethod.Page.getResourceTree }.count == 2)
 
         session.detach()
@@ -1099,221 +1162,6 @@ struct NetworkTransportDriverTests {
         await session.detach()
     }
 
-    @Test
-    func networkTransportDriverRebindsStableBootstrapRowsAcrossTargetChanges() async {
-        let backend = FakeRegistryBackend(
-            capabilities: [.rootMessaging, .pageMessaging, .pageTargetRouting, .domDomain, .networkDomain, .networkBootstrapSnapshot],
-            pageResultProvider: { method, _ in
-                guard method == WITransportMethod.Network.getBootstrapSnapshot else {
-                    return nil
-                }
-                return makeBootstrapSnapshotResultPayload(
-                    resources: [
-                        makeBootstrapResourcePayload(
-                            bootstrapRowID: "target-swap",
-                            rawRequestID: "request-target-swap",
-                            ownerSessionID: "page-provisional",
-                            frameID: "frame-main",
-                            targetIdentifier: "page-provisional",
-                            url: "https://example.com/swap.js",
-                            method: "UNKNOWN",
-                            requestType: "Script",
-                            mimeType: "text/javascript",
-                            phase: "inFlight"
-                        ),
-                    ]
-                )
-            }
-        )
-        let driver = NetworkTransportDriver(transportSessionFactory: makeTransportSessionFactory(using: backend))
-        let webView = makeIsolatedTestWebView()
-
-        await driver.attachPageWebView(webView)
-        await driver.waitForAttachForTesting()
-
-        backend.emitRootEvent(
-            method: "Target.didCommitProvisionalTarget",
-            params: [
-                "oldTargetId": "page-provisional",
-                "newTargetId": "page-committed",
-            ]
-        )
-        backend.emitPageEvent(
-            method: "Network.requestWillBeSent",
-            params: [
-                "requestId": "request-target-swap",
-                "timestamp": 12.0,
-                "type": "Script",
-                "request": [
-                    "url": "https://example.com/swap.js",
-                    "method": "GET",
-                    "headers": [:],
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-        backend.emitPageEvent(
-            method: "Network.responseReceived",
-            params: [
-                "requestId": "request-target-swap",
-                "timestamp": 13.0,
-                "type": "Script",
-                "response": [
-                    "url": "https://example.com/swap.js",
-                    "status": 200,
-                    "statusText": "OK",
-                    "headers": [:],
-                    "mimeType": "text/javascript",
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-        backend.emitPageEvent(
-            method: "Network.loadingFinished",
-            params: [
-                "requestId": "request-target-swap",
-                "timestamp": 14.0,
-                "metrics": [
-                    "responseBodyBytesReceived": 64,
-                    "responseBodyDecodedSize": 64,
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-
-        #expect(await waitForCondition {
-            let matches = driver.store.entries.filter { $0.url == "https://example.com/swap.js" }
-            guard let entry = matches.first else {
-                return false
-            }
-            return matches.count == 1
-                && entry.sessionID == "page-committed"
-                && entry.phase == .completed
-                && entry.statusCode == 200
-                && entry.encodedBodyLength == 64
-        })
-
-        await driver.detachPageWebView(preparing: .stopped)
-    }
-
-    @Test
-    func networkTransportDriverMatchesRedirectedStableContinuationByPreviousURL() async {
-        let backend = FakeRegistryBackend(
-            capabilities: [.rootMessaging, .pageMessaging, .pageTargetRouting, .domDomain, .networkDomain, .networkBootstrapSnapshot],
-            pageResultProvider: { method, _ in
-                guard method == WITransportMethod.Network.getBootstrapSnapshot else {
-                    return nil
-                }
-                return makeBootstrapSnapshotResultPayload(
-                    resources: [
-                        makeBootstrapResourcePayload(
-                            bootstrapRowID: "redirect-rebind",
-                            rawRequestID: "request-redirect-rebind",
-                            ownerSessionID: "page-provisional",
-                            frameID: "frame-main",
-                            targetIdentifier: "page-provisional",
-                            url: "https://example.com/original.js",
-                            method: "GET",
-                            requestType: "Script",
-                            mimeType: "text/javascript",
-                            phase: "inFlight"
-                        ),
-                    ]
-                )
-            }
-        )
-        let driver = NetworkTransportDriver(transportSessionFactory: makeTransportSessionFactory(using: backend))
-        let webView = makeIsolatedTestWebView()
-
-        await driver.attachPageWebView(webView)
-        await driver.waitForAttachForTesting()
-
-        backend.emitRootEvent(
-            method: "Target.didCommitProvisionalTarget",
-            params: [
-                "oldTargetId": "page-provisional",
-                "newTargetId": "page-committed",
-            ]
-        )
-        backend.emitPageEvent(
-            method: "Network.requestWillBeSent",
-            params: [
-                "requestId": "request-redirect-rebind",
-                "timestamp": 12.0,
-                "type": "Script",
-                "request": [
-                    "url": "https://example.com/final.js",
-                    "method": "GET",
-                    "headers": [:],
-                ],
-                "redirectResponse": [
-                    "url": "https://example.com/original.js",
-                    "status": 302,
-                    "statusText": "Found",
-                    "headers": [
-                        "Location": "https://example.com/final.js",
-                    ],
-                    "mimeType": "text/javascript",
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-        backend.emitPageEvent(
-            method: "Network.responseReceived",
-            params: [
-                "requestId": "request-redirect-rebind",
-                "timestamp": 13.0,
-                "type": "Script",
-                "response": [
-                    "url": "https://example.com/final.js",
-                    "status": 200,
-                    "statusText": "OK",
-                    "headers": [:],
-                    "mimeType": "text/javascript",
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-        backend.emitPageEvent(
-            method: "Network.loadingFinished",
-            params: [
-                "requestId": "request-redirect-rebind",
-                "timestamp": 14.0,
-                "metrics": [
-                    "responseBodyBytesReceived": 64,
-                    "responseBodyDecodedSize": 64,
-                ],
-            ],
-            targetIdentifier: "page-committed"
-        )
-
-        let matchedRedirectEntries = await waitForCondition {
-            let originalMatches = driver.store.entries.filter { $0.url == "https://example.com/original.js" }
-            let finalMatches = driver.store.entries.filter { $0.url == "https://example.com/final.js" }
-            guard let originalEntry = originalMatches.first,
-                  let finalEntry = finalMatches.first else {
-                return false
-            }
-            return originalMatches.count == 1
-                && finalMatches.count == 1
-                && originalEntry.sessionID == "page-committed"
-                && originalEntry.phase == .completed
-                && originalEntry.statusCode == 302
-                && finalEntry.sessionID == "page-committed"
-                && finalEntry.phase == .completed
-                && finalEntry.statusCode == 200
-                && finalEntry.encodedBodyLength == 64
-        }
-        if !matchedRedirectEntries {
-            let snapshot = driver.store.entries.map {
-                "\($0.url)|session=\($0.sessionID)|phase=\($0.phase.rawValue)|status=\($0.statusCode.map(String.init) ?? "nil")|bytes=\($0.encodedBodyLength.map(String.init) ?? "nil")"
-            }
-            Issue.record("redirect continuity snapshot: \(snapshot)")
-        }
-        #expect(matchedRedirectEntries)
-
-        await driver.detachPageWebView(preparing: .stopped)
-    }
 }
 
 @MainActor
@@ -1584,67 +1432,6 @@ private func makeFrameResourcePayload(
     }
     if let targetId {
         payload["targetId"] = targetId
-    }
-    return payload
-}
-
-private func makeBootstrapSnapshotResultPayload(resources: [[String: Any]]) -> [String: Any] {
-    ["resources": resources]
-}
-
-private func makeBootstrapResourcePayload(
-    bootstrapRowID: String,
-    rawRequestID: String? = nil,
-    ownerSessionID: String,
-    frameID: String? = nil,
-    targetIdentifier: String? = nil,
-    url: String,
-    method: String,
-    requestType: String,
-    mimeType: String,
-    statusCode: Int? = nil,
-    statusText: String? = nil,
-    phase: String,
-    requestHeaders: [String: String] = [:],
-    responseHeaders: [String: String] = [:],
-    canceled: Bool? = nil,
-    errorDescription: String? = nil,
-    bodyFetchDescriptor: [String: Any]? = nil
-) -> [String: Any] {
-    var payload: [String: Any] = [
-        "bootstrapRowID": bootstrapRowID,
-        "ownerSessionID": ownerSessionID,
-        "url": url,
-        "method": method,
-        "requestType": requestType,
-        "mimeType": mimeType,
-        "phase": phase,
-        "requestHeaders": requestHeaders,
-        "responseHeaders": responseHeaders,
-    ]
-    if let rawRequestID {
-        payload["rawRequestID"] = rawRequestID
-    }
-    if let frameID {
-        payload["frameID"] = frameID
-    }
-    if let targetIdentifier {
-        payload["targetIdentifier"] = targetIdentifier
-    }
-    if let statusCode {
-        payload["statusCode"] = statusCode
-    }
-    if let statusText {
-        payload["statusText"] = statusText
-    }
-    if let canceled {
-        payload["canceled"] = canceled
-    }
-    if let errorDescription {
-        payload["errorDescription"] = errorDescription
-    }
-    if let bodyFetchDescriptor {
-        payload["bodyFetchDescriptor"] = bodyFetchDescriptor
     }
     return payload
 }

--- a/Tests/WebInspectorTransportTests/WITransportWebKitLocalSymbolResolverTests.swift
+++ b/Tests/WebInspectorTransportTests/WITransportWebKitLocalSymbolResolverTests.swift
@@ -31,7 +31,6 @@ struct WITransportNativeInspectorSymbolResolverTests {
         #expect(resolution.destroyStringImplAddress != 0)
         #expect(resolution.backendDispatcherDispatchAddress != 0)
         #expect(resolution.supportSnapshot.isSupported)
-        #expect(!resolution.supportSnapshot.capabilities.contains(.networkBootstrapSnapshot))
         #if os(iOS)
         #expect(resolution.backendKind == .iOSNativeInspector)
         #elseif os(macOS)


### PR DESCRIPTION
## Purpose
Align Phase 1 of the native-only network cleanup with WebKit's actual Inspector Protocol by removing unsupported Network commands and making request body capture native-contract only.

## Changes
- Remove unsupported `Network.getRequestPostData`, `Network.getBootstrapSnapshot`, and `networkBootstrapSnapshot` capability plumbing.
- Make request bodies inline-only from `requestWillBeSent.request.postData`, while preserving response body fetch via `Network.getResponseBody` and `Page.getResourceContent`.
- Collapse bootstrap loading to `Page.getResourceTree` and update transport tests for inline/missing request bodies and sent-byte metrics.

## Testing
- `git diff --check`
- `git diff --cached --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorTransportTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `codex-review` on the Phase 1 changes: no findings

## Screenshots
- Not applicable (no UI changes).