### PR TITLE
[codex] Native-only Network Cleanup: Phase 2

### DIFF
--- a/Docs/MIGRATION.md
+++ b/Docs/MIGRATION.md
@@ -76,8 +76,10 @@ injected through `WIInspectorDependencies`.
 
 ```swift
 let dependencies = WIInspectorDependencies.testing {
-    $0.network = WIInspectorNetworkClient(
-        networkAgentScript: { "" }
+    $0.domFrontend = WIInspectorDOMFrontendClient(
+        domTreeViewScript: { "" },
+        mainFileURL: { nil },
+        resourcesDirectoryURL: { nil }
     )
 }
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -79,8 +79,10 @@ let inspector = WIViewController(
 
 ```swift
 let dependencies = WIInspectorDependencies.testing {
-    $0.network = WIInspectorNetworkClient(
-        networkAgentScript: { "" }
+    $0.domFrontend = WIInspectorDOMFrontendClient(
+        domTreeViewScript: { "" },
+        mainFileURL: { nil },
+        resourcesDirectoryURL: { nil }
     )
 }
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ boundaries through `WIInspectorDependencies`.
 
 ```swift
 let dependencies = WIInspectorDependencies.testing {
-    $0.network = WIInspectorNetworkClient(
-        networkAgentScript: { "" }
+    $0.domFrontend = WIInspectorDOMFrontendClient(
+        domTreeViewScript: { "" },
+        mainFileURL: { nil },
+        resourcesDirectoryURL: { nil }
     )
 }
 

--- a/Sources/WebInspectorEngine/Network/WINetworkRuntime.swift
+++ b/Sources/WebInspectorEngine/Network/WINetworkRuntime.swift
@@ -154,45 +154,55 @@ private extension WINetworkRuntime {
 }
 
 @MainActor
-private final class WINetworkUnavailableBackend: WINetworkBackend {
-    weak var webView: WKWebView?
-    let store = NetworkStore()
+package final class WINetworkUnsupportedBackend: WINetworkBackend {
+    package var webView: WKWebView? {
+        nil
+    }
 
-    let support = WIBackendSupport(
-        availability: .unsupported,
-        backendKind: .unsupported,
-        failureReason: "No backend was provided."
-    )
+    package let store = NetworkStore()
+    package let support: WIBackendSupport
 
-    func setMode(_ mode: NetworkLoggingMode) async {
+    package init(reason: String = "Network backend is unsupported.") {
+        self.support = WIBackendSupport(
+            availability: .unsupported,
+            backendKind: .unsupported,
+            failureReason: reason
+        )
+    }
+
+    package func setMode(_ mode: NetworkLoggingMode) async {
         store.setRecording(mode != .stopped)
         if mode == .stopped {
             store.reset()
         }
     }
 
-    func attachPageWebView(_ newWebView: WKWebView?) async {
-        webView = newWebView
+    package func attachPageWebView(_ newWebView: WKWebView?) async {
     }
 
-    func detachPageWebView(preparing modeBeforeDetach: NetworkLoggingMode?) async {
-        _ = modeBeforeDetach
-        webView = nil
+    package func detachPageWebView(preparing modeBeforeDetach: NetworkLoggingMode?) async {
+        if let modeBeforeDetach {
+            store.setRecording(modeBeforeDetach != .stopped)
+            if modeBeforeDetach == .stopped {
+                store.reset()
+            }
+        }
     }
 
-    func clearNetworkLogs() async {
+    package func clearNetworkLogs() async {
         store.clear()
     }
 
-    func tearDownForDeinit() {
-        webView = nil
+    package func tearDownForDeinit() {
         store.setRecording(false)
         store.reset()
     }
 
-    func fetchBodyResult(locator: NetworkDeferredBodyLocator, role: NetworkBody.Role) async -> WINetworkBodyFetchResult {
-        _ = locator
-        _ = role
+    package func supportsDeferredLoading(for role: NetworkBody.Role) -> Bool {
+        false
+    }
+
+    package func fetchBodyResult(locator: NetworkDeferredBodyLocator, role: NetworkBody.Role) async -> WINetworkBodyFetchResult {
         return .agentUnavailable
     }
 }

--- a/Sources/WebInspectorRuntime/Network/WINetworkRuntime.swift
+++ b/Sources/WebInspectorRuntime/Network/WINetworkRuntime.swift
@@ -32,9 +32,7 @@ public final class WINetworkRuntime {
             configuration: configuration,
             supportSnapshot: dependencies.transport.supportSnapshot(),
             sharedTransport: sharedTransport
-        ) {
-            NetworkPageAgent(dependencies: dependencies.makeNetworkPageAgentDependencies())
-        }
+        )
         let session = NetworkSession(
             configuration: configuration,
             backend: backend

--- a/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
+++ b/Sources/WebInspectorRuntime/Session/WIInspectorDependencies.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WebKit
 import WebInspectorBridge
-import WebInspectorEngine
 import WebInspectorScripts
 import WebInspectorTransport
 
@@ -15,20 +14,17 @@ public protocol WIInspectorDependencyClient {
 public struct WIInspectorDependencies: WIInspectorDependencyClient {
     public var transport: WIInspectorTransportClient
     public var domFrontend: WIInspectorDOMFrontendClient
-    public var network: WIInspectorNetworkClient
     public var webKitSPI: WIInspectorWebKitSPIClient
     public var platform: WIInspectorPlatformClient
 
     public init(
         transport: WIInspectorTransportClient = .liveValue,
         domFrontend: WIInspectorDOMFrontendClient = .liveValue,
-        network: WIInspectorNetworkClient = .liveValue,
         webKitSPI: WIInspectorWebKitSPIClient = .liveValue,
         platform: WIInspectorPlatformClient = .liveValue
     ) {
         self.transport = transport
         self.domFrontend = domFrontend
-        self.network = network
         self.webKitSPI = webKitSPI
         self.platform = platform
     }
@@ -41,7 +37,6 @@ public struct WIInspectorDependencies: WIInspectorDependencyClient {
         Self(
             transport: .testValue,
             domFrontend: .testValue,
-            network: .testValue,
             webKitSPI: .testValue,
             platform: .testValue
         )
@@ -55,17 +50,6 @@ public struct WIInspectorDependencies: WIInspectorDependencyClient {
 
     package func makeSharedTransport() -> WISharedInspectorTransport {
         transport.makeSharedTransport()
-    }
-
-    package func makeNetworkPageAgentDependencies() -> NetworkPageAgentDependencies {
-        NetworkPageAgentDependencies(
-            controllerStateRegistry: network.controllerStateRegistry,
-            startupMode: webKitSPI.startupBridgeMode,
-            modeForAttachment: webKitSPI.bridgeModeForAttachment,
-            loadNetworkAgentScriptSource: network.networkAgentScript,
-            supportsResourceLoadDelegate: webKitSPI.supportsResourceLoadDelegate,
-            setResourceLoadDelegate: webKitSPI.setResourceLoadDelegate
-        )
     }
 }
 
@@ -187,40 +171,6 @@ public struct WIInspectorDOMFrontendClient: WIInspectorDependencyClient {
 
     func makeInspectorWebView() -> InspectorWebView {
         InspectorWebView(dependencies: self)
-    }
-}
-
-@MainActor
-public struct WIInspectorNetworkClient: WIInspectorDependencyClient {
-    public var networkAgentScript: @MainActor @Sendable () throws -> String
-    package var controllerStateRegistry: WIUserContentControllerStateRegistry
-
-    public init(
-        networkAgentScript: @escaping @MainActor @Sendable () throws -> String = {
-            try WebInspectorScripts.networkAgent()
-        }
-    ) {
-        self.networkAgentScript = networkAgentScript
-        self.controllerStateRegistry = .shared
-    }
-
-    package init(
-        networkAgentScript: @escaping @MainActor @Sendable () throws -> String,
-        controllerStateRegistry: WIUserContentControllerStateRegistry
-    ) {
-        self.networkAgentScript = networkAgentScript
-        self.controllerStateRegistry = controllerStateRegistry
-    }
-
-    public static var liveValue: Self {
-        Self()
-    }
-
-    public static var testValue: Self {
-        Self(
-            networkAgentScript: { "" },
-            controllerStateRegistry: .shared
-        )
     }
 }
 

--- a/Sources/WebInspectorTransport/WIBackendFactory.swift
+++ b/Sources/WebInspectorTransport/WIBackendFactory.swift
@@ -5,17 +5,15 @@ package enum WIBackendFactory {
     package static func makeNetworkBackend(
         configuration: NetworkConfiguration,
         supportSnapshot: WITransportSupportSnapshot? = nil,
-        sharedTransport: WISharedInspectorTransport? = nil,
-        pageAgentFactory: @escaping @MainActor () -> any WINetworkBackend = {
-            NetworkPageAgent()
-        }
+        sharedTransport: WISharedInspectorTransport? = nil
     ) -> any WINetworkBackend {
         let resolvedSupport = WIBackendFactoryTesting.networkSupportSnapshotOverride
             ?? supportSnapshot
             ?? WITransportSession().supportSnapshot
-        _ = configuration
         guard resolvedSupport.isSupported else {
-            return pageAgentFactory()
+            return WINetworkUnsupportedBackend(
+                reason: resolvedSupport.failureReason ?? "WebInspectorTransport is unsupported."
+            )
         }
         return NetworkTransportDriver(
             sharedTransport: sharedTransport,
@@ -28,11 +26,11 @@ package enum WIBackendFactory {
 @_spi(Monocly) public enum WIBackendFactoryTesting {
     @TaskLocal public static var networkSupportSnapshotOverride: WITransportSupportSnapshot?
 
-    public static func withPageAgentFallback<T>(
-        reason: String = "test override",
+    public static func withNetworkSupportSnapshotOverride<T>(
+        _ supportSnapshot: WITransportSupportSnapshot,
         operation: () throws -> T
     ) rethrows -> T {
-        try $networkSupportSnapshotOverride.withValue(.unsupported(reason: reason)) {
+        try $networkSupportSnapshotOverride.withValue(supportSnapshot) {
             try operation()
         }
     }

--- a/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
+++ b/Tests/WebInspectorRuntimeTests/WIInspectorDependenciesTests.swift
@@ -1,5 +1,4 @@
 import Testing
-import WebInspectorBridge
 import WebKit
 #if canImport(UIKit)
 import UIKit
@@ -30,7 +29,6 @@ struct WIInspectorDependenciesTests {
         #expect(try dependencies.domFrontend.domTreeViewScript() == "")
         #expect(dependencies.domFrontend.mainFileURL() == nil)
         #expect(dependencies.domFrontend.resourcesDirectoryURL() == nil)
-        #expect(try dependencies.network.networkAgentScript() == "")
 
         let webView = WKWebView(frame: .zero)
         #expect(dependencies.webKitSPI.hasPrivateInspectorAccess(webView) == false)
@@ -51,9 +49,6 @@ struct WIInspectorDependenciesTests {
                 mainFileURL: { URL(fileURLWithPath: "/tmp/dom-tree-view.html") },
                 resourcesDirectoryURL: { URL(fileURLWithPath: "/tmp/dom-tree-view") }
             )
-            $0.network = WIInspectorNetworkClient(
-                networkAgentScript: { "custom-network-script" }
-            )
             $0.webKitSPI = WIInspectorWebKitSPIClient(
                 setNodeSearchEnabled: { _, enabled in enabled }
             )
@@ -62,15 +57,7 @@ struct WIInspectorDependenciesTests {
         #expect(try dependencies.domFrontend.domTreeViewScript() == "custom-dom-script")
         #expect(dependencies.domFrontend.mainFileURL()?.path == "/tmp/dom-tree-view.html")
         #expect(dependencies.domFrontend.resourcesDirectoryURL()?.path == "/tmp/dom-tree-view")
-        #expect(try dependencies.network.networkAgentScript() == "custom-network-script")
         #expect(dependencies.webKitSPI.setNodeSearchEnabled(WKWebView(frame: .zero), true))
-
-        let webView = WKWebView(frame: .zero)
-        let networkDependencies = dependencies.makeNetworkPageAgentDependencies()
-        #expect(networkDependencies.startupMode() == .legacyJSON)
-        #expect(networkDependencies.modeForAttachment(webView) == .legacyJSON)
-        #expect(networkDependencies.supportsResourceLoadDelegate(webView) == false)
-        #expect(networkDependencies.setResourceLoadDelegate(webView, nil) == false)
     }
 
     @Test
@@ -98,10 +85,11 @@ struct WIInspectorDependenciesTests {
     }
 
     @Test
-    func networkRuntimeFallsBackToInjectedPageAgentWhenTransportIsUnsupported() {
+    func networkRuntimeUsesUnsupportedBackendWhenTransportIsUnsupported() {
         let runtime = WINetworkRuntime(dependencies: .testValue)
 
-        #expect(runtime.model.session.testBackendTypeName() == "NetworkPageAgent")
+        #expect(runtime.model.session.testBackendTypeName() == "WINetworkUnsupportedBackend")
+        #expect(runtime.model.session.backendSupport.isSupported == false)
     }
 
 #if canImport(UIKit)

--- a/Tests/WebInspectorTransportTests/WIBackendFactoryTests.swift
+++ b/Tests/WebInspectorTransportTests/WIBackendFactoryTests.swift
@@ -1,18 +1,20 @@
 import Testing
+import WebKit
 @testable import WebInspectorEngine
 @_spi(Monocly) @testable import WebInspectorTransport
 
 @MainActor
 struct WIBackendFactoryTests {
     @Test
-    func makeNetworkBackendFallsBackToPageAgentWhenTransportIsUnsupported() {
+    func makeNetworkBackendReturnsUnsupportedBackendWhenTransportIsUnsupported() {
         let backend = WIBackendFactory.makeNetworkBackend(
             configuration: .init(),
             supportSnapshot: .unsupported(reason: "test")
         )
 
-        #expect(String(describing: type(of: backend)) == "NetworkPageAgent")
-        #expect(backend.support.isSupported)
+        #expect(String(describing: type(of: backend)) == "WINetworkUnsupportedBackend")
+        #expect(backend.support.isSupported == false)
+        #expect(backend.support.failureReason == "test")
     }
 
     @Test
@@ -29,8 +31,10 @@ struct WIBackendFactoryTests {
     }
 
     @Test
-    func pageAgentFallbackOverrideWinsOverInjectedSupportedSnapshot() {
-        let backend = WIBackendFactoryTesting.withPageAgentFallback {
+    func supportSnapshotOverrideWinsOverInjectedSupportedSnapshot() {
+        let backend = WIBackendFactoryTesting.withNetworkSupportSnapshotOverride(
+            .unsupported(reason: "override")
+        ) {
             WIBackendFactory.makeNetworkBackend(
                 configuration: .init(),
                 supportSnapshot: .supported(
@@ -40,6 +44,79 @@ struct WIBackendFactoryTests {
             )
         }
 
-        #expect(String(describing: type(of: backend)) == "NetworkPageAgent")
+        #expect(String(describing: type(of: backend)) == "WINetworkUnsupportedBackend")
+        #expect(backend.support.failureReason == "override")
     }
+
+    @Test
+    func unsupportedNetworkBackendKeepsEmptyStoreAndReportsAgentUnavailable() async {
+        let backend = WIBackendFactory.makeNetworkBackend(
+            configuration: .init(),
+            supportSnapshot: .unsupported(reason: "test")
+        )
+
+        #expect(backend.store.isRecording)
+        await backend.setMode(.active)
+        await backend.attachPageWebView(WKWebView(frame: .zero))
+
+        #expect(backend.webView == nil)
+        #expect(backend.store.entries.isEmpty)
+
+        backend.store.applySnapshots([makeSnapshot(requestID: 1)])
+        #expect(backend.store.entries.count == 1)
+        await backend.clearNetworkLogs()
+        #expect(backend.store.entries.isEmpty)
+        #expect(backend.store.isRecording)
+
+        backend.store.applySnapshots([makeSnapshot(requestID: 2)])
+        await backend.detachPageWebView(preparing: .stopped)
+        #expect(backend.store.entries.isEmpty)
+        #expect(backend.store.isRecording == false)
+
+        await backend.setMode(.active)
+        #expect(backend.store.isRecording)
+        #expect(backend.supportsDeferredLoading(for: .response) == false)
+
+        let result = await backend.fetchBodyResult(
+            locator: .networkRequest(id: "request-1", targetIdentifier: nil),
+            role: .response
+        )
+        guard case .agentUnavailable = result else {
+            Issue.record("Expected unsupported backend body fetch to return agentUnavailable.")
+            return
+        }
+    }
+}
+
+private func makeSnapshot(requestID: Int) -> NetworkEntry.Snapshot {
+    NetworkEntry.Snapshot(
+        sessionID: "session",
+        requestID: requestID,
+        request: NetworkEntry.Request(
+            url: "https://example.com/\(requestID)",
+            method: "GET",
+            headers: NetworkHeaders(),
+            body: nil,
+            bodyBytesSent: nil,
+            type: "Document",
+            wallTime: nil
+        ),
+        response: NetworkEntry.Response(
+            statusCode: nil,
+            statusText: "",
+            mimeType: nil,
+            headers: NetworkHeaders(),
+            body: nil,
+            blockedCookies: [],
+            errorDescription: nil
+        ),
+        transfer: NetworkEntry.Transfer(
+            startTimestamp: 0,
+            endTimestamp: nil,
+            duration: nil,
+            encodedBodyLength: nil,
+            decodedBodyLength: nil,
+            phase: .pending
+        )
+    )
 }


### PR DESCRIPTION
## Purpose
Continue the native-only Network cleanup by removing the runtime/factory contract that fell back to the JavaScript `NetworkPageAgent` when native transport support was unavailable.

## Changes
- Make `WIBackendFactory.makeNetworkBackend` native-only: supported transport returns `NetworkTransportDriver`, unsupported transport returns `WINetworkUnsupportedBackend` with the support failure reason.
- Remove `WIInspectorDependencies.network`, `WIInspectorNetworkClient.networkAgentScript`, and `makeNetworkPageAgentDependencies()` from the runtime dependency surface.
- Update `WINetworkRuntime` backend selection to use only the transport support snapshot and shared native transport.
- Promote the unsupported backend to a package-visible implementation that keeps store lifecycle state consistent while returning `.agentUnavailable` for body fetches.
- Update Runtime/Transport tests and dependency-injection docs, including localized README examples, to reflect the native/unsupported split.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorTransportTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorIntegrationTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorRuntimeTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `codex-review` on the Phase 2 changes: no findings

## Screenshots
- Not applicable (no UI changes).