### PR TITLE
[codex] Repair iframe DOM model flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,184 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-tests:
+    name: Package Tests (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: iOS 18 latest if available
+            runner: macos-26
+            xcode_channel: stable
+            xcode_major: '26'
+            ios_major: '18'
+            test_scope: native
+            optional: 'true'
+          - name: iOS 26 latest
+            runner: macos-26
+            xcode_channel: stable
+            xcode_major: '26'
+            ios_major: '26'
+            test_scope: full
+          - name: latest iOS beta if available
+            runner: macos-26
+            xcode_channel: prerelease
+            xcode_major: ''
+            ios_major: ''
+            test_scope: native
+            optional: 'true'
+    runs-on: ${{ matrix.runner }}
+    env:
+      XCODE_CHANNEL: ${{ matrix.xcode_channel }}
+      XCODE_MAJOR: ${{ matrix.xcode_major }}
+      IOS_MAJOR: ${{ matrix.ios_major }}
+      TEST_SCOPE: ${{ matrix.test_scope }}
+      OPTIONAL_CONFIGURATION: ${{ matrix.optional }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Resolve Xcode
+        run: |
+          ruby <<'RUBY'
+          channel = ENV.fetch("XCODE_CHANNEL")
+          xcode_major = ENV.fetch("XCODE_MAJOR", "")
+          optional = ENV.fetch("OPTIONAL_CONFIGURATION", "") == "true"
+
+          candidates = Dir["/Applications/Xcode*.app"].select { |path| File.directory?(path) }
+          candidates = candidates.select do |path|
+            xcode_major.empty? || File.basename(path).match?(/Xcode_#{Regexp.escape(xcode_major)}(?:[_.-]|\z)/)
+          end
+
+          def prerelease_xcode_path?(path)
+            labels = [path, File.realpath(path)].map { |candidate| File.basename(candidate).downcase }
+            labels.any? do |label|
+              label.match?(/beta|release[ _-]?candidate|(?:^|[_. -])rc(?:$|[_. -])/)
+            end
+          end
+
+          candidates = candidates.select do |path|
+            channel == "prerelease" ? prerelease_xcode_path?(path) : !prerelease_xcode_path?(path)
+          end
+
+          def version_components(path)
+            version = File.basename(path)[/Xcode[_-](\d+(?:[._]\d+)*)/, 1]
+            version.to_s.tr("_", ".").split(".").map(&:to_i)
+          end
+
+          selected = candidates.max_by { |path| version_components(path) }
+          unless selected
+            message = "No #{channel} Xcode#{xcode_major.empty? ? "" : " #{xcode_major}"} installation found"
+            if optional
+              File.open(ENV.fetch("GITHUB_ENV"), "a") { |env| env.puts "SKIP_TESTS=1" }
+              puts "#{message}; skipping optional job"
+              exit 0
+            end
+            abort(message)
+          end
+
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "DEVELOPER_DIR=#{selected}/Contents/Developer"
+          end
+          puts "Resolved Xcode: #{selected}"
+          RUBY
+
+      - name: Resolve latest iOS simulator
+        if: env.SKIP_TESTS != '1'
+        run: |
+          ruby <<'RUBY'
+          require "json"
+
+          ios_major = ENV.fetch("IOS_MAJOR", "")
+          optional = ENV.fetch("OPTIONAL_CONFIGURATION", "") == "true"
+          devices = JSON.parse(`xcrun simctl list devices available --json`).fetch("devices")
+          matches = []
+
+          devices.each do |runtime, runtime_devices|
+            next unless runtime =~ /SimRuntime\.iOS-(\d+(?:-\d+)*)$/
+
+            version = Regexp.last_match(1).tr("-", ".")
+            next if !ios_major.empty? && version.split(".").first != ios_major
+
+            available_devices = runtime_devices.select { |device| device.fetch("isAvailable", true) }
+            preferred_devices = available_devices.select { |device| device["name"].start_with?("iPhone") }
+            selected_devices = preferred_devices.empty? ? available_devices : preferred_devices
+
+            selected_devices.each do |device|
+              matches << [version.split(".").map(&:to_i), version, device.fetch("name"), device.fetch("udid")]
+            end
+          end
+
+          if matches.empty?
+            message = "No available iOS #{ios_major.empty? ? "" : "#{ios_major}.x "}simulator found"
+            if optional
+              File.open(ENV.fetch("GITHUB_ENV"), "a") { |env| env.puts "SKIP_TESTS=1" }
+              puts "#{message}; skipping optional job"
+              exit 0
+            end
+            warn message
+            system("xcrun simctl list devices available")
+            exit 1
+          end
+
+          _, version, device_name, udid = matches.max_by { |components, _, _, _| components }
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "DESTINATION=platform=iOS Simulator,id=#{udid}"
+            env.puts "RESOLVED_IOS_VERSION=#{version}"
+          end
+          puts "Resolved simulator: #{device_name} iOS #{version} (#{udid})"
+          RUBY
+
+      - name: Show Xcode and simulator environment
+        if: env.SKIP_TESTS != '1'
+        run: |
+          xcodebuild -version
+          xcodebuild -showsdks
+          echo "Destination: ${DESTINATION}"
+          echo "Resolved iOS: ${RESOLVED_IOS_VERSION}"
+          echo "Test scope: ${TEST_SCOPE}"
+
+      - name: Run package tests
+        if: env.SKIP_TESTS != '1'
+        run: |
+          test_arguments=()
+          if [[ "${TEST_SCOPE}" == "native" ]]; then
+            test_arguments+=(
+              "-only-testing:WebInspectorNativeBridgeTests"
+              "-only-testing:WebInspectorNativeSymbolsTests"
+            )
+          fi
+
+          xcodebuild test \
+            -workspace WebInspectorKit.xcworkspace \
+            -scheme WebInspectorKit \
+            -destination "${DESTINATION}" \
+            -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            -maximum-concurrent-test-simulator-destinations 1 \
+            "${test_arguments[@]}"
+
+      - name: Report optional skip
+        if: env.SKIP_TESTS == '1'
+        run: echo "No requested optional Xcode/iOS simulator configuration is available on this runner."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
 # Repository Guidelines
 
+## Testing
 
+- Package tests can be run from Xcode through the shared `WebInspectorKit` scheme.
+- Default validation command:
+
+```sh
+xcodebuild test \
+  -workspace WebInspectorKit.xcworkspace \
+  -scheme WebInspectorKit \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
+```

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -51,12 +51,6 @@ private extension UnicodeScalar {
     }
 }
 
-private extension ProtocolTarget {
-    var isTopLevelPage: Bool {
-        kind == .page && parentFrameID == nil
-    }
-}
-
 @MainActor
 @Observable
 package final class DOMTargetState {
@@ -227,27 +221,6 @@ package final class DOMDocumentState {
 
 package typealias DOMDocument = DOMDocumentState
 
-@MainActor
-@Observable
-package final class FrameDocumentProjection {
-    package var ownerNodeID: DOMNode.ID?
-    package var frameTargetID: ProtocolTarget.ID
-    package var frameDocumentID: DOMDocument.ID
-    package var state: FrameDocumentProjectionState
-
-    package init(
-        ownerNodeID: DOMNode.ID?,
-        frameTargetID: ProtocolTarget.ID,
-        frameDocumentID: DOMDocument.ID,
-        state: FrameDocumentProjectionState
-    ) {
-        self.ownerNodeID = ownerNodeID
-        self.frameTargetID = frameTargetID
-        self.frameDocumentID = frameDocumentID
-        self.state = state
-    }
-}
-
 package struct DOMTransaction {
     package typealias ID = DOMTransactionIdentifier
 
@@ -395,12 +368,10 @@ package final class DOMSession {
     package private(set) var treeRevision: UInt64
     package private(set) var selectionRevision: UInt64
 
-    private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
-    private var targetStatesByID: [ProtocolTarget.ID: DOMTargetState]
-    private var framesByID: [DOMFrame.ID: DOMFrame]
-    private var frameDocumentProjections: [ProtocolTarget.ID: FrameDocumentProjection]
+    private var targetGraph: DOMTargetGraph
+    private var documentStore: DOMDocumentStore
+    private var frameDocumentProjectionIndex: FrameDocumentProjectionIndex
     private var selection: DOMSelection
-    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
     private var nextSelectionRequestRawID: UInt64
 
     package init() {
@@ -408,88 +379,42 @@ package final class DOMSession {
         mainFrameID = nil
         treeRevision = 0
         selectionRevision = 0
-        targetsByID = [:]
-        targetStatesByID = [:]
-        framesByID = [:]
-        frameDocumentProjections = [:]
+        targetGraph = DOMTargetGraph()
+        documentStore = DOMDocumentStore()
+        frameDocumentProjectionIndex = FrameDocumentProjectionIndex()
         selection = DOMSelection()
-        executionContextsByID = [:]
         nextSelectionRequestRawID = 0
     }
 
     private func targetBelongsToCurrentPage(_ targetID: ProtocolTarget.ID) -> Bool {
-        guard targetsByID[targetID] != nil else {
-            return false
-        }
-        guard currentPageTargetID != targetID else {
-            return true
-        }
-        guard let frameID = targetsByID[targetID]?.frameID else {
-            return false
-        }
-
-        var currentFrameID: DOMFrame.ID? = frameID
-        var visitedFrameIDs = Set<DOMFrame.ID>()
-        while let candidateFrameID = currentFrameID,
-              visitedFrameIDs.insert(candidateFrameID).inserted {
-            if candidateFrameID == mainFrameID {
-                return true
-            }
-            currentFrameID = framesByID[candidateFrameID]?.parentFrameID
-        }
-        return false
+        targetGraph.targetBelongsToCurrentPage(
+            targetID,
+            currentPageTargetID: currentPageTargetID,
+            mainFrameID: mainFrameID
+        )
     }
 
     private func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {
-        let state = targetStatesByID[targetID] ?? DOMTargetState(targetID: targetID)
-        targetStatesByID[targetID] = state
-        return state
+        documentStore.state(for: targetID)
     }
 
     private func currentState(for targetID: ProtocolTarget.ID) -> DOMTargetState? {
         guard targetBelongsToCurrentPage(targetID) || currentPageTargetID == nil else {
             return nil
         }
-        return targetStatesByID[targetID]
+        return documentStore.stateIfPresent(for: targetID)
     }
 
     private func currentDocument(for documentID: DOMDocument.ID) -> DOMDocument? {
-        guard let document = targetStatesByID[documentID.targetID]?.currentDocument,
-              document.id == documentID,
-              document.lifecycle == .loaded else {
-            return nil
-        }
-        return document
+        documentStore.currentDocument(for: documentID)
     }
 
     private func document(for nodeID: DOMNode.ID) -> DOMDocument? {
         currentDocument(for: nodeID.documentID)
     }
 
-    private func attachFrameTarget(_ target: ProtocolTarget) {
-        guard let frameID = target.frameID else {
-            return
-        }
-        let frame = frameWithID(frameID, parentFrameID: target.parentFrameID)
-        frame.targetID = target.id
-        _ = state(for: target.id)
-    }
-
     private func attachKnownFrameTargets() {
-        var attachedTargetIDs = Set<ProtocolTarget.ID>()
-        var didAttach = true
-        while didAttach {
-            didAttach = false
-            for target in targetsByID.values where target.kind == .frame && attachedTargetIDs.contains(target.id) == false {
-                guard let parentFrameID = target.parentFrameID,
-                      parentFrameID == mainFrameID || framesByID[parentFrameID] != nil else {
-                    continue
-                }
-                attachFrameTarget(target)
-                attachedTargetIDs.insert(target.id)
-                didAttach = true
-            }
-        }
+        targetGraph.attachKnownFrameTargets(mainFrameID: mainFrameID)
     }
 
     package func reset() {
@@ -497,12 +422,10 @@ package final class DOMSession {
         mainFrameID = nil
         treeRevision = 0
         selectionRevision = 0
-        targetsByID.removeAll()
-        targetStatesByID.removeAll()
-        framesByID.removeAll()
-        frameDocumentProjections.removeAll()
+        targetGraph.reset()
+        documentStore.reset()
+        frameDocumentProjectionIndex.removeAll()
         selection = DOMSelection()
-        executionContextsByID.removeAll()
         nextSelectionRequestRawID = 0
     }
 
@@ -510,26 +433,11 @@ package final class DOMSession {
         _ record: ProtocolTargetRecord,
         makeCurrentMainPage: Bool = false
     ) {
-        let target = targetsByID[record.id] ?? ProtocolTarget(
-            id: record.id,
-            kind: record.kind,
-            frameID: record.frameID,
-            parentFrameID: record.parentFrameID,
-            capabilities: record.capabilities,
-            isProvisional: record.isProvisional,
-            isPaused: record.isPaused
-        )
-        target.kind = record.kind
-        target.frameID = record.frameID
-        target.parentFrameID = record.parentFrameID
-        target.capabilities = record.capabilities
-        target.isProvisional = record.isProvisional
-        target.isPaused = record.isPaused
-        targetsByID[record.id] = target
+        targetGraph.upsertTarget(from: record)
         _ = state(for: record.id)
 
         if record.kind == .frame {
-            attachFrameTarget(target)
+            targetGraph.attachFrameTarget(record.id)
         }
 
         guard makeCurrentMainPage, record.kind == .page else {
@@ -540,13 +448,11 @@ package final class DOMSession {
     }
 
     package func promoteTargetToCurrentPage(_ targetID: ProtocolTarget.ID) {
-        guard let target = targetsByID[targetID],
-              target.kind == .page,
-              target.parentFrameID == nil else {
+        guard targetGraph.isTopLevelPageTarget(targetID) else {
             return
         }
 
-        let resolvedMainFrameID = target.frameID ?? DOMFrame.ID("main:\(targetID.rawValue)")
+        let resolvedMainFrameID = targetGraph.targetFrameID(for: targetID) ?? DOMFrame.ID("main:\(targetID.rawValue)")
         if let currentPageTargetID, currentPageTargetID != targetID {
             selection = DOMSelection()
             selectionRevision &+= 1
@@ -554,22 +460,13 @@ package final class DOMSession {
         currentPageTargetID = targetID
         mainFrameID = resolvedMainFrameID
         _ = state(for: targetID)
-        let mainFrame = frameWithID(resolvedMainFrameID, parentFrameID: nil)
-        mainFrame.targetID = targetID
-        target.frameID = resolvedMainFrameID
+        targetGraph.assignMainFrame(resolvedMainFrameID, to: targetID)
         attachKnownFrameTargets()
         treeRevision &+= 1
     }
 
     package func applyTargetCommitted(targetID: ProtocolTarget.ID) {
-        guard let target = targetsByID[targetID] else {
-            return
-        }
-
-        target.isProvisional = false
-        if target.kind == .frame {
-            attachFrameTarget(target)
-        }
+        targetGraph.markTargetCommitted(targetID)
     }
 
     package func applyTargetCommitted(oldTargetID: ProtocolTarget.ID, newTargetID: ProtocolTarget.ID) {
@@ -579,71 +476,40 @@ package final class DOMSession {
         }
 
         if currentPageTargetID == oldTargetID,
-           let existingNewTarget = targetsByID[newTargetID],
-           !existingNewTarget.isTopLevelPage {
+           targetGraph.containsTarget(newTargetID),
+           !targetGraph.isTopLevelPageTarget(newTargetID) {
             applyTargetCommitted(targetID: newTargetID)
             return
         }
 
-        guard let oldTarget = targetsByID.removeValue(forKey: oldTargetID) else {
+        guard let commit = targetGraph.commitTarget(oldTargetID: oldTargetID, newTargetID: newTargetID) else {
             return
         }
 
-        let existingNewTarget = targetsByID[newTargetID]
-        let frameID = existingNewTarget?.frameID ?? oldTarget.frameID
-        let parentFrameID = existingNewTarget?.parentFrameID ?? oldTarget.parentFrameID
-        let committedTarget = existingNewTarget ?? ProtocolTarget(
-            id: newTargetID,
-            kind: oldTarget.kind,
-            frameID: frameID,
-            parentFrameID: parentFrameID,
-            capabilities: oldTarget.capabilities,
-            isProvisional: false,
-            isPaused: oldTarget.isPaused
-        )
-        committedTarget.kind = existingNewTarget?.kind ?? oldTarget.kind
-        committedTarget.frameID = frameID
-        committedTarget.parentFrameID = parentFrameID
-        committedTarget.capabilities = existingNewTarget?.capabilities ?? oldTarget.capabilities
-        committedTarget.isProvisional = false
-        committedTarget.isPaused = existingNewTarget?.isPaused ?? oldTarget.isPaused
-        targetsByID[newTargetID] = committedTarget
-
-        if let oldState = targetStatesByID.removeValue(forKey: oldTargetID) {
+        if let oldState = documentStore.removeState(for: oldTargetID) {
             oldState.currentDocument?.transactions.removeAll()
             let newState = state(for: newTargetID)
             if let oldDocument = oldState.currentDocument {
                 oldDocument.lifecycle = .invalidated
-                clearCurrentDocumentReference(oldDocument.id, target: oldTarget)
+                clearCurrentDocumentReference(
+                    oldDocument.id,
+                    targetID: oldTargetID,
+                    targetFrameID: commit.oldFrameID
+                )
                 newState.currentDocument = nil
             }
         }
 
-        if let frameID {
-            let frame = frameWithID(frameID, parentFrameID: parentFrameID)
-            if frame.targetID == oldTargetID || frame.targetID == nil {
-                frame.targetID = newTargetID
-            }
+        if frameDocumentProjectionIndex.moveProjection(from: oldTargetID, to: newTargetID) != nil {
+            updateFrameDocumentProjectionState(frameTargetID: newTargetID)
         }
 
-        if let projection = frameDocumentProjections.removeValue(forKey: oldTargetID) {
-            projection.frameTargetID = newTargetID
-            frameDocumentProjections[newTargetID] = projection
-            updateFrameDocumentProjectionState(projection)
-        }
-
-        for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
-            executionContextsByID[contextID] = ExecutionContextRecord(
-                id: record.id,
-                targetID: newTargetID,
-                frameID: record.frameID
-            )
-        }
+        targetGraph.retargetExecutionContexts(from: oldTargetID, to: newTargetID)
 
         if currentPageTargetID == oldTargetID {
             currentPageTargetID = newTargetID
             if let mainFrameID {
-                frameWithID(mainFrameID, parentFrameID: nil).targetID = newTargetID
+                targetGraph.setFrameTargetID(newTargetID, for: mainFrameID)
             }
         }
 
@@ -652,34 +518,34 @@ package final class DOMSession {
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTarget.ID) {
-        guard let target = targetsByID.removeValue(forKey: targetID) else {
+        guard let removal = targetGraph.removeTarget(targetID) else {
             return
         }
-        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
-        if let documentID = targetStatesByID[targetID]?.currentDocument?.id {
+        targetGraph.removeExecutionContexts(targetID: targetID)
+        if let documentID = documentStore.currentDocument(forTargetID: targetID)?.id {
             removeDocument(documentID)
         }
-        frameDocumentProjections.removeValue(forKey: targetID)
-        if let frameID = target.frameID,
-           framesByID[frameID]?.targetID == targetID {
-            framesByID[frameID]?.targetID = nil
-            framesByID[frameID]?.currentDocumentID = nil
+        frameDocumentProjectionIndex.removeValue(forKey: targetID)
+        if let frameID = removal.frameID,
+           targetGraph.frameTargetID(frameID) == targetID {
+            targetGraph.setFrameTargetID(nil, for: frameID)
+            targetGraph.setFrameCurrentDocumentID(nil, for: frameID)
         }
         if currentPageTargetID == targetID {
             currentPageTargetID = nil
             mainFrameID = nil
             selection = DOMSelection()
         }
-        targetStatesByID.removeValue(forKey: targetID)
+        documentStore.removeState(for: targetID)
         reconcileSelection()
         treeRevision &+= 1
     }
 
     package func applyExecutionContextCreated(_ record: ExecutionContextRecord) {
-        guard targetsByID[record.targetID] != nil else {
+        guard targetGraph.containsTarget(record.targetID) else {
             return
         }
-        executionContextsByID[record.id] = record
+        targetGraph.recordExecutionContext(record)
     }
 
     package func applyExecutionContextCreated(
@@ -692,7 +558,7 @@ package final class DOMSession {
 
     @discardableResult
     package func replaceDocumentRoot(_ root: DOMNodePayload, targetID: ProtocolTarget.ID) -> DOMNode.ID {
-        guard let target = targetsByID[targetID] else {
+        guard targetGraph.containsTarget(targetID) else {
             preconditionFailure("replaceDocumentRoot requires a known ProtocolTarget")
         }
         let targetState = state(for: targetID)
@@ -718,14 +584,14 @@ package final class DOMSession {
         )
         targetState.currentDocument = document
 
-        if let frameID = target.frameID {
-            framesByID[frameID]?.currentDocumentID = documentID
+        if let frameID = targetGraph.targetFrameID(for: targetID) {
+            targetGraph.setFrameCurrentDocumentID(documentID, for: frameID)
         }
         if currentPageTargetID == targetID,
            let mainFrameID {
-            framesByID[mainFrameID]?.currentDocumentID = documentID
+            targetGraph.setFrameCurrentDocumentID(documentID, for: mainFrameID)
         }
-        if target.kind == .frame {
+        if targetGraph.targetKind(for: targetID) == .frame {
             setFrameDocumentProjection(frameTargetID: targetID, frameDocumentID: documentID)
         }
         updateAllFrameDocumentProjectionStates()
@@ -736,26 +602,24 @@ package final class DOMSession {
     }
 
     package func invalidateDocument(targetID: ProtocolTarget.ID) {
-        guard let target = targetsByID[targetID],
-              let targetState = targetStatesByID[targetID],
+        guard let targetState = documentStore.stateIfPresent(for: targetID),
               let document = targetState.currentDocument else {
             return
         }
         let documentID = document.id
         document.lifecycle = .invalidated
         document.transactions.removeAll()
-        if let frameID = target.frameID,
-           framesByID[frameID]?.currentDocumentID == documentID {
-            framesByID[frameID]?.currentDocumentID = nil
+        if let frameID = targetGraph.targetFrameID(for: targetID),
+           targetGraph.frameCurrentDocumentID(frameID) == documentID {
+            targetGraph.setFrameCurrentDocumentID(nil, for: frameID)
         }
         if currentPageTargetID == targetID,
            let mainFrameID {
-            framesByID[mainFrameID]?.currentDocumentID = nil
+            targetGraph.clearFrameCurrentDocumentID(mainFrameID, matching: documentID)
         }
-        if let projection = frameDocumentProjections[targetID],
+        if let projection = frameDocumentProjectionIndex[targetID],
            projection.frameDocumentID == documentID {
-            projection.ownerNodeID = nil
-            projection.state = .pending
+            detachFrameDocumentProjection(frameTargetID: targetID)
         }
         reconcileSelection()
         treeRevision &+= 1
@@ -771,7 +635,7 @@ package final class DOMSession {
         children payloads: [DOMNodePayload],
         eventSequence: UInt64
     ) {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded else {
             return
         }
@@ -787,7 +651,7 @@ package final class DOMSession {
         payload: DOMNodePayload,
         eventSequence _: UInt64
     ) {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded else {
             return
         }
@@ -946,19 +810,15 @@ package final class DOMSession {
     }
 
     package func currentDocumentID(for targetID: ProtocolTarget.ID) -> DOMDocument.ID? {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
-              document.lifecycle == .loaded else {
-            return nil
-        }
-        return document.id
+        documentStore.currentLoadedDocumentID(for: targetID)
     }
 
     package func targetCapabilities(for targetID: ProtocolTarget.ID) -> ProtocolTargetCapabilities {
-        targetsByID[targetID]?.capabilities ?? []
+        targetGraph.targetCapabilities(for: targetID)
     }
 
     package func targetKind(for targetID: ProtocolTarget.ID) -> ProtocolTargetKind? {
-        targetsByID[targetID]?.kind
+        targetGraph.targetKind(for: targetID)
     }
 
     package func getDocumentIntent(targetID: ProtocolTarget.ID) -> DOMCommandIntent? {
@@ -981,7 +841,7 @@ package final class DOMSession {
 
     package var currentPageRootNode: DOMNode? {
         guard let targetID = currentPageTargetID,
-              let document = targetStatesByID[targetID]?.currentDocument,
+              let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded
         else {
             return nil
@@ -990,7 +850,7 @@ package final class DOMSession {
     }
 
     package func node(for id: DOMNode.ID) -> DOMNode? {
-        currentDocument(for: id.documentID)?.nodesByID[id]
+        documentStore.node(for: id)
     }
 
     package func visibleDOMTreeChildren(of node: DOMNode) -> [DOMNode] {
@@ -1048,7 +908,7 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
     ) -> Result<DOMNode.ID, SelectionResolutionFailure> {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded else {
             return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
         }
@@ -1081,11 +941,12 @@ package final class DOMSession {
     }
 
     package func pendingFrameOwnerHydrationIntent(issuedSequence: UInt64 = 0) -> DOMCommandIntent? {
-        guard let (frameTargetID, _) = frameDocumentProjections
-            .sorted(by: { $0.key.rawValue < $1.key.rawValue })
-            .first(where: { $0.value.state == .pending }) else {
+        guard let pendingProjection = frameDocumentProjectionIndex.values
+            .sorted(by: { $0.frameTargetID.rawValue < $1.frameTargetID.rawValue })
+            .first(where: { $0.state == .pending }) else {
             return nil
         }
+        let frameTargetID = pendingProjection.frameTargetID
         guard let ownerDocument = ownerDocument(forFrameTargetID: frameTargetID),
               let node = ownerHydrationNode(in: ownerDocument) else {
             return nil
@@ -1099,7 +960,7 @@ package final class DOMSession {
     }
 
     package func clearOwnerHydrationTransactions(targetID: ProtocolTarget.ID) {
-        targetStatesByID[targetID]?.currentDocument?.removeOwnerHydrationTransactions()
+        documentStore.clearOwnerHydrationTransactions(targetID: targetID)
     }
 
     package func actionIdentity(
@@ -1108,7 +969,7 @@ package final class DOMSession {
     ) -> DOMActionIdentity? {
         guard let node = node(for: nodeID),
               let resolvedCommandTargetID = commandTargetID ?? currentPageTargetID,
-              targetsByID[resolvedCommandTargetID] != nil else {
+              targetGraph.containsTarget(resolvedCommandTargetID) else {
             return nil
         }
 
@@ -1150,7 +1011,7 @@ package final class DOMSession {
         enabled: Bool
     ) -> DOMCommandIntent? {
         guard let targetID = targetID ?? currentPageTargetID,
-              targetsByID[targetID] != nil else {
+              targetGraph.containsTarget(targetID) else {
             return nil
         }
         return .setInspectModeEnabled(targetID: targetID, enabled: enabled)
@@ -1244,7 +1105,7 @@ package final class DOMSession {
         guard objectID.isEmpty == false else {
             return failSelection(.missingObjectID)
         }
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded,
               document.nodesByID[document.rootNodeID] != nil else {
             return failSelection(.missingCurrentDocument(targetID))
@@ -1273,7 +1134,7 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
     ) -> DOMRequestNodeResolution {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.lifecycle == .loaded else {
             return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
         }
@@ -1314,68 +1175,39 @@ package final class DOMSession {
     }
 
     package func treeProjection(rootTargetID: ProtocolTarget.ID) -> DOMTreeProjection {
-        var rows: [DOMTreeRow] = []
-        var visited = Set<DOMNode.ID>()
-        if let document = targetStatesByID[rootTargetID]?.currentDocument,
-           document.lifecycle == .loaded {
-            appendProjectionRows(document.rootNodeID, depth: 0, visited: &visited, rows: &rows)
+        guard let document = documentStore.currentDocument(forTargetID: rootTargetID),
+              document.lifecycle == .loaded else {
+            return DOMTreeProjection()
         }
-        return DOMTreeProjection(rows: rows)
+        return DOMTreeProjectionBuilder(
+            rootDocument: document,
+            selectedNodeID: selection.selectedNodeID,
+            nodeProvider: { [weak self] nodeID in
+                self?.node(for: nodeID)
+            },
+            frameDocumentRootResolver: { [weak self] ownerNodeID in
+                self?.projectedFrameDocumentRootID(for: ownerNodeID)
+            }
+        )
+        .build()
     }
 
     package func snapshot() -> DOMSessionSnapshot {
-        let documents = targetStatesByID.values.compactMap(\.currentDocument)
+        let documents = documentStore.currentDocuments
         let documentsByID = Dictionary(uniqueKeysWithValues: documents.map { ($0.id, $0) })
         let nodesByID = Dictionary(uniqueKeysWithValues: documents.flatMap { document in
             document.nodesByID.map { ($0.key, $0.value) }
         })
-        let currentNodeIDByKey = Dictionary(uniqueKeysWithValues: targetStatesByID.values.compactMap { state -> [(DOMNodeCurrentKey, DOMNode.ID)]? in
-            guard let document = state.currentDocument else {
-                return nil
-            }
-            guard document.lifecycle == .loaded else {
-                return []
-            }
-            return document.currentNodeIDByProtocolNodeID.map {
-                (DOMNodeCurrentKey(targetID: state.targetID, nodeID: $0.key), $0.value)
-            }
-        }.flatMap { $0 })
-        let transactions = documents.flatMap { document in
-            document.transactions.values
-        }
+        let currentNodeIDByKey = documentStore.currentNodeIDsByKey()
+        let transactions = documentStore.transactions()
         return DOMSessionSnapshot(
             currentPageTargetID: currentPageTargetID,
             mainFrameID: mainFrameID,
             treeRevision: treeRevision,
             selectionRevision: selectionRevision,
-            targetsByID: targetsByID.mapValues {
-                ProtocolTargetSnapshot(
-                    id: $0.id,
-                    kind: $0.kind,
-                    frameID: $0.frameID,
-                    parentFrameID: $0.parentFrameID,
-                    capabilities: $0.capabilities,
-                    isProvisional: $0.isProvisional,
-                    isPaused: $0.isPaused,
-                    currentDocumentID: currentDocumentID(for: $0.id)
-                )
-            },
-            targetStatesByID: targetStatesByID.mapValues { state in
-                DOMTargetStateSnapshot(
-                    targetID: state.targetID,
-                    currentDocumentID: currentDocumentID(for: state.targetID),
-                    transactionIDs: state.currentDocument.map { Array($0.transactions.keys) } ?? []
-                )
-            },
-            framesByID: framesByID.mapValues {
-                DOMFrameSnapshot(
-                    id: $0.id,
-                    parentFrameID: $0.parentFrameID,
-                    childFrameIDs: $0.childFrameIDs,
-                    targetID: $0.targetID,
-                    currentDocumentID: $0.currentDocumentID
-                )
-            },
+            targetsByID: targetGraph.targetSnapshots(currentDocumentID: currentDocumentID(for:)),
+            targetStatesByID: documentStore.targetStateSnapshots(currentDocumentID: currentDocumentID(for:)),
+            framesByID: targetGraph.frameSnapshots(),
             documentsByID: documentsByID.mapValues {
                 DOMDocumentSnapshot(
                     id: $0.id,
@@ -1411,14 +1243,7 @@ package final class DOMSession {
                     shadowRootType: node.shadowRootType
                 )
             },
-            frameDocumentProjections: frameDocumentProjections.mapValues {
-                FrameDocumentProjectionSnapshot(
-                    ownerNodeID: $0.ownerNodeID,
-                    frameTargetID: $0.frameTargetID,
-                    frameDocumentID: $0.frameDocumentID,
-                    state: $0.state
-                )
-            },
+            frameDocumentProjections: frameDocumentProjectionIndex.snapshots(),
             transactions: transactions.map {
                 DOMTransactionSnapshot(
                     id: $0.id,
@@ -1430,7 +1255,7 @@ package final class DOMSession {
                 )
             },
             currentNodeIDByKey: currentNodeIDByKey,
-            executionContextsByID: executionContextsByID,
+            executionContextsByID: targetGraph.executionContextSnapshots(),
             selection: DOMSelectionSnapshot(
                 selectedNodeID: selection.selectedNodeID,
                 pendingRequest: selection.pendingRequest.map {
@@ -1439,17 +1264,6 @@ package final class DOMSession {
                 failure: selection.failure
             )
         )
-    }
-
-    private func frameWithID(_ frameID: DOMFrame.ID, parentFrameID: DOMFrame.ID?) -> DOMFrame {
-        let frame = framesByID[frameID] ?? DOMFrame(id: frameID, parentFrameID: parentFrameID)
-        frame.parentFrameID = parentFrameID
-        framesByID[frameID] = frame
-        if let parentFrameID {
-            let parent = frameWithID(parentFrameID, parentFrameID: nil)
-            parent.childFrameIDs.insert(frameID)
-        }
-        return frame
     }
 
     private func buildSubtree(
@@ -1529,14 +1343,14 @@ package final class DOMSession {
     }
 
     private func removeDocuments(for targetID: ProtocolTarget.ID) {
-        guard let documentID = targetStatesByID[targetID]?.currentDocument?.id else {
+        guard let documentID = documentStore.currentDocument(forTargetID: targetID)?.id else {
             return
         }
         removeDocument(documentID)
     }
 
     private func removeDocument(_ documentID: DOMDocument.ID) {
-        guard let targetState = targetStatesByID[documentID.targetID],
+        guard let targetState = documentStore.stateIfPresent(for: documentID.targetID),
               let document = targetState.currentDocument,
               document.id == documentID else {
             return
@@ -1544,9 +1358,8 @@ package final class DOMSession {
         document.lifecycle = .invalidated
         targetState.currentDocument = nil
         document.transactions.removeAll()
-        if let target = targetsByID[document.targetID] {
-            clearCurrentDocumentReference(documentID, target: target)
-        }
+        clearCurrentDocumentReference(documentID, targetID: document.targetID)
+        updateAllFrameDocumentProjectionStates()
         if selection.selectedNodeID?.documentID == documentID {
             selection.selectedNodeID = nil
             selection.failure = nil
@@ -1554,16 +1367,26 @@ package final class DOMSession {
         }
     }
 
-    private func clearCurrentDocumentReference(_ documentID: DOMDocument.ID, target: ProtocolTarget) {
-        if let frameID = target.frameID,
-           framesByID[frameID]?.currentDocumentID == documentID {
-            framesByID[frameID]?.currentDocumentID = nil
-        }
-        if currentPageTargetID == target.id,
-           let mainFrameID,
-           framesByID[mainFrameID]?.currentDocumentID == documentID {
-            framesByID[mainFrameID]?.currentDocumentID = nil
-        }
+    private func clearCurrentDocumentReference(_ documentID: DOMDocument.ID, targetID: ProtocolTarget.ID) {
+        clearCurrentDocumentReference(
+            documentID,
+            targetID: targetID,
+            targetFrameID: targetGraph.targetFrameID(for: targetID)
+        )
+    }
+
+    private func clearCurrentDocumentReference(
+        _ documentID: DOMDocument.ID,
+        targetID: ProtocolTarget.ID,
+        targetFrameID: DOMFrame.ID?
+    ) {
+        targetGraph.clearCurrentDocumentReference(
+            documentID,
+            targetFrameID: targetFrameID,
+            targetID: targetID,
+            currentPageTargetID: currentPageTargetID,
+            mainFrameID: mainFrameID
+        )
     }
 
     @discardableResult
@@ -1573,7 +1396,7 @@ package final class DOMSession {
         kind: DOMTransactionKind,
         issuedSequence: UInt64
     ) -> DOMTransaction.ID? {
-        guard let targetState = targetStatesByID[targetID],
+        guard let targetState = documentStore.stateIfPresent(for: targetID),
               targetState.currentDocument === document else {
             return nil
         }
@@ -1581,20 +1404,14 @@ package final class DOMSession {
     }
 
     private func removeTransaction(_ transactionID: DOMTransaction.ID, targetID: ProtocolTarget.ID?) {
-        if let targetID {
-            targetStatesByID[targetID]?.currentDocument?.removeTransaction(transactionID)
-            return
-        }
-        for state in targetStatesByID.values {
-            state.currentDocument?.removeTransaction(transactionID)
-        }
+        documentStore.removeTransaction(transactionID, targetID: targetID)
     }
 
     private func hasActiveOwnerHydrationTransaction(
         targetID: ProtocolTarget.ID,
         documentID: DOMDocument.ID
     ) -> Bool {
-        guard let document = targetStatesByID[targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: targetID),
               document.id == documentID else {
             return false
         }
@@ -1833,7 +1650,7 @@ package final class DOMSession {
     }
 
     private func canApplyDOMEvent(to nodeID: DOMNode.ID) -> Bool {
-        guard let document = targetStatesByID[nodeID.documentID.targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: nodeID.documentID.targetID),
               document.id == nodeID.documentID,
               document.lifecycle == .loaded else {
             return false
@@ -1882,7 +1699,7 @@ package final class DOMSession {
     }
 
     private func removeNodeSubtree(_ nodeID: DOMNode.ID, detachFromParent: Bool) {
-        guard let document = targetStatesByID[nodeID.documentID.targetID]?.currentDocument,
+        guard let document = documentStore.currentDocument(forTargetID: nodeID.documentID.targetID),
               document.id == nodeID.documentID,
               let node = document.nodesByID[nodeID] else {
             return
@@ -1893,9 +1710,8 @@ package final class DOMSession {
         for childID in node.protocolOwnedChildren {
             removeNodeSubtree(childID, detachFromParent: false)
         }
-        for projection in frameDocumentProjections.values where projection.ownerNodeID == nodeID {
-            projection.ownerNodeID = nil
-            projection.state = .pending
+        for projection in frameDocumentProjectionIndex.values where projection.ownerNodeID == nodeID {
+            detachFrameDocumentProjection(frameTargetID: projection.frameTargetID)
         }
         if document.currentNodeIDByProtocolNodeID[node.protocolNodeID] == nodeID {
             document.currentNodeIDByProtocolNodeID.removeValue(forKey: node.protocolNodeID)
@@ -1950,84 +1766,76 @@ package final class DOMSession {
     }
 
     private func projectedFrameOwnerKeys(inSubtree rootID: DOMNode.ID) -> [ProtocolTarget.ID: DOMNodeCurrentKey] {
-        var keys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
-        var stack = [rootID]
-        while let nodeID = stack.popLast() {
-            guard let node = node(for: nodeID) else {
-                continue
-            }
-            for projection in frameDocumentProjections.values where projection.ownerNodeID == nodeID {
-                keys[projection.frameTargetID] = DOMNodeCurrentKey(
-                    targetID: nodeID.documentID.targetID,
-                    nodeID: node.protocolNodeID
-                )
-            }
-            stack.append(contentsOf: node.protocolOwnedChildren)
+        frameDocumentProjectionIndex.ownerKeys(inSubtree: rootID) { [weak self] nodeID in
+            self?.node(for: nodeID)
         }
-        return keys
     }
 
     private func reattachFrameDocumentProjections(using ownerKeys: [ProtocolTarget.ID: DOMNodeCurrentKey]) {
         for (frameTargetID, ownerKey) in ownerKeys {
-            guard let projection = frameDocumentProjections[frameTargetID],
-                  let ownerNodeID = targetStatesByID[ownerKey.targetID]?.currentDocument?.currentNodeIDByProtocolNodeID[ownerKey.nodeID],
+            guard frameDocumentProjectionIndex[frameTargetID] != nil,
+                  let ownerNodeID = documentStore.currentNodeID(targetID: ownerKey.targetID, rawNodeID: ownerKey.nodeID),
                   let ownerNode = node(for: ownerNodeID),
                   ownerNode.isFrameOwner,
                   canApplyDOMEvent(to: ownerNodeID) else {
                 continue
             }
-            projection.ownerNodeID = ownerNodeID
-            projection.state = .attached
+            attachFrameDocumentProjection(frameTargetID: frameTargetID, to: ownerNodeID)
         }
     }
 
     private func setFrameDocumentProjection(frameTargetID: ProtocolTarget.ID, frameDocumentID: DOMDocument.ID) {
-        let projection = frameDocumentProjections[frameTargetID] ?? FrameDocumentProjection(
-            ownerNodeID: nil,
+        frameDocumentProjectionIndex.setFrameDocument(
             frameTargetID: frameTargetID,
-            frameDocumentID: frameDocumentID,
-            state: .pending
+            frameDocumentID: frameDocumentID
         )
-        projection.frameTargetID = frameTargetID
-        projection.frameDocumentID = frameDocumentID
-        projection.ownerNodeID = nil
-        projection.state = .pending
-        frameDocumentProjections[frameTargetID] = projection
     }
 
     private func updateAllFrameDocumentProjectionStates() {
-        for projection in frameDocumentProjections.values {
-            updateFrameDocumentProjectionState(projection)
+        for frameTargetID in frameDocumentProjectionIndex.frameTargetIDs {
+            updateFrameDocumentProjectionState(frameTargetID: frameTargetID)
         }
     }
 
-    private func updateFrameDocumentProjectionState(_ projection: FrameDocumentProjection) {
+    private func updateFrameDocumentProjectionState(frameTargetID: ProtocolTarget.ID) {
+        guard let projection = frameDocumentProjectionIndex[frameTargetID] else {
+            return
+        }
         guard let document = currentDocument(for: projection.frameDocumentID),
               let frameRoot = document.nodesByID[document.rootNodeID] else {
-            projection.ownerNodeID = nil
-            projection.state = .pending
+            detachFrameDocumentProjection(frameTargetID: frameTargetID)
             return
         }
 
         if let ownerNodeID = projection.ownerNodeID,
            frameDocumentProjection(projection, canRemainAttachedTo: ownerNodeID, frameRoot: frameRoot) {
-            projection.state = .attached
+            attachFrameDocumentProjection(frameTargetID: frameTargetID, to: ownerNodeID)
             return
         }
 
-        projection.ownerNodeID = nil
         let candidates = ownerCandidates(forFrameDocumentRoot: frameRoot)
         switch candidates.count {
         case 0:
-            projection.ownerNodeID = nil
-            projection.state = .pending
+            detachFrameDocumentProjection(frameTargetID: frameTargetID)
         case 1:
-            projection.ownerNodeID = candidates[0]
-            projection.state = .attached
+            attachFrameDocumentProjection(frameTargetID: frameTargetID, to: candidates[0])
         default:
-            projection.ownerNodeID = nil
-            projection.state = .ambiguous
+            detachFrameDocumentProjection(frameTargetID: frameTargetID, state: .ambiguous)
         }
+    }
+
+    private func attachFrameDocumentProjection(
+        frameTargetID: ProtocolTarget.ID,
+        to ownerNodeID: DOMNode.ID
+    ) {
+        frameDocumentProjectionIndex.attach(frameTargetID: frameTargetID, to: ownerNodeID)
+    }
+
+    private func detachFrameDocumentProjection(
+        frameTargetID: ProtocolTarget.ID,
+        state: FrameDocumentProjectionState = .pending
+    ) {
+        frameDocumentProjectionIndex.detach(frameTargetID: frameTargetID, state: state)
     }
 
     private func frameDocumentProjection(
@@ -2044,8 +1852,8 @@ package final class DOMSession {
             && ownerDocument(forFrameTargetID: frameTargetID)?.id == document.id
             && nodeIsConnectedToDocumentTree(ownerNodeID, in: document)
             && frameOwner(ownerNode, matchesFrameTargetID: frameTargetID, frameDocumentURL: frameRoot.documentURL)
-            && frameDocumentProjections.values.allSatisfy {
-                $0 === projection || $0.ownerNodeID != ownerNodeID || $0.state != .attached
+            && frameDocumentProjectionIndex.values.allSatisfy {
+                $0.frameTargetID == projection.frameTargetID || $0.ownerNodeID != ownerNodeID || $0.state != .attached
             }
     }
 
@@ -2057,7 +1865,7 @@ package final class DOMSession {
 
         let attachableCandidates = ownerCandidateNodes(in: ownerDocument)
             .filter { projectionCanAttach(to: $0.node, in: $0.document) }
-        if let frameID = targetsByID[frameTargetID]?.frameID {
+        if let frameID = targetGraph.targetFrameID(for: frameTargetID) {
             let frameIDMatches = attachableCandidates
                 .filter { $0.node.ownerFrameID == frameID }
             if frameIDMatches.isEmpty == false {
@@ -2082,18 +1890,18 @@ package final class DOMSession {
     }
 
     private func ownerDocument(forFrameTargetID frameTargetID: ProtocolTarget.ID) -> DOMDocument? {
-        guard let target = targetsByID[frameTargetID] else {
+        guard targetGraph.containsTarget(frameTargetID) else {
             return nil
         }
 
-        if let parentFrameID = target.parentFrameID {
-            guard let parentDocumentID = framesByID[parentFrameID]?.currentDocumentID else {
+        if let parentFrameID = targetGraph.targetParentFrameID(for: frameTargetID) {
+            guard let parentDocumentID = targetGraph.frameCurrentDocumentID(parentFrameID) else {
                 return nil
             }
             return currentDocument(for: parentDocumentID)
         }
         guard let pageTargetID = currentPageTargetID,
-              let pageDocument = targetStatesByID[pageTargetID]?.currentDocument,
+              let pageDocument = documentStore.currentDocument(forTargetID: pageTargetID),
               pageDocument.lifecycle == .loaded else {
             return nil
         }
@@ -2107,7 +1915,7 @@ package final class DOMSession {
     }
 
     private func frameOwnerIsAlreadyAttached(_ nodeID: DOMNode.ID) -> Bool {
-        frameDocumentProjections.values.contains {
+        frameDocumentProjectionIndex.values.contains {
             $0.ownerNodeID == nodeID && $0.state == .attached
         }
     }
@@ -2141,7 +1949,7 @@ package final class DOMSession {
         matchesFrameTargetID frameTargetID: ProtocolTarget.ID,
         frameDocumentURL: String?
     ) -> Bool {
-        if let frameID = targetsByID[frameTargetID]?.frameID,
+        if let frameID = targetGraph.targetFrameID(for: frameTargetID),
            owner.ownerFrameID == frameID {
             return true
         }
@@ -2186,64 +1994,14 @@ package final class DOMSession {
     }
 
     private func projectedFrameDocumentRootID(for ownerNodeID: DOMNode.ID) -> DOMNode.ID? {
-        for projection in frameDocumentProjections.values where projection.ownerNodeID == ownerNodeID && projection.state == .attached {
-            guard let document = currentDocument(for: projection.frameDocumentID) else {
-                continue
-            }
-            return document.rootNodeID
+        frameDocumentProjectionIndex.projectedFrameDocumentRootID(forOwnerNodeID: ownerNodeID) { [weak self] documentID in
+            self?.currentDocument(for: documentID)
         }
-        return nil
     }
 
     private func projectedVisibleChildren(of node: DOMNode) -> [DOMNode.ID] {
-        var children: [DOMNode.ID] = []
-        if let templateContentID = node.templateContentID {
-            children.append(templateContentID)
-        }
-        if let beforePseudoElementID = node.beforePseudoElementID {
-            children.append(beforePseudoElementID)
-        }
-        children.append(contentsOf: node.otherPseudoElementIDs)
-        children.append(contentsOf: projectedEffectiveChildren(of: node))
-        if let afterPseudoElementID = node.afterPseudoElementID {
-            children.append(afterPseudoElementID)
-        }
-        return children
-    }
-
-    private func projectedEffectiveChildren(of node: DOMNode) -> [DOMNode.ID] {
-        if node.isFrameOwner,
-           let rootNodeID = projectedFrameDocumentRootID(for: node.id) {
-            return [rootNodeID]
-        }
-        if let contentDocumentID = node.contentDocumentID {
-            return [contentDocumentID]
-        }
-        return node.shadowRootIDs + node.regularChildren.loadedChildren
-    }
-
-    private func appendProjectionRows(
-        _ nodeID: DOMNode.ID,
-        depth: Int,
-        visited: inout Set<DOMNode.ID>,
-        rows: inout [DOMTreeRow]
-    ) {
-        guard visited.insert(nodeID).inserted,
-              let node = node(for: nodeID) else {
-            return
-        }
-        let visibleChildren = projectedVisibleChildren(of: node)
-        rows.append(
-            DOMTreeRow(
-                nodeID: nodeID,
-                depth: depth,
-                nodeName: node.nodeName,
-                isSelected: selection.selectedNodeID == nodeID,
-                hasVisibleChildren: !visibleChildren.isEmpty || node.regularChildren.knownCount > 0
-            )
-        )
-        for childID in visibleChildren {
-            appendProjectionRows(childID, depth: depth + 1, visited: &visited, rows: &rows)
+        DOMTreeProjectionBuilder.visibleChildIDs(of: node) { [weak self] ownerNodeID in
+            self?.projectedFrameDocumentRootID(for: ownerNodeID)
         }
     }
 

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1,14 +1,6 @@
 import Foundation
 import Observation
 
-#if DEBUG
-private func domProjectionTrace(_ message: @autoclosure () -> String) {
-    print("[WebInspectorCore.DOM.Projection] \(message())")
-}
-#else
-private func domProjectionTrace(_ message: @autoclosure () -> String) {}
-#endif
-
 @MainActor
 @Observable
 package final class ProtocolTarget {
@@ -824,7 +816,6 @@ package final class DOMSession {
             document.removeChildNodesTransactions(parentRawNodeID: parent.protocolNodeID)
             return
         }
-        let hadOwnerHydration = document.hasActiveOwnerHydrationTransaction()
         var replacementOwnerKeys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
         for childID in parent.regularChildren.loadedChildren {
             replacementOwnerKeys.merge(projectedFrameOwnerKeys(inSubtree: childID)) { current, _ in current }
@@ -846,11 +837,6 @@ package final class DOMSession {
             treeRevision &+= 1
         } else {
             completePendingSelectionIfPossible(in: document)
-        }
-        if hadOwnerHydration {
-            domProjectionTrace(
-                "ownerHydration.setChildNodes target=\(document.targetID.rawValue) parent=\(traceNode(parent)) children=\(payloads.count) projections=\(frameProjectionTraceSummary())"
-            )
         }
     }
 
@@ -1641,9 +1627,6 @@ package final class DOMSession {
             kind: .ownerHydration(frameTargetID: frameTargetID),
             issuedSequence: issuedSequence
         )
-        domProjectionTrace(
-            "ownerHydration.request frameTarget=\(frameTargetID.rawValue) target=\(document.targetID.rawValue) node=\(traceNode(node)) issuedSequence=\(issuedSequence)"
-        )
         return .requestChildNodes(
             targetID: document.targetID,
             nodeID: node.protocolNodeID,
@@ -2001,9 +1984,6 @@ package final class DOMSession {
         projection.state = .pending
         frameDocumentProjections[frameTargetID] = projection
         updateFrameDocumentProjectionState(projection)
-        domProjectionTrace(
-            "frameDocument.register frameTarget=\(frameTargetID.rawValue) document=\(traceDocument(frameDocumentID)) state=\(projection.state) owner=\(traceNodeID(projection.ownerNodeID)) candidates=\(traceOwnerCandidateCount(for: frameDocumentID))"
-        )
     }
 
     private func updateAllFrameDocumentProjectionStates() {
@@ -2013,24 +1993,12 @@ package final class DOMSession {
     }
 
     private func updateFrameDocumentProjectionState(_ projection: FrameDocumentProjection) {
-        let previousState = projection.state
-        let previousOwnerNodeID = projection.ownerNodeID
-        var candidateCount: Int?
-        var frameDocumentURL: String?
-        defer {
-            if previousState != projection.state || previousOwnerNodeID != projection.ownerNodeID {
-                domProjectionTrace(
-                    "projection.update frameTarget=\(projection.frameTargetID.rawValue) document=\(traceDocument(projection.frameDocumentID)) url=\(frameDocumentURL ?? "nil") state=\(previousState)->\(projection.state) owner=\(traceNodeID(previousOwnerNodeID))->\(traceNodeID(projection.ownerNodeID)) candidates=\(candidateCount.map(String.init) ?? "n/a")"
-                )
-            }
-        }
         guard let document = currentDocument(for: projection.frameDocumentID),
               let frameRoot = document.nodesByID[document.rootNodeID] else {
             projection.ownerNodeID = nil
             projection.state = .pending
             return
         }
-        frameDocumentURL = frameRoot.documentURL
 
         if let ownerNodeID = projection.ownerNodeID,
            node(for: ownerNodeID) != nil {
@@ -2039,7 +2007,6 @@ package final class DOMSession {
         }
 
         let candidates = ownerCandidates(forFrameDocumentRoot: frameRoot)
-        candidateCount = candidates.count
         switch candidates.count {
         case 0:
             projection.ownerNodeID = nil
@@ -2096,48 +2063,6 @@ package final class DOMSession {
             return lhs.documentID.localDocumentLifetimeID < rhs.documentID.localDocumentLifetimeID
         }
         return lhs.nodeID.rawValue < rhs.nodeID.rawValue
-    }
-
-    private func frameProjectionTraceSummary() -> String {
-        let entries = frameDocumentProjections.values
-            .sorted { $0.frameTargetID.rawValue < $1.frameTargetID.rawValue }
-            .prefix(8)
-            .map { projection in
-                "\(projection.frameTargetID.rawValue):\(projection.state):owner=\(traceNodeID(projection.ownerNodeID)):candidates=\(traceOwnerCandidateCount(for: projection.frameDocumentID)):doc=\(traceDocument(projection.frameDocumentID))"
-            }
-        let suffix = frameDocumentProjections.count > entries.count ? ",..." : ""
-        return "[" + entries.joined(separator: ",") + suffix + "]"
-    }
-
-    private func traceOwnerCandidateCount(for frameDocumentID: DOMDocument.ID) -> String {
-        guard let document = currentDocument(for: frameDocumentID),
-              let root = document.nodesByID[document.rootNodeID] else {
-            return "n/a"
-        }
-        return String(ownerCandidates(forFrameDocumentRoot: root).count)
-    }
-
-    private func traceDocument(_ documentID: DOMDocument.ID) -> String {
-        guard let document = currentDocument(for: documentID),
-              let root = document.nodesByID[document.rootNodeID] else {
-            return "\(documentID.targetID.rawValue)#\(documentID.localDocumentLifetimeID.rawValue):missing"
-        }
-        let url = root.documentURL ?? "nil"
-        return "\(documentID.targetID.rawValue)#\(documentID.localDocumentLifetimeID.rawValue):url=\(url)"
-    }
-
-    private func traceNodeID(_ nodeID: DOMNode.ID?) -> String {
-        guard let nodeID else {
-            return "nil"
-        }
-        guard let node = node(for: nodeID) else {
-            return "\(nodeID.documentID.targetID.rawValue)#\(nodeID.nodeID.rawValue):missing"
-        }
-        return traceNode(node)
-    }
-
-    private func traceNode(_ node: DOMNode) -> String {
-        "\(node.id.documentID.targetID.rawValue)#\(node.protocolNodeID.rawValue)<\(node.nodeName)>"
     }
 
     private func frameOwner(_ owner: DOMNode, matchesFrameDocumentURL frameDocumentURL: String) -> Bool {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -727,9 +727,8 @@ package final class DOMSession {
         }
         if target.kind == .frame {
             setFrameDocumentProjection(frameTargetID: targetID, frameDocumentID: documentID)
-        } else {
-            updateAllFrameDocumentProjectionStates()
         }
+        updateAllFrameDocumentProjectionStates()
 
         reconcileSelection()
         treeRevision &+= 1
@@ -1994,7 +1993,6 @@ package final class DOMSession {
         projection.ownerNodeID = nil
         projection.state = .pending
         frameDocumentProjections[frameTargetID] = projection
-        updateFrameDocumentProjectionState(projection)
     }
 
     private func updateAllFrameDocumentProjectionStates() {
@@ -2073,10 +2071,15 @@ package final class DOMSession {
     }
 
     private func ownerDocument(forFrameTargetID frameTargetID: ProtocolTarget.ID) -> DOMDocument? {
-        if let parentFrameID = targetsByID[frameTargetID]?.parentFrameID,
-           let parentDocumentID = framesByID[parentFrameID]?.currentDocumentID,
-           let parentDocument = currentDocument(for: parentDocumentID) {
-            return parentDocument
+        guard let target = targetsByID[frameTargetID] else {
+            return nil
+        }
+
+        if let parentFrameID = target.parentFrameID {
+            guard let parentDocumentID = framesByID[parentFrameID]?.currentDocumentID else {
+                return nil
+            }
+            return currentDocument(for: parentDocumentID)
         }
         guard let pageTargetID = currentPageTargetID,
               let pageDocument = targetStatesByID[pageTargetID]?.currentDocument,

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1290,7 +1290,8 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
     ) -> DOMRequestNodeResolution {
-        guard let document = targetStatesByID[targetID]?.currentDocument else {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
             return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
         }
         guard let pendingRequest = selection.pendingRequest,

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -2001,11 +2001,12 @@ package final class DOMSession {
         }
 
         if let ownerNodeID = projection.ownerNodeID,
-           node(for: ownerNodeID) != nil {
+           frameDocumentProjection(projection, canRemainAttachedTo: ownerNodeID, frameRoot: frameRoot) {
             projection.state = .attached
             return
         }
 
+        projection.ownerNodeID = nil
         let candidates = ownerCandidates(forFrameDocumentRoot: frameRoot)
         switch candidates.count {
         case 0:
@@ -2018,6 +2019,25 @@ package final class DOMSession {
             projection.ownerNodeID = nil
             projection.state = .ambiguous
         }
+    }
+
+    private func frameDocumentProjection(
+        _ projection: FrameDocumentProjection,
+        canRemainAttachedTo ownerNodeID: DOMNode.ID,
+        frameRoot: DOMNode
+    ) -> Bool {
+        guard let document = currentDocument(for: ownerNodeID.documentID),
+              let ownerNode = document.nodesByID[ownerNodeID],
+              let frameDocumentURL = frameRoot.documentURL,
+              frameDocumentURL.isEmpty == false else {
+            return false
+        }
+        return ownerNode.isFrameOwner
+            && nodeIsConnectedToDocumentTree(ownerNodeID, in: document)
+            && frameOwner(ownerNode, matchesFrameDocumentURL: frameDocumentURL)
+            && frameDocumentProjections.values.allSatisfy {
+                $0 === projection || $0.ownerNodeID != ownerNodeID || $0.state != .attached
+            }
     }
 
     private func ownerCandidates(forFrameDocumentRoot frameRoot: DOMNode) -> [DOMNode.ID] {
@@ -2066,9 +2086,8 @@ package final class DOMSession {
     }
 
     private func frameOwner(_ owner: DOMNode, matchesFrameDocumentURL frameDocumentURL: String) -> Bool {
-        guard let source = attribute(named: "src", in: owner),
-              source.isEmpty == false else {
-            return false
+        guard let source = explicitFrameSource(for: owner) else {
+            return frameDocumentURLIsDefaultBlank(frameDocumentURL)
         }
         if source == frameDocumentURL {
             return true
@@ -2078,6 +2097,18 @@ package final class DOMSession {
             return false
         }
         return resolvedSource == resolvedFrameDocumentURL
+    }
+
+    private func explicitFrameSource(for owner: DOMNode) -> String? {
+        guard let source = attribute(named: "src", in: owner),
+              source.isEmpty == false else {
+            return nil
+        }
+        return source
+    }
+
+    private func frameDocumentURLIsDefaultBlank(_ url: String) -> Bool {
+        url == "about:blank" || resolvedURL(url, relativeTo: nil) == "about:blank"
     }
 
     private func attribute(named name: String, in node: DOMNode) -> String? {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1048,7 +1048,8 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
     ) -> Result<DOMNode.ID, SelectionResolutionFailure> {
-        guard let document = targetStatesByID[targetID]?.currentDocument else {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
             return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
         }
         let key = DOMNodeCurrentKey(targetID: targetID, nodeID: nodeID)
@@ -1095,6 +1096,10 @@ package final class DOMSession {
             node: node,
             issuedSequence: issuedSequence
         )
+    }
+
+    package func clearOwnerHydrationTransactions(targetID: ProtocolTarget.ID) {
+        targetStatesByID[targetID]?.currentDocument?.removeOwnerHydrationTransactions()
     }
 
     package func actionIdentity(

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1085,36 +1085,14 @@ package final class DOMSession {
             .first(where: { $0.value.state == .pending }) else {
             return nil
         }
-        guard let pageTargetID = currentPageTargetID,
-              let pageDocument = targetStatesByID[pageTargetID]?.currentDocument,
-              pageDocument.lifecycle == .loaded else {
-            return nil
-        }
-        if let body = bodyElement(in: pageDocument),
-           let intent = ownerHydrationIntent(
-            frameTargetID: frameTargetID,
-            document: pageDocument,
-            node: body,
-            issuedSequence: issuedSequence
-           ) {
-            return intent
-        }
-        if let html = documentElement(in: pageDocument),
-           let intent = ownerHydrationIntent(
-            frameTargetID: frameTargetID,
-            document: pageDocument,
-            node: html,
-            issuedSequence: issuedSequence
-           ) {
-            return intent
-        }
-        guard let root = pageDocument.nodesByID[pageDocument.rootNodeID] else {
+        guard let ownerDocument = ownerDocument(forFrameTargetID: frameTargetID),
+              let node = ownerHydrationNode(in: ownerDocument) else {
             return nil
         }
         return ownerHydrationIntent(
             frameTargetID: frameTargetID,
-            document: pageDocument,
-            node: root,
+            document: ownerDocument,
+            node: node,
             issuedSequence: issuedSequence
         )
     }
@@ -1635,6 +1613,26 @@ package final class DOMSession {
         )
     }
 
+    private func ownerHydrationNode(in document: DOMDocument) -> DOMNode? {
+        let roots = [bodyElement(in: document), documentElement(in: document), document.nodesByID[document.rootNodeID]]
+            .compactMap { $0 }
+        var pending = roots
+        var visited = Set<DOMNode.ID>()
+        while pending.isEmpty == false {
+            let node = pending.removeFirst()
+            guard visited.insert(node.id).inserted else {
+                continue
+            }
+            if hasUnloadedRegularChildren(node) {
+                return node
+            }
+            pending.append(
+                contentsOf: node.regularChildren.loadedChildren.compactMap { document.nodesByID[$0] }
+            )
+        }
+        return nil
+    }
+
     private func documentElement(in document: DOMDocument) -> DOMNode? {
         guard let root = document.nodesByID[document.rootNodeID] else {
             return nil
@@ -2034,6 +2032,7 @@ package final class DOMSession {
             return false
         }
         return ownerNode.isFrameOwner
+            && ownerDocument(forFrameTargetID: frameRoot.id.documentID.targetID)?.id == document.id
             && nodeIsConnectedToDocumentTree(ownerNodeID, in: document)
             && frameOwner(ownerNode, matchesFrameDocumentURL: frameDocumentURL)
             && frameDocumentProjections.values.allSatisfy {
@@ -2043,11 +2042,12 @@ package final class DOMSession {
 
     private func ownerCandidates(forFrameDocumentRoot frameRoot: DOMNode) -> [DOMNode.ID] {
         guard let frameDocumentURL = frameRoot.documentURL,
-              frameDocumentURL.isEmpty == false else {
+              frameDocumentURL.isEmpty == false,
+              let ownerDocument = ownerDocument(forFrameTargetID: frameRoot.id.documentID.targetID) else {
             return []
         }
 
-        return ownerCandidateNodes()
+        return ownerCandidateNodes(in: ownerDocument)
             .filter { entry in
                 projectionCanAttach(to: entry.node, in: entry.document)
                     && frameOwner(entry.node, matchesFrameDocumentURL: frameDocumentURL)
@@ -2056,12 +2056,22 @@ package final class DOMSession {
             .sorted(by: sortNodeIDs)
     }
 
-    private func ownerCandidateNodes() -> [(document: DOMDocument, node: DOMNode)] {
-        targetStatesByID.values
-            .compactMap(\.currentDocument)
-            .flatMap { document in
-                document.nodesByID.values.map { (document, $0) }
-            }
+    private func ownerCandidateNodes(in document: DOMDocument) -> [(document: DOMDocument, node: DOMNode)] {
+        document.nodesByID.values.map { (document, $0) }
+    }
+
+    private func ownerDocument(forFrameTargetID frameTargetID: ProtocolTarget.ID) -> DOMDocument? {
+        if let parentFrameID = targetsByID[frameTargetID]?.parentFrameID,
+           let parentDocumentID = framesByID[parentFrameID]?.currentDocumentID,
+           let parentDocument = currentDocument(for: parentDocumentID) {
+            return parentDocument
+        }
+        guard let pageTargetID = currentPageTargetID,
+              let pageDocument = targetStatesByID[pageTargetID]?.currentDocument,
+              pageDocument.lifecycle == .loaded else {
+            return nil
+        }
+        return pageDocument
     }
 
     private func projectionCanAttach(to candidate: DOMNode, in document: DOMDocument) -> Bool {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -2036,32 +2036,43 @@ package final class DOMSession {
         frameRoot: DOMNode
     ) -> Bool {
         guard let document = currentDocument(for: ownerNodeID.documentID),
-              let ownerNode = document.nodesByID[ownerNodeID],
-              let frameDocumentURL = frameRoot.documentURL,
-              frameDocumentURL.isEmpty == false else {
+              let ownerNode = document.nodesByID[ownerNodeID] else {
             return false
         }
+        let frameTargetID = frameRoot.id.documentID.targetID
         return ownerNode.isFrameOwner
-            && ownerDocument(forFrameTargetID: frameRoot.id.documentID.targetID)?.id == document.id
+            && ownerDocument(forFrameTargetID: frameTargetID)?.id == document.id
             && nodeIsConnectedToDocumentTree(ownerNodeID, in: document)
-            && frameOwner(ownerNode, matchesFrameDocumentURL: frameDocumentURL)
+            && frameOwner(ownerNode, matchesFrameTargetID: frameTargetID, frameDocumentURL: frameRoot.documentURL)
             && frameDocumentProjections.values.allSatisfy {
                 $0 === projection || $0.ownerNodeID != ownerNodeID || $0.state != .attached
             }
     }
 
     private func ownerCandidates(forFrameDocumentRoot frameRoot: DOMNode) -> [DOMNode.ID] {
-        guard let frameDocumentURL = frameRoot.documentURL,
-              frameDocumentURL.isEmpty == false,
-              let ownerDocument = ownerDocument(forFrameTargetID: frameRoot.id.documentID.targetID) else {
+        let frameTargetID = frameRoot.id.documentID.targetID
+        guard let ownerDocument = ownerDocument(forFrameTargetID: frameTargetID) else {
             return []
         }
 
-        return ownerCandidateNodes(in: ownerDocument)
-            .filter { entry in
-                projectionCanAttach(to: entry.node, in: entry.document)
-                    && frameOwner(entry.node, matchesFrameDocumentURL: frameDocumentURL)
+        let attachableCandidates = ownerCandidateNodes(in: ownerDocument)
+            .filter { projectionCanAttach(to: $0.node, in: $0.document) }
+        if let frameID = targetsByID[frameTargetID]?.frameID {
+            let frameIDMatches = attachableCandidates
+                .filter { $0.node.ownerFrameID == frameID }
+            if frameIDMatches.isEmpty == false {
+                return frameIDMatches
+                    .map { $0.node.id }
+                    .sorted(by: sortNodeIDs)
             }
+        }
+
+        guard let frameDocumentURL = frameRoot.documentURL,
+              frameDocumentURL.isEmpty == false else {
+            return []
+        }
+        return attachableCandidates
+            .filter { frameOwner($0.node, matchesFrameDocumentURL: frameDocumentURL) }
             .map { $0.node.id }
             .sorted(by: sortNodeIDs)
     }
@@ -2123,6 +2134,22 @@ package final class DOMSession {
             return false
         }
         return resolvedSource == resolvedFrameDocumentURL
+    }
+
+    private func frameOwner(
+        _ owner: DOMNode,
+        matchesFrameTargetID frameTargetID: ProtocolTarget.ID,
+        frameDocumentURL: String?
+    ) -> Bool {
+        if let frameID = targetsByID[frameTargetID]?.frameID,
+           owner.ownerFrameID == frameID {
+            return true
+        }
+        guard let frameDocumentURL,
+              frameDocumentURL.isEmpty == false else {
+            return false
+        }
+        return frameOwner(owner, matchesFrameDocumentURL: frameDocumentURL)
     }
 
     private func explicitFrameSource(for owner: DOMNode) -> String? {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -614,6 +614,7 @@ package final class DOMSession {
             let newState = state(for: newTargetID)
             if let oldDocument = oldState.currentDocument {
                 oldDocument.lifecycle = .invalidated
+                clearCurrentDocumentReference(oldDocument.id, target: oldTarget)
                 newState.currentDocument = nil
             }
         }
@@ -1544,19 +1545,25 @@ package final class DOMSession {
         document.lifecycle = .invalidated
         targetState.currentDocument = nil
         document.transactions.removeAll()
-        if let frameID = targetsByID[document.targetID]?.frameID,
-           framesByID[frameID]?.currentDocumentID == documentID {
-            framesByID[frameID]?.currentDocumentID = nil
-        }
-        if currentPageTargetID == document.targetID,
-           let mainFrameID,
-           framesByID[mainFrameID]?.currentDocumentID == documentID {
-            framesByID[mainFrameID]?.currentDocumentID = nil
+        if let target = targetsByID[document.targetID] {
+            clearCurrentDocumentReference(documentID, target: target)
         }
         if selection.selectedNodeID?.documentID == documentID {
             selection.selectedNodeID = nil
             selection.failure = nil
             selectionRevision &+= 1
+        }
+    }
+
+    private func clearCurrentDocumentReference(_ documentID: DOMDocument.ID, target: ProtocolTarget) {
+        if let frameID = target.frameID,
+           framesByID[frameID]?.currentDocumentID == documentID {
+            framesByID[frameID]?.currentDocumentID = nil
+        }
+        if currentPageTargetID == target.id,
+           let mainFrameID,
+           framesByID[mainFrameID]?.currentDocumentID == documentID {
+            framesByID[mainFrameID]?.currentDocumentID = nil
         }
     }
 

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1,6 +1,14 @@
 import Foundation
 import Observation
 
+#if DEBUG
+private func domProjectionTrace(_ message: @autoclosure () -> String) {
+    print("[WebInspectorCore.DOM.Projection] \(message())")
+}
+#else
+private func domProjectionTrace(_ message: @autoclosure () -> String) {}
+#endif
+
 @MainActor
 @Observable
 package final class ProtocolTarget {
@@ -10,15 +18,16 @@ package final class ProtocolTarget {
     package var kind: ProtocolTargetKind
     package var frameID: DOMFrame.ID?
     package var parentFrameID: DOMFrame.ID?
+    package var capabilities: ProtocolTargetCapabilities
     package var isProvisional: Bool
     package var isPaused: Bool
-    package var currentDocumentID: DOMDocument.ID?
 
     package init(
         id: ID,
         kind: ProtocolTargetKind,
         frameID: DOMFrame.ID?,
         parentFrameID: DOMFrame.ID?,
+        capabilities: ProtocolTargetCapabilities,
         isProvisional: Bool,
         isPaused: Bool
     ) {
@@ -26,6 +35,7 @@ package final class ProtocolTarget {
         self.kind = kind
         self.frameID = frameID
         self.parentFrameID = parentFrameID
+        self.capabilities = capabilities
         self.isProvisional = isProvisional
         self.isPaused = isPaused
     }
@@ -57,24 +67,23 @@ private extension ProtocolTarget {
 
 @MainActor
 @Observable
-package final class DOMPage {
-    package typealias ID = ProtocolTarget.ID
+package final class DOMTargetState {
+    package let targetID: ProtocolTarget.ID
+    package var currentDocument: DOMDocumentState?
+    package var nextDocumentLifetimeID: UInt64
 
-    package let id: ID
-    package let mainTargetID: ProtocolTarget.ID
-    package let mainFrameID: DOMFrame.ID
-    package var navigationGeneration: UInt64
+    package init(targetID: ProtocolTarget.ID) {
+        self.targetID = targetID
+        currentDocument = nil
+        nextDocumentLifetimeID = 0
+    }
 
-    package init(
-        id: ID,
-        mainTargetID: ProtocolTarget.ID,
-        mainFrameID: DOMFrame.ID,
-        navigationGeneration: UInt64 = 0
-    ) {
-        self.id = id
-        self.mainTargetID = mainTargetID
-        self.mainFrameID = mainFrameID
-        self.navigationGeneration = navigationGeneration
+    package func nextDocumentID() -> DOMDocument.ID {
+        nextDocumentLifetimeID &+= 1
+        return DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: DOMDocumentLifetimeIdentifier(nextDocumentLifetimeID)
+        )
     }
 }
 
@@ -86,7 +95,6 @@ package final class DOMFrame {
     package let id: ID
     package var parentFrameID: ID?
     package var childFrameIDs: Set<ID>
-    package var ownerNodeID: DOMNode.ID?
     package var targetID: ProtocolTarget.ID?
     package var currentDocumentID: DOMDocument.ID?
 
@@ -99,20 +107,165 @@ package final class DOMFrame {
 
 @MainActor
 @Observable
-package final class DOMDocument {
+package final class DOMDocumentState {
     package typealias ID = DOMDocumentIdentifier
 
     package let id: ID
     package let targetID: ProtocolTarget.ID
-    package let generation: DOMDocumentGeneration
+    package let localDocumentLifetimeID: DOMDocumentLifetimeIdentifier
+    package var lifecycle: DOMDocumentLifecycle
     package let rootNodeID: DOMNode.ID
+    package var nodesByID: [DOMNode.ID: DOMNode]
+    package var currentNodeIDByProtocolNodeID: [DOMProtocolNodeID: DOMNode.ID]
+    package var transactions: [DOMTransaction.ID: DOMTransaction]
+    package var nextTransactionID: UInt64
 
-    package init(id: ID, targetID: ProtocolTarget.ID, generation: DOMDocumentGeneration, rootNodeID: DOMNode.ID) {
+    package init(
+        id: ID,
+        targetID: ProtocolTarget.ID,
+        lifecycle: DOMDocumentLifecycle,
+        rootNodeID: DOMNode.ID,
+        nodesByID: [DOMNode.ID: DOMNode],
+        currentNodeIDByProtocolNodeID: [DOMProtocolNodeID: DOMNode.ID]
+    ) {
         self.id = id
         self.targetID = targetID
-        self.generation = generation
+        self.localDocumentLifetimeID = id.localDocumentLifetimeID
+        self.lifecycle = lifecycle
         self.rootNodeID = rootNodeID
+        self.nodesByID = nodesByID
+        self.currentNodeIDByProtocolNodeID = currentNodeIDByProtocolNodeID
+        transactions = [:]
+        nextTransactionID = 0
     }
+
+    package func nextTransactionIdentifier() -> DOMTransaction.ID {
+        nextTransactionID &+= 1
+        return DOMTransaction.ID(nextTransactionID)
+    }
+
+    @discardableResult
+    package func startTransaction(kind: DOMTransactionKind, issuedSequence: UInt64) -> DOMTransaction.ID {
+        let transactionID = nextTransactionIdentifier()
+        transactions[transactionID] = DOMTransaction(
+            id: transactionID,
+            targetID: targetID,
+            documentID: id,
+            kind: kind,
+            issuedSequence: issuedSequence,
+            requestedProtocolNodeID: nil,
+            pathFragmentsByParentRawNodeID: [:]
+        )
+        return transactionID
+    }
+
+    package func removeTransaction(_ transactionID: DOMTransaction.ID) {
+        transactions.removeValue(forKey: transactionID)
+    }
+
+    package func removeChildNodesTransactions(parentRawNodeID: DOMProtocolNodeID) {
+        removeTransactions { transaction in
+            transaction.kind == .requestChildNodes(parentRawNodeID: parentRawNodeID)
+        }
+    }
+
+    package func removeOwnerHydrationTransactions() {
+        removeTransactions { transaction in
+            if case .ownerHydration = transaction.kind {
+                return true
+            }
+            return false
+        }
+    }
+
+    package func hasActiveOwnerHydrationTransaction() -> Bool {
+        transactions.values.contains { transaction in
+            if case .ownerHydration = transaction.kind {
+                return true
+            }
+            return false
+        }
+    }
+
+    package func storePendingPathFragments(
+        parentRawNodeID: DOMProtocolNodeID,
+        payloads: [DOMNodePayload]
+    ) {
+        for transactionID in Array(transactions.keys) {
+            guard var transaction = transactions[transactionID] else {
+                continue
+            }
+            switch transaction.kind {
+            case .requestNode:
+                transaction.pathFragmentsByParentRawNodeID[parentRawNodeID] = payloads
+            case let .requestChildNodes(transactionParentRawNodeID) where transactionParentRawNodeID == parentRawNodeID:
+                transaction.pathFragmentsByParentRawNodeID[parentRawNodeID] = payloads
+            case .requestChildNodes:
+                continue
+            case .ownerHydration:
+                continue
+            }
+            transactions[transactionID] = transaction
+        }
+    }
+
+    package func recordRequestedProtocolNodeID(
+        _ nodeID: DOMProtocolNodeID,
+        for transactionID: DOMTransaction.ID
+    ) -> Bool {
+        guard var transaction = transactions[transactionID],
+              transaction.documentID == id else {
+            return false
+        }
+        transaction.requestedProtocolNodeID = nodeID
+        transactions[transactionID] = transaction
+        return true
+    }
+
+    private func removeTransactions(where shouldRemove: (DOMTransaction) -> Bool) {
+        for transactionID in Array(transactions.keys) {
+            guard let transaction = transactions[transactionID],
+                  shouldRemove(transaction) else {
+                continue
+            }
+            transactions.removeValue(forKey: transactionID)
+        }
+    }
+}
+
+package typealias DOMDocument = DOMDocumentState
+
+@MainActor
+@Observable
+package final class FrameDocumentProjection {
+    package var ownerNodeID: DOMNode.ID?
+    package var frameTargetID: ProtocolTarget.ID
+    package var frameDocumentID: DOMDocument.ID
+    package var state: FrameDocumentProjectionState
+
+    package init(
+        ownerNodeID: DOMNode.ID?,
+        frameTargetID: ProtocolTarget.ID,
+        frameDocumentID: DOMDocument.ID,
+        state: FrameDocumentProjectionState
+    ) {
+        self.ownerNodeID = ownerNodeID
+        self.frameTargetID = frameTargetID
+        self.frameDocumentID = frameDocumentID
+        self.state = state
+    }
+}
+
+package struct DOMTransaction {
+    package typealias ID = DOMTransactionIdentifier
+
+    package var id: ID
+    package var targetID: ProtocolTarget.ID
+    package var documentID: DOMDocument.ID
+    package var kind: DOMTransactionKind
+    package var issuedSequence: UInt64
+    package var requestedProtocolNodeID: DOMProtocolNodeID?
+    package var pathFragmentsByParentRawNodeID: [DOMProtocolNodeID: [DOMNodePayload]]
 }
 
 package enum DOMRegularChildState {
@@ -149,7 +302,9 @@ package final class DOMNode {
     package var nodeName: String
     package var localName: String
     package var nodeValue: String
-    package var frameID: DOMFrame.ID?
+    package var ownerFrameID: DOMFrame.ID?
+    package var documentURL: String?
+    package var baseURL: String?
     package var attributes: [DOMAttribute]
     package var parentID: ID?
     package var previousSiblingID: ID?
@@ -171,7 +326,9 @@ package final class DOMNode {
         self.nodeName = payload.nodeName
         self.localName = payload.localName
         self.nodeValue = payload.nodeValue
-        self.frameID = payload.frameID
+        self.ownerFrameID = payload.ownerFrameID
+        self.documentURL = payload.documentURL
+        self.baseURL = payload.baseURL
         self.attributes = payload.attributes
         self.parentID = parentID
         self.previousSiblingID = nil
@@ -223,6 +380,7 @@ package struct DOMSelectionRequest {
     package var id: SelectionRequestIdentifier
     package var targetID: ProtocolTarget.ID
     package var documentID: DOMDocument.ID
+    package var transactionID: DOMTransaction.ID?
 }
 
 package struct DOMSelection {
@@ -240,47 +398,120 @@ package struct DOMSelection {
 @MainActor
 @Observable
 package final class DOMSession {
-    package private(set) var currentPage: DOMPage?
+    package private(set) var currentPageTargetID: ProtocolTarget.ID?
+    package private(set) var mainFrameID: DOMFrame.ID?
     package private(set) var treeRevision: UInt64
     package private(set) var selectionRevision: UInt64
 
     private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
+    private var targetStatesByID: [ProtocolTarget.ID: DOMTargetState]
     private var framesByID: [DOMFrame.ID: DOMFrame]
-    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
-    private var documentsByID: [DOMDocument.ID: DOMDocument]
-    private var nodesByID: [DOMNode.ID: DOMNode]
-    private var currentNodeIDByKey: [DOMNodeCurrentKey: DOMNode.ID]
-    private var nextGenerationByTargetID: [ProtocolTarget.ID: UInt64]
-    private var nextSelectionRequestRawID: UInt64
+    private var frameDocumentProjections: [ProtocolTarget.ID: FrameDocumentProjection]
     private var selection: DOMSelection
+    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+    private var nextSelectionRequestRawID: UInt64
 
     package init() {
-        targetsByID = [:]
-        framesByID = [:]
-        executionContextsByID = [:]
-        documentsByID = [:]
-        nodesByID = [:]
-        currentNodeIDByKey = [:]
-        nextGenerationByTargetID = [:]
-        nextSelectionRequestRawID = 0
-        selection = DOMSelection()
+        currentPageTargetID = nil
+        mainFrameID = nil
         treeRevision = 0
         selectionRevision = 0
+        targetsByID = [:]
+        targetStatesByID = [:]
+        framesByID = [:]
+        frameDocumentProjections = [:]
+        selection = DOMSelection()
+        executionContextsByID = [:]
+        nextSelectionRequestRawID = 0
+    }
+
+    private func targetBelongsToCurrentPage(_ targetID: ProtocolTarget.ID) -> Bool {
+        guard targetsByID[targetID] != nil else {
+            return false
+        }
+        guard currentPageTargetID != targetID else {
+            return true
+        }
+        guard let frameID = targetsByID[targetID]?.frameID else {
+            return false
+        }
+
+        var currentFrameID: DOMFrame.ID? = frameID
+        var visitedFrameIDs = Set<DOMFrame.ID>()
+        while let candidateFrameID = currentFrameID,
+              visitedFrameIDs.insert(candidateFrameID).inserted {
+            if candidateFrameID == mainFrameID {
+                return true
+            }
+            currentFrameID = framesByID[candidateFrameID]?.parentFrameID
+        }
+        return false
+    }
+
+    private func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {
+        let state = targetStatesByID[targetID] ?? DOMTargetState(targetID: targetID)
+        targetStatesByID[targetID] = state
+        return state
+    }
+
+    private func currentState(for targetID: ProtocolTarget.ID) -> DOMTargetState? {
+        guard targetBelongsToCurrentPage(targetID) || currentPageTargetID == nil else {
+            return nil
+        }
+        return targetStatesByID[targetID]
+    }
+
+    private func currentDocument(for documentID: DOMDocument.ID) -> DOMDocument? {
+        guard let document = targetStatesByID[documentID.targetID]?.currentDocument,
+              document.id == documentID,
+              document.lifecycle == .loaded else {
+            return nil
+        }
+        return document
+    }
+
+    private func document(for nodeID: DOMNode.ID) -> DOMDocument? {
+        currentDocument(for: nodeID.documentID)
+    }
+
+    private func attachFrameTarget(_ target: ProtocolTarget) {
+        guard let frameID = target.frameID else {
+            return
+        }
+        let frame = frameWithID(frameID, parentFrameID: target.parentFrameID)
+        frame.targetID = target.id
+        _ = state(for: target.id)
+    }
+
+    private func attachKnownFrameTargets() {
+        var attachedTargetIDs = Set<ProtocolTarget.ID>()
+        var didAttach = true
+        while didAttach {
+            didAttach = false
+            for target in targetsByID.values where target.kind == .frame && attachedTargetIDs.contains(target.id) == false {
+                guard let parentFrameID = target.parentFrameID,
+                      parentFrameID == mainFrameID || framesByID[parentFrameID] != nil else {
+                    continue
+                }
+                attachFrameTarget(target)
+                attachedTargetIDs.insert(target.id)
+                didAttach = true
+            }
+        }
     }
 
     package func reset() {
-        currentPage = nil
+        currentPageTargetID = nil
+        mainFrameID = nil
+        treeRevision = 0
+        selectionRevision = 0
         targetsByID.removeAll()
+        targetStatesByID.removeAll()
         framesByID.removeAll()
-        executionContextsByID.removeAll()
-        documentsByID.removeAll()
-        nodesByID.removeAll()
-        currentNodeIDByKey.removeAll()
-        nextGenerationByTargetID.removeAll()
-        nextSelectionRequestRawID = 0
+        frameDocumentProjections.removeAll()
         selection = DOMSelection()
-        treeRevision &+= 1
-        selectionRevision &+= 1
+        executionContextsByID.removeAll()
+        nextSelectionRequestRawID = 0
     }
 
     package func applyTargetCreated(
@@ -292,20 +523,21 @@ package final class DOMSession {
             kind: record.kind,
             frameID: record.frameID,
             parentFrameID: record.parentFrameID,
+            capabilities: record.capabilities,
             isProvisional: record.isProvisional,
             isPaused: record.isPaused
         )
         target.kind = record.kind
         target.frameID = record.frameID
         target.parentFrameID = record.parentFrameID
+        target.capabilities = record.capabilities
         target.isProvisional = record.isProvisional
         target.isPaused = record.isPaused
         targetsByID[record.id] = target
+        _ = state(for: record.id)
 
-        if let frameID = record.frameID {
-            let frame = frameWithID(frameID, parentFrameID: record.parentFrameID)
-            frame.targetID = record.id
-            target.frameID = frameID
+        if record.kind == .frame {
+            attachFrameTarget(target)
         }
 
         guard makeCurrentMainPage, record.kind == .page else {
@@ -322,11 +554,18 @@ package final class DOMSession {
             return
         }
 
-        let mainFrameID = target.frameID ?? DOMFrame.ID("main:\(targetID.rawValue)")
-        let mainFrame = frameWithID(mainFrameID, parentFrameID: nil)
+        let resolvedMainFrameID = target.frameID ?? DOMFrame.ID("main:\(targetID.rawValue)")
+        if let currentPageTargetID, currentPageTargetID != targetID {
+            selection = DOMSelection()
+            selectionRevision &+= 1
+        }
+        currentPageTargetID = targetID
+        mainFrameID = resolvedMainFrameID
+        _ = state(for: targetID)
+        let mainFrame = frameWithID(resolvedMainFrameID, parentFrameID: nil)
         mainFrame.targetID = targetID
-        target.frameID = mainFrameID
-        currentPage = DOMPage(id: targetID, mainTargetID: targetID, mainFrameID: mainFrameID)
+        target.frameID = resolvedMainFrameID
+        attachKnownFrameTargets()
         treeRevision &+= 1
     }
 
@@ -336,9 +575,8 @@ package final class DOMSession {
         }
 
         target.isProvisional = false
-        if let frameID = target.frameID {
-            let frame = frameWithID(frameID, parentFrameID: target.parentFrameID)
-            frame.targetID = targetID
+        if target.kind == .frame {
+            attachFrameTarget(target)
         }
     }
 
@@ -348,7 +586,7 @@ package final class DOMSession {
             return
         }
 
-        if currentPage?.mainTargetID == oldTargetID,
+        if currentPageTargetID == oldTargetID,
            let existingNewTarget = targetsByID[newTargetID],
            !existingNewTarget.isTopLevelPage {
             applyTargetCommitted(targetID: newTargetID)
@@ -367,20 +605,24 @@ package final class DOMSession {
             kind: oldTarget.kind,
             frameID: frameID,
             parentFrameID: parentFrameID,
+            capabilities: oldTarget.capabilities,
             isProvisional: false,
             isPaused: oldTarget.isPaused
         )
         committedTarget.kind = existingNewTarget?.kind ?? oldTarget.kind
         committedTarget.frameID = frameID
         committedTarget.parentFrameID = parentFrameID
+        committedTarget.capabilities = existingNewTarget?.capabilities ?? oldTarget.capabilities
         committedTarget.isProvisional = false
         committedTarget.isPaused = existingNewTarget?.isPaused ?? oldTarget.isPaused
         targetsByID[newTargetID] = committedTarget
 
-        if let oldDocumentID = oldTarget.currentDocumentID {
-            removeDocument(oldDocumentID)
-            if committedTarget.currentDocumentID == oldDocumentID {
-                committedTarget.currentDocumentID = nil
+        if let oldState = targetStatesByID.removeValue(forKey: oldTargetID) {
+            oldState.currentDocument?.transactions.removeAll()
+            let newState = state(for: newTargetID)
+            if let oldDocument = oldState.currentDocument {
+                oldDocument.lifecycle = .invalidated
+                newState.currentDocument = nil
             }
         }
 
@@ -389,9 +631,12 @@ package final class DOMSession {
             if frame.targetID == oldTargetID || frame.targetID == nil {
                 frame.targetID = newTargetID
             }
-            if frame.currentDocumentID == oldTarget.currentDocumentID {
-                frame.currentDocumentID = committedTarget.currentDocumentID
-            }
+        }
+
+        if let projection = frameDocumentProjections.removeValue(forKey: oldTargetID) {
+            projection.frameTargetID = newTargetID
+            frameDocumentProjections[newTargetID] = projection
+            updateFrameDocumentProjectionState(projection)
         }
 
         for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
@@ -402,15 +647,10 @@ package final class DOMSession {
             )
         }
 
-        if let previousPage = currentPage, previousPage.mainTargetID == oldTargetID {
-            currentPage = DOMPage(
-                id: newTargetID,
-                mainTargetID: newTargetID,
-                mainFrameID: previousPage.mainFrameID,
-                navigationGeneration: previousPage.navigationGeneration
-            )
-            if framesByID[previousPage.mainFrameID]?.targetID == oldTargetID {
-                framesByID[previousPage.mainFrameID]?.targetID = newTargetID
+        if currentPageTargetID == oldTargetID {
+            currentPageTargetID = newTargetID
+            if let mainFrameID {
+                frameWithID(mainFrameID, parentFrameID: nil).targetID = newTargetID
             }
         }
 
@@ -423,16 +663,21 @@ package final class DOMSession {
             return
         }
         executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
-        if let documentID = target.currentDocumentID {
+        if let documentID = targetStatesByID[targetID]?.currentDocument?.id {
             removeDocument(documentID)
         }
-        if let frameID = target.frameID, framesByID[frameID]?.targetID == targetID {
+        frameDocumentProjections.removeValue(forKey: targetID)
+        if let frameID = target.frameID,
+           framesByID[frameID]?.targetID == targetID {
             framesByID[frameID]?.targetID = nil
             framesByID[frameID]?.currentDocumentID = nil
         }
-        if currentPage?.mainTargetID == targetID {
-            currentPage = nil
+        if currentPageTargetID == targetID {
+            currentPageTargetID = nil
+            mainFrameID = nil
+            selection = DOMSelection()
         }
+        targetStatesByID.removeValue(forKey: targetID)
         reconcileSelection()
         treeRevision &+= 1
     }
@@ -457,23 +702,40 @@ package final class DOMSession {
         guard let target = targetsByID[targetID] else {
             preconditionFailure("replaceDocumentRoot requires a known ProtocolTarget")
         }
-        if let currentDocumentID = target.currentDocumentID {
-            removeDocument(currentDocumentID)
-        }
+        let targetState = state(for: targetID)
+        removeDocuments(for: targetID)
 
-        let generation = nextGeneration(for: targetID)
-        let documentID = DOMDocument.ID(targetID: targetID, generation: generation)
-        let rootNodeID = buildSubtree(root, documentID: documentID, parentID: nil)
-        let document = DOMDocument(id: documentID, targetID: targetID, generation: generation, rootNodeID: rootNodeID)
-        documentsByID[documentID] = document
-        target.currentDocumentID = documentID
+        let documentID = targetState.nextDocumentID()
+        var nodesByID: [DOMNode.ID: DOMNode] = [:]
+        var currentNodeIDByProtocolNodeID: [DOMProtocolNodeID: DOMNode.ID] = [:]
+        let rootNodeID = buildSubtree(
+            root,
+            documentID: documentID,
+            parentID: nil,
+            nodesByID: &nodesByID,
+            currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID
+        )
+        let document = DOMDocument(
+            id: documentID,
+            targetID: targetID,
+            lifecycle: .loaded,
+            rootNodeID: rootNodeID,
+            nodesByID: nodesByID,
+            currentNodeIDByProtocolNodeID: currentNodeIDByProtocolNodeID
+        )
+        targetState.currentDocument = document
 
         if let frameID = target.frameID {
             framesByID[frameID]?.currentDocumentID = documentID
         }
-        if currentPage?.mainTargetID == targetID {
-            currentPage?.navigationGeneration &+= 1
-            framesByID[currentPage!.mainFrameID]?.currentDocumentID = documentID
+        if currentPageTargetID == targetID,
+           let mainFrameID {
+            framesByID[mainFrameID]?.currentDocumentID = documentID
+        }
+        if target.kind == .frame {
+            setFrameDocumentProjection(frameTargetID: targetID, frameDocumentID: documentID)
+        } else {
+            updateAllFrameDocumentProjectionStates()
         }
 
         reconcileSelection()
@@ -481,21 +743,115 @@ package final class DOMSession {
         return rootNodeID
     }
 
-    package func applySetChildNodes(parent nodeID: DOMNode.ID, children payloads: [DOMNodePayload]) {
-        guard let parent = nodesByID[nodeID] else {
+    package func invalidateDocument(targetID: ProtocolTarget.ID) {
+        guard let target = targetsByID[targetID],
+              let targetState = targetStatesByID[targetID],
+              let document = targetState.currentDocument else {
             return
         }
+        let documentID = document.id
+        document.lifecycle = .invalidated
+        document.transactions.removeAll()
+        if let frameID = target.frameID,
+           framesByID[frameID]?.currentDocumentID == documentID {
+            framesByID[frameID]?.currentDocumentID = nil
+        }
+        if currentPageTargetID == targetID,
+           let mainFrameID {
+            framesByID[mainFrameID]?.currentDocumentID = nil
+        }
+        if let projection = frameDocumentProjections[targetID],
+           projection.frameDocumentID == documentID {
+            projection.ownerNodeID = nil
+            projection.state = .pending
+        }
+        reconcileSelection()
+        treeRevision &+= 1
+    }
+
+    package func applySetChildNodes(parent nodeID: DOMNode.ID, children payloads: [DOMNodePayload]) {
+        applySetChildNodes(parent: nodeID, children: payloads, eventSequence: .max)
+    }
+
+    package func applySetChildNodes(
+        targetID: ProtocolTarget.ID,
+        parentRawNodeID: DOMProtocolNodeID,
+        children payloads: [DOMNodePayload],
+        eventSequence: UInt64
+    ) {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
+            return
+        }
+        if let parentID = document.currentNodeIDByProtocolNodeID[parentRawNodeID] {
+            applySetChildNodes(parent: parentID, children: payloads, eventSequence: eventSequence)
+            return
+        }
+        document.storePendingPathFragments(parentRawNodeID: parentRawNodeID, payloads: payloads)
+    }
+
+    package func applyDetachedRoot(
+        targetID: ProtocolTarget.ID,
+        payload: DOMNodePayload,
+        eventSequence _: UInt64
+    ) {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
+            return
+        }
+        guard !payloadContainsConnectedDocumentNode(payload, in: document) else {
+            return
+        }
+        let nodeID = DOMNode.ID(documentID: document.id, nodeID: payload.nodeID)
+        if document.nodesByID[nodeID] != nil {
+            removeNodeSubtree(nodeID, detachFromParent: true)
+        }
+        buildSubtree(payload, document: document, parentID: nil)
+        completePendingSelectionIfPossible(in: document)
+    }
+
+    package func applySetChildNodes(parent nodeID: DOMNode.ID, children payloads: [DOMNodePayload], eventSequence: UInt64) {
+        guard let document = currentDocument(for: nodeID.documentID),
+              let parent = document.nodesByID[nodeID] else {
+            return
+        }
+        guard canApplyDOMEvent(to: nodeID) else {
+            return
+        }
+        let affectsVisibleTree = nodeIsConnectedToDocumentTree(nodeID, in: document)
+        if parent.isFrameOwner,
+           projectedFrameDocumentRootID(for: parent.id) != nil {
+            document.removeChildNodesTransactions(parentRawNodeID: parent.protocolNodeID)
+            return
+        }
+        let hadOwnerHydration = document.hasActiveOwnerHydrationTransaction()
+        var replacementOwnerKeys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
         for childID in parent.regularChildren.loadedChildren {
+            replacementOwnerKeys.merge(projectedFrameOwnerKeys(inSubtree: childID)) { current, _ in current }
             removeNodeSubtree(childID, detachFromParent: false)
         }
         parent.regularChildren = .loaded(
             payloads.map {
-                buildSubtree($0, documentID: nodeID.documentID, parentID: nodeID)
+                buildSubtree($0, document: document, parentID: nodeID)
             }
         )
         relinkProtocolEffectiveChildren(of: parent)
-        reconcileSelection()
-        treeRevision &+= 1
+        reattachFrameDocumentProjections(using: replacementOwnerKeys)
+        document.removeChildNodesTransactions(parentRawNodeID: parent.protocolNodeID)
+        document.removeOwnerHydrationTransactions()
+        splicePendingTransactionFragments(parentRawNodeID: parent.protocolNodeID, into: document)
+        if affectsVisibleTree {
+            updateAllFrameDocumentProjectionStates()
+            reconcileSelection()
+            treeRevision &+= 1
+        } else {
+            completePendingSelectionIfPossible(in: document)
+        }
+        if hadOwnerHydration {
+            domProjectionTrace(
+                "ownerHydration.setChildNodes target=\(document.targetID.rawValue) parent=\(traceNode(parent)) children=\(payloads.count) projections=\(frameProjectionTraceSummary())"
+            )
+        }
     }
 
     @discardableResult
@@ -504,10 +860,17 @@ package final class DOMSession {
         previousSibling previousSiblingID: DOMNode.ID?,
         child payload: DOMNodePayload
     ) -> DOMNode.ID? {
-        guard let parent = nodesByID[parentID] else {
+        guard let document = currentDocument(for: parentID.documentID),
+              let parent = document.nodesByID[parentID] else {
             return nil
         }
-        let childID = buildSubtree(payload, documentID: parentID.documentID, parentID: parentID)
+        guard canApplyDOMEvent(to: parentID) else {
+            return nil
+        }
+        let affectsVisibleTree = nodeIsConnectedToDocumentTree(parentID, in: document)
+        let replacementOwnerKeys = document.currentNodeIDByProtocolNodeID[payload.nodeID]
+            .map { projectedFrameOwnerKeys(inSubtree: $0) } ?? [:]
+        let childID = buildSubtree(payload, document: document, parentID: parentID)
         var children = parent.regularChildren.loadedChildren.filter { $0 != childID }
         if let previousSiblingID,
            let previousIndex = children.firstIndex(of: previousSiblingID) {
@@ -517,23 +880,106 @@ package final class DOMSession {
         }
         parent.regularChildren = .loaded(children)
         relinkProtocolEffectiveChildren(of: parent)
-        reconcileSelection()
-        treeRevision &+= 1
+        if affectsVisibleTree {
+            reattachFrameDocumentProjections(using: replacementOwnerKeys)
+            updateAllFrameDocumentProjectionStates()
+            reconcileSelection()
+            treeRevision &+= 1
+        } else {
+            completePendingSelectionIfPossible(in: document)
+        }
         return childID
     }
 
     package func applyNodeRemoved(_ nodeID: DOMNode.ID) {
+        guard let document = currentDocument(for: nodeID.documentID),
+              canApplyDOMEvent(to: nodeID) else {
+            return
+        }
+        let affectsVisibleTree = nodeIsConnectedToDocumentTree(nodeID, in: document)
         removeNodeSubtree(nodeID, detachFromParent: true)
-        reconcileSelection()
-        treeRevision &+= 1
+        if affectsVisibleTree {
+            updateAllFrameDocumentProjectionStates()
+            reconcileSelection()
+            treeRevision &+= 1
+        }
     }
 
-    package var currentPageTargetID: ProtocolTarget.ID? {
-        currentPage?.mainTargetID
+    package func applyChildNodeCountUpdated(_ nodeID: DOMNode.ID, count: Int) {
+        guard let document = currentDocument(for: nodeID.documentID),
+              let node = document.nodesByID[nodeID],
+              canApplyDOMEvent(to: nodeID) else {
+            return
+        }
+        if case .unrequested = node.regularChildren {
+            node.regularChildren = .unrequested(count: max(0, count))
+            if nodeIsConnectedToDocumentTree(nodeID, in: document) {
+                treeRevision &+= 1
+            }
+        }
+    }
+
+    package func applyAttributeModified(_ nodeID: DOMNode.ID, name: String, value: String) {
+        guard let document = currentDocument(for: nodeID.documentID),
+              let node = document.nodesByID[nodeID],
+              canApplyDOMEvent(to: nodeID) else {
+            return
+        }
+        if let index = node.attributes.firstIndex(where: { $0.name == name }) {
+            guard node.attributes[index].value != value else {
+                return
+            }
+            node.attributes[index].value = value
+        } else {
+            node.attributes.append(.init(name: name, value: value))
+        }
+        if node.isFrameOwner,
+           name.caseInsensitiveCompare("src") == .orderedSame {
+            updateAllFrameDocumentProjectionStates()
+        }
+        if nodeIsConnectedToDocumentTree(nodeID, in: document) {
+            treeRevision &+= 1
+        }
+    }
+
+    package func applyAttributeRemoved(_ nodeID: DOMNode.ID, name: String) {
+        guard let document = currentDocument(for: nodeID.documentID),
+              let node = document.nodesByID[nodeID],
+              canApplyDOMEvent(to: nodeID),
+              let index = node.attributes.firstIndex(where: { $0.name == name }) else {
+            return
+        }
+        node.attributes.remove(at: index)
+        if node.isFrameOwner,
+           name.caseInsensitiveCompare("src") == .orderedSame {
+            updateAllFrameDocumentProjectionStates()
+        }
+        if nodeIsConnectedToDocumentTree(nodeID, in: document) {
+            treeRevision &+= 1
+        }
     }
 
     package func currentDocumentID(for targetID: ProtocolTarget.ID) -> DOMDocument.ID? {
-        targetsByID[targetID]?.currentDocumentID
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
+            return nil
+        }
+        return document.id
+    }
+
+    package func targetCapabilities(for targetID: ProtocolTarget.ID) -> ProtocolTargetCapabilities {
+        targetsByID[targetID]?.capabilities ?? []
+    }
+
+    package func targetKind(for targetID: ProtocolTarget.ID) -> ProtocolTargetKind? {
+        targetsByID[targetID]?.kind
+    }
+
+    package func getDocumentIntent(targetID: ProtocolTarget.ID) -> DOMCommandIntent? {
+        guard targetCapabilities(for: targetID).contains(.dom) else {
+            return nil
+        }
+        return .getDocument(targetID: targetID)
     }
 
     package var selectedNodeID: DOMNode.ID? {
@@ -541,29 +987,38 @@ package final class DOMSession {
     }
 
     package var selectedNode: DOMNode? {
-        selection.selectedNodeID.flatMap { nodesByID[$0] }
+        guard let selectedNodeID = selection.selectedNodeID else {
+            return nil
+        }
+        return node(for: selectedNodeID)
     }
 
     package var currentPageRootNode: DOMNode? {
-        guard let targetID = currentPage?.mainTargetID,
-              let documentID = targetsByID[targetID]?.currentDocumentID,
-              let rootNodeID = documentsByID[documentID]?.rootNodeID
+        guard let targetID = currentPageTargetID,
+              let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded
         else {
             return nil
         }
-        return nodesByID[rootNodeID]
+        return document.nodesByID[document.rootNodeID]
     }
 
     package func node(for id: DOMNode.ID) -> DOMNode? {
-        nodesByID[id]
+        currentDocument(for: id.documentID)?.nodesByID[id]
     }
 
     package func visibleDOMTreeChildren(of node: DOMNode) -> [DOMNode] {
-        projectedVisibleChildren(of: node).compactMap { nodesByID[$0] }
+        guard currentDocument(for: node.id.documentID) != nil else {
+            return []
+        }
+        return projectedVisibleChildren(of: node).compactMap { self.node(for: $0) }
     }
 
     package func hasVisibleDOMTreeChildren(_ node: DOMNode) -> Bool {
-        !projectedVisibleChildren(of: node).isEmpty || node.regularChildren.knownCount > 0
+        guard currentDocument(for: node.id.documentID) != nil else {
+            return node.regularChildren.knownCount > 0
+        }
+        return !projectedVisibleChildren(of: node).isEmpty || node.regularChildren.knownCount > 0
     }
 
     package func hasUnloadedRegularChildren(_ node: DOMNode) -> Bool {
@@ -575,15 +1030,20 @@ package final class DOMSession {
 
     package func isTemplateContent(_ node: DOMNode) -> Bool {
         guard let parentID = node.parentID,
-              let parent = nodesByID[parentID] else {
+              let parent = self.node(for: parentID) else {
             return false
         }
         return parent.templateContentID == node.id
     }
 
     package func selectNode(_ nodeID: DOMNode.ID?) {
-        if let nodeID, nodesByID[nodeID] == nil {
-            return
+        if let nodeID {
+            guard node(for: nodeID) != nil else {
+                return
+            }
+        }
+        if let pendingTransactionID = selection.pendingRequest?.transactionID {
+            removeTransaction(pendingTransactionID, targetID: selection.pendingRequest?.targetID)
         }
         let hasSelectionStateChange = selection.selectedNodeID != nodeID
             || selection.pendingRequest != nil
@@ -602,19 +1062,30 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
     ) -> Result<DOMNode.ID, SelectionResolutionFailure> {
+        guard let document = targetStatesByID[targetID]?.currentDocument else {
+            return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
+        }
         let key = DOMNodeCurrentKey(targetID: targetID, nodeID: nodeID)
-        guard let resolvedNodeID = currentNodeIDByKey[key] else {
+        guard let resolvedNodeID = document.currentNodeIDByProtocolNodeID[nodeID] else {
             return failSelection(.unresolvedNode(key), clearSelected: false)
         }
         selectNode(resolvedNodeID)
         return .success(resolvedNodeID)
     }
 
-    package func requestChildNodesIntent(for nodeID: DOMNode.ID, depth: Int = 3) -> DOMCommandIntent? {
-        guard let node = nodesByID[nodeID],
-              hasUnloadedRegularChildren(node) else {
+    package func requestChildNodesIntent(for nodeID: DOMNode.ID, depth: Int = 3, issuedSequence: UInt64 = 0) -> DOMCommandIntent? {
+        guard let document = currentDocument(for: nodeID.documentID),
+              let node = document.nodesByID[nodeID],
+              hasUnloadedRegularChildren(node),
+              canApplyDOMEvent(to: nodeID) else {
             return nil
         }
+        registerTransaction(
+            targetID: nodeID.documentID.targetID,
+            document: document,
+            kind: .requestChildNodes(parentRawNodeID: node.protocolNodeID),
+            issuedSequence: issuedSequence
+        )
         return .requestChildNodes(
             targetID: nodeID.documentID.targetID,
             nodeID: node.protocolNodeID,
@@ -622,12 +1093,52 @@ package final class DOMSession {
         )
     }
 
+    package func pendingFrameOwnerHydrationIntent(issuedSequence: UInt64 = 0) -> DOMCommandIntent? {
+        guard let (frameTargetID, _) = frameDocumentProjections
+            .sorted(by: { $0.key.rawValue < $1.key.rawValue })
+            .first(where: { $0.value.state == .pending }) else {
+            return nil
+        }
+        guard let pageTargetID = currentPageTargetID,
+              let pageDocument = targetStatesByID[pageTargetID]?.currentDocument,
+              pageDocument.lifecycle == .loaded else {
+            return nil
+        }
+        if let body = bodyElement(in: pageDocument),
+           let intent = ownerHydrationIntent(
+            frameTargetID: frameTargetID,
+            document: pageDocument,
+            node: body,
+            issuedSequence: issuedSequence
+           ) {
+            return intent
+        }
+        if let html = documentElement(in: pageDocument),
+           let intent = ownerHydrationIntent(
+            frameTargetID: frameTargetID,
+            document: pageDocument,
+            node: html,
+            issuedSequence: issuedSequence
+           ) {
+            return intent
+        }
+        guard let root = pageDocument.nodesByID[pageDocument.rootNodeID] else {
+            return nil
+        }
+        return ownerHydrationIntent(
+            frameTargetID: frameTargetID,
+            document: pageDocument,
+            node: root,
+            issuedSequence: issuedSequence
+        )
+    }
+
     package func actionIdentity(
         for nodeID: DOMNode.ID,
         commandTargetID: ProtocolTarget.ID? = nil
     ) -> DOMActionIdentity? {
-        guard let node = nodesByID[nodeID],
-              let resolvedCommandTargetID = commandTargetID ?? currentPage?.mainTargetID,
+        guard let node = node(for: nodeID),
+              let resolvedCommandTargetID = commandTargetID ?? currentPageTargetID,
               targetsByID[resolvedCommandTargetID] != nil else {
             return nil
         }
@@ -659,7 +1170,7 @@ package final class DOMSession {
     }
 
     package func hideHighlightIntent(targetID: ProtocolTarget.ID? = nil) -> DOMCommandIntent? {
-        guard let targetID = targetID ?? currentPage?.mainTargetID else {
+        guard let targetID = targetID ?? currentPageTargetID else {
             return nil
         }
         return .hideHighlight(targetID: targetID)
@@ -669,7 +1180,7 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID? = nil,
         enabled: Bool
     ) -> DOMCommandIntent? {
-        guard let targetID = targetID ?? currentPage?.mainTargetID,
+        guard let targetID = targetID ?? currentPageTargetID,
               targetsByID[targetID] != nil else {
             return nil
         }
@@ -758,18 +1269,32 @@ package final class DOMSession {
 
     package func beginInspectSelectionRequest(
         targetID: ProtocolTarget.ID,
-        objectID: String
+        objectID: String,
+        issuedSequence: UInt64 = 0
     ) -> Result<DOMCommandIntent, SelectionResolutionFailure> {
         guard objectID.isEmpty == false else {
             return failSelection(.missingObjectID)
         }
-        guard let documentID = targetsByID[targetID]?.currentDocumentID else {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded,
+              document.nodesByID[document.rootNodeID] != nil else {
             return failSelection(.missingCurrentDocument(targetID))
         }
 
         nextSelectionRequestRawID &+= 1
         let requestID = SelectionRequestIdentifier(nextSelectionRequestRawID)
-        selection.pendingRequest = DOMSelectionRequest(id: requestID, targetID: targetID, documentID: documentID)
+        let transactionID = registerTransaction(
+            targetID: targetID,
+            document: document,
+            kind: .requestNode(selectionRequestID: requestID, objectID: objectID),
+            issuedSequence: issuedSequence
+        )
+        selection.pendingRequest = DOMSelectionRequest(
+            id: requestID,
+            targetID: targetID,
+            documentID: document.id,
+            transactionID: transactionID
+        )
         selection.failure = nil
         return .success(.requestNode(selectionRequestID: requestID, targetID: targetID, objectID: objectID))
     }
@@ -778,7 +1303,10 @@ package final class DOMSession {
         selectionRequestID: SelectionRequestIdentifier,
         targetID: ProtocolTarget.ID,
         nodeID: DOMProtocolNodeID
-    ) -> Result<DOMNode.ID, SelectionResolutionFailure> {
+    ) -> DOMRequestNodeResolution {
+        guard let document = targetStatesByID[targetID]?.currentDocument else {
+            return failSelection(.missingCurrentDocument(targetID), clearSelected: false)
+        }
         guard let pendingRequest = selection.pendingRequest,
               pendingRequest.id == selectionRequestID else {
             return failSelection(
@@ -789,56 +1317,84 @@ package final class DOMSession {
         guard pendingRequest.targetID == targetID else {
             return failSelection(.targetMismatch(expected: pendingRequest.targetID, received: targetID))
         }
-        let currentDocumentID = targetsByID[targetID]?.currentDocumentID
+        let currentDocumentID = document.id
         guard currentDocumentID == pendingRequest.documentID else {
             return failSelection(
                 .staleDocument(expected: pendingRequest.documentID, actual: currentDocumentID),
                 clearSelected: false
             )
         }
-
         let key = DOMNodeCurrentKey(targetID: targetID, nodeID: nodeID)
-        guard let selectedNodeID = currentNodeIDByKey[key],
-              selectedNodeID.documentID == pendingRequest.documentID else {
-            return failSelection(.unresolvedNode(key))
+        materializePendingRequestNodePath(
+            document: document,
+            nodeID: nodeID
+        )
+        if let selectedNodeID = document.currentNodeIDByProtocolNodeID[nodeID],
+           selectedNodeID.documentID == pendingRequest.documentID {
+            completePendingSelection(selectedNodeID, pendingRequest: pendingRequest)
+            return .resolved(selectedNodeID)
         }
 
-        selection.selectedNodeID = selectedNodeID
-        selection.pendingRequest = nil
+        guard let transactionID = pendingRequest.transactionID,
+              document.recordRequestedProtocolNodeID(nodeID, for: transactionID) else {
+            return failSelection(.unresolvedNode(key))
+        }
         selection.failure = nil
-        selectionRevision &+= 1
-        return .success(selectedNodeID)
+        return .pending(key)
     }
 
     package func treeProjection(rootTargetID: ProtocolTarget.ID) -> DOMTreeProjection {
         var rows: [DOMTreeRow] = []
         var visited = Set<DOMNode.ID>()
-        if let documentID = targetsByID[rootTargetID]?.currentDocumentID,
-           let rootNodeID = documentsByID[documentID]?.rootNodeID {
-            appendProjectionRows(rootNodeID, depth: 0, visited: &visited, rows: &rows)
+        if let document = targetStatesByID[rootTargetID]?.currentDocument,
+           document.lifecycle == .loaded {
+            appendProjectionRows(document.rootNodeID, depth: 0, visited: &visited, rows: &rows)
         }
         return DOMTreeProjection(rows: rows)
     }
 
     package func snapshot() -> DOMSessionSnapshot {
-        DOMSessionSnapshot(
-            currentPage: currentPage.map {
-                DOMPageSnapshot(
-                    id: $0.id,
-                    mainTargetID: $0.mainTargetID,
-                    mainFrameID: $0.mainFrameID,
-                    navigationGeneration: $0.navigationGeneration
-                )
-            },
+        let documents = targetStatesByID.values.compactMap(\.currentDocument)
+        let documentsByID = Dictionary(uniqueKeysWithValues: documents.map { ($0.id, $0) })
+        let nodesByID = Dictionary(uniqueKeysWithValues: documents.flatMap { document in
+            document.nodesByID.map { ($0.key, $0.value) }
+        })
+        let currentNodeIDByKey = Dictionary(uniqueKeysWithValues: targetStatesByID.values.compactMap { state -> [(DOMNodeCurrentKey, DOMNode.ID)]? in
+            guard let document = state.currentDocument else {
+                return nil
+            }
+            guard document.lifecycle == .loaded else {
+                return []
+            }
+            return document.currentNodeIDByProtocolNodeID.map {
+                (DOMNodeCurrentKey(targetID: state.targetID, nodeID: $0.key), $0.value)
+            }
+        }.flatMap { $0 })
+        let transactions = documents.flatMap { document in
+            document.transactions.values
+        }
+        return DOMSessionSnapshot(
+            currentPageTargetID: currentPageTargetID,
+            mainFrameID: mainFrameID,
+            treeRevision: treeRevision,
+            selectionRevision: selectionRevision,
             targetsByID: targetsByID.mapValues {
                 ProtocolTargetSnapshot(
                     id: $0.id,
                     kind: $0.kind,
                     frameID: $0.frameID,
                     parentFrameID: $0.parentFrameID,
+                    capabilities: $0.capabilities,
                     isProvisional: $0.isProvisional,
                     isPaused: $0.isPaused,
-                    currentDocumentID: $0.currentDocumentID
+                    currentDocumentID: currentDocumentID(for: $0.id)
+                )
+            },
+            targetStatesByID: targetStatesByID.mapValues { state in
+                DOMTargetStateSnapshot(
+                    targetID: state.targetID,
+                    currentDocumentID: currentDocumentID(for: state.targetID),
+                    transactionIDs: state.currentDocument.map { Array($0.transactions.keys) } ?? []
                 )
             },
             framesByID: framesByID.mapValues {
@@ -846,7 +1402,6 @@ package final class DOMSession {
                     id: $0.id,
                     parentFrameID: $0.parentFrameID,
                     childFrameIDs: $0.childFrameIDs,
-                    ownerNodeID: $0.ownerNodeID,
                     targetID: $0.targetID,
                     currentDocumentID: $0.currentDocumentID
                 )
@@ -855,7 +1410,8 @@ package final class DOMSession {
                 DOMDocumentSnapshot(
                     id: $0.id,
                     targetID: $0.targetID,
-                    generation: $0.generation,
+                    localDocumentLifetimeID: $0.localDocumentLifetimeID,
+                    lifecycle: $0.lifecycle,
                     rootNodeID: $0.rootNodeID
                 )
             },
@@ -867,7 +1423,9 @@ package final class DOMSession {
                     nodeName: node.nodeName,
                     localName: node.localName,
                     nodeValue: node.nodeValue,
-                    frameID: node.frameID,
+                    ownerFrameID: node.ownerFrameID,
+                    documentURL: node.documentURL,
+                    baseURL: node.baseURL,
                     attributes: node.attributes,
                     parentID: node.parentID,
                     previousSiblingID: node.previousSiblingID,
@@ -881,6 +1439,24 @@ package final class DOMSession {
                     afterPseudoElementID: node.afterPseudoElementID,
                     pseudoType: node.pseudoType,
                     shadowRootType: node.shadowRootType
+                )
+            },
+            frameDocumentProjections: frameDocumentProjections.mapValues {
+                FrameDocumentProjectionSnapshot(
+                    ownerNodeID: $0.ownerNodeID,
+                    frameTargetID: $0.frameTargetID,
+                    frameDocumentID: $0.frameDocumentID,
+                    state: $0.state
+                )
+            },
+            transactions: transactions.map {
+                DOMTransactionSnapshot(
+                    id: $0.id,
+                    targetID: $0.targetID,
+                    documentID: $0.documentID,
+                    kind: $0.kind,
+                    issuedSequence: $0.issuedSequence,
+                    requestedProtocolNodeID: $0.requestedProtocolNodeID
                 )
             },
             currentNodeIDByKey: currentNodeIDByKey,
@@ -906,26 +1482,17 @@ package final class DOMSession {
         return frame
     }
 
-    private func nextGeneration(for targetID: ProtocolTarget.ID) -> DOMDocumentGeneration {
-        let next = (nextGenerationByTargetID[targetID] ?? 0) + 1
-        nextGenerationByTargetID[targetID] = next
-        return DOMDocumentGeneration(next)
-    }
-
     private func buildSubtree(
         _ payload: DOMNodePayload,
         documentID: DOMDocument.ID,
-        parentID: DOMNode.ID?
+        parentID: DOMNode.ID?,
+        nodesByID: inout [DOMNode.ID: DOMNode],
+        currentNodeIDByProtocolNodeID: inout [DOMProtocolNodeID: DOMNode.ID]
     ) -> DOMNode.ID {
         let nodeID = DOMNode.ID(documentID: documentID, nodeID: payload.nodeID)
-        let currentKey = DOMNodeCurrentKey(targetID: documentID.targetID, nodeID: payload.nodeID)
-        if let existingNodeID = currentNodeIDByKey[currentKey], existingNodeID != nodeID {
-            removeNodeSubtree(existingNodeID, detachFromParent: true)
-        }
-
         let node = DOMNode(id: nodeID, payload: payload, parentID: parentID)
         nodesByID[nodeID] = node
-        currentNodeIDByKey[currentKey] = nodeID
+        currentNodeIDByProtocolNodeID[payload.nodeID] = nodeID
 
         switch payload.regularChildren {
         case let .unrequested(count):
@@ -933,48 +1500,398 @@ package final class DOMSession {
         case let .loaded(children):
             node.regularChildren = .loaded(
                 children.map {
-                    buildSubtree($0, documentID: documentID, parentID: nodeID)
+                    buildSubtree(
+                        $0,
+                        documentID: documentID,
+                        parentID: nodeID,
+                        nodesByID: &nodesByID,
+                        currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID
+                    )
                 }
             )
         }
 
         node.contentDocumentID = payload.contentDocument.first.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
         node.shadowRootIDs = payload.shadowRoots.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
         node.templateContentID = payload.templateContent.first.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
         node.beforePseudoElementID = payload.beforePseudoElement.first.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
         node.otherPseudoElementIDs = payload.otherPseudoElements.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
         node.afterPseudoElementID = payload.afterPseudoElement.first.map {
-            buildSubtree($0, documentID: documentID, parentID: nodeID)
+            buildSubtree($0, documentID: documentID, parentID: nodeID, nodesByID: &nodesByID, currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID)
         }
 
-        if node.isFrameOwner, let frameID = node.frameID {
-            let frame = frameWithID(frameID, parentFrameID: nil)
-            frame.ownerNodeID = nodeID
-        }
-
-        relinkProtocolEffectiveChildren(of: node)
+        relinkProtocolEffectiveChildren(of: node, nodesByID: nodesByID)
         return nodeID
     }
 
-    private func removeDocument(_ documentID: DOMDocument.ID) {
-        guard let document = documentsByID.removeValue(forKey: documentID) else {
+    @discardableResult
+    private func buildSubtree(
+        _ payload: DOMNodePayload,
+        document: DOMDocument,
+        parentID: DOMNode.ID?
+    ) -> DOMNode.ID {
+        if let existingNodeID = document.currentNodeIDByProtocolNodeID[payload.nodeID],
+           existingNodeID != DOMNode.ID(documentID: document.id, nodeID: payload.nodeID) {
+            removeNodeSubtree(existingNodeID, detachFromParent: true)
+        }
+        var nodesByID = document.nodesByID
+        var currentNodeIDByProtocolNodeID = document.currentNodeIDByProtocolNodeID
+        let nodeID = buildSubtree(
+            payload,
+            documentID: document.id,
+            parentID: parentID,
+            nodesByID: &nodesByID,
+            currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID
+        )
+        document.nodesByID = nodesByID
+        document.currentNodeIDByProtocolNodeID = currentNodeIDByProtocolNodeID
+        return nodeID
+    }
+
+    private func removeDocuments(for targetID: ProtocolTarget.ID) {
+        guard let documentID = targetStatesByID[targetID]?.currentDocument?.id else {
             return
         }
-        removeNodeSubtree(document.rootNodeID, detachFromParent: false)
+        removeDocument(documentID)
+    }
+
+    private func removeDocument(_ documentID: DOMDocument.ID) {
+        guard let targetState = targetStatesByID[documentID.targetID],
+              let document = targetState.currentDocument,
+              document.id == documentID else {
+            return
+        }
+        document.lifecycle = .invalidated
+        targetState.currentDocument = nil
+        document.transactions.removeAll()
+        if let frameID = targetsByID[document.targetID]?.frameID,
+           framesByID[frameID]?.currentDocumentID == documentID {
+            framesByID[frameID]?.currentDocumentID = nil
+        }
+        if currentPageTargetID == document.targetID,
+           let mainFrameID,
+           framesByID[mainFrameID]?.currentDocumentID == documentID {
+            framesByID[mainFrameID]?.currentDocumentID = nil
+        }
+        if selection.selectedNodeID?.documentID == documentID {
+            selection.selectedNodeID = nil
+            selection.failure = nil
+            selectionRevision &+= 1
+        }
+    }
+
+    @discardableResult
+    private func registerTransaction(
+        targetID: ProtocolTarget.ID,
+        document: DOMDocument,
+        kind: DOMTransactionKind,
+        issuedSequence: UInt64
+    ) -> DOMTransaction.ID? {
+        guard let targetState = targetStatesByID[targetID],
+              targetState.currentDocument === document else {
+            return nil
+        }
+        return document.startTransaction(kind: kind, issuedSequence: issuedSequence)
+    }
+
+    private func removeTransaction(_ transactionID: DOMTransaction.ID, targetID: ProtocolTarget.ID?) {
+        if let targetID {
+            targetStatesByID[targetID]?.currentDocument?.removeTransaction(transactionID)
+            return
+        }
+        for state in targetStatesByID.values {
+            state.currentDocument?.removeTransaction(transactionID)
+        }
+    }
+
+    private func hasActiveOwnerHydrationTransaction(
+        targetID: ProtocolTarget.ID,
+        documentID: DOMDocument.ID
+    ) -> Bool {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.id == documentID else {
+            return false
+        }
+        return document.hasActiveOwnerHydrationTransaction()
+    }
+
+    private func ownerHydrationIntent(
+        frameTargetID: ProtocolTarget.ID,
+        document: DOMDocument,
+        node: DOMNode,
+        issuedSequence: UInt64
+    ) -> DOMCommandIntent? {
+        guard hasUnloadedRegularChildren(node),
+              !hasActiveOwnerHydrationTransaction(targetID: document.targetID, documentID: document.id) else {
+            return nil
+        }
+        registerTransaction(
+            targetID: document.targetID,
+            document: document,
+            kind: .ownerHydration(frameTargetID: frameTargetID),
+            issuedSequence: issuedSequence
+        )
+        domProjectionTrace(
+            "ownerHydration.request frameTarget=\(frameTargetID.rawValue) target=\(document.targetID.rawValue) node=\(traceNode(node)) issuedSequence=\(issuedSequence)"
+        )
+        return .requestChildNodes(
+            targetID: document.targetID,
+            nodeID: node.protocolNodeID,
+            depth: 1
+        )
+    }
+
+    private func documentElement(in document: DOMDocument) -> DOMNode? {
+        guard let root = document.nodesByID[document.rootNodeID] else {
+            return nil
+        }
+        return root.regularChildren.loadedChildren
+            .compactMap { document.nodesByID[$0] }
+            .first { node in
+                node.nodeType == .element && normalizedElementName(node) == "html"
+            }
+    }
+
+    private func bodyElement(in document: DOMDocument) -> DOMNode? {
+        guard let html = documentElement(in: document) else {
+            return nil
+        }
+        return html.regularChildren.loadedChildren
+            .compactMap { document.nodesByID[$0] }
+            .first { node in
+                node.nodeType == .element && normalizedElementName(node) == "body"
+            }
+    }
+
+    private func normalizedElementName(_ node: DOMNode) -> String {
+        (node.localName.isEmpty ? node.nodeName : node.localName).lowercased()
+    }
+
+    private func splicePendingTransactionFragments(parentRawNodeID: DOMProtocolNodeID, into document: DOMDocument) {
+        var visitedParentRawNodeIDs = Set<DOMProtocolNodeID>()
+        splicePendingTransactionFragments(
+            parentRawNodeID: parentRawNodeID,
+            into: document,
+            visitedParentRawNodeIDs: &visitedParentRawNodeIDs
+        )
+        completePendingSelectionIfPossible(in: document)
+    }
+
+    private func splicePendingTransactionFragments(
+        parentRawNodeID: DOMProtocolNodeID,
+        into document: DOMDocument,
+        visitedParentRawNodeIDs: inout Set<DOMProtocolNodeID>
+    ) {
+        guard visitedParentRawNodeIDs.insert(parentRawNodeID).inserted else {
+            return
+        }
+        for transactionID in Array(document.transactions.keys) {
+            guard var transaction = document.transactions[transactionID],
+                  let fragments = transaction.pathFragmentsByParentRawNodeID.removeValue(forKey: parentRawNodeID),
+                  let parentID = document.currentNodeIDByProtocolNodeID[parentRawNodeID],
+                  let parent = document.nodesByID[parentID] else {
+                continue
+            }
+            let replacementOwnerKeys = parent.regularChildren.loadedChildren
+                .reduce(into: [ProtocolTarget.ID: DOMNodeCurrentKey]()) { partialResult, childID in
+                    partialResult.merge(projectedFrameOwnerKeys(inSubtree: childID)) { current, _ in current }
+                }
+            for childID in parent.regularChildren.loadedChildren {
+                removeNodeSubtree(childID, detachFromParent: false)
+            }
+            parent.regularChildren = .loaded(fragments.map {
+                buildSubtree($0, document: document, parentID: parentID)
+            })
+            relinkProtocolEffectiveChildren(of: parent)
+            reattachFrameDocumentProjections(using: replacementOwnerKeys)
+            document.transactions[transactionID] = transaction
+            for childID in parent.regularChildren.loadedChildren {
+                guard let child = document.nodesByID[childID] else {
+                    continue
+                }
+                splicePendingTransactionFragments(
+                    parentRawNodeID: child.protocolNodeID,
+                    into: document,
+                    visitedParentRawNodeIDs: &visitedParentRawNodeIDs
+                )
+            }
+        }
+    }
+
+    private func materializePendingRequestNodePath(
+        document: DOMDocument,
+        nodeID: DOMProtocolNodeID
+    ) {
+        for transaction in document.transactions.values {
+            guard case .requestNode = transaction.kind,
+                  let anchorRawNodeID = knownAncestorRawNodeID(
+                    for: nodeID,
+                    in: transaction,
+                    document: document
+                  ) else {
+                continue
+            }
+            splicePendingTransactionFragments(parentRawNodeID: anchorRawNodeID, into: document)
+            if document.currentNodeIDByProtocolNodeID[nodeID] != nil {
+                return
+            }
+        }
+    }
+
+    private func completePendingSelectionIfPossible(in document: DOMDocument) {
+        guard let pendingRequest = selection.pendingRequest,
+              pendingRequest.targetID == document.targetID,
+              pendingRequest.documentID == document.id,
+              let transactionID = pendingRequest.transactionID,
+              let transaction = document.transactions[transactionID],
+              let requestedProtocolNodeID = transaction.requestedProtocolNodeID else {
+            return
+        }
+
+        guard let selectedNodeID = document.currentNodeIDByProtocolNodeID[requestedProtocolNodeID],
+              selectedNodeID.documentID == document.id else {
+            return
+        }
+        completePendingSelection(selectedNodeID, pendingRequest: pendingRequest)
+    }
+
+    private func knownAncestorRawNodeID(
+        for nodeID: DOMProtocolNodeID,
+        in transaction: DOMTransaction,
+        document: DOMDocument
+    ) -> DOMProtocolNodeID? {
+        if document.currentNodeIDByProtocolNodeID[nodeID] != nil {
+            return nodeID
+        }
+
+        let parentRawNodeIDByChildRawNodeID = parentRawNodeIDByChildRawNodeID(
+            in: transaction.pathFragmentsByParentRawNodeID
+        )
+        var currentRawNodeID = nodeID
+        var visitedRawNodeIDs = Set<DOMProtocolNodeID>()
+        while visitedRawNodeIDs.insert(currentRawNodeID).inserted,
+              let parentRawNodeID = parentRawNodeIDByChildRawNodeID[currentRawNodeID] {
+            if document.currentNodeIDByProtocolNodeID[parentRawNodeID] != nil {
+                return parentRawNodeID
+            }
+            currentRawNodeID = parentRawNodeID
+        }
+        return nil
+    }
+
+    private func parentRawNodeIDByChildRawNodeID(
+        in fragmentsByParentRawNodeID: [DOMProtocolNodeID: [DOMNodePayload]]
+    ) -> [DOMProtocolNodeID: DOMProtocolNodeID] {
+        var parentRawNodeIDByChildRawNodeID: [DOMProtocolNodeID: DOMProtocolNodeID] = [:]
+        for (parentRawNodeID, fragments) in fragmentsByParentRawNodeID {
+            for fragment in fragments {
+                appendParentRawNodeIDs(
+                    fragment,
+                    parentRawNodeID: parentRawNodeID,
+                    to: &parentRawNodeIDByChildRawNodeID
+                )
+            }
+        }
+        return parentRawNodeIDByChildRawNodeID
+    }
+
+    private func appendParentRawNodeIDs(
+        _ payload: DOMNodePayload,
+        parentRawNodeID: DOMProtocolNodeID,
+        to parentRawNodeIDByChildRawNodeID: inout [DOMProtocolNodeID: DOMProtocolNodeID]
+    ) {
+        parentRawNodeIDByChildRawNodeID[payload.nodeID] = parentRawNodeID
+        let regularChildren: [DOMNodePayload]
+        switch payload.regularChildren {
+        case let .loaded(children):
+            regularChildren = children
+        case .unrequested:
+            regularChildren = []
+        }
+        for child in regularChildren {
+            appendParentRawNodeIDs(
+                child,
+                parentRawNodeID: payload.nodeID,
+                to: &parentRawNodeIDByChildRawNodeID
+            )
+        }
+        for child in payload.contentDocument
+            + payload.shadowRoots
+            + payload.templateContent
+            + payload.beforePseudoElement
+            + payload.otherPseudoElements
+            + payload.afterPseudoElement {
+            appendParentRawNodeIDs(
+                child,
+                parentRawNodeID: payload.nodeID,
+                to: &parentRawNodeIDByChildRawNodeID
+            )
+        }
+    }
+
+    private func canApplyDOMEvent(to nodeID: DOMNode.ID) -> Bool {
+        guard let document = targetStatesByID[nodeID.documentID.targetID]?.currentDocument,
+              document.id == nodeID.documentID,
+              document.lifecycle == .loaded else {
+            return false
+        }
+        return document.nodesByID[nodeID] != nil
+    }
+
+    private func nodeIsConnectedToDocumentTree(_ nodeID: DOMNode.ID, in document: DOMDocument) -> Bool {
+        var currentNodeID: DOMNode.ID? = nodeID
+        var visitedNodeIDs = Set<DOMNode.ID>()
+        while let candidateID = currentNodeID,
+              visitedNodeIDs.insert(candidateID).inserted {
+            if candidateID == document.rootNodeID {
+                return true
+            }
+            currentNodeID = document.nodesByID[candidateID]?.parentID
+        }
+        return false
+    }
+
+    private func payloadContainsConnectedDocumentNode(_ payload: DOMNodePayload, in document: DOMDocument) -> Bool {
+        if let existingNodeID = document.currentNodeIDByProtocolNodeID[payload.nodeID],
+           nodeIsConnectedToDocumentTree(existingNodeID, in: document) {
+            return true
+        }
+        for child in payloadOwnedChildren(payload) {
+            if payloadContainsConnectedDocumentNode(child, in: document) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func payloadOwnedChildren(_ payload: DOMNodePayload) -> [DOMNodePayload] {
+        var children: [DOMNodePayload] = []
+        if case let .loaded(regularChildren) = payload.regularChildren {
+            children.append(contentsOf: regularChildren)
+        }
+        children.append(contentsOf: payload.contentDocument)
+        children.append(contentsOf: payload.shadowRoots)
+        children.append(contentsOf: payload.templateContent)
+        children.append(contentsOf: payload.beforePseudoElement)
+        children.append(contentsOf: payload.otherPseudoElements)
+        children.append(contentsOf: payload.afterPseudoElement)
+        return children
     }
 
     private func removeNodeSubtree(_ nodeID: DOMNode.ID, detachFromParent: Bool) {
-        guard let node = nodesByID[nodeID] else {
+        guard let document = targetStatesByID[nodeID.documentID.targetID]?.currentDocument,
+              document.id == nodeID.documentID,
+              let node = document.nodesByID[nodeID] else {
             return
         }
         if detachFromParent {
@@ -983,20 +1900,18 @@ package final class DOMSession {
         for childID in node.protocolOwnedChildren {
             removeNodeSubtree(childID, detachFromParent: false)
         }
-        if node.isFrameOwner,
-           let frameID = node.frameID,
-           framesByID[frameID]?.ownerNodeID == nodeID {
-            framesByID[frameID]?.ownerNodeID = nil
+        for projection in frameDocumentProjections.values where projection.ownerNodeID == nodeID {
+            projection.ownerNodeID = nil
+            projection.state = .pending
         }
-        let currentKey = DOMNodeCurrentKey(targetID: nodeID.documentID.targetID, nodeID: node.protocolNodeID)
-        if currentNodeIDByKey[currentKey] == nodeID {
-            currentNodeIDByKey.removeValue(forKey: currentKey)
+        if document.currentNodeIDByProtocolNodeID[node.protocolNodeID] == nodeID {
+            document.currentNodeIDByProtocolNodeID.removeValue(forKey: node.protocolNodeID)
         }
-        nodesByID.removeValue(forKey: nodeID)
+        document.nodesByID.removeValue(forKey: nodeID)
     }
 
     private func detachNode(_ nodeID: DOMNode.ID, from parentID: DOMNode.ID?) {
-        guard let parentID, let parent = nodesByID[parentID] else {
+        guard let parentID, let parent = node(for: parentID) else {
             return
         }
         parent.regularChildren = .loaded(parent.regularChildren.loadedChildren.filter { $0 != nodeID })
@@ -1020,6 +1935,18 @@ package final class DOMSession {
     private func relinkProtocolEffectiveChildren(of parent: DOMNode) {
         let children = parent.protocolEffectiveChildren
         for (index, childID) in children.enumerated() {
+            guard let child = node(for: childID) else {
+                continue
+            }
+            child.parentID = parent.id
+            child.previousSiblingID = index > 0 ? children[index - 1] : nil
+            child.nextSiblingID = index + 1 < children.count ? children[index + 1] : nil
+        }
+    }
+
+    private func relinkProtocolEffectiveChildren(of parent: DOMNode, nodesByID: [DOMNode.ID: DOMNode]) {
+        let children = parent.protocolEffectiveChildren
+        for (index, childID) in children.enumerated() {
             guard let child = nodesByID[childID] else {
                 continue
             }
@@ -1027,6 +1954,236 @@ package final class DOMSession {
             child.previousSiblingID = index > 0 ? children[index - 1] : nil
             child.nextSiblingID = index + 1 < children.count ? children[index + 1] : nil
         }
+    }
+
+    private func projectedFrameOwnerKeys(inSubtree rootID: DOMNode.ID) -> [ProtocolTarget.ID: DOMNodeCurrentKey] {
+        var keys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
+        var stack = [rootID]
+        while let nodeID = stack.popLast() {
+            guard let node = node(for: nodeID) else {
+                continue
+            }
+            for projection in frameDocumentProjections.values where projection.ownerNodeID == nodeID {
+                keys[projection.frameTargetID] = DOMNodeCurrentKey(
+                    targetID: nodeID.documentID.targetID,
+                    nodeID: node.protocolNodeID
+                )
+            }
+            stack.append(contentsOf: node.protocolOwnedChildren)
+        }
+        return keys
+    }
+
+    private func reattachFrameDocumentProjections(using ownerKeys: [ProtocolTarget.ID: DOMNodeCurrentKey]) {
+        for (frameTargetID, ownerKey) in ownerKeys {
+            guard let projection = frameDocumentProjections[frameTargetID],
+                  let ownerNodeID = targetStatesByID[ownerKey.targetID]?.currentDocument?.currentNodeIDByProtocolNodeID[ownerKey.nodeID],
+                  let ownerNode = node(for: ownerNodeID),
+                  ownerNode.isFrameOwner,
+                  canApplyDOMEvent(to: ownerNodeID) else {
+                continue
+            }
+            projection.ownerNodeID = ownerNodeID
+            projection.state = .attached
+        }
+    }
+
+    private func setFrameDocumentProjection(frameTargetID: ProtocolTarget.ID, frameDocumentID: DOMDocument.ID) {
+        let projection = frameDocumentProjections[frameTargetID] ?? FrameDocumentProjection(
+            ownerNodeID: nil,
+            frameTargetID: frameTargetID,
+            frameDocumentID: frameDocumentID,
+            state: .pending
+        )
+        projection.frameTargetID = frameTargetID
+        projection.frameDocumentID = frameDocumentID
+        projection.ownerNodeID = nil
+        projection.state = .pending
+        frameDocumentProjections[frameTargetID] = projection
+        updateFrameDocumentProjectionState(projection)
+        domProjectionTrace(
+            "frameDocument.register frameTarget=\(frameTargetID.rawValue) document=\(traceDocument(frameDocumentID)) state=\(projection.state) owner=\(traceNodeID(projection.ownerNodeID)) candidates=\(traceOwnerCandidateCount(for: frameDocumentID))"
+        )
+    }
+
+    private func updateAllFrameDocumentProjectionStates() {
+        for projection in frameDocumentProjections.values {
+            updateFrameDocumentProjectionState(projection)
+        }
+    }
+
+    private func updateFrameDocumentProjectionState(_ projection: FrameDocumentProjection) {
+        let previousState = projection.state
+        let previousOwnerNodeID = projection.ownerNodeID
+        var candidateCount: Int?
+        var frameDocumentURL: String?
+        defer {
+            if previousState != projection.state || previousOwnerNodeID != projection.ownerNodeID {
+                domProjectionTrace(
+                    "projection.update frameTarget=\(projection.frameTargetID.rawValue) document=\(traceDocument(projection.frameDocumentID)) url=\(frameDocumentURL ?? "nil") state=\(previousState)->\(projection.state) owner=\(traceNodeID(previousOwnerNodeID))->\(traceNodeID(projection.ownerNodeID)) candidates=\(candidateCount.map(String.init) ?? "n/a")"
+                )
+            }
+        }
+        guard let document = currentDocument(for: projection.frameDocumentID),
+              let frameRoot = document.nodesByID[document.rootNodeID] else {
+            projection.ownerNodeID = nil
+            projection.state = .pending
+            return
+        }
+        frameDocumentURL = frameRoot.documentURL
+
+        if let ownerNodeID = projection.ownerNodeID,
+           node(for: ownerNodeID) != nil {
+            projection.state = .attached
+            return
+        }
+
+        let candidates = ownerCandidates(forFrameDocumentRoot: frameRoot)
+        candidateCount = candidates.count
+        switch candidates.count {
+        case 0:
+            projection.ownerNodeID = nil
+            projection.state = .pending
+        case 1:
+            projection.ownerNodeID = candidates[0]
+            projection.state = .attached
+        default:
+            projection.ownerNodeID = nil
+            projection.state = .ambiguous
+        }
+    }
+
+    private func ownerCandidates(forFrameDocumentRoot frameRoot: DOMNode) -> [DOMNode.ID] {
+        guard let frameDocumentURL = frameRoot.documentURL,
+              frameDocumentURL.isEmpty == false else {
+            return []
+        }
+
+        return ownerCandidateNodes()
+            .filter { entry in
+                projectionCanAttach(to: entry.node, in: entry.document)
+                    && frameOwner(entry.node, matchesFrameDocumentURL: frameDocumentURL)
+            }
+            .map { $0.node.id }
+            .sorted(by: sortNodeIDs)
+    }
+
+    private func ownerCandidateNodes() -> [(document: DOMDocument, node: DOMNode)] {
+        targetStatesByID.values
+            .compactMap(\.currentDocument)
+            .flatMap { document in
+                document.nodesByID.values.map { (document, $0) }
+            }
+    }
+
+    private func projectionCanAttach(to candidate: DOMNode, in document: DOMDocument) -> Bool {
+        candidate.isFrameOwner
+            && frameOwnerIsAlreadyAttached(candidate.id) == false
+            && nodeIsConnectedToDocumentTree(candidate.id, in: document)
+    }
+
+    private func frameOwnerIsAlreadyAttached(_ nodeID: DOMNode.ID) -> Bool {
+        frameDocumentProjections.values.contains {
+            $0.ownerNodeID == nodeID && $0.state == .attached
+        }
+    }
+
+    private func sortNodeIDs(_ lhs: DOMNode.ID, _ rhs: DOMNode.ID) -> Bool {
+        if lhs.documentID.targetID.rawValue != rhs.documentID.targetID.rawValue {
+            return lhs.documentID.targetID.rawValue < rhs.documentID.targetID.rawValue
+        }
+        if lhs.documentID.localDocumentLifetimeID != rhs.documentID.localDocumentLifetimeID {
+            return lhs.documentID.localDocumentLifetimeID < rhs.documentID.localDocumentLifetimeID
+        }
+        return lhs.nodeID.rawValue < rhs.nodeID.rawValue
+    }
+
+    private func frameProjectionTraceSummary() -> String {
+        let entries = frameDocumentProjections.values
+            .sorted { $0.frameTargetID.rawValue < $1.frameTargetID.rawValue }
+            .prefix(8)
+            .map { projection in
+                "\(projection.frameTargetID.rawValue):\(projection.state):owner=\(traceNodeID(projection.ownerNodeID)):candidates=\(traceOwnerCandidateCount(for: projection.frameDocumentID)):doc=\(traceDocument(projection.frameDocumentID))"
+            }
+        let suffix = frameDocumentProjections.count > entries.count ? ",..." : ""
+        return "[" + entries.joined(separator: ",") + suffix + "]"
+    }
+
+    private func traceOwnerCandidateCount(for frameDocumentID: DOMDocument.ID) -> String {
+        guard let document = currentDocument(for: frameDocumentID),
+              let root = document.nodesByID[document.rootNodeID] else {
+            return "n/a"
+        }
+        return String(ownerCandidates(forFrameDocumentRoot: root).count)
+    }
+
+    private func traceDocument(_ documentID: DOMDocument.ID) -> String {
+        guard let document = currentDocument(for: documentID),
+              let root = document.nodesByID[document.rootNodeID] else {
+            return "\(documentID.targetID.rawValue)#\(documentID.localDocumentLifetimeID.rawValue):missing"
+        }
+        let url = root.documentURL ?? "nil"
+        return "\(documentID.targetID.rawValue)#\(documentID.localDocumentLifetimeID.rawValue):url=\(url)"
+    }
+
+    private func traceNodeID(_ nodeID: DOMNode.ID?) -> String {
+        guard let nodeID else {
+            return "nil"
+        }
+        guard let node = node(for: nodeID) else {
+            return "\(nodeID.documentID.targetID.rawValue)#\(nodeID.nodeID.rawValue):missing"
+        }
+        return traceNode(node)
+    }
+
+    private func traceNode(_ node: DOMNode) -> String {
+        "\(node.id.documentID.targetID.rawValue)#\(node.protocolNodeID.rawValue)<\(node.nodeName)>"
+    }
+
+    private func frameOwner(_ owner: DOMNode, matchesFrameDocumentURL frameDocumentURL: String) -> Bool {
+        guard let source = attribute(named: "src", in: owner),
+              source.isEmpty == false else {
+            return false
+        }
+        if source == frameDocumentURL {
+            return true
+        }
+        guard let resolvedSource = resolvedURL(source, relativeTo: documentURL(for: owner)),
+              let resolvedFrameDocumentURL = resolvedURL(frameDocumentURL, relativeTo: nil) else {
+            return false
+        }
+        return resolvedSource == resolvedFrameDocumentURL
+    }
+
+    private func attribute(named name: String, in node: DOMNode) -> String? {
+        node.attributes.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+
+    private func documentURL(for node: DOMNode) -> String? {
+        guard let document = currentDocument(for: node.id.documentID),
+              let root = document.nodesByID[document.rootNodeID] else {
+            return nil
+        }
+        return root.baseURL ?? root.documentURL
+    }
+
+    private func resolvedURL(_ string: String, relativeTo base: String?) -> String? {
+        if let base,
+           let baseURL = URL(string: base),
+           let url = URL(string: string, relativeTo: baseURL) {
+            return url.absoluteURL.absoluteString
+        }
+        return URL(string: string)?.absoluteURL.absoluteString
+    }
+
+    private func projectedFrameDocumentRootID(for ownerNodeID: DOMNode.ID) -> DOMNode.ID? {
+        for projection in frameDocumentProjections.values where projection.ownerNodeID == ownerNodeID && projection.state == .attached {
+            guard let document = currentDocument(for: projection.frameDocumentID) else {
+                continue
+            }
+            return document.rootNodeID
+        }
+        return nil
     }
 
     private func projectedVisibleChildren(of node: DOMNode) -> [DOMNode.ID] {
@@ -1047,9 +2204,7 @@ package final class DOMSession {
 
     private func projectedEffectiveChildren(of node: DOMNode) -> [DOMNode.ID] {
         if node.isFrameOwner,
-           let frameID = node.frameID,
-           let documentID = framesByID[frameID]?.currentDocumentID,
-           let rootNodeID = documentsByID[documentID]?.rootNodeID {
+           let rootNodeID = projectedFrameDocumentRootID(for: node.id) {
             return [rootNodeID]
         }
         if let contentDocumentID = node.contentDocumentID {
@@ -1065,7 +2220,7 @@ package final class DOMSession {
         rows: inout [DOMTreeRow]
     ) {
         guard visited.insert(nodeID).inserted,
-              let node = nodesByID[nodeID] else {
+              let node = node(for: nodeID) else {
             return
         }
         let visibleChildren = projectedVisibleChildren(of: node)
@@ -1093,7 +2248,10 @@ package final class DOMSession {
     }
 
     private func parent(of node: DOMNode) -> DOMNode? {
-        node.parentID.flatMap { nodesByID[$0] }
+        guard let parentID = node.parentID else {
+            return nil
+        }
+        return self.node(for: parentID)
     }
 
     private func selectorTraversalParent(for node: DOMNode) -> DOMNode? {
@@ -1199,7 +2357,7 @@ package final class DOMSession {
             return 0
         }
 
-        let siblings = parent.regularChildren.loadedChildren.compactMap { nodesByID[$0] }
+        let siblings = parent.regularChildren.loadedChildren.compactMap { self.node(for: $0) }
         guard siblings.count > 1 else {
             return 0
         }
@@ -1249,7 +2407,7 @@ package final class DOMSession {
         guard let parent = parent(of: node) else {
             return [node]
         }
-        return parent.regularChildren.loadedChildren.compactMap { nodesByID[$0] }.filter(nodeIsElementLike)
+        return parent.regularChildren.loadedChildren.compactMap { self.node(for: $0) }.filter(nodeIsElementLike)
     }
 
     private func selectorNodeName(for node: DOMNode) -> String {
@@ -1324,10 +2482,23 @@ package final class DOMSession {
 
     private func reconcileSelection() {
         guard let selectedNodeID = selection.selectedNodeID,
-              nodesByID[selectedNodeID] == nil else {
+              node(for: selectedNodeID) == nil else {
             return
         }
         selection.selectedNodeID = nil
+        selection.failure = nil
+        selectionRevision &+= 1
+    }
+
+    private func completePendingSelection(
+        _ selectedNodeID: DOMNode.ID,
+        pendingRequest: DOMSelectionRequest
+    ) {
+        if let transactionID = pendingRequest.transactionID {
+            removeTransaction(transactionID, targetID: pendingRequest.targetID)
+        }
+        selection.selectedNodeID = selectedNodeID
+        selection.pendingRequest = nil
         selection.failure = nil
         selectionRevision &+= 1
     }
@@ -1339,6 +2510,9 @@ package final class DOMSession {
         let previousSelectedNodeID = selection.selectedNodeID
         let previousHadPendingRequest = selection.pendingRequest != nil
         let previousFailure = selection.failure
+        if let pendingTransactionID = selection.pendingRequest?.transactionID {
+            removeTransaction(pendingTransactionID, targetID: selection.pendingRequest?.targetID)
+        }
         if clearSelected {
             selection.selectedNodeID = nil
         }
@@ -1359,6 +2533,9 @@ package final class DOMSession {
         let previousSelectedNodeID = selection.selectedNodeID
         let previousHadPendingRequest = selection.pendingRequest != nil
         let previousFailure = selection.failure
+        if let pendingTransactionID = selection.pendingRequest?.transactionID {
+            removeTransaction(pendingTransactionID, targetID: selection.pendingRequest?.targetID)
+        }
         if clearSelected {
             selection.selectedNodeID = nil
         }
@@ -1370,5 +2547,28 @@ package final class DOMSession {
             selectionRevision &+= 1
         }
         return .failure(failure)
+    }
+
+    private func failSelection(
+        _ failure: SelectionResolutionFailure,
+        clearSelected: Bool = true
+    ) -> DOMRequestNodeResolution {
+        let previousSelectedNodeID = selection.selectedNodeID
+        let previousHadPendingRequest = selection.pendingRequest != nil
+        let previousFailure = selection.failure
+        if let pendingTransactionID = selection.pendingRequest?.transactionID {
+            removeTransaction(pendingTransactionID, targetID: selection.pendingRequest?.targetID)
+        }
+        if clearSelected {
+            selection.selectedNodeID = nil
+        }
+        selection.pendingRequest = nil
+        selection.failure = failure
+        if (clearSelected && previousSelectedNodeID != nil)
+            || previousHadPendingRequest
+            || previousFailure != failure {
+            selectionRevision &+= 1
+        }
+        return .failed(failure)
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -22,9 +22,40 @@ package struct DOMTreeRow: Equatable, Sendable {
 
 package struct DOMTreeProjection: Equatable, Sendable {
     package var rows: [DOMTreeRow]
+    package var rootNodeIDs: [DOMNodeIdentifier]
+    package var childrenByNodeID: [DOMNodeIdentifier: [DOMNodeIdentifier]]
+    package var parentByNodeID: [DOMNodeIdentifier: DOMNodeIdentifier]
 
-    package init(rows: [DOMTreeRow]) {
+    package init(
+        rows: [DOMTreeRow] = [],
+        rootNodeIDs: [DOMNodeIdentifier] = [],
+        childrenByNodeID: [DOMNodeIdentifier: [DOMNodeIdentifier]] = [:],
+        parentByNodeID: [DOMNodeIdentifier: DOMNodeIdentifier] = [:]
+    ) {
         self.rows = rows
+        self.rootNodeIDs = rootNodeIDs
+        self.childrenByNodeID = childrenByNodeID
+        self.parentByNodeID = parentByNodeID
+    }
+
+    package func children(of nodeID: DOMNodeIdentifier) -> [DOMNodeIdentifier] {
+        childrenByNodeID[nodeID] ?? []
+    }
+
+    package func parent(of nodeID: DOMNodeIdentifier) -> DOMNodeIdentifier? {
+        parentByNodeID[nodeID]
+    }
+
+    package func ancestorNodeIDs(of nodeID: DOMNodeIdentifier) -> [DOMNodeIdentifier] {
+        var ancestors: [DOMNodeIdentifier] = []
+        var visited = Set<DOMNodeIdentifier>()
+        var current = parentByNodeID[nodeID]
+        while let ancestorID = current,
+              visited.insert(ancestorID).inserted {
+            ancestors.append(ancestorID)
+            current = parentByNodeID[ancestorID]
+        }
+        return ancestors
     }
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -33,32 +33,45 @@ package struct ProtocolTargetSnapshot: Equatable, Sendable {
     package var kind: ProtocolTargetKind
     package var frameID: DOMFrameIdentifier?
     package var parentFrameID: DOMFrameIdentifier?
+    package var capabilities: ProtocolTargetCapabilities
     package var isProvisional: Bool
     package var isPaused: Bool
     package var currentDocumentID: DOMDocumentIdentifier?
-}
-
-package struct DOMPageSnapshot: Equatable, Sendable {
-    package var id: ProtocolTargetIdentifier
-    package var mainTargetID: ProtocolTargetIdentifier
-    package var mainFrameID: DOMFrameIdentifier
-    package var navigationGeneration: UInt64
 }
 
 package struct DOMFrameSnapshot: Equatable, Sendable {
     package var id: DOMFrameIdentifier
     package var parentFrameID: DOMFrameIdentifier?
     package var childFrameIDs: Set<DOMFrameIdentifier>
-    package var ownerNodeID: DOMNodeIdentifier?
     package var targetID: ProtocolTargetIdentifier?
     package var currentDocumentID: DOMDocumentIdentifier?
+}
+
+package enum DOMDocumentLifecycle: Equatable, Sendable {
+    case loading
+    case loaded
+    case invalidated
 }
 
 package struct DOMDocumentSnapshot: Equatable, Sendable {
     package var id: DOMDocumentIdentifier
     package var targetID: ProtocolTargetIdentifier
-    package var generation: DOMDocumentGeneration
+    package var localDocumentLifetimeID: DOMDocumentLifetimeIdentifier
+    package var lifecycle: DOMDocumentLifecycle
     package var rootNodeID: DOMNodeIdentifier
+}
+
+package enum FrameDocumentProjectionState: Equatable, Sendable {
+    case pending
+    case attached
+    case ambiguous
+}
+
+package struct FrameDocumentProjectionSnapshot: Equatable, Sendable {
+    package var ownerNodeID: DOMNodeIdentifier?
+    package var frameTargetID: ProtocolTargetIdentifier
+    package var frameDocumentID: DOMDocumentIdentifier
+    package var state: FrameDocumentProjectionState
 }
 
 package enum DOMRegularChildrenSnapshot: Equatable, Sendable {
@@ -91,7 +104,9 @@ package struct DOMNodeSnapshot: Equatable, Sendable {
     package var nodeName: String
     package var localName: String
     package var nodeValue: String
-    package var frameID: DOMFrameIdentifier?
+    package var ownerFrameID: DOMFrameIdentifier?
+    package var documentURL: String?
+    package var baseURL: String?
     package var attributes: [DOMAttribute]
     package var parentID: DOMNodeIdentifier?
     package var previousSiblingID: DOMNodeIdentifier?
@@ -117,6 +132,21 @@ package struct SelectionRequestSnapshot: Equatable, Sendable {
     package var documentID: DOMDocumentIdentifier
 }
 
+package struct DOMTargetStateSnapshot: Equatable, Sendable {
+    package var targetID: ProtocolTargetIdentifier
+    package var currentDocumentID: DOMDocumentIdentifier?
+    package var transactionIDs: [DOMTransactionIdentifier]
+}
+
+package struct DOMTransactionSnapshot: Equatable, Sendable {
+    package var id: DOMTransactionIdentifier
+    package var targetID: ProtocolTargetIdentifier
+    package var documentID: DOMDocumentIdentifier
+    package var kind: DOMTransactionKind
+    package var issuedSequence: UInt64
+    package var requestedProtocolNodeID: DOMProtocolNodeID?
+}
+
 package struct DOMSelectionSnapshot: Equatable, Sendable {
     package var selectedNodeID: DOMNodeIdentifier?
     package var pendingRequest: SelectionRequestSnapshot?
@@ -124,12 +154,28 @@ package struct DOMSelectionSnapshot: Equatable, Sendable {
 }
 
 package struct DOMSessionSnapshot: Equatable, Sendable {
-    package var currentPage: DOMPageSnapshot?
+    package var currentPageTargetID: ProtocolTargetIdentifier?
+    package var mainFrameID: DOMFrameIdentifier?
+    package var treeRevision: UInt64
+    package var selectionRevision: UInt64
     package var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetSnapshot]
+    package var targetStatesByID: [ProtocolTargetIdentifier: DOMTargetStateSnapshot]
     package var framesByID: [DOMFrameIdentifier: DOMFrameSnapshot]
     package var documentsByID: [DOMDocumentIdentifier: DOMDocumentSnapshot]
     package var nodesByID: [DOMNodeIdentifier: DOMNodeSnapshot]
+    package var frameDocumentProjections: [ProtocolTargetIdentifier: FrameDocumentProjectionSnapshot]
+    package var transactions: [DOMTransactionSnapshot]
     package var currentNodeIDByKey: [DOMNodeCurrentKey: DOMNodeIdentifier]
     package var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
     package var selection: DOMSelectionSnapshot
+}
+
+package extension DOMSessionSnapshot {
+    var currentPageDocumentID: DOMDocumentIdentifier? {
+        guard let currentPageTargetID else {
+            return nil
+        }
+        return targetStatesByID[currentPageTargetID]?.currentDocumentID
+            ?? targetsByID[currentPageTargetID]?.currentDocumentID
+    }
 }

--- a/Sources/WebInspectorCore/DOM/DOMProtocol.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProtocol.swift
@@ -10,7 +10,7 @@ package struct DOMProtocolNodeID: RawRepresentable, Hashable, Codable, Sendable 
     }
 }
 
-package struct DOMDocumentGeneration: RawRepresentable, Hashable, Comparable, Codable, Sendable {
+package struct DOMDocumentLifetimeIdentifier: RawRepresentable, Hashable, Comparable, Codable, Sendable {
     package let rawValue: UInt64
 
     package init(_ rawValue: UInt64) {
@@ -28,11 +28,17 @@ package struct DOMDocumentGeneration: RawRepresentable, Hashable, Comparable, Co
 
 package struct DOMDocumentIdentifier: Hashable, Sendable {
     package var targetID: ProtocolTargetIdentifier
-    package var generation: DOMDocumentGeneration
+    package var localDocumentLifetimeID: DOMDocumentLifetimeIdentifier
 
-    package init(targetID: ProtocolTargetIdentifier, generation: DOMDocumentGeneration) {
+    /// Local handle used for snapshots and node identity. This is not a
+    /// protocol identity and must not be used for target/frame discovery.
+    package init(targetID: ProtocolTargetIdentifier, localDocumentLifetimeID: DOMDocumentLifetimeIdentifier) {
         self.targetID = targetID
-        self.generation = generation
+        self.localDocumentLifetimeID = localDocumentLifetimeID
+    }
+
+    package var generation: DOMDocumentLifetimeIdentifier {
+        localDocumentLifetimeID
     }
 }
 
@@ -53,6 +59,41 @@ package struct DOMNodeCurrentKey: Hashable, Sendable {
     package init(targetID: ProtocolTargetIdentifier, nodeID: DOMProtocolNodeID) {
         self.targetID = targetID
         self.nodeID = nodeID
+    }
+}
+
+package struct DOMTransactionIdentifier: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: UInt64
+
+    package init(_ rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+}
+
+package enum DOMTransactionKind: Equatable, Sendable {
+    case requestChildNodes(parentRawNodeID: DOMProtocolNodeID)
+    case requestNode(selectionRequestID: SelectionRequestIdentifier, objectID: String)
+    case ownerHydration(frameTargetID: ProtocolTargetIdentifier)
+}
+
+package enum DOMRequestNodeResolution: Equatable, Sendable {
+    case resolved(DOMNodeIdentifier)
+    case pending(DOMNodeCurrentKey)
+    case failed(SelectionResolutionFailure)
+
+    package func get() throws -> DOMNodeIdentifier {
+        switch self {
+        case let .resolved(nodeID):
+            return nodeID
+        case let .pending(key):
+            throw SelectionResolutionFailure.unresolvedNode(key)
+        case let .failed(failure):
+            throw failure
+        }
     }
 }
 
@@ -92,7 +133,9 @@ package struct DOMNodePayload: Equatable, Sendable {
     package var nodeName: String
     package var localName: String
     package var nodeValue: String
-    package var frameID: DOMFrameIdentifier?
+    package var ownerFrameID: DOMFrameIdentifier?
+    package var documentURL: String?
+    package var baseURL: String?
     package var attributes: [DOMAttribute]
     package var regularChildren: DOMRegularChildrenPayload
     package var contentDocument: [DOMNodePayload]
@@ -110,7 +153,9 @@ package struct DOMNodePayload: Equatable, Sendable {
         nodeName: String,
         localName: String = "",
         nodeValue: String = "",
-        frameID: DOMFrameIdentifier? = nil,
+        ownerFrameID: DOMFrameIdentifier? = nil,
+        documentURL: String? = nil,
+        baseURL: String? = nil,
         attributes: [DOMAttribute] = [],
         regularChildren: DOMRegularChildrenPayload = .unrequested(count: 0),
         contentDocument: DOMNodePayload? = nil,
@@ -127,7 +172,9 @@ package struct DOMNodePayload: Equatable, Sendable {
         self.nodeName = nodeName
         self.localName = localName
         self.nodeValue = nodeValue
-        self.frameID = frameID
+        self.ownerFrameID = ownerFrameID
+        self.documentURL = documentURL
+        self.baseURL = baseURL
         self.attributes = attributes
         self.regularChildren = regularChildren
         self.contentDocument = contentDocument.map { [$0] } ?? []

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -1,0 +1,677 @@
+import Foundation
+
+package struct DOMTargetCommit: Equatable, Sendable {
+    package var oldFrameID: DOMFrame.ID?
+}
+
+package struct DOMTargetRemoval: Equatable, Sendable {
+    package var frameID: DOMFrame.ID?
+}
+
+@MainActor
+package final class DOMTargetGraph {
+    private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
+    private var framesByID: [DOMFrame.ID: DOMFrame]
+    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+
+    package init() {
+        targetsByID = [:]
+        framesByID = [:]
+        executionContextsByID = [:]
+    }
+
+    package func reset() {
+        targetsByID.removeAll()
+        framesByID.removeAll()
+        executionContextsByID.removeAll()
+    }
+
+    package func containsTarget(_ targetID: ProtocolTarget.ID) -> Bool {
+        targetsByID[targetID] != nil
+    }
+
+    private func target(for targetID: ProtocolTarget.ID) -> ProtocolTarget? {
+        targetsByID[targetID]
+    }
+
+    package func targetKind(for targetID: ProtocolTarget.ID) -> ProtocolTargetKind? {
+        targetsByID[targetID]?.kind
+    }
+
+    package func targetCapabilities(for targetID: ProtocolTarget.ID) -> ProtocolTargetCapabilities {
+        targetsByID[targetID]?.capabilities ?? []
+    }
+
+    package func targetFrameID(for targetID: ProtocolTarget.ID) -> DOMFrame.ID? {
+        targetsByID[targetID]?.frameID
+    }
+
+    package func targetParentFrameID(for targetID: ProtocolTarget.ID) -> DOMFrame.ID? {
+        targetsByID[targetID]?.parentFrameID
+    }
+
+    package func isTopLevelPageTarget(_ targetID: ProtocolTarget.ID) -> Bool {
+        guard let target = targetsByID[targetID] else {
+            return false
+        }
+        return target.kind == .page && target.parentFrameID == nil
+    }
+
+    package func upsertTarget(from record: ProtocolTargetRecord) {
+        let target = targetsByID[record.id] ?? ProtocolTarget(
+            id: record.id,
+            kind: record.kind,
+            frameID: record.frameID,
+            parentFrameID: record.parentFrameID,
+            capabilities: record.capabilities,
+            isProvisional: record.isProvisional,
+            isPaused: record.isPaused
+        )
+        target.kind = record.kind
+        target.frameID = record.frameID
+        target.parentFrameID = record.parentFrameID
+        target.capabilities = record.capabilities
+        target.isProvisional = record.isProvisional
+        target.isPaused = record.isPaused
+        targetsByID[record.id] = target
+    }
+
+    package func removeTarget(_ targetID: ProtocolTarget.ID) -> DOMTargetRemoval? {
+        guard let target = targetsByID.removeValue(forKey: targetID) else {
+            return nil
+        }
+        return DOMTargetRemoval(frameID: target.frameID)
+    }
+
+    @discardableResult
+    package func markTargetCommitted(_ targetID: ProtocolTarget.ID) -> Bool {
+        guard let target = targetsByID[targetID] else {
+            return false
+        }
+        target.isProvisional = false
+        if target.kind == .frame {
+            attachFrameTarget(target)
+        }
+        return true
+    }
+
+    package func commitTarget(oldTargetID: ProtocolTarget.ID, newTargetID: ProtocolTarget.ID) -> DOMTargetCommit? {
+        guard let oldTarget = targetsByID.removeValue(forKey: oldTargetID) else {
+            return nil
+        }
+        let existingNewTarget = targetsByID[newTargetID]
+        let frameID = existingNewTarget?.frameID ?? oldTarget.frameID
+        let parentFrameID = existingNewTarget?.parentFrameID ?? oldTarget.parentFrameID
+        let committedTarget = existingNewTarget ?? ProtocolTarget(
+            id: newTargetID,
+            kind: oldTarget.kind,
+            frameID: frameID,
+            parentFrameID: parentFrameID,
+            capabilities: oldTarget.capabilities,
+            isProvisional: false,
+            isPaused: oldTarget.isPaused
+        )
+        committedTarget.kind = existingNewTarget?.kind ?? oldTarget.kind
+        committedTarget.frameID = frameID
+        committedTarget.parentFrameID = parentFrameID
+        committedTarget.capabilities = existingNewTarget?.capabilities ?? oldTarget.capabilities
+        committedTarget.isProvisional = false
+        committedTarget.isPaused = existingNewTarget?.isPaused ?? oldTarget.isPaused
+        targetsByID[newTargetID] = committedTarget
+        if let frameID {
+            retargetFrame(frameID, from: oldTargetID, to: newTargetID)
+        }
+        return DOMTargetCommit(oldFrameID: oldTarget.frameID)
+    }
+
+    package func targetBelongsToCurrentPage(
+        _ targetID: ProtocolTarget.ID,
+        currentPageTargetID: ProtocolTarget.ID?,
+        mainFrameID: DOMFrame.ID?
+    ) -> Bool {
+        guard targetsByID[targetID] != nil else {
+            return false
+        }
+        guard currentPageTargetID != targetID else {
+            return true
+        }
+        guard let frameID = targetsByID[targetID]?.frameID else {
+            return false
+        }
+
+        var currentFrameID: DOMFrame.ID? = frameID
+        var visitedFrameIDs = Set<DOMFrame.ID>()
+        while let candidateFrameID = currentFrameID,
+              visitedFrameIDs.insert(candidateFrameID).inserted {
+            if candidateFrameID == mainFrameID {
+                return true
+            }
+            currentFrameID = framesByID[candidateFrameID]?.parentFrameID
+        }
+        return false
+    }
+
+    private func frameWithID(_ frameID: DOMFrame.ID, parentFrameID: DOMFrame.ID?) -> DOMFrame {
+        let frame = framesByID[frameID] ?? DOMFrame(id: frameID, parentFrameID: parentFrameID)
+        frame.parentFrameID = parentFrameID
+        framesByID[frameID] = frame
+        if let parentFrameID {
+            let parent = frameWithID(parentFrameID, parentFrameID: nil)
+            parent.childFrameIDs.insert(frameID)
+        }
+        return frame
+    }
+
+    package func hasFrame(_ frameID: DOMFrame.ID) -> Bool {
+        framesByID[frameID] != nil
+    }
+
+    package func frameCurrentDocumentID(_ frameID: DOMFrame.ID) -> DOMDocument.ID? {
+        framesByID[frameID]?.currentDocumentID
+    }
+
+    package func setFrameCurrentDocumentID(_ documentID: DOMDocument.ID?, for frameID: DOMFrame.ID) {
+        framesByID[frameID]?.currentDocumentID = documentID
+    }
+
+    package func clearFrameCurrentDocumentID(_ frameID: DOMFrame.ID, matching documentID: DOMDocument.ID) {
+        if framesByID[frameID]?.currentDocumentID == documentID {
+            framesByID[frameID]?.currentDocumentID = nil
+        }
+    }
+
+    package func setFrameTargetID(_ targetID: ProtocolTarget.ID?, for frameID: DOMFrame.ID) {
+        framesByID[frameID]?.targetID = targetID
+    }
+
+    package func frameTargetID(_ frameID: DOMFrame.ID) -> ProtocolTarget.ID? {
+        framesByID[frameID]?.targetID
+    }
+
+    package func assignMainFrame(_ frameID: DOMFrame.ID, to targetID: ProtocolTarget.ID) {
+        let frame = frameWithID(frameID, parentFrameID: nil)
+        frame.targetID = targetID
+        targetsByID[targetID]?.frameID = frameID
+    }
+
+    package func attachFrameTarget(_ targetID: ProtocolTarget.ID) {
+        guard let target = targetsByID[targetID] else {
+            return
+        }
+        attachFrameTarget(target)
+    }
+
+    private func attachFrameTarget(_ target: ProtocolTarget) {
+        guard let frameID = target.frameID else {
+            return
+        }
+        let frame = frameWithID(frameID, parentFrameID: target.parentFrameID)
+        frame.targetID = target.id
+    }
+
+    package func attachKnownFrameTargets(mainFrameID: DOMFrame.ID?) {
+        var attachedTargetIDs = Set<ProtocolTarget.ID>()
+        var didAttach = true
+        while didAttach {
+            didAttach = false
+            for target in targetsByID.values where target.kind == .frame && attachedTargetIDs.contains(target.id) == false {
+                guard let parentFrameID = target.parentFrameID,
+                      parentFrameID == mainFrameID || framesByID[parentFrameID] != nil else {
+                    continue
+                }
+                attachFrameTarget(target)
+                attachedTargetIDs.insert(target.id)
+                didAttach = true
+            }
+        }
+    }
+
+    private func retargetFrame(_ frameID: DOMFrame.ID, from oldTargetID: ProtocolTarget.ID, to newTargetID: ProtocolTarget.ID) {
+        let frame = frameWithID(frameID, parentFrameID: target(for: newTargetID)?.parentFrameID)
+        if frame.targetID == oldTargetID || frame.targetID == nil {
+            frame.targetID = newTargetID
+        }
+    }
+
+    package func clearCurrentDocumentReference(
+        _ documentID: DOMDocument.ID,
+        targetFrameID: DOMFrame.ID?,
+        targetID: ProtocolTarget.ID,
+        currentPageTargetID: ProtocolTarget.ID?,
+        mainFrameID: DOMFrame.ID?
+    ) {
+        if let frameID = targetFrameID,
+           framesByID[frameID]?.currentDocumentID == documentID {
+            framesByID[frameID]?.currentDocumentID = nil
+        }
+        if currentPageTargetID == targetID,
+           let mainFrameID,
+           framesByID[mainFrameID]?.currentDocumentID == documentID {
+            framesByID[mainFrameID]?.currentDocumentID = nil
+        }
+    }
+
+    package func removeExecutionContexts(targetID: ProtocolTarget.ID) {
+        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+    }
+
+    package func retargetExecutionContexts(from oldTargetID: ProtocolTarget.ID, to newTargetID: ProtocolTarget.ID) {
+        for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
+            executionContextsByID[contextID] = ExecutionContextRecord(
+                id: record.id,
+                targetID: newTargetID,
+                frameID: record.frameID
+            )
+        }
+    }
+
+    package func recordExecutionContext(_ record: ExecutionContextRecord) {
+        executionContextsByID[record.id] = record
+    }
+
+    package func targetSnapshots(
+        currentDocumentID: (ProtocolTarget.ID) -> DOMDocument.ID?
+    ) -> [ProtocolTarget.ID: ProtocolTargetSnapshot] {
+        targetsByID.mapValues {
+            ProtocolTargetSnapshot(
+                id: $0.id,
+                kind: $0.kind,
+                frameID: $0.frameID,
+                parentFrameID: $0.parentFrameID,
+                capabilities: $0.capabilities,
+                isProvisional: $0.isProvisional,
+                isPaused: $0.isPaused,
+                currentDocumentID: currentDocumentID($0.id)
+            )
+        }
+    }
+
+    package func frameSnapshots() -> [DOMFrame.ID: DOMFrameSnapshot] {
+        framesByID.mapValues {
+            DOMFrameSnapshot(
+                id: $0.id,
+                parentFrameID: $0.parentFrameID,
+                childFrameIDs: $0.childFrameIDs,
+                targetID: $0.targetID,
+                currentDocumentID: $0.currentDocumentID
+            )
+        }
+    }
+
+    package func executionContextSnapshots() -> [ExecutionContextID: ExecutionContextRecord] {
+        executionContextsByID
+    }
+}
+
+@MainActor
+package final class DOMDocumentStore {
+    private var targetStatesByID: [ProtocolTarget.ID: DOMTargetState]
+
+    package init() {
+        targetStatesByID = [:]
+    }
+
+    package func reset() {
+        targetStatesByID.removeAll()
+    }
+
+    package func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {
+        let state = targetStatesByID[targetID] ?? DOMTargetState(targetID: targetID)
+        targetStatesByID[targetID] = state
+        return state
+    }
+
+    package func stateIfPresent(for targetID: ProtocolTarget.ID) -> DOMTargetState? {
+        targetStatesByID[targetID]
+    }
+
+    @discardableResult
+    package func removeState(for targetID: ProtocolTarget.ID) -> DOMTargetState? {
+        targetStatesByID.removeValue(forKey: targetID)
+    }
+
+    package func currentDocument(forTargetID targetID: ProtocolTarget.ID) -> DOMDocument? {
+        targetStatesByID[targetID]?.currentDocument
+    }
+
+    package func currentLoadedDocumentID(for targetID: ProtocolTarget.ID) -> DOMDocument.ID? {
+        guard let document = targetStatesByID[targetID]?.currentDocument,
+              document.lifecycle == .loaded else {
+            return nil
+        }
+        return document.id
+    }
+
+    package func currentDocument(for documentID: DOMDocument.ID) -> DOMDocument? {
+        guard let document = targetStatesByID[documentID.targetID]?.currentDocument,
+              document.id == documentID,
+              document.lifecycle == .loaded else {
+            return nil
+        }
+        return document
+    }
+
+    package func node(for nodeID: DOMNode.ID) -> DOMNode? {
+        currentDocument(for: nodeID.documentID)?.nodesByID[nodeID]
+    }
+
+    package var currentDocuments: [DOMDocument] {
+        targetStatesByID.values.compactMap(\.currentDocument)
+    }
+
+    package func currentNodeIDsByKey() -> [DOMNodeCurrentKey: DOMNode.ID] {
+        Dictionary(uniqueKeysWithValues: targetStatesByID.values.compactMap { state -> [(DOMNodeCurrentKey, DOMNode.ID)]? in
+            guard let document = state.currentDocument else {
+                return nil
+            }
+            guard document.lifecycle == .loaded else {
+                return []
+            }
+            return document.currentNodeIDByProtocolNodeID.map {
+                (DOMNodeCurrentKey(targetID: state.targetID, nodeID: $0.key), $0.value)
+            }
+        }.flatMap { $0 })
+    }
+
+    package func transactions() -> [DOMTransaction] {
+        currentDocuments.flatMap { document in
+            document.transactions.values
+        }
+    }
+
+    package func currentNodeID(targetID: ProtocolTarget.ID, rawNodeID: DOMProtocolNodeID) -> DOMNode.ID? {
+        targetStatesByID[targetID]?.currentDocument?.currentNodeIDByProtocolNodeID[rawNodeID]
+    }
+
+    package func removeTransaction(_ transactionID: DOMTransaction.ID, targetID: ProtocolTarget.ID?) {
+        if let targetID {
+            targetStatesByID[targetID]?.currentDocument?.removeTransaction(transactionID)
+            return
+        }
+        for state in targetStatesByID.values {
+            state.currentDocument?.removeTransaction(transactionID)
+        }
+    }
+
+    package func clearOwnerHydrationTransactions(targetID: ProtocolTarget.ID) {
+        targetStatesByID[targetID]?.currentDocument?.removeOwnerHydrationTransactions()
+    }
+
+    package func targetStateSnapshots(
+        currentDocumentID: (ProtocolTarget.ID) -> DOMDocument.ID?
+    ) -> [ProtocolTarget.ID: DOMTargetStateSnapshot] {
+        targetStatesByID.mapValues { state in
+            DOMTargetStateSnapshot(
+                targetID: state.targetID,
+                currentDocumentID: currentDocumentID(state.targetID),
+                transactionIDs: state.currentDocument.map { Array($0.transactions.keys) } ?? []
+            )
+        }
+    }
+}
+
+package struct FrameDocumentProjection: Equatable, Sendable {
+    package var ownerNodeID: DOMNode.ID?
+    package var frameTargetID: ProtocolTarget.ID
+    package var frameDocumentID: DOMDocument.ID
+    package var state: FrameDocumentProjectionState
+
+    package init(
+        ownerNodeID: DOMNode.ID?,
+        frameTargetID: ProtocolTarget.ID,
+        frameDocumentID: DOMDocument.ID,
+        state: FrameDocumentProjectionState
+    ) {
+        self.ownerNodeID = ownerNodeID
+        self.frameTargetID = frameTargetID
+        self.frameDocumentID = frameDocumentID
+        self.state = state
+    }
+}
+
+@MainActor
+package struct FrameDocumentProjectionIndex {
+    private var projectionsByFrameTargetID: [ProtocolTarget.ID: FrameDocumentProjection]
+
+    package init() {
+        projectionsByFrameTargetID = [:]
+    }
+
+    package var values: Dictionary<ProtocolTarget.ID, FrameDocumentProjection>.Values {
+        projectionsByFrameTargetID.values
+    }
+
+    package var frameTargetIDs: Dictionary<ProtocolTarget.ID, FrameDocumentProjection>.Keys {
+        projectionsByFrameTargetID.keys
+    }
+
+    package subscript(frameTargetID: ProtocolTarget.ID) -> FrameDocumentProjection? {
+        projectionsByFrameTargetID[frameTargetID]
+    }
+
+    package mutating func removeAll() {
+        projectionsByFrameTargetID.removeAll()
+    }
+
+    @discardableResult
+    package mutating func removeValue(forKey frameTargetID: ProtocolTarget.ID) -> FrameDocumentProjection? {
+        projectionsByFrameTargetID.removeValue(forKey: frameTargetID)
+    }
+
+    @discardableResult
+    package mutating func moveProjection(
+        from oldTargetID: ProtocolTarget.ID,
+        to newTargetID: ProtocolTarget.ID
+    ) -> FrameDocumentProjection? {
+        guard var projection = projectionsByFrameTargetID.removeValue(forKey: oldTargetID) else {
+            return nil
+        }
+        projection.frameTargetID = newTargetID
+        projectionsByFrameTargetID[newTargetID] = projection
+        return projection
+    }
+
+    @discardableResult
+    package mutating func setFrameDocument(
+        frameTargetID: ProtocolTarget.ID,
+        frameDocumentID: DOMDocument.ID
+    ) -> FrameDocumentProjection {
+        var projection = projectionsByFrameTargetID[frameTargetID] ?? FrameDocumentProjection(
+            ownerNodeID: nil,
+            frameTargetID: frameTargetID,
+            frameDocumentID: frameDocumentID,
+            state: .pending
+        )
+        projection.frameTargetID = frameTargetID
+        projection.frameDocumentID = frameDocumentID
+        projection.ownerNodeID = nil
+        projection.state = .pending
+        projectionsByFrameTargetID[frameTargetID] = projection
+        return projection
+    }
+
+    package mutating func attach(frameTargetID: ProtocolTarget.ID, to ownerNodeID: DOMNode.ID) {
+        guard var projection = projectionsByFrameTargetID[frameTargetID] else {
+            return
+        }
+        projection.ownerNodeID = ownerNodeID
+        projection.state = .attached
+        projectionsByFrameTargetID[frameTargetID] = projection
+    }
+
+    package mutating func detach(
+        frameTargetID: ProtocolTarget.ID,
+        state: FrameDocumentProjectionState = .pending
+    ) {
+        guard var projection = projectionsByFrameTargetID[frameTargetID] else {
+            return
+        }
+        projection.ownerNodeID = nil
+        projection.state = state
+        projectionsByFrameTargetID[frameTargetID] = projection
+    }
+
+    package func projectedFrameDocumentRootID(
+        forOwnerNodeID ownerNodeID: DOMNode.ID,
+        documentProvider: (DOMDocument.ID) -> DOMDocument?
+    ) -> DOMNode.ID? {
+        for projection in projectionsByFrameTargetID.values
+            where projection.ownerNodeID == ownerNodeID && projection.state == .attached {
+            guard let document = documentProvider(projection.frameDocumentID) else {
+                continue
+            }
+            return document.rootNodeID
+        }
+        return nil
+    }
+
+    package func ownerKeys(
+        inSubtree rootID: DOMNode.ID,
+        nodeProvider: (DOMNode.ID) -> DOMNode?
+    ) -> [ProtocolTarget.ID: DOMNodeCurrentKey] {
+        var keys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
+        var stack = [rootID]
+        while let nodeID = stack.popLast() {
+            guard let node = nodeProvider(nodeID) else {
+                continue
+            }
+            for projection in projectionsByFrameTargetID.values where projection.ownerNodeID == nodeID {
+                keys[projection.frameTargetID] = DOMNodeCurrentKey(
+                    targetID: nodeID.documentID.targetID,
+                    nodeID: node.protocolNodeID
+                )
+            }
+            stack.append(contentsOf: node.protocolOwnedChildren)
+        }
+        return keys
+    }
+
+    package func snapshots() -> [ProtocolTarget.ID: FrameDocumentProjectionSnapshot] {
+        projectionsByFrameTargetID.mapValues { projection in
+            FrameDocumentProjectionSnapshot(
+                ownerNodeID: projection.ownerNodeID,
+                frameTargetID: projection.frameTargetID,
+                frameDocumentID: projection.frameDocumentID,
+                state: projection.state
+            )
+        }
+    }
+}
+
+@MainActor
+package struct DOMTreeProjectionBuilder {
+    package typealias NodeProvider = @MainActor (DOMNode.ID) -> DOMNode?
+    package typealias FrameDocumentRootResolver = @MainActor (DOMNode.ID) -> DOMNode.ID?
+
+    private let rootDocument: DOMDocument
+    private let selectedNodeID: DOMNode.ID?
+    private let nodeProvider: NodeProvider
+    private let frameDocumentRootResolver: FrameDocumentRootResolver
+
+    package init(
+        rootDocument: DOMDocument,
+        selectedNodeID: DOMNode.ID?,
+        nodeProvider: @escaping NodeProvider,
+        frameDocumentRootResolver: @escaping FrameDocumentRootResolver
+    ) {
+        self.rootDocument = rootDocument
+        self.selectedNodeID = selectedNodeID
+        self.nodeProvider = nodeProvider
+        self.frameDocumentRootResolver = frameDocumentRootResolver
+    }
+
+    package func build() -> DOMTreeProjection {
+        var rows: [DOMTreeRow] = []
+        var childrenByNodeID: [DOMNode.ID: [DOMNode.ID]] = [:]
+        var parentByNodeID: [DOMNode.ID: DOMNode.ID] = [:]
+        var visited = Set<DOMNode.ID>()
+
+        append(
+            rootDocument.rootNodeID,
+            depth: 0,
+            rows: &rows,
+            childrenByNodeID: &childrenByNodeID,
+            parentByNodeID: &parentByNodeID,
+            visited: &visited
+        )
+
+        return DOMTreeProjection(
+            rows: rows,
+            rootNodeIDs: [rootDocument.rootNodeID],
+            childrenByNodeID: childrenByNodeID,
+            parentByNodeID: parentByNodeID
+        )
+    }
+
+    package static func visibleChildIDs(
+        of node: DOMNode,
+        frameDocumentRootResolver: FrameDocumentRootResolver
+    ) -> [DOMNode.ID] {
+        var children: [DOMNode.ID] = []
+        if let templateContentID = node.templateContentID {
+            children.append(templateContentID)
+        }
+        if let beforePseudoElementID = node.beforePseudoElementID {
+            children.append(beforePseudoElementID)
+        }
+        children.append(contentsOf: node.otherPseudoElementIDs)
+        children.append(contentsOf: effectiveChildIDs(of: node, frameDocumentRootResolver: frameDocumentRootResolver))
+        if let afterPseudoElementID = node.afterPseudoElementID {
+            children.append(afterPseudoElementID)
+        }
+        return children
+    }
+
+    private static func effectiveChildIDs(
+        of node: DOMNode,
+        frameDocumentRootResolver: FrameDocumentRootResolver
+    ) -> [DOMNode.ID] {
+        if node.isFrameOwner,
+           let rootNodeID = frameDocumentRootResolver(node.id) {
+            return [rootNodeID]
+        }
+        if let contentDocumentID = node.contentDocumentID {
+            return [contentDocumentID]
+        }
+        return node.shadowRootIDs + node.regularChildren.loadedChildren
+    }
+
+    private func append(
+        _ nodeID: DOMNode.ID,
+        depth: Int,
+        rows: inout [DOMTreeRow],
+        childrenByNodeID: inout [DOMNode.ID: [DOMNode.ID]],
+        parentByNodeID: inout [DOMNode.ID: DOMNode.ID],
+        visited: inout Set<DOMNode.ID>
+    ) {
+        guard visited.insert(nodeID).inserted,
+              let node = nodeProvider(nodeID) else {
+            return
+        }
+        let visibleChildren = Self.visibleChildIDs(
+            of: node,
+            frameDocumentRootResolver: frameDocumentRootResolver
+        )
+        childrenByNodeID[nodeID] = visibleChildren
+        rows.append(
+            DOMTreeRow(
+                nodeID: nodeID,
+                depth: depth,
+                nodeName: node.nodeName,
+                isSelected: selectedNodeID == nodeID,
+                hasVisibleChildren: !visibleChildren.isEmpty || node.regularChildren.knownCount > 0
+            )
+        )
+        for childID in visibleChildren {
+            parentByNodeID[childID] = nodeID
+            append(
+                childID,
+                depth: depth + 1,
+                rows: &rows,
+                childrenByNodeID: &childrenByNodeID,
+                parentByNodeID: &parentByNodeID,
+                visited: &visited
+            )
+        }
+    }
+}

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -65,11 +65,67 @@ package enum ProtocolTargetKind: Equatable, Sendable {
     }
 }
 
+package struct ProtocolTargetCapabilities: OptionSet, Equatable, Sendable {
+    package let rawValue: UInt8
+
+    package init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    package static let dom = Self(rawValue: 1 << 0)
+    package static let runtime = Self(rawValue: 1 << 1)
+    package static let target = Self(rawValue: 1 << 2)
+    package static let inspector = Self(rawValue: 1 << 3)
+    package static let network = Self(rawValue: 1 << 4)
+
+    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network]
+    package static let frameDefault: Self = []
+    package static let workerDefault: Self = [.runtime]
+    package static let serviceWorkerDefault: Self = [.runtime, .network]
+
+    package static func protocolDefault(for kind: ProtocolTargetKind) -> Self {
+        switch kind {
+        case .page:
+            return .pageDefault
+        case .frame:
+            return .frameDefault
+        case .worker:
+            return .workerDefault
+        case .serviceWorker:
+            return .serviceWorkerDefault
+        case .other:
+            return []
+        }
+    }
+
+    package init(domainNames: [String]) {
+        var capabilities: Self = []
+        for domainName in domainNames {
+            switch domainName.lowercased() {
+            case "dom":
+                capabilities.insert(.dom)
+            case "runtime":
+                capabilities.insert(.runtime)
+            case "target":
+                capabilities.insert(.target)
+            case "inspector":
+                capabilities.insert(.inspector)
+            case "network":
+                capabilities.insert(.network)
+            default:
+                break
+            }
+        }
+        self = capabilities
+    }
+}
+
 package struct ProtocolTargetRecord: Equatable, Sendable {
     package var id: ProtocolTargetIdentifier
     package var kind: ProtocolTargetKind
     package var frameID: DOMFrameIdentifier?
     package var parentFrameID: DOMFrameIdentifier?
+    package var capabilities: ProtocolTargetCapabilities
     package var isProvisional: Bool
     package var isPaused: Bool
 
@@ -78,6 +134,7 @@ package struct ProtocolTargetRecord: Equatable, Sendable {
         kind: ProtocolTargetKind,
         frameID: DOMFrameIdentifier? = nil,
         parentFrameID: DOMFrameIdentifier? = nil,
+        capabilities: ProtocolTargetCapabilities = [],
         isProvisional: Bool = false,
         isPaused: Bool = false
     ) {
@@ -85,6 +142,7 @@ package struct ProtocolTargetRecord: Equatable, Sendable {
         self.kind = kind
         self.frameID = frameID
         self.parentFrameID = parentFrameID
+        self.capabilities = capabilities
         self.isProvisional = isProvisional
         self.isPaused = isPaused
     }

--- a/Sources/WebInspectorRuntime/DomainEventPump.swift
+++ b/Sources/WebInspectorRuntime/DomainEventPump.swift
@@ -11,6 +11,10 @@ package final class DomainEventPump {
         appliedSequence = 0
     }
 
+    deinit {
+        task?.cancel()
+    }
+
     package func start(
         stream: AsyncStream<ProtocolEventEnvelope>,
         apply: @escaping @MainActor @Sendable (ProtocolEventEnvelope) async -> Void

--- a/Sources/WebInspectorRuntime/DomainEventPump.swift
+++ b/Sources/WebInspectorRuntime/DomainEventPump.swift
@@ -3,18 +3,11 @@ import WebInspectorTransport
 @MainActor
 package final class DomainEventPump {
     private var task: Task<Void, Never>?
-    private var nextWaiterID: UInt64
-    private var waiters: [UInt64: (sequence: UInt64, promise: ReplyPromise<Void>)]
 
     package private(set) var appliedSequence: UInt64
-    package var pendingWaiterCount: Int {
-        waiters.count
-    }
 
     package init() {
         task = nil
-        nextWaiterID = 0
-        waiters = [:]
         appliedSequence = 0
     }
 
@@ -37,55 +30,9 @@ package final class DomainEventPump {
     package func stop() {
         task?.cancel()
         task = nil
-        let pendingWaiters = waiters.values.map(\.promise)
-        waiters.removeAll()
-        for promise in pendingWaiters {
-            Task {
-                await promise.fulfill(.success(()))
-            }
-        }
-    }
-
-    package func waitUntilApplied(_ sequence: UInt64, timeout: Duration? = nil) async {
-        guard sequence > appliedSequence else {
-            return
-        }
-
-        nextWaiterID &+= 1
-        let waiterID = nextWaiterID
-        let promise = ReplyPromise<Void>()
-        waiters[waiterID] = (sequence, promise)
-        let timeoutTask: Task<Void, Never>? = timeout.map { timeout in
-            Task {
-                do {
-                    try await Task.sleep(for: timeout)
-                } catch {
-                    return
-                }
-                await promise.fulfill(.success(()))
-            }
-        }
-        defer {
-            timeoutTask?.cancel()
-            waiters.removeValue(forKey: waiterID)
-        }
-        do {
-            try await promise.value()
-        } catch {
-            return
-        }
     }
 
     private func markApplied(_ sequence: UInt64) {
         appliedSequence = max(appliedSequence, sequence)
-        let readyWaiters = waiters.filter { $0.value.sequence <= appliedSequence }
-        for waiterID in readyWaiters.keys {
-            waiters.removeValue(forKey: waiterID)
-        }
-        for waiter in readyWaiters.values {
-            Task {
-                await waiter.promise.fulfill(.success(()))
-            }
-        }
     }
 }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -261,6 +261,7 @@ package final class InspectorSession {
             pendingConnection = nil
             connection = nextConnection
             isAttached = true
+            startDOMDocumentRequestsForAttachedFrameTargets()
             lastError = nil
         } catch {
             guard connection === nextConnection || pendingConnection === nextConnection else {
@@ -737,6 +738,15 @@ package final class InspectorSession {
         }
     }
 
+    private func startDOMDocumentRequestsForAttachedFrameTargets() {
+        for target in dom.snapshot().targetsByID.values
+        where target.kind == .frame
+            && target.capabilities.contains(.dom)
+            && target.currentDocumentID == nil {
+            startDOMDocumentRequest(targetID: target.id, reason: "attachedFrameTarget")
+        }
+    }
+
     private func handleDOMEvent(_ event: ProtocolEventEnvelope) async {
         do {
             if let inspectEvent = try DOMTransportAdapter.inspectEvent(from: event) {
@@ -1018,7 +1028,7 @@ package final class InspectorSession {
     }
 
     private func refreshDOMDocumentAfterBackendUpdate(_ event: ProtocolEventEnvelope) {
-        guard let targetID = event.targetID,
+        guard let targetID = event.targetID ?? dom.currentPageTargetID,
               dom.currentDocumentID(for: targetID) != nil || dom.currentPageTargetID == targetID else {
             return
         }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -167,6 +167,7 @@ package final class InspectorSession {
     @ObservationIgnored private var pendingConnection: InspectorConnection?
     @ObservationIgnored private var highlightedDOMTargetID: ProtocolTargetIdentifier?
     @ObservationIgnored private var elementPickerTargetID: ProtocolTargetIdentifier?
+    @ObservationIgnored private var elementPickerGeneration: UInt64
     @ObservationIgnored private weak var deleteUndoManager: UndoManager?
     @ObservationIgnored private var deleteUndoStates: [DOMDeleteUndoState]
     @ObservationIgnored private let deleteUndoOperationQueue: DOMDeleteUndoOperationQueue
@@ -187,6 +188,7 @@ package final class InspectorSession {
         pendingConnection = nil
         highlightedDOMTargetID = nil
         elementPickerTargetID = nil
+        elementPickerGeneration = 0
         deleteUndoManager = nil
         deleteUndoStates = []
         deleteUndoOperationQueue = DOMDeleteUndoOperationQueue()
@@ -373,6 +375,7 @@ package final class InspectorSession {
             await cancelElementPicker()
         }
 
+        elementPickerGeneration &+= 1
         elementPickerTargetID = targetID
         isSelectingElement = true
 
@@ -734,8 +737,11 @@ package final class InspectorSession {
                 startPageTargetDocumentRequestAfterCommit(targetID: targetID, connection: connection)
             }
             if event.method == "Target.didCommitProvisionalTarget",
-               let committedTargetID = targetCommittedID(from: event) {
-                startFrameTargetDocumentRequestAfterCommit(targetID: committedTargetID)
+               let committedTarget = targetCommittedParams(from: event) {
+                if let oldTargetID = committedTarget.oldTargetId {
+                    cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
+                }
+                startFrameTargetDocumentRequestAfterCommit(targetID: committedTarget.newTargetId)
             }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -793,6 +799,7 @@ package final class InspectorSession {
                 try await perform(intent)
             } catch {
                 InspectorRuntimeLog.warning("frameOwnerHydration.failed intent=\(intent) error=\(error)")
+                clearOwnerHydrationTransaction(for: intent)
                 lastError = InspectorSessionError(String(describing: error))
             }
         }
@@ -807,9 +814,13 @@ package final class InspectorSession {
             )
             return
         }
+        let pickerGeneration = elementPickerGeneration
         do {
             try await resolvePickerSelection(event, activeTargetID: activeTargetID)
         } catch {
+            guard isCurrentElementPicker(generation: pickerGeneration, targetID: activeTargetID) else {
+                return
+            }
             recordElementPickerFailure(
                 reason: "selectionResolveFailed",
                 targetID: activeTargetID,
@@ -818,7 +829,7 @@ package final class InspectorSession {
             lastError = InspectorSessionError(String(describing: error))
         }
 
-        await completeElementPicker()
+        await completeElementPicker(generation: pickerGeneration, targetID: activeTargetID)
     }
 
     private func resolvePickerSelection(
@@ -919,6 +930,7 @@ package final class InspectorSession {
     }
 
     private func clearElementPickerState(invalidatePendingSelection: Bool = false) {
+        elementPickerGeneration &+= 1
         elementPickerTargetID = nil
         isSelectingElement = false
         if invalidatePendingSelection {
@@ -943,11 +955,16 @@ package final class InspectorSession {
         InspectorRuntimeLog.warning(message)
     }
 
-    private func completeElementPicker() async {
-        let targetID = elementPickerTargetID ?? dom.currentPageTargetID
+    private func isCurrentElementPicker(generation: UInt64, targetID: ProtocolTargetIdentifier) -> Bool {
+        isSelectingElement && elementPickerGeneration == generation && elementPickerTargetID == targetID
+    }
+
+    private func completeElementPicker(generation: UInt64, targetID: ProtocolTargetIdentifier) async {
+        guard isCurrentElementPicker(generation: generation, targetID: targetID) else {
+            return
+        }
         clearElementPickerState()
-        guard let targetID,
-              let intent = dom.setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
+        guard let intent = dom.setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
             return
         }
         do {
@@ -1080,7 +1097,7 @@ package final class InspectorSession {
         return params.targetId
     }
 
-    private func targetCommittedID(from event: ProtocolEventEnvelope) -> ProtocolTargetIdentifier? {
+    private func targetCommittedParams(from event: ProtocolEventEnvelope) -> TargetCommittedEventParams? {
         guard event.method == "Target.didCommitProvisionalTarget",
               let params = try? TransportMessageParser.decode(
                   TargetCommittedEventParams.self,
@@ -1088,7 +1105,14 @@ package final class InspectorSession {
               ) else {
             return nil
         }
-        return params.newTargetId
+        return params
+    }
+
+    private func clearOwnerHydrationTransaction(for intent: DOMCommandIntent) {
+        guard case let .requestChildNodes(targetID, _, _) = intent else {
+            return
+        }
+        dom.clearOwnerHydrationTransactions(targetID: targetID)
     }
 
     private func shouldIgnoreFrameDocumentRequestError(_ error: any Error) -> Bool {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1206,19 +1206,14 @@ package final class InspectorSession {
         }
     }
 
-    package static func prepareInspectability(for webView: WKWebView) -> Bool? {
-        guard #available(iOS 16.4, macOS 13.3, *) else {
-            return nil
-        }
-
+    package static func prepareInspectability(for webView: WKWebView) -> Bool {
         let originalValue = webView.isInspectable
         webView.isInspectable = true
         return originalValue
     }
 
     package static func restoreInspectabilityIfNeeded(on webView: WKWebView, originalValue: Bool?) {
-        guard #available(iOS 16.4, macOS 13.3, *),
-              let originalValue else {
+        guard let originalValue else {
             return
         }
         webView.isInspectable = originalValue

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -733,6 +733,10 @@ package final class InspectorSession {
                let connection {
                 startPageTargetDocumentRequestAfterCommit(targetID: targetID, connection: connection)
             }
+            if event.method == "Target.didCommitProvisionalTarget",
+               let committedTargetID = targetCommittedID(from: event) {
+                startFrameTargetDocumentRequestAfterCommit(targetID: committedTargetID)
+            }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
         }
@@ -745,6 +749,17 @@ package final class InspectorSession {
             && target.currentDocumentID == nil {
             startDOMDocumentRequest(targetID: target.id, reason: "attachedFrameTarget")
         }
+    }
+
+    private func startFrameTargetDocumentRequestAfterCommit(targetID: ProtocolTargetIdentifier) {
+        guard isAttached,
+              let target = dom.snapshot().targetsByID[targetID],
+              target.kind == .frame,
+              target.capabilities.contains(.dom),
+              target.currentDocumentID == nil else {
+            return
+        }
+        startDOMDocumentRequest(targetID: targetID, reason: "frameTargetCommit")
     }
 
     private func handleDOMEvent(_ event: ProtocolEventEnvelope) async {
@@ -1063,6 +1078,17 @@ package final class InspectorSession {
             return nil
         }
         return params.targetId
+    }
+
+    private func targetCommittedID(from event: ProtocolEventEnvelope) -> ProtocolTargetIdentifier? {
+        guard event.method == "Target.didCommitProvisionalTarget",
+              let params = try? TransportMessageParser.decode(
+                  TargetCommittedEventParams.self,
+                  from: event.paramsData
+              ) else {
+            return nil
+        }
+        return params.newTargetId
     }
 
     private func shouldIgnoreFrameDocumentRequestError(_ error: any Error) -> Bool {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1,28 +1,25 @@
 import Foundation
 import Observation
+import OSLog
 import Synchronization
 import WebKit
 import WebInspectorCore
 import WebInspectorTransport
 
-#if DEBUG
-private func inspectorRuntimeTrace(_ message: @autoclosure () -> String) {}
+private enum InspectorRuntimeLog {
+    private static let logger = Logger(
+        subsystem: "com.lynnswap.WebInspectorKit",
+        category: "Runtime"
+    )
 
-private func inspectorRuntimeFailureTrace(_ message: @autoclosure () -> String) {
-    print("[WebInspectorRuntime.Failure] \(message())")
+    static func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+    }
+
+    static func warning(_ message: String) {
+        logger.warning("\(message, privacy: .public)")
+    }
 }
-
-private func inspectorRuntimeDOMTrace(_ message: @autoclosure () -> String) {
-    print("[WebInspectorRuntime.DOM] \(message())")
-}
-
-private func inspectorRuntimeVerboseTrace(_ message: @autoclosure () -> String) {}
-#else
-private func inspectorRuntimeTrace(_ message: @autoclosure () -> String) {}
-private func inspectorRuntimeFailureTrace(_ message: @autoclosure () -> String) {}
-private func inspectorRuntimeDOMTrace(_ message: @autoclosure () -> String) {}
-private func inspectorRuntimeVerboseTrace(_ message: @autoclosure () -> String) {}
-#endif
 
 package struct InspectorSessionError: Error, Equatable, Sendable, CustomStringConvertible {
     package var message: String
@@ -111,61 +108,6 @@ private struct TargetDestroyedEventParams: Decodable {
 private struct TargetCommittedEventParams: Decodable {
     var oldTargetId: ProtocolTargetIdentifier?
     var newTargetId: ProtocolTargetIdentifier
-}
-
-private struct DOMGetDocumentTracePayload: Decodable {
-    var root: DOMNodeTracePayload
-}
-
-private struct DOMNodeTracePayload: Decodable {
-    var nodeId: Int?
-    var nodeName: String?
-    var documentURL: String?
-    var baseURL: String?
-    var childNodeCount: Int?
-    var children: [DOMNodeTracePayload]?
-
-    var summary: String {
-        let name = nodeName ?? "?"
-        let id = nodeId.map(String.init) ?? "?"
-        let url = documentURL.map { " url=\(shortTraceValue($0))" } ?? ""
-        let base = baseURL.map { " base=\(shortTraceValue($0))" } ?? ""
-        let count = childNodeCount.map { " count=\($0)" } ?? ""
-        let childSummary = (children ?? [])
-            .prefix(4)
-            .map(\.shallowSummary)
-            .joined(separator: ",")
-        if childSummary.isEmpty {
-            return "\(name)#\(id)\(url)\(base)\(count)"
-        }
-        return "\(name)#\(id)\(url)\(base)\(count)[\(childSummary)]"
-    }
-
-    private var shallowSummary: String {
-        let name = nodeName ?? "?"
-        let id = nodeId.map(String.init) ?? "?"
-        let count = childNodeCount.map { " count=\($0)" } ?? ""
-        let childSummary = (children ?? [])
-            .prefix(4)
-            .map { child in
-                let childName = child.nodeName ?? "?"
-                let childID = child.nodeId.map(String.init) ?? "?"
-                let childCount = child.childNodeCount.map { " count=\($0)" } ?? ""
-                return "\(childName)#\(childID)\(childCount)"
-            }
-            .joined(separator: ",")
-        if childSummary.isEmpty {
-            return "\(name)#\(id)\(count)"
-        }
-        return "\(name)#\(id)\(count)[\(childSummary)]"
-    }
-}
-
-private func shortTraceValue(_ value: String, limit: Int = 160) -> String {
-    guard value.count > limit else {
-        return value
-    }
-    return "\(value.prefix(limit))..."
 }
 
 @MainActor
@@ -408,9 +350,6 @@ package final class InspectorSession {
 
     package func cancelElementPicker() async {
         let targetID = elementPickerTargetID ?? dom.currentPageTargetID
-        if isSelectingElement {
-            inspectorRuntimeTrace("picker.cancel target=\(targetID?.rawValue ?? "nil")")
-        }
         clearElementPickerState(invalidatePendingSelection: true)
         guard let targetID,
               let intent = dom.setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
@@ -493,7 +432,6 @@ package final class InspectorSession {
         }
 
         do {
-            inspectorRuntimeTrace("documentEnsure.request target=\(targetID.rawValue)")
             try await reloadDOMDocument(targetID: targetID)
             return dom.currentPageRootNode != nil
         } catch is CancellationError {
@@ -502,7 +440,6 @@ package final class InspectorSession {
                 return dom.currentPageRootNode != nil
             }
             do {
-                inspectorRuntimeTrace("documentEnsure.retry target=\(targetID.rawValue)")
                 try await reloadDOMDocument(targetID: targetID)
                 return dom.currentPageRootNode != nil
             } catch {
@@ -533,15 +470,13 @@ package final class InspectorSession {
         let connection = try activeConnection()
         let transport = connection.transport
         let command = try DOMTransportAdapter.command(for: intent)
-        traceCommandSend(command)
         let result: ProtocolCommandResult
         do {
             result = try await transport.send(command)
         } catch {
-            inspectorRuntimeFailureTrace("command.error method=\(command.method) routing=\(command.routing) error=\(error)")
+            InspectorRuntimeLog.error("command.error method=\(command.method) routing=\(command.routing) error=\(error)")
             throw error
         }
-        traceCommandReply(command, result: result)
         try ensureCurrentConnection(connection)
 
         switch intent {
@@ -554,12 +489,10 @@ package final class InspectorSession {
                 to: dom
             )
             switch selectionResult {
-            case let .resolved(nodeID):
-                inspectorRuntimeVerboseTrace("requestNode.select success target=\(targetID.rawValue) node=\(nodeID.nodeID.rawValue) document=\(nodeID.documentID)")
-            case let .pending(key):
-                inspectorRuntimeTrace("requestNode.select pending target=\(targetID.rawValue) node=\(key.nodeID.rawValue) reason=awaiting-setChildNodes")
+            case .resolved, .pending:
+                break
             case let .failed(failure):
-                inspectorRuntimeFailureTrace("requestNode.selectFailure target=\(targetID.rawValue) failure=\(failure)")
+                InspectorRuntimeLog.warning("requestNode.selectFailure target=\(targetID.rawValue) failure=\(failure)")
                 lastError = InspectorSessionError(String(describing: failure))
             }
         case .requestChildNodes:
@@ -652,7 +585,6 @@ package final class InspectorSession {
     }
 
     private func bootstrap(mainTargetID: ProtocolTargetIdentifier, connection: InspectorConnection) async throws {
-        inspectorRuntimeDOMTrace("bootstrap.start target=\(mainTargetID.rawValue)")
         _ = try await sendTargetCommand(domain: .inspector, method: "Inspector.enable", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
         _ = try await sendTargetCommand(domain: .inspector, method: "Inspector.initialized", targetID: mainTargetID, connection: connection)
@@ -675,7 +607,6 @@ package final class InspectorSession {
         )
         try ensureCurrentConnection(connection)
         connection.bootstrappedTargetIDs.insert(mainTargetID)
-        inspectorRuntimeDOMTrace("bootstrap.done target=\(mainTargetID.rawValue)")
     }
 
     private func sendTargetCommand(
@@ -704,10 +635,6 @@ package final class InspectorSession {
     }
 
     private func handleProtocolEvent(_ event: ProtocolEventEnvelope) async {
-        traceEvent(event, phase: "begin")
-        defer {
-            traceEvent(event, phase: "end")
-        }
         switch event.domain {
         case .target:
             await handleTargetEvent(event)
@@ -733,7 +660,6 @@ package final class InspectorSession {
             guard let inspectEvent = try DOMTransportAdapter.inspectEvent(from: event) else {
                 return
             }
-            inspectorRuntimeVerboseTrace("inspect.event seq=\(event.sequence) target=\(event.targetID?.rawValue ?? "nil") activePicker=\(elementPickerTargetID?.rawValue ?? "nil") selecting=\(isSelectingElement)")
             await handleInspectEvent(inspectEvent)
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -752,14 +678,7 @@ package final class InspectorSession {
                let createdTarget,
                createdTarget.kind == .frame {
                 if createdTarget.capabilities.contains(.dom) {
-                    inspectorRuntimeDOMTrace(
-                        "frameTarget.created action=getDocument target=\(createdTarget.id.rawValue) frame=\(createdTarget.frameID?.rawValue ?? "nil") parentFrame=\(createdTarget.parentFrameID?.rawValue ?? "nil") caps=\(createdTarget.capabilities.rawValue)"
-                    )
                     startDOMDocumentRequest(targetID: createdTarget.id, reason: "frameTargetCreated")
-                } else {
-                    inspectorRuntimeTrace(
-                        "frameTarget.created action=skipNoDOM target=\(createdTarget.id.rawValue) frame=\(createdTarget.frameID?.rawValue ?? "nil") parentFrame=\(createdTarget.parentFrameID?.rawValue ?? "nil") caps=\(createdTarget.capabilities.rawValue)"
-                    )
                 }
             }
             if event.method == "Target.didCommitProvisionalTarget",
@@ -796,7 +715,6 @@ package final class InspectorSession {
         guard let intent = dom.pendingFrameOwnerHydrationIntent(issuedSequence: currentAppliedDOMSequence) else {
             return
         }
-        inspectorRuntimeDOMTrace("frameOwnerHydration.perform intent=\(intent)")
         Task { @MainActor [weak self] in
             guard let self else {
                 return
@@ -804,7 +722,7 @@ package final class InspectorSession {
             do {
                 try await perform(intent)
             } catch {
-                inspectorRuntimeFailureTrace("frameOwnerHydration.failed intent=\(intent) error=\(error)")
+                InspectorRuntimeLog.warning("frameOwnerHydration.failed intent=\(intent) error=\(error)")
                 lastError = InspectorSessionError(String(describing: error))
             }
         }
@@ -839,7 +757,6 @@ package final class InspectorSession {
     ) async throws {
         switch inspectRoute(for: event, activeTargetID: activeTargetID) {
         case let .remoteObject(targetID, objectID):
-            inspectorRuntimeVerboseTrace("inspect.route remoteObject target=\(targetID.rawValue) object=\(objectID) hasDocument=\(dom.currentDocumentID(for: targetID) != nil)")
             if dom.currentDocumentID(for: targetID) == nil {
                 try await reloadDOMDocument(targetID: targetID)
             }
@@ -858,7 +775,6 @@ package final class InspectorSession {
                 throw InspectorSessionError("DOM.requestNode could not be issued: \(failure)")
             }
         case let .protocolNode(targetID, nodeID):
-            inspectorRuntimeVerboseTrace("inspect.route protocolNode target=\(targetID.rawValue) node=\(nodeID.rawValue)")
             let result = dom.selectProtocolNode(targetID: targetID, nodeID: nodeID)
             if case let .failure(failure) = result {
                 guard case .unresolvedNode = failure else {
@@ -897,11 +813,6 @@ package final class InspectorSession {
         if let executionContextID = remoteObject.injectedScriptID,
            let targetID = dom.snapshot().executionContextsByID[executionContextID]?.targetID {
             return targetID
-        }
-        if let executionContextID = remoteObject.injectedScriptID {
-            inspectorRuntimeTrace(
-                "inspect.routeFallback reason=unknownExecutionContext injectedScriptID=\(executionContextID.rawValue) eventTarget=\(eventTargetID?.rawValue ?? "nil") activeTarget=\(activeTargetID.rawValue)"
-            )
         }
         return eventTargetID ?? activeTargetID
     }
@@ -959,7 +870,7 @@ package final class InspectorSession {
         if !details.isEmpty {
             message += " \(details)"
         }
-        inspectorRuntimeFailureTrace(message)
+        InspectorRuntimeLog.warning(message)
     }
 
     private func completeElementPicker() async {
@@ -996,21 +907,14 @@ package final class InspectorSession {
         if force {
             cancelDOMDocumentRequest(targetID: targetID, reason: "force-\(reason)")
         } else if let activeHandle = domDocumentRequestHandlesByTargetID[targetID] {
-            inspectorRuntimeTrace("documentRequest.pending target=\(targetID.rawValue) reason=active-request caller=\(reason)")
             return activeHandle
         }
         guard let intent = dom.getDocumentIntent(targetID: targetID) else {
-            inspectorRuntimeDOMTrace(
-                "getDocument.skip target=\(targetID.rawValue) reason=noDOMCapability kind=\(String(describing: dom.targetKind(for: targetID)))"
-            )
             return nil
         }
 
         let targetKind = dom.targetKind(for: targetID)
         let handle = DOMDocumentRequestHandle(targetID: targetID, targetKind: targetKind)
-        inspectorRuntimeDOMTrace(
-            "getDocument.start target=\(targetID.rawValue) kind=\(String(describing: targetKind)) reason=\(reason)"
-        )
         let task = Task { @MainActor [weak self] in
             guard let self else {
                 return
@@ -1023,26 +927,21 @@ package final class InspectorSession {
             do {
                 let connection = try activeConnection()
                 let command = try DOMTransportAdapter.command(for: intent)
-                traceCommandSend(command)
                 let result = try await connection.transport.send(command)
                 try Task.checkCancellation()
                 try ensureCurrentConnection(connection)
-                traceCommandReply(command, result: result)
                 guard domDocumentRequestHandlesByTargetID[targetID] === handle else {
-                    inspectorRuntimeDOMTrace("getDocument.dropReply target=\(targetID.rawValue) reason=request-gate-reset")
                     return
                 }
                 try applyGetDocumentResult(result)
                 lastError = nil
             } catch is CancellationError {
-                inspectorRuntimeDOMTrace("getDocument.cancelled target=\(targetID.rawValue) reason=\(reason)")
                 throw CancellationError()
             } catch {
                 if handle.targetKind == .frame, shouldIgnoreFrameDocumentRequestError(error) {
-                    inspectorRuntimeDOMTrace("getDocument.frameDrop target=\(targetID.rawValue) reason=\(reason) error=\(error)")
                     return
                 }
-                inspectorRuntimeFailureTrace("getDocument.failed target=\(targetID.rawValue) reason=\(reason) error=\(error)")
+                InspectorRuntimeLog.error("getDocument.failed target=\(targetID.rawValue) reason=\(reason) error=\(error)")
                 lastError = InspectorSessionError(String(describing: error))
                 throw error
             }
@@ -1076,15 +975,12 @@ package final class InspectorSession {
     private func refreshDOMDocumentAfterBackendUpdate(_ event: ProtocolEventEnvelope) {
         guard let targetID = event.targetID,
               dom.currentDocumentID(for: targetID) != nil || dom.currentPageTargetID == targetID else {
-            inspectorRuntimeTrace("documentUpdated.drop seq=\(event.sequence) target=\(event.targetID?.rawValue ?? "nil") currentPage=\(dom.currentPageTargetID?.rawValue ?? "nil")")
             return
         }
         let targetKind = dom.targetKind(for: targetID)
-        inspectorRuntimeTrace("documentUpdated.invalidate seq=\(event.sequence) target=\(targetID.rawValue) kind=\(String(describing: targetKind)) currentDocument=\(String(describing: dom.currentDocumentID(for: targetID)))")
         cancelDOMDocumentRequest(targetID: targetID, reason: "documentUpdated")
         dom.invalidateDocument(targetID: targetID)
         if targetKind == .frame {
-            inspectorRuntimeTrace("documentUpdated.requestFrame target=\(targetID.rawValue)")
             startDOMDocumentRequest(targetID: targetID, force: true, reason: "frameDocumentUpdated")
         }
     }
@@ -1093,13 +989,11 @@ package final class InspectorSession {
         guard let handle = domDocumentRequestHandlesByTargetID.removeValue(forKey: targetID) else {
             return
         }
-        inspectorRuntimeTrace("documentRequest.cancel target=\(targetID.rawValue) reason=\(reason)")
         handle.task?.cancel()
     }
 
     private func cancelDOMDocumentRequests() {
-        for (targetID, handle) in domDocumentRequestHandlesByTargetID {
-            inspectorRuntimeTrace("documentRequest.cancel target=\(targetID.rawValue) reason=session-reset")
+        for handle in domDocumentRequestHandlesByTargetID.values {
             handle.task?.cancel()
         }
         domDocumentRequestHandlesByTargetID.removeAll()
@@ -1134,14 +1028,11 @@ package final class InspectorSession {
 
     private func applyGetDocumentResult(_ result: ProtocolCommandResult) throws {
         guard let targetID = result.targetID else {
-            inspectorRuntimeTrace("getDocument.drop reason=missing-target")
             return
         }
         guard dom.targetKind(for: targetID) != nil else {
-            inspectorRuntimeTrace("getDocument.drop target=\(targetID.rawValue) reason=missing-target-kind")
             return
         }
-        traceGetDocumentResult(result)
         try DOMTransportAdapter.applyGetDocumentResult(result, to: dom)
         startPendingFrameOwnerHydration()
         lastError = nil
@@ -1313,40 +1204,6 @@ package final class InspectorSession {
         guard connection === candidate || pendingConnection === candidate else {
             throw TransportError.transportClosed
         }
-    }
-
-    private func traceCommandSend(_ command: ProtocolCommand) {
-        switch command.method {
-        case "DOM.getDocument", "DOM.requestNode":
-            inspectorRuntimeTrace("command.send method=\(command.method) routing=\(command.routing) appliedSeq=\(currentAppliedDOMSequence)")
-        default:
-            break
-        }
-    }
-
-    private func traceCommandReply(_ command: ProtocolCommand, result: ProtocolCommandResult) {
-        switch command.method {
-        case "DOM.getDocument", "DOM.requestNode":
-            inspectorRuntimeTrace("command.reply method=\(command.method) target=\(result.targetID?.rawValue ?? "nil") replySeq=\(result.receivedSequence) domSeq=\(result.receivedSequence(for: .dom))")
-        default:
-            break
-        }
-    }
-
-    private func traceEvent(_ event: ProtocolEventEnvelope, phase: String) {
-        switch event.domain {
-        case .target:
-            inspectorRuntimeTrace("event.\(phase) seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil")")
-        case .dom where event.method == "DOM.documentUpdated" || event.method == "DOM.inspect":
-            inspectorRuntimeTrace("event.\(phase) seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil")")
-        default:
-            break
-        }
-    }
-
-    private func traceGetDocumentResult(_ result: ProtocolCommandResult) {
-        let summary = (try? JSONDecoder().decode(DOMGetDocumentTracePayload.self, from: result.resultData).root.summary) ?? "decode-failed"
-        inspectorRuntimeDOMTrace("getDocument.apply target=\(result.targetID?.rawValue ?? "nil") replySeq=\(result.receivedSequence) domSeq=\(result.receivedSequence(for: .dom)) root=\(summary)")
     }
 
     package static func prepareInspectability(for webView: WKWebView) -> Bool? {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1190,9 +1190,6 @@ package final class InspectorSession {
         rememberDeleteUndoManager(undoManager)
         trackDeleteUndoState(state)
         undoManager.registerUndo(withTarget: self) { target in
-            guard target.deleteUndoStateIsCurrent(state, undoManager: undoManager, operation: "undo") else {
-                return
-            }
             target.registerRedoDelete(state, undoManager: undoManager)
             Task { @MainActor in
                 await target.performUndoDelete(state, undoManager: undoManager)
@@ -1205,9 +1202,6 @@ package final class InspectorSession {
         rememberDeleteUndoManager(undoManager)
         trackDeleteUndoState(state)
         undoManager.registerUndo(withTarget: self) { target in
-            guard target.deleteUndoStateIsCurrent(state, undoManager: undoManager, operation: "redo") else {
-                return
-            }
             target.registerUndoDelete(state, undoManager: undoManager)
             Task { @MainActor in
                 await target.performRedoDelete(state, undoManager: undoManager)

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -64,6 +64,49 @@ private final class DOMDeleteUndoState {
 }
 
 @MainActor
+private final class DOMDeleteUndoOperationQueue {
+    private var generation: UInt64 = 0
+    private var tail: Task<Void, Never>?
+    private var tasksByID: [UInt64: Task<Void, Never>] = [:]
+    private var nextTaskID: UInt64 = 0
+
+    func enqueue(_ operation: @escaping @MainActor (UInt64) async -> Void) {
+        let previousOperation = tail
+        let operationGeneration = generation
+        nextTaskID &+= 1
+        let taskID = nextTaskID
+        let task = Task { @MainActor [weak self] in
+            await previousOperation?.value
+            guard let self else {
+                return
+            }
+            defer {
+                tasksByID[taskID] = nil
+            }
+            guard isCurrent(operationGeneration) else {
+                return
+            }
+            await operation(operationGeneration)
+        }
+        tail = task
+        tasksByID[taskID] = task
+    }
+
+    func invalidate() {
+        generation &+= 1
+        for task in tasksByID.values {
+            task.cancel()
+        }
+        tasksByID.removeAll()
+        tail = nil
+    }
+
+    func isCurrent(_ operationGeneration: UInt64) -> Bool {
+        Task.isCancelled == false && generation == operationGeneration
+    }
+}
+
+@MainActor
 private final class InspectorConnection {
     let transport: TransportSession
     weak var webView: WKWebView?
@@ -126,6 +169,7 @@ package final class InspectorSession {
     @ObservationIgnored private var elementPickerTargetID: ProtocolTargetIdentifier?
     @ObservationIgnored private weak var deleteUndoManager: UndoManager?
     @ObservationIgnored private var deleteUndoStates: [DOMDeleteUndoState]
+    @ObservationIgnored private let deleteUndoOperationQueue: DOMDeleteUndoOperationQueue
     @ObservationIgnored private var domDocumentRequestHandlesByTargetID: [ProtocolTargetIdentifier: DOMDocumentRequestHandle]
 
     package init(
@@ -145,6 +189,7 @@ package final class InspectorSession {
         elementPickerTargetID = nil
         deleteUndoManager = nil
         deleteUndoStates = []
+        deleteUndoOperationQueue = DOMDeleteUndoOperationQueue()
         domDocumentRequestHandlesByTargetID = [:]
     }
 
@@ -1082,8 +1127,8 @@ package final class InspectorSession {
         trackDeleteUndoState(state)
         undoManager.registerUndo(withTarget: self) { target in
             target.registerRedoDelete(state, undoManager: undoManager)
-            Task { @MainActor in
-                await target.performUndoDelete(state, undoManager: undoManager)
+            target.enqueueDeleteUndoOperation { [weak target] generation in
+                await target?.performUndoDelete(state, undoManager: undoManager, generation: generation)
             }
         }
         undoManager.setActionName("Delete Node")
@@ -1094,39 +1139,85 @@ package final class InspectorSession {
         trackDeleteUndoState(state)
         undoManager.registerUndo(withTarget: self) { target in
             target.registerUndoDelete(state, undoManager: undoManager)
-            Task { @MainActor in
-                await target.performRedoDelete(state, undoManager: undoManager)
+            target.enqueueDeleteUndoOperation { [weak target] generation in
+                await target?.performRedoDelete(state, undoManager: undoManager, generation: generation)
             }
         }
         undoManager.setActionName("Delete Node")
     }
 
-    private func performUndoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager) async {
+    private func enqueueDeleteUndoOperation(_ operation: @escaping @MainActor (UInt64) async -> Void) {
+        deleteUndoOperationQueue.enqueue(operation)
+    }
+
+    private func performUndoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager, generation: UInt64) async {
+        guard deleteUndoOperationIsCurrent(generation) else {
+            return
+        }
         guard deleteUndoStateIsCurrent(state, undoManager: undoManager, operation: "undo") else {
             return
         }
         do {
+            try Task.checkCancellation()
             try await perform(.undo(targetID: state.commandTargetID))
+            try Task.checkCancellation()
+            guard deleteUndoOperationIsCurrent(generation) else {
+                return
+            }
             try await reloadDOMDocument(targetID: state.documentTargetID)
+            try Task.checkCancellation()
+            guard deleteUndoOperationIsCurrent(generation) else {
+                return
+            }
             updateDeleteUndoDocumentID(state, undoManager: undoManager)
+        } catch is CancellationError {
+            handleDeleteUndoOperationError(CancellationError(), undoManager: undoManager, generation: generation)
         } catch {
-            clearDeleteUndoHistory(using: undoManager)
-            lastError = InspectorSessionError(String(describing: error))
+            handleDeleteUndoOperationError(error, undoManager: undoManager, generation: generation)
         }
     }
 
-    private func performRedoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager) async {
+    private func performRedoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager, generation: UInt64) async {
+        guard deleteUndoOperationIsCurrent(generation) else {
+            return
+        }
         guard deleteUndoStateIsCurrent(state, undoManager: undoManager, operation: "redo") else {
             return
         }
         do {
+            try Task.checkCancellation()
             try await perform(.redo(targetID: state.commandTargetID))
+            try Task.checkCancellation()
+            guard deleteUndoOperationIsCurrent(generation) else {
+                return
+            }
             try await reloadDOMDocument(targetID: state.documentTargetID)
+            try Task.checkCancellation()
+            guard deleteUndoOperationIsCurrent(generation) else {
+                return
+            }
             updateDeleteUndoDocumentID(state, undoManager: undoManager)
+        } catch is CancellationError {
+            handleDeleteUndoOperationError(CancellationError(), undoManager: undoManager, generation: generation)
         } catch {
-            clearDeleteUndoHistory(using: undoManager)
-            lastError = InspectorSessionError(String(describing: error))
+            handleDeleteUndoOperationError(error, undoManager: undoManager, generation: generation)
         }
+    }
+
+    private func deleteUndoOperationIsCurrent(_ generation: UInt64) -> Bool {
+        deleteUndoOperationQueue.isCurrent(generation)
+    }
+
+    private func handleDeleteUndoOperationError(
+        _ error: any Error,
+        undoManager: UndoManager,
+        generation: UInt64
+    ) {
+        guard deleteUndoOperationIsCurrent(generation) else {
+            return
+        }
+        clearDeleteUndoHistory(using: undoManager)
+        lastError = InspectorSessionError(String(describing: error))
     }
 
     private func deleteUndoStateIsCurrent(
@@ -1176,6 +1267,7 @@ package final class InspectorSession {
             deleteUndoManager = nil
         }
         deleteUndoStates.removeAll()
+        deleteUndoOperationQueue.invalidate()
     }
 
     private func seedDOMSession(from snapshot: TransportSnapshot) {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -163,6 +163,7 @@ package final class InspectorSession {
     @ObservationIgnored private var highlightedDOMTargetID: ProtocolTargetIdentifier?
     @ObservationIgnored private var elementPickerTargetID: ProtocolTargetIdentifier?
     @ObservationIgnored private var elementPickerGeneration: UInt64
+    @ObservationIgnored private var elementPickerAcceptsInspectEvents: Bool
     @ObservationIgnored private weak var deleteUndoManager: UndoManager?
     @ObservationIgnored private var deleteUndoStates: [DOMDeleteUndoState]
     @ObservationIgnored private let deleteUndoOperationQueue: DOMDeleteUndoOperationQueue
@@ -184,6 +185,7 @@ package final class InspectorSession {
         highlightedDOMTargetID = nil
         elementPickerTargetID = nil
         elementPickerGeneration = 0
+        elementPickerAcceptsInspectEvents = false
         deleteUndoManager = nil
         deleteUndoStates = []
         deleteUndoOperationQueue = DOMDeleteUndoOperationQueue()
@@ -371,7 +373,9 @@ package final class InspectorSession {
         }
 
         elementPickerGeneration &+= 1
+        let pickerGeneration = elementPickerGeneration
         elementPickerTargetID = targetID
+        elementPickerAcceptsInspectEvents = false
         isSelectingElement = true
 
         do {
@@ -380,6 +384,10 @@ package final class InspectorSession {
                 throw InspectorSessionError("DOM inspect mode is not available.")
             }
             try await perform(intent)
+            guard isElementPickerSession(generation: pickerGeneration, targetID: targetID) else {
+                return
+            }
+            elementPickerAcceptsInspectEvents = true
             lastError = nil
         } catch {
             recordElementPickerFailure(
@@ -803,6 +811,7 @@ package final class InspectorSession {
 
     private func handleInspectEvent(_ event: DOMInspectEvent) async {
         guard isSelectingElement,
+              elementPickerAcceptsInspectEvents,
               let activeTargetID = elementPickerTargetID else {
             recordElementPickerFailure(
                 reason: "inspectEventWithoutActivePicker",
@@ -928,6 +937,7 @@ package final class InspectorSession {
     private func clearElementPickerState(invalidatePendingSelection: Bool = false) {
         elementPickerGeneration &+= 1
         elementPickerTargetID = nil
+        elementPickerAcceptsInspectEvents = false
         isSelectingElement = false
         if invalidatePendingSelection {
             dom.selectNode(dom.selectedNodeID)
@@ -951,8 +961,12 @@ package final class InspectorSession {
         InspectorRuntimeLog.warning(message)
     }
 
-    private func isCurrentElementPicker(generation: UInt64, targetID: ProtocolTargetIdentifier) -> Bool {
+    private func isElementPickerSession(generation: UInt64, targetID: ProtocolTargetIdentifier) -> Bool {
         isSelectingElement && elementPickerGeneration == generation && elementPickerTargetID == targetID
+    }
+
+    private func isCurrentElementPicker(generation: UInt64, targetID: ProtocolTargetIdentifier) -> Bool {
+        isElementPickerSession(generation: generation, targetID: targetID) && elementPickerAcceptsInspectEvents
     }
 
     private func completeElementPicker(generation: UInt64, targetID: ProtocolTargetIdentifier) async {
@@ -1056,16 +1070,25 @@ package final class InspectorSession {
     }
 
     private func refreshDOMDocumentAfterBackendUpdate(_ event: ProtocolEventEnvelope) {
-        guard let targetID = event.targetID ?? dom.currentPageTargetID,
-              dom.currentDocumentID(for: targetID) != nil || dom.currentPageTargetID == targetID else {
+        guard let targetID = event.targetID ?? dom.currentPageTargetID else {
             return
         }
-        let targetKind = dom.targetKind(for: targetID)
-        cancelDOMDocumentRequest(targetID: targetID, reason: "documentUpdated")
+        let activeRequest = domDocumentRequestHandlesByTargetID[targetID]
+        let targetKind = dom.targetKind(for: targetID) ?? activeRequest?.targetKind
+        let isCurrentPageTarget = dom.currentPageTargetID == targetID
+        let hasCurrentDocument = dom.currentDocumentID(for: targetID) != nil
+        let hasActiveFrameDocumentRequest = targetKind == .frame && activeRequest != nil
+        guard hasCurrentDocument || isCurrentPageTarget || hasActiveFrameDocumentRequest else {
+            return
+        }
+
         dom.invalidateDocument(targetID: targetID)
         if targetKind == .frame {
             startDOMDocumentRequest(targetID: targetID, force: true, reason: "frameDocumentUpdated")
+            return
         }
+
+        cancelDOMDocumentRequest(targetID: targetID, reason: "documentUpdated")
     }
 
     private func cancelDOMDocumentRequest(targetID: ProtocolTargetIdentifier, reason: String) {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -148,11 +148,6 @@ private struct TargetDestroyedEventParams: Decodable {
     var targetId: ProtocolTargetIdentifier
 }
 
-private struct TargetCommittedEventParams: Decodable {
-    var oldTargetId: ProtocolTargetIdentifier?
-    var newTargetId: ProtocolTargetIdentifier
-}
-
 @MainActor
 @Observable
 package final class InspectorSession {
@@ -718,11 +713,12 @@ package final class InspectorSession {
     private func handleTargetEvent(_ event: ProtocolEventEnvelope) async {
         do {
             let destroyedTargetID = targetDestroyedID(from: event)
+            let targetCommit = try DOMTransportAdapter.targetCommitResolution(from: event, snapshot: dom.snapshot())
             let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
             if let destroyedTargetID {
                 cancelDOMDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
             }
-            applyElementPickerTargetLifecycle(event)
+            applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
             if isAttached,
                let createdTarget,
                createdTarget.kind == .frame {
@@ -737,11 +733,11 @@ package final class InspectorSession {
                 startPageTargetDocumentRequestAfterCommit(targetID: targetID, connection: connection)
             }
             if event.method == "Target.didCommitProvisionalTarget",
-               let committedTarget = targetCommittedParams(from: event) {
-                if let oldTargetID = committedTarget.oldTargetId {
+               let targetCommit {
+                if let oldTargetID = targetCommit.oldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
                 }
-                startFrameTargetDocumentRequestAfterCommit(targetID: committedTarget.newTargetId)
+                startFrameTargetDocumentRequestAfterCommit(targetID: targetCommit.newTargetID)
             }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -1097,17 +1093,6 @@ package final class InspectorSession {
         return params.targetId
     }
 
-    private func targetCommittedParams(from event: ProtocolEventEnvelope) -> TargetCommittedEventParams? {
-        guard event.method == "Target.didCommitProvisionalTarget",
-              let params = try? TransportMessageParser.decode(
-                  TargetCommittedEventParams.self,
-                  from: event.paramsData
-              ) else {
-            return nil
-        }
-        return params
-    }
-
     private func clearOwnerHydrationTransaction(for intent: DOMCommandIntent) {
         guard case let .requestChildNodes(targetID, _, _) = intent else {
             return
@@ -1147,7 +1132,10 @@ package final class InspectorSession {
         connection?.eventPump?.appliedSequence ?? 0
     }
 
-    private func applyElementPickerTargetLifecycle(_ event: ProtocolEventEnvelope) {
+    private func applyElementPickerTargetLifecycle(
+        _ event: ProtocolEventEnvelope,
+        targetCommit: DOMTransportAdapter.TargetCommitResolution?
+    ) {
         guard let activeTargetID = elementPickerTargetID else {
             return
         }
@@ -1164,17 +1152,14 @@ package final class InspectorSession {
             recordElementPickerFailure(reason: "targetDestroyedBeforeInspectEvent", targetID: activeTargetID)
             clearElementPickerState(invalidatePendingSelection: true)
         case "Target.didCommitProvisionalTarget":
-            guard let params = try? TransportMessageParser.decode(
-                TargetCommittedEventParams.self,
-                from: event.paramsData
-            ),
-                params.oldTargetId == activeTargetID else {
+            guard let targetCommit,
+                  targetCommit.oldTargetID == activeTargetID else {
                 return
             }
             recordElementPickerFailure(
                 reason: "targetCommitBeforeInspectEvent",
                 targetID: activeTargetID,
-                details: "newTarget=\(params.newTargetId.rawValue)"
+                details: "newTarget=\(targetCommit.newTargetID.rawValue)"
             )
             clearElementPickerState(invalidatePendingSelection: true)
         default:

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -5,6 +5,25 @@ import WebKit
 import WebInspectorCore
 import WebInspectorTransport
 
+#if DEBUG
+private func inspectorRuntimeTrace(_ message: @autoclosure () -> String) {}
+
+private func inspectorRuntimeFailureTrace(_ message: @autoclosure () -> String) {
+    print("[WebInspectorRuntime.Failure] \(message())")
+}
+
+private func inspectorRuntimeDOMTrace(_ message: @autoclosure () -> String) {
+    print("[WebInspectorRuntime.DOM] \(message())")
+}
+
+private func inspectorRuntimeVerboseTrace(_ message: @autoclosure () -> String) {}
+#else
+private func inspectorRuntimeTrace(_ message: @autoclosure () -> String) {}
+private func inspectorRuntimeFailureTrace(_ message: @autoclosure () -> String) {}
+private func inspectorRuntimeDOMTrace(_ message: @autoclosure () -> String) {}
+private func inspectorRuntimeVerboseTrace(_ message: @autoclosure () -> String) {}
+#endif
+
 package struct InspectorSessionError: Error, Equatable, Sendable, CustomStringConvertible {
     package var message: String
 
@@ -20,16 +39,13 @@ package struct InspectorSessionError: Error, Equatable, Sendable, CustomStringCo
 package struct InspectorSessionConfiguration: Equatable, Sendable {
     package var responseTimeout: Duration
     package var bootstrapTimeout: Duration
-    package var eventApplicationTimeout: Duration
 
     package init(
         responseTimeout: Duration = .seconds(5),
-        bootstrapTimeout: Duration = .seconds(5),
-        eventApplicationTimeout: Duration = .milliseconds(250)
+        bootstrapTimeout: Duration = .seconds(5)
     ) {
         self.responseTimeout = responseTimeout
         self.bootstrapTimeout = bootstrapTimeout
-        self.eventApplicationTimeout = eventApplicationTimeout
     }
 }
 
@@ -55,7 +71,7 @@ private final class InspectorConnection {
     let transport: TransportSession
     weak var webView: WKWebView?
     let originalInspectability: Bool?
-    var pumps: [ProtocolDomain: DomainEventPump]
+    var eventPump: DomainEventPump?
     var bootstrappedTargetIDs: Set<ProtocolTargetIdentifier>
 
     init(
@@ -66,14 +82,90 @@ private final class InspectorConnection {
         self.transport = transport
         self.webView = webView
         self.originalInspectability = originalInspectability
-        pumps = [:]
+        eventPump = nil
         bootstrappedTargetIDs = []
+    }
+}
+
+@MainActor
+private final class DOMDocumentRequestHandle {
+    let targetID: ProtocolTargetIdentifier
+    let targetKind: ProtocolTargetKind?
+    var task: Task<Void, Error>?
+
+    init(targetID: ProtocolTargetIdentifier, targetKind: ProtocolTargetKind?) {
+        self.targetID = targetID
+        self.targetKind = targetKind
     }
 }
 
 private enum DOMInspectRoute {
     case remoteObject(targetID: ProtocolTargetIdentifier, objectID: String)
     case protocolNode(targetID: ProtocolTargetIdentifier, nodeID: DOMProtocolNodeID)
+}
+
+private struct TargetDestroyedEventParams: Decodable {
+    var targetId: ProtocolTargetIdentifier
+}
+
+private struct TargetCommittedEventParams: Decodable {
+    var oldTargetId: ProtocolTargetIdentifier?
+    var newTargetId: ProtocolTargetIdentifier
+}
+
+private struct DOMGetDocumentTracePayload: Decodable {
+    var root: DOMNodeTracePayload
+}
+
+private struct DOMNodeTracePayload: Decodable {
+    var nodeId: Int?
+    var nodeName: String?
+    var documentURL: String?
+    var baseURL: String?
+    var childNodeCount: Int?
+    var children: [DOMNodeTracePayload]?
+
+    var summary: String {
+        let name = nodeName ?? "?"
+        let id = nodeId.map(String.init) ?? "?"
+        let url = documentURL.map { " url=\(shortTraceValue($0))" } ?? ""
+        let base = baseURL.map { " base=\(shortTraceValue($0))" } ?? ""
+        let count = childNodeCount.map { " count=\($0)" } ?? ""
+        let childSummary = (children ?? [])
+            .prefix(4)
+            .map(\.shallowSummary)
+            .joined(separator: ",")
+        if childSummary.isEmpty {
+            return "\(name)#\(id)\(url)\(base)\(count)"
+        }
+        return "\(name)#\(id)\(url)\(base)\(count)[\(childSummary)]"
+    }
+
+    private var shallowSummary: String {
+        let name = nodeName ?? "?"
+        let id = nodeId.map(String.init) ?? "?"
+        let count = childNodeCount.map { " count=\($0)" } ?? ""
+        let childSummary = (children ?? [])
+            .prefix(4)
+            .map { child in
+                let childName = child.nodeName ?? "?"
+                let childID = child.nodeId.map(String.init) ?? "?"
+                let childCount = child.childNodeCount.map { " count=\($0)" } ?? ""
+                return "\(childName)#\(childID)\(childCount)"
+            }
+            .joined(separator: ",")
+        if childSummary.isEmpty {
+            return "\(name)#\(id)\(count)"
+        }
+        return "\(name)#\(id)\(count)[\(childSummary)]"
+    }
+}
+
+private func shortTraceValue(_ value: String, limit: Int = 160) -> String {
+    guard value.count > limit else {
+        return value
+    }
+    return "\(value.prefix(limit))..."
 }
 
 @MainActor
@@ -90,10 +182,9 @@ package final class InspectorSession {
     @ObservationIgnored private var pendingConnection: InspectorConnection?
     @ObservationIgnored private var highlightedDOMTargetID: ProtocolTargetIdentifier?
     @ObservationIgnored private var elementPickerTargetID: ProtocolTargetIdentifier?
-    @ObservationIgnored private var elementPickerGeneration: UInt64
-    @ObservationIgnored private var acceptsElementPickerEvents: Bool
     @ObservationIgnored private weak var deleteUndoManager: UndoManager?
     @ObservationIgnored private var deleteUndoStates: [DOMDeleteUndoState]
+    @ObservationIgnored private var domDocumentRequestHandlesByTargetID: [ProtocolTargetIdentifier: DOMDocumentRequestHandle]
 
     package init(
         configuration: InspectorSessionConfiguration = .init(),
@@ -110,10 +201,9 @@ package final class InspectorSession {
         pendingConnection = nil
         highlightedDOMTargetID = nil
         elementPickerTargetID = nil
-        elementPickerGeneration = 0
-        acceptsElementPickerEvents = false
         deleteUndoManager = nil
         deleteUndoStates = []
+        domDocumentRequestHandlesByTargetID = [:]
     }
 
     package func attach(to webView: WKWebView) async throws {
@@ -230,6 +320,7 @@ package final class InspectorSession {
         }
         dom.reset()
         network.reset()
+        cancelDOMDocumentRequests()
         highlightedDOMTargetID = nil
         clearElementPickerState(invalidatePendingSelection: true)
         clearDeleteUndoHistory()
@@ -269,40 +360,57 @@ package final class InspectorSession {
     }
 
     package func beginElementPicker() async throws {
-        let targetID = try currentPageTargetForDOMAction()
+        var targetID = try currentPageTargetForDOMAction()
+        if dom.currentPageRootNode == nil {
+            let loaded = await ensureDOMDocumentLoaded()
+            guard loaded else {
+                recordElementPickerFailure(
+                    reason: "documentNotReady",
+                    targetID: targetID,
+                    details: "current=\(dom.currentPageTargetID?.rawValue ?? "nil") root=false"
+                )
+                throw InspectorSessionError("DOM is not ready for element selection.")
+            }
+            targetID = try currentPageTargetForDOMAction()
+        }
         guard canSelectElement else {
+            recordElementPickerFailure(
+                reason: "documentNotReady",
+                targetID: targetID,
+                details: "current=\(dom.currentPageTargetID?.rawValue ?? "nil") root=\(dom.currentPageRootNode != nil) attached=\(isAttached)"
+            )
             throw InspectorSessionError("DOM is not ready for element selection.")
         }
         if isSelectingElement {
             await cancelElementPicker()
         }
 
-        elementPickerGeneration &+= 1
-        let generation = elementPickerGeneration
         elementPickerTargetID = targetID
-        acceptsElementPickerEvents = false
         isSelectingElement = true
 
         do {
             guard let intent = dom.setInspectModeEnabledIntent(targetID: targetID, enabled: true) else {
+                recordElementPickerFailure(reason: "inspectModeUnavailable", targetID: targetID)
                 throw InspectorSessionError("DOM inspect mode is not available.")
             }
             try await perform(intent)
-            guard isCurrentElementPickerGeneration(generation) else {
-                return
-            }
-            acceptsElementPickerEvents = true
             lastError = nil
         } catch {
-            if isCurrentElementPickerGeneration(generation) {
-                clearElementPickerState(invalidatePendingSelection: true)
-            }
+            recordElementPickerFailure(
+                reason: "inspectModeCommandFailed",
+                targetID: targetID,
+                details: "error=\(error)"
+            )
+            clearElementPickerState(invalidatePendingSelection: true)
             throw error
         }
     }
 
     package func cancelElementPicker() async {
         let targetID = elementPickerTargetID ?? dom.currentPageTargetID
+        if isSelectingElement {
+            inspectorRuntimeTrace("picker.cancel target=\(targetID?.rawValue ?? "nil")")
+        }
         clearElementPickerState(invalidatePendingSelection: true)
         guard let targetID,
               let intent = dom.setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
@@ -371,7 +479,40 @@ package final class InspectorSession {
             await cancelElementPicker()
         }
         clearDeleteUndoHistory()
-        try await reloadDOMDocument(targetID: currentPageTargetForDOMAction())
+        try await reloadDOMDocument(targetID: currentPageTargetForDOMAction(), force: true)
+    }
+
+    @discardableResult
+    package func ensureDOMDocumentLoaded() async -> Bool {
+        guard isAttached,
+              let targetID = dom.currentPageTargetID else {
+            return false
+        }
+        guard dom.currentPageRootNode == nil else {
+            return true
+        }
+
+        do {
+            inspectorRuntimeTrace("documentEnsure.request target=\(targetID.rawValue)")
+            try await reloadDOMDocument(targetID: targetID)
+            return dom.currentPageRootNode != nil
+        } catch is CancellationError {
+            guard isAttached,
+                  dom.currentPageRootNode == nil else {
+                return dom.currentPageRootNode != nil
+            }
+            do {
+                inspectorRuntimeTrace("documentEnsure.retry target=\(targetID.rawValue)")
+                try await reloadDOMDocument(targetID: targetID)
+                return dom.currentPageRootNode != nil
+            } catch {
+                lastError = InspectorSessionError(String(describing: error))
+                return false
+            }
+        } catch {
+            lastError = InspectorSessionError(String(describing: error))
+            return false
+        }
     }
 
     package func reloadPage() async throws {
@@ -380,6 +521,7 @@ package final class InspectorSession {
         clearDeleteUndoHistory()
         dom.reset()
         network.reset()
+        cancelDOMDocumentRequests()
         if let connection {
             seedDOMSession(from: await connection.transport.snapshot())
         }
@@ -391,24 +533,33 @@ package final class InspectorSession {
         let connection = try activeConnection()
         let transport = connection.transport
         let command = try DOMTransportAdapter.command(for: intent)
-        let result = try await transport.send(command)
+        traceCommandSend(command)
+        let result: ProtocolCommandResult
+        do {
+            result = try await transport.send(command)
+        } catch {
+            inspectorRuntimeFailureTrace("command.error method=\(command.method) routing=\(command.routing) error=\(error)")
+            throw error
+        }
+        traceCommandReply(command, result: result)
         try ensureCurrentConnection(connection)
 
         switch intent {
         case .getDocument:
-            try DOMTransportAdapter.applyGetDocumentResult(result, to: dom)
+            try applyGetDocumentResult(result)
         case let .requestNode(selectionRequestID, targetID, _):
-            let domSequence = result.receivedSequence(for: .dom)
-            if requestNodeResultMayNeedDOMPathPush(result, targetID: targetID, domSequence: domSequence) {
-                await waitForAppliedSequence(domSequence, domain: .dom, connection: connection)
-                try ensureCurrentConnection(connection)
-            }
             let selectionResult = try DOMTransportAdapter.applyRequestNodeResult(
                 result,
                 selectionRequestID: selectionRequestID,
                 to: dom
             )
-            if case let .failure(failure) = selectionResult {
+            switch selectionResult {
+            case let .resolved(nodeID):
+                inspectorRuntimeVerboseTrace("requestNode.select success target=\(targetID.rawValue) node=\(nodeID.nodeID.rawValue) document=\(nodeID.documentID)")
+            case let .pending(key):
+                inspectorRuntimeTrace("requestNode.select pending target=\(targetID.rawValue) node=\(key.nodeID.rawValue) reason=awaiting-setChildNodes")
+            case let .failed(failure):
+                inspectorRuntimeFailureTrace("requestNode.selectFailure target=\(targetID.rawValue) failure=\(failure)")
                 lastError = InspectorSessionError(String(describing: failure))
             }
         case .requestChildNodes:
@@ -431,7 +582,11 @@ package final class InspectorSession {
 
     @discardableResult
     package func requestChildNodes(for nodeID: DOMNodeIdentifier, depth: Int = 3) async -> Bool {
-        guard let intent = dom.requestChildNodesIntent(for: nodeID, depth: depth) else {
+        guard let intent = dom.requestChildNodesIntent(
+            for: nodeID,
+            depth: depth,
+            issuedSequence: currentAppliedDOMSequence
+        ) else {
             return false
         }
         do {
@@ -497,6 +652,7 @@ package final class InspectorSession {
     }
 
     private func bootstrap(mainTargetID: ProtocolTargetIdentifier, connection: InspectorConnection) async throws {
+        inspectorRuntimeDOMTrace("bootstrap.start target=\(mainTargetID.rawValue)")
         _ = try await sendTargetCommand(domain: .inspector, method: "Inspector.enable", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
         _ = try await sendTargetCommand(domain: .inspector, method: "Inspector.initialized", targetID: mainTargetID, connection: connection)
@@ -508,7 +664,7 @@ package final class InspectorSession {
 
         let documentResult = try await sendTargetCommand(domain: .dom, method: "DOM.getDocument", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
-        try DOMTransportAdapter.applyGetDocumentResult(documentResult, to: dom)
+        try applyGetDocumentResult(documentResult)
 
         _ = try await connection.transport.send(
             ProtocolCommand(
@@ -519,6 +675,7 @@ package final class InspectorSession {
         )
         try ensureCurrentConnection(connection)
         connection.bootstrappedTargetIDs.insert(mainTargetID)
+        inspectorRuntimeDOMTrace("bootstrap.done target=\(mainTargetID.rawValue)")
     }
 
     private func sendTargetCommand(
@@ -539,42 +696,36 @@ package final class InspectorSession {
     private func startPumps(connection: InspectorConnection) async {
         stopPumps(connection)
         let transport = connection.transport
-        let targetPump = DomainEventPump()
-        targetPump.start(stream: await transport.events(for: .target)) { [weak self] event in
-            await self?.handleTargetEvent(event)
+        let eventPump = DomainEventPump()
+        eventPump.start(stream: await transport.orderedEvents()) { [weak self] event in
+            await self?.handleProtocolEvent(event)
         }
+        connection.eventPump = eventPump
+    }
 
-        let runtimePump = DomainEventPump()
-        runtimePump.start(stream: await transport.events(for: .runtime)) { [weak self] event in
-            self?.applyEvent(event) {
+    private func handleProtocolEvent(_ event: ProtocolEventEnvelope) async {
+        traceEvent(event, phase: "begin")
+        defer {
+            traceEvent(event, phase: "end")
+        }
+        switch event.domain {
+        case .target:
+            await handleTargetEvent(event)
+        case .runtime:
+            applyEvent(event) {
                 try DOMTransportAdapter.applyRuntimeEvent(event, to: $0.dom)
             }
-        }
-
-        let inspectorPump = DomainEventPump()
-        inspectorPump.start(stream: await transport.events(for: .inspector)) { [weak self] event in
-            await self?.handleInspectorEvent(event)
-        }
-
-        let domPump = DomainEventPump()
-        domPump.start(stream: await transport.events(for: .dom)) { [weak self] event in
-            await self?.handleDOMEvent(event)
-        }
-
-        let networkPump = DomainEventPump()
-        networkPump.start(stream: await transport.events(for: .network)) { [weak self] event in
-            self?.applyEvent(event) {
+        case .inspector:
+            await handleInspectorEvent(event)
+        case .dom:
+            await handleDOMEvent(event)
+        case .network:
+            applyEvent(event) {
                 try NetworkTransportAdapter.applyNetworkEvent(event, to: $0.network)
             }
+        default:
+            break
         }
-
-        connection.pumps = [
-            .target: targetPump,
-            .runtime: runtimePump,
-            .inspector: inspectorPump,
-            .dom: domPump,
-            .network: networkPump,
-        ]
     }
 
     private func handleInspectorEvent(_ event: ProtocolEventEnvelope) async {
@@ -582,6 +733,7 @@ package final class InspectorSession {
             guard let inspectEvent = try DOMTransportAdapter.inspectEvent(from: event) else {
                 return
             }
+            inspectorRuntimeVerboseTrace("inspect.event seq=\(event.sequence) target=\(event.targetID?.rawValue ?? "nil") activePicker=\(elementPickerTargetID?.rawValue ?? "nil") selecting=\(isSelectingElement)")
             await handleInspectEvent(inspectEvent)
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -590,16 +742,31 @@ package final class InspectorSession {
 
     private func handleTargetEvent(_ event: ProtocolEventEnvelope) async {
         do {
-            try DOMTransportAdapter.applyTargetEvent(event, to: dom)
+            let destroyedTargetID = targetDestroyedID(from: event)
+            let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
+            if let destroyedTargetID {
+                cancelDOMDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
+            }
+            applyElementPickerTargetLifecycle(event)
+            if isAttached,
+               let createdTarget,
+               createdTarget.kind == .frame {
+                if createdTarget.capabilities.contains(.dom) {
+                    inspectorRuntimeDOMTrace(
+                        "frameTarget.created action=getDocument target=\(createdTarget.id.rawValue) frame=\(createdTarget.frameID?.rawValue ?? "nil") parentFrame=\(createdTarget.parentFrameID?.rawValue ?? "nil") caps=\(createdTarget.capabilities.rawValue)"
+                    )
+                    startDOMDocumentRequest(targetID: createdTarget.id, reason: "frameTargetCreated")
+                } else {
+                    inspectorRuntimeTrace(
+                        "frameTarget.created action=skipNoDOM target=\(createdTarget.id.rawValue) frame=\(createdTarget.frameID?.rawValue ?? "nil") parentFrame=\(createdTarget.parentFrameID?.rawValue ?? "nil") caps=\(createdTarget.capabilities.rawValue)"
+                    )
+                }
+            }
             if event.method == "Target.didCommitProvisionalTarget",
                dom.currentPageRootNode == nil,
                let targetID = dom.currentPageTargetID,
                let connection {
-                if connection.bootstrappedTargetIDs.contains(targetID) {
-                    try await reloadDOMDocument(targetID: targetID)
-                } else {
-                    try await bootstrap(mainTargetID: targetID, connection: connection)
-                }
+                startPageTargetDocumentRequestAfterCommit(targetID: targetID, connection: connection)
             }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -613,30 +780,57 @@ package final class InspectorSession {
                 return
             }
             if event.method == "DOM.documentUpdated" {
-                try await refreshDOMDocumentAfterBackendUpdate(event)
+                refreshDOMDocumentAfterBackendUpdate(event)
                 return
             }
             try DOMTransportAdapter.applyDOMEvent(event, to: dom)
+            if event.method == "DOM.setChildNodes" {
+                startPendingFrameOwnerHydration()
+            }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
         }
     }
 
-    private func handleInspectEvent(_ event: DOMInspectEvent) async {
-        guard acceptsElementPickerEvents,
-              let activeTargetID = elementPickerTargetID else {
+    private func startPendingFrameOwnerHydration() {
+        guard let intent = dom.pendingFrameOwnerHydrationIntent(issuedSequence: currentAppliedDOMSequence) else {
             return
         }
-        let generation = elementPickerGeneration
-        acceptsElementPickerEvents = false
+        inspectorRuntimeDOMTrace("frameOwnerHydration.perform intent=\(intent)")
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            do {
+                try await perform(intent)
+            } catch {
+                inspectorRuntimeFailureTrace("frameOwnerHydration.failed intent=\(intent) error=\(error)")
+                lastError = InspectorSessionError(String(describing: error))
+            }
+        }
+    }
 
+    private func handleInspectEvent(_ event: DOMInspectEvent) async {
+        guard isSelectingElement,
+              let activeTargetID = elementPickerTargetID else {
+            recordElementPickerFailure(
+                reason: "inspectEventWithoutActivePicker",
+                details: "activeTarget=\(elementPickerTargetID?.rawValue ?? "nil")"
+            )
+            return
+        }
         do {
             try await resolvePickerSelection(event, activeTargetID: activeTargetID)
         } catch {
+            recordElementPickerFailure(
+                reason: "selectionResolveFailed",
+                targetID: activeTargetID,
+                details: "error=\(error)"
+            )
             lastError = InspectorSessionError(String(describing: error))
         }
 
-        await completeElementPicker(generation: generation)
+        await completeElementPicker()
     }
 
     private func resolvePickerSelection(
@@ -645,27 +839,35 @@ package final class InspectorSession {
     ) async throws {
         switch inspectRoute(for: event, activeTargetID: activeTargetID) {
         case let .remoteObject(targetID, objectID):
+            inspectorRuntimeVerboseTrace("inspect.route remoteObject target=\(targetID.rawValue) object=\(objectID) hasDocument=\(dom.currentDocumentID(for: targetID) != nil)")
             if dom.currentDocumentID(for: targetID) == nil {
                 try await reloadDOMDocument(targetID: targetID)
             }
-            let intentResult = dom.beginInspectSelectionRequest(targetID: targetID, objectID: objectID)
+            let intentResult = dom.beginInspectSelectionRequest(
+                targetID: targetID,
+                objectID: objectID,
+                issuedSequence: currentAppliedDOMSequence
+            )
             switch intentResult {
             case let .success(intent):
                 try await perform(intent)
+                if let failure = dom.snapshot().selection.failure {
+                    throw InspectorSessionError("DOM.requestNode failed: \(failure)")
+                }
             case let .failure(failure):
-                lastError = InspectorSessionError(String(describing: failure))
+                throw InspectorSessionError("DOM.requestNode could not be issued: \(failure)")
             }
         case let .protocolNode(targetID, nodeID):
+            inspectorRuntimeVerboseTrace("inspect.route protocolNode target=\(targetID.rawValue) node=\(nodeID.rawValue)")
             let result = dom.selectProtocolNode(targetID: targetID, nodeID: nodeID)
             if case let .failure(failure) = result {
                 guard case .unresolvedNode = failure else {
-                    lastError = InspectorSessionError(String(describing: failure))
-                    return
+                    throw InspectorSessionError("DOM protocol-node selection failed: \(failure)")
                 }
                 try await reloadDOMDocument(targetID: targetID)
                 let retryResult = dom.selectProtocolNode(targetID: targetID, nodeID: nodeID)
                 if case let .failure(retryFailure) = retryResult {
-                    lastError = InspectorSessionError(String(describing: retryFailure))
+                    throw InspectorSessionError("DOM protocol-node selection failed after reload: \(retryFailure)")
                 }
             }
         }
@@ -696,14 +898,17 @@ package final class InspectorSession {
            let targetID = dom.snapshot().executionContextsByID[executionContextID]?.targetID {
             return targetID
         }
+        if let executionContextID = remoteObject.injectedScriptID {
+            inspectorRuntimeTrace(
+                "inspect.routeFallback reason=unknownExecutionContext injectedScriptID=\(executionContextID.rawValue) eventTarget=\(eventTargetID?.rawValue ?? "nil") activeTarget=\(activeTargetID.rawValue)"
+            )
+        }
         return eventTargetID ?? activeTargetID
     }
 
     private func stopPumps(_ connection: InspectorConnection) {
-        for pump in connection.pumps.values {
-            pump.stop()
-        }
-        connection.pumps.removeAll()
+        connection.eventPump?.stop()
+        connection.eventPump = nil
     }
 
     private func applyEvent(
@@ -734,22 +939,30 @@ package final class InspectorSession {
 
     private func clearElementPickerState(invalidatePendingSelection: Bool = false) {
         elementPickerTargetID = nil
-        acceptsElementPickerEvents = false
         isSelectingElement = false
         if invalidatePendingSelection {
             dom.selectNode(dom.selectedNodeID)
         }
-        elementPickerGeneration &+= 1
     }
 
-    private func isCurrentElementPickerGeneration(_ generation: UInt64) -> Bool {
-        generation == elementPickerGeneration && isSelectingElement
-    }
-
-    private func completeElementPicker(generation: UInt64) async {
-        guard isCurrentElementPickerGeneration(generation) else {
-            return
+    private func recordElementPickerFailure(
+        reason: String,
+        targetID: ProtocolTargetIdentifier? = nil,
+        details: String = ""
+    ) {
+        let resolvedTargetID = targetID ?? elementPickerTargetID
+        var message = "picker.failure reason=\(reason)"
+        message += " target=\(resolvedTargetID?.rawValue ?? "nil")"
+        message += " currentPage=\(dom.currentPageTargetID?.rawValue ?? "nil")"
+        message += " hasRoot=\(dom.currentPageRootNode != nil)"
+        message += " selecting=\(isSelectingElement)"
+        if !details.isEmpty {
+            message += " \(details)"
         }
+        inspectorRuntimeFailureTrace(message)
+    }
+
+    private func completeElementPicker() async {
         let targetID = elementPickerTargetID ?? dom.currentPageTargetID
         clearElementPickerState()
         guard let targetID,
@@ -763,18 +976,214 @@ package final class InspectorSession {
         }
     }
 
-    private func reloadDOMDocument(targetID: ProtocolTargetIdentifier) async throws {
-        try await perform(.getDocument(targetID: targetID))
+    private func reloadDOMDocument(
+        targetID: ProtocolTargetIdentifier,
+        force: Bool = false
+    ) async throws {
+        guard let handle = startDOMDocumentRequest(targetID: targetID, force: force, reason: "explicit") else {
+            return
+        }
+        try await handle.task?.value
         lastError = nil
     }
 
-    private func refreshDOMDocumentAfterBackendUpdate(_ event: ProtocolEventEnvelope) async throws {
-        let targetID = event.targetID ?? dom.currentPageTargetID
-        guard let targetID,
-              dom.currentDocumentID(for: targetID) != nil || dom.currentPageTargetID == targetID else {
+    @discardableResult
+    private func startDOMDocumentRequest(
+        targetID: ProtocolTargetIdentifier,
+        force: Bool = false,
+        reason: String
+    ) -> DOMDocumentRequestHandle? {
+        if force {
+            cancelDOMDocumentRequest(targetID: targetID, reason: "force-\(reason)")
+        } else if let activeHandle = domDocumentRequestHandlesByTargetID[targetID] {
+            inspectorRuntimeTrace("documentRequest.pending target=\(targetID.rawValue) reason=active-request caller=\(reason)")
+            return activeHandle
+        }
+        guard let intent = dom.getDocumentIntent(targetID: targetID) else {
+            inspectorRuntimeDOMTrace(
+                "getDocument.skip target=\(targetID.rawValue) reason=noDOMCapability kind=\(String(describing: dom.targetKind(for: targetID)))"
+            )
+            return nil
+        }
+
+        let targetKind = dom.targetKind(for: targetID)
+        let handle = DOMDocumentRequestHandle(targetID: targetID, targetKind: targetKind)
+        inspectorRuntimeDOMTrace(
+            "getDocument.start target=\(targetID.rawValue) kind=\(String(describing: targetKind)) reason=\(reason)"
+        )
+        let task = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                if domDocumentRequestHandlesByTargetID[targetID] === handle {
+                    domDocumentRequestHandlesByTargetID.removeValue(forKey: targetID)
+                }
+            }
+            do {
+                let connection = try activeConnection()
+                let command = try DOMTransportAdapter.command(for: intent)
+                traceCommandSend(command)
+                let result = try await connection.transport.send(command)
+                try Task.checkCancellation()
+                try ensureCurrentConnection(connection)
+                traceCommandReply(command, result: result)
+                guard domDocumentRequestHandlesByTargetID[targetID] === handle else {
+                    inspectorRuntimeDOMTrace("getDocument.dropReply target=\(targetID.rawValue) reason=request-gate-reset")
+                    return
+                }
+                try applyGetDocumentResult(result)
+                lastError = nil
+            } catch is CancellationError {
+                inspectorRuntimeDOMTrace("getDocument.cancelled target=\(targetID.rawValue) reason=\(reason)")
+                throw CancellationError()
+            } catch {
+                if handle.targetKind == .frame, shouldIgnoreFrameDocumentRequestError(error) {
+                    inspectorRuntimeDOMTrace("getDocument.frameDrop target=\(targetID.rawValue) reason=\(reason) error=\(error)")
+                    return
+                }
+                inspectorRuntimeFailureTrace("getDocument.failed target=\(targetID.rawValue) reason=\(reason) error=\(error)")
+                lastError = InspectorSessionError(String(describing: error))
+                throw error
+            }
+        }
+        handle.task = task
+        domDocumentRequestHandlesByTargetID[targetID] = handle
+        return handle
+    }
+
+    private func startPageTargetDocumentRequestAfterCommit(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection
+    ) {
+        if connection.bootstrappedTargetIDs.contains(targetID) {
+            startDOMDocumentRequest(targetID: targetID, reason: "pageTargetCommit")
             return
         }
-        try await reloadDOMDocument(targetID: targetID)
+
+        Task { @MainActor [weak self, connection] in
+            guard let self else {
+                return
+            }
+            do {
+                try await bootstrap(mainTargetID: targetID, connection: connection)
+            } catch {
+                lastError = InspectorSessionError(String(describing: error))
+            }
+        }
+    }
+
+    private func refreshDOMDocumentAfterBackendUpdate(_ event: ProtocolEventEnvelope) {
+        guard let targetID = event.targetID,
+              dom.currentDocumentID(for: targetID) != nil || dom.currentPageTargetID == targetID else {
+            inspectorRuntimeTrace("documentUpdated.drop seq=\(event.sequence) target=\(event.targetID?.rawValue ?? "nil") currentPage=\(dom.currentPageTargetID?.rawValue ?? "nil")")
+            return
+        }
+        let targetKind = dom.targetKind(for: targetID)
+        inspectorRuntimeTrace("documentUpdated.invalidate seq=\(event.sequence) target=\(targetID.rawValue) kind=\(String(describing: targetKind)) currentDocument=\(String(describing: dom.currentDocumentID(for: targetID)))")
+        cancelDOMDocumentRequest(targetID: targetID, reason: "documentUpdated")
+        dom.invalidateDocument(targetID: targetID)
+        if targetKind == .frame {
+            inspectorRuntimeTrace("documentUpdated.requestFrame target=\(targetID.rawValue)")
+            startDOMDocumentRequest(targetID: targetID, force: true, reason: "frameDocumentUpdated")
+        }
+    }
+
+    private func cancelDOMDocumentRequest(targetID: ProtocolTargetIdentifier, reason: String) {
+        guard let handle = domDocumentRequestHandlesByTargetID.removeValue(forKey: targetID) else {
+            return
+        }
+        inspectorRuntimeTrace("documentRequest.cancel target=\(targetID.rawValue) reason=\(reason)")
+        handle.task?.cancel()
+    }
+
+    private func cancelDOMDocumentRequests() {
+        for (targetID, handle) in domDocumentRequestHandlesByTargetID {
+            inspectorRuntimeTrace("documentRequest.cancel target=\(targetID.rawValue) reason=session-reset")
+            handle.task?.cancel()
+        }
+        domDocumentRequestHandlesByTargetID.removeAll()
+    }
+
+    private func targetDestroyedID(from event: ProtocolEventEnvelope) -> ProtocolTargetIdentifier? {
+        guard event.method == "Target.targetDestroyed",
+              let params = try? TransportMessageParser.decode(
+                  TargetDestroyedEventParams.self,
+                  from: event.paramsData
+              ) else {
+            return nil
+        }
+        return params.targetId
+    }
+
+    private func shouldIgnoreFrameDocumentRequestError(_ error: any Error) -> Bool {
+        switch error {
+        case is CancellationError:
+            return true
+        case let error as TransportError:
+            switch error {
+            case .missingTarget, .replyTimeout:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
+
+    private func applyGetDocumentResult(_ result: ProtocolCommandResult) throws {
+        guard let targetID = result.targetID else {
+            inspectorRuntimeTrace("getDocument.drop reason=missing-target")
+            return
+        }
+        guard dom.targetKind(for: targetID) != nil else {
+            inspectorRuntimeTrace("getDocument.drop target=\(targetID.rawValue) reason=missing-target-kind")
+            return
+        }
+        traceGetDocumentResult(result)
+        try DOMTransportAdapter.applyGetDocumentResult(result, to: dom)
+        startPendingFrameOwnerHydration()
+        lastError = nil
+    }
+
+    private var currentAppliedDOMSequence: UInt64 {
+        connection?.eventPump?.appliedSequence ?? 0
+    }
+
+    private func applyElementPickerTargetLifecycle(_ event: ProtocolEventEnvelope) {
+        guard let activeTargetID = elementPickerTargetID else {
+            return
+        }
+
+        switch event.method {
+        case "Target.targetDestroyed":
+            guard let params = try? TransportMessageParser.decode(
+                TargetDestroyedEventParams.self,
+                from: event.paramsData
+            ),
+                params.targetId == activeTargetID else {
+                return
+            }
+            recordElementPickerFailure(reason: "targetDestroyedBeforeInspectEvent", targetID: activeTargetID)
+            clearElementPickerState(invalidatePendingSelection: true)
+        case "Target.didCommitProvisionalTarget":
+            guard let params = try? TransportMessageParser.decode(
+                TargetCommittedEventParams.self,
+                from: event.paramsData
+            ),
+                params.oldTargetId == activeTargetID else {
+                return
+            }
+            recordElementPickerFailure(
+                reason: "targetCommitBeforeInspectEvent",
+                targetID: activeTargetID,
+                details: "newTarget=\(params.newTargetId.rawValue)"
+            )
+            clearElementPickerState(invalidatePendingSelection: true)
+        default:
+            return
+        }
     }
 
     private func registerUndoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager) {
@@ -898,17 +1307,6 @@ package final class InspectorSession {
         }
     }
 
-    private func waitForAppliedSequence(
-        _ sequence: UInt64,
-        domain: ProtocolDomain,
-        connection: InspectorConnection
-    ) async {
-        await connection.pumps[domain]?.waitUntilApplied(
-            sequence,
-            timeout: configuration.eventApplicationTimeout
-        )
-    }
-
     private func activeConnection() throws -> InspectorConnection {
         guard isAttached,
               let connection else {
@@ -923,17 +1321,38 @@ package final class InspectorSession {
         }
     }
 
-    private func requestNodeResultMayNeedDOMPathPush(
-        _ result: ProtocolCommandResult,
-        targetID: ProtocolTargetIdentifier,
-        domSequence: UInt64
-    ) -> Bool {
-        guard domSequence > 0,
-              let payload = try? TransportMessageParser.decode(RequestNodeResultPayload.self, from: result.resultData) else {
-            return false
+    private func traceCommandSend(_ command: ProtocolCommand) {
+        switch command.method {
+        case "DOM.getDocument", "DOM.requestNode":
+            inspectorRuntimeTrace("command.send method=\(command.method) routing=\(command.routing) appliedSeq=\(currentAppliedDOMSequence)")
+        default:
+            break
         }
-        let key = DOMNodeCurrentKey(targetID: targetID, nodeID: payload.nodeId)
-        return dom.snapshot().currentNodeIDByKey[key] == nil
+    }
+
+    private func traceCommandReply(_ command: ProtocolCommand, result: ProtocolCommandResult) {
+        switch command.method {
+        case "DOM.getDocument", "DOM.requestNode":
+            inspectorRuntimeTrace("command.reply method=\(command.method) target=\(result.targetID?.rawValue ?? "nil") replySeq=\(result.receivedSequence) domSeq=\(result.receivedSequence(for: .dom))")
+        default:
+            break
+        }
+    }
+
+    private func traceEvent(_ event: ProtocolEventEnvelope, phase: String) {
+        switch event.domain {
+        case .target:
+            inspectorRuntimeTrace("event.\(phase) seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil")")
+        case .dom where event.method == "DOM.documentUpdated" || event.method == "DOM.inspect":
+            inspectorRuntimeTrace("event.\(phase) seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil")")
+        default:
+            break
+        }
+    }
+
+    private func traceGetDocumentResult(_ result: ProtocolCommandResult) {
+        let summary = (try? JSONDecoder().decode(DOMGetDocumentTracePayload.self, from: result.resultData).root.summary) ?? "decode-failed"
+        inspectorRuntimeDOMTrace("getDocument.apply target=\(result.targetID?.rawValue ?? "nil") replySeq=\(result.receivedSequence) domSeq=\(result.receivedSequence(for: .dom)) root=\(summary)")
     }
 
     package static func prepareInspectability(for webView: WKWebView) -> Bool? {

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -202,8 +202,7 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(SetChildNodesParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             if params.parentId.rawValue == 0 {
-                guard snapshot.targetsByID[targetID]?.kind != .frame,
-                      let detachedRoot = params.nodes.first?.payload else {
+                guard let detachedRoot = params.nodes.first?.payload else {
                     return
                 }
                 session.applyDetachedRoot(targetID: targetID, payload: detachedRoot, eventSequence: event.sequence)

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -2,6 +2,11 @@ import Foundation
 import WebInspectorCore
 
 package enum DOMTransportAdapter {
+    package struct TargetCommitResolution: Equatable, Sendable {
+        package var oldTargetID: ProtocolTargetIdentifier?
+        package var newTargetID: ProtocolTargetIdentifier
+    }
+
     package static func command(for intent: DOMCommandIntent) throws -> ProtocolCommand {
         switch intent {
         case let .getDocument(targetID):
@@ -103,24 +108,40 @@ package enum DOMTransportAdapter {
             session.applyTargetDestroyed(params.targetId)
             return nil
         case "Target.didCommitProvisionalTarget":
-            let params = try TransportMessageParser.decode(TargetCommittedParams.self, from: event.paramsData)
             let snapshotBeforeCommit = session.snapshot()
-            if let oldTargetId = params.oldTargetId ?? inferredOldTargetIDForOldlessCommit(params, snapshot: snapshotBeforeCommit) {
-                session.applyTargetCommitted(oldTargetID: oldTargetId, newTargetID: params.newTargetId)
+            guard let commit = try targetCommitResolution(from: event, snapshot: snapshotBeforeCommit) else {
+                return nil
+            }
+            if let oldTargetID = commit.oldTargetID {
+                session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: commit.newTargetID)
             } else {
-                session.applyTargetCommitted(targetID: params.newTargetId)
+                session.applyTargetCommitted(targetID: commit.newTargetID)
             }
             let snapshot = session.snapshot()
             if snapshotBeforeCommit.currentPageTargetID == nil,
-               let target = snapshot.targetsByID[params.newTargetId],
+               let target = snapshot.targetsByID[commit.newTargetID],
                target.kind == .page,
                target.parentFrameID == nil {
-                session.promoteTargetToCurrentPage(params.newTargetId)
+                session.promoteTargetToCurrentPage(commit.newTargetID)
             }
             return nil
         default:
             return nil
         }
+    }
+
+    package static func targetCommitResolution(
+        from event: ProtocolEventEnvelope,
+        snapshot: DOMSessionSnapshot
+    ) throws -> TargetCommitResolution? {
+        guard event.method == "Target.didCommitProvisionalTarget" else {
+            return nil
+        }
+        let params = try TransportMessageParser.decode(TargetCommittedParams.self, from: event.paramsData)
+        return TargetCommitResolution(
+            oldTargetID: params.oldTargetId ?? inferredOldTargetIDForOldlessCommit(params, snapshot: snapshot),
+            newTargetID: params.newTargetId
+        )
     }
 
     @MainActor

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -2,12 +2,6 @@ import Foundation
 import WebInspectorCore
 
 package enum DOMTransportAdapter {
-#if DEBUG
-    private static func domAdapterTrace(_ message: @autoclosure () -> String) {}
-#else
-    private static func domAdapterTrace(_ message: @autoclosure () -> String) {}
-#endif
-
     package static func command(for intent: DOMCommandIntent) throws -> ProtocolCommand {
         switch intent {
         case let .getDocument(targetID):
@@ -218,7 +212,6 @@ package enum DOMTransportAdapter {
             if let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentId)] {
                 session.applySetChildNodes(parent: parentID, children: params.nodes.map(\.payload), eventSequence: event.sequence)
             } else {
-                domAdapterTrace("setChildNodes.fragment target=\(targetID.rawValue) parent=\(params.parentId.rawValue) reason=missingCurrentNode children=\(nodeSummary(params.nodes.map(\.payload)))")
                 session.applySetChildNodes(
                     targetID: targetID,
                     parentRawNodeID: params.parentId,
@@ -230,7 +223,6 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(ChildNodeInsertedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentNodeId)] else {
-                domAdapterTrace("childNodeInserted.drop target=\(targetID.rawValue) parent=\(params.parentNodeId.rawValue) reason=missingCurrentNode child=\(nodeSummary(params.node.payload))")
                 return
             }
             let previousSiblingID = params.previousNodeId.flatMap {
@@ -241,7 +233,6 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(ChildNodeRemovedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
-                domAdapterTrace("childNodeRemoved.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) reason=missingCurrentNode")
                 return
             }
             session.applyNodeRemoved(nodeID)
@@ -256,7 +247,6 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(AttributeModifiedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
-                domAdapterTrace("attributeModified.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) name=\(params.name) reason=missingCurrentNode")
                 return
             }
             session.applyAttributeModified(nodeID, name: params.name, value: params.value)
@@ -264,32 +254,12 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(AttributeRemovedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
-                domAdapterTrace("attributeRemoved.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) name=\(params.name) reason=missingCurrentNode")
                 return
             }
             session.applyAttributeRemoved(nodeID, name: params.name)
         default:
             break
         }
-    }
-
-    private static func nodeSummary(_ node: DOMNodeSnapshot?) -> String {
-        guard let node else {
-            return "nil"
-        }
-        return "\(node.nodeName)#\(node.protocolNodeID.rawValue)"
-    }
-
-    private static func nodeSummary(_ payload: DOMNodePayload) -> String {
-        "\(payload.nodeName)#\(payload.nodeID.rawValue)"
-    }
-
-    private static func nodeSummary(_ payloads: [DOMNodePayload]) -> String {
-        let prefix = payloads.prefix(8).map(nodeSummary).joined(separator: ",")
-        if payloads.count > 8 {
-            return "[\(prefix),... total=\(payloads.count)]"
-        }
-        return "[\(prefix)]"
     }
 
     private static func data(_ object: [String: Any]) throws -> Data {

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -2,6 +2,12 @@ import Foundation
 import WebInspectorCore
 
 package enum DOMTransportAdapter {
+#if DEBUG
+    private static func domAdapterTrace(_ message: @autoclosure () -> String) {}
+#else
+    private static func domAdapterTrace(_ message: @autoclosure () -> String) {}
+#endif
+
     package static func command(for intent: DOMCommandIntent) throws -> ProtocolCommand {
         switch intent {
         case let .getDocument(targetID):
@@ -85,20 +91,23 @@ package enum DOMTransportAdapter {
     }
 
     @MainActor
-    package static func applyTargetEvent(_ event: ProtocolEventEnvelope, to session: DOMSession) throws {
+    @discardableResult
+    package static func applyTargetEvent(_ event: ProtocolEventEnvelope, to session: DOMSession) throws -> ProtocolTargetRecord? {
         switch event.method {
         case "Target.targetCreated":
             let params = try TransportMessageParser.decode(TargetCreatedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
-            let record = params.targetInfo.record(currentMainFrameID: snapshot.currentPage?.mainFrameID)
-            let makeCurrentMainPage = snapshot.currentPage == nil
+            let record = params.targetInfo.record(currentMainFrameID: snapshot.mainFrameID)
+            let makeCurrentMainPage = snapshot.currentPageTargetID == nil
                 && record.kind == .page
                 && record.parentFrameID == nil
                 && !record.isProvisional
             session.applyTargetCreated(record, makeCurrentMainPage: makeCurrentMainPage)
+            return record
         case "Target.targetDestroyed":
             let params = try TransportMessageParser.decode(TargetDestroyedParams.self, from: event.paramsData)
             session.applyTargetDestroyed(params.targetId)
+            return nil
         case "Target.didCommitProvisionalTarget":
             let params = try TransportMessageParser.decode(TargetCommittedParams.self, from: event.paramsData)
             let snapshotBeforeCommit = session.snapshot()
@@ -108,14 +117,15 @@ package enum DOMTransportAdapter {
                 session.applyTargetCommitted(targetID: params.newTargetId)
             }
             let snapshot = session.snapshot()
-            if snapshotBeforeCommit.currentPage == nil,
+            if snapshotBeforeCommit.currentPageTargetID == nil,
                let target = snapshot.targetsByID[params.newTargetId],
                target.kind == .page,
                target.parentFrameID == nil {
                 session.promoteTargetToCurrentPage(params.newTargetId)
             }
+            return nil
         default:
-            break
+            return nil
         }
     }
 
@@ -149,9 +159,9 @@ package enum DOMTransportAdapter {
         _ result: ProtocolCommandResult,
         selectionRequestID: SelectionRequestIdentifier,
         to session: DOMSession
-    ) throws -> Result<DOMNodeIdentifier, SelectionResolutionFailure> {
+    ) throws -> DOMRequestNodeResolution {
         guard let targetID = result.targetID else {
-            return .failure(.targetMismatch(expected: ProtocolTargetIdentifier(""), received: ProtocolTargetIdentifier("")))
+            return .failed(.targetMismatch(expected: ProtocolTargetIdentifier(""), received: ProtocolTargetIdentifier("")))
         }
         let payload = try TransportMessageParser.decode(RequestNodeResult.self, from: result.resultData)
         return session.applyRequestNodeResult(
@@ -197,14 +207,30 @@ package enum DOMTransportAdapter {
         case "DOM.setChildNodes":
             let params = try TransportMessageParser.decode(SetChildNodesParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
-            guard let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentId)] else {
+            if params.parentId.rawValue == 0 {
+                guard snapshot.targetsByID[targetID]?.kind != .frame,
+                      let detachedRoot = params.nodes.first?.payload else {
+                    return
+                }
+                session.applyDetachedRoot(targetID: targetID, payload: detachedRoot, eventSequence: event.sequence)
                 return
             }
-            session.applySetChildNodes(parent: parentID, children: params.nodes.map(\.payload))
+            if let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentId)] {
+                session.applySetChildNodes(parent: parentID, children: params.nodes.map(\.payload), eventSequence: event.sequence)
+            } else {
+                domAdapterTrace("setChildNodes.fragment target=\(targetID.rawValue) parent=\(params.parentId.rawValue) reason=missingCurrentNode children=\(nodeSummary(params.nodes.map(\.payload)))")
+                session.applySetChildNodes(
+                    targetID: targetID,
+                    parentRawNodeID: params.parentId,
+                    children: params.nodes.map(\.payload),
+                    eventSequence: event.sequence
+                )
+            }
         case "DOM.childNodeInserted":
             let params = try TransportMessageParser.decode(ChildNodeInsertedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentNodeId)] else {
+                domAdapterTrace("childNodeInserted.drop target=\(targetID.rawValue) parent=\(params.parentNodeId.rawValue) reason=missingCurrentNode child=\(nodeSummary(params.node.payload))")
                 return
             }
             let previousSiblingID = params.previousNodeId.flatMap {
@@ -215,12 +241,55 @@ package enum DOMTransportAdapter {
             let params = try TransportMessageParser.decode(ChildNodeRemovedParams.self, from: event.paramsData)
             let snapshot = session.snapshot()
             guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+                domAdapterTrace("childNodeRemoved.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) reason=missingCurrentNode")
                 return
             }
             session.applyNodeRemoved(nodeID)
+        case "DOM.childNodeCountUpdated":
+            let params = try TransportMessageParser.decode(ChildNodeCountUpdatedParams.self, from: event.paramsData)
+            let snapshot = session.snapshot()
+            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+                return
+            }
+            session.applyChildNodeCountUpdated(nodeID, count: params.childNodeCount)
+        case "DOM.attributeModified":
+            let params = try TransportMessageParser.decode(AttributeModifiedParams.self, from: event.paramsData)
+            let snapshot = session.snapshot()
+            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+                domAdapterTrace("attributeModified.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) name=\(params.name) reason=missingCurrentNode")
+                return
+            }
+            session.applyAttributeModified(nodeID, name: params.name, value: params.value)
+        case "DOM.attributeRemoved":
+            let params = try TransportMessageParser.decode(AttributeRemovedParams.self, from: event.paramsData)
+            let snapshot = session.snapshot()
+            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+                domAdapterTrace("attributeRemoved.drop target=\(targetID.rawValue) node=\(params.nodeId.rawValue) name=\(params.name) reason=missingCurrentNode")
+                return
+            }
+            session.applyAttributeRemoved(nodeID, name: params.name)
         default:
             break
         }
+    }
+
+    private static func nodeSummary(_ node: DOMNodeSnapshot?) -> String {
+        guard let node else {
+            return "nil"
+        }
+        return "\(node.nodeName)#\(node.protocolNodeID.rawValue)"
+    }
+
+    private static func nodeSummary(_ payload: DOMNodePayload) -> String {
+        "\(payload.nodeName)#\(payload.nodeID.rawValue)"
+    }
+
+    private static func nodeSummary(_ payloads: [DOMNodePayload]) -> String {
+        let prefix = payloads.prefix(8).map(nodeSummary).joined(separator: ",")
+        if payloads.count > 8 {
+            return "[\(prefix),... total=\(payloads.count)]"
+        }
+        return "[\(prefix)]"
     }
 
     private static func data(_ object: [String: Any]) throws -> Data {
@@ -259,8 +328,20 @@ package enum DOMTransportAdapter {
         _ params: TargetCommittedParams,
         snapshot: DOMSessionSnapshot
     ) -> ProtocolTargetIdentifier? {
-        guard params.oldTargetId == nil,
-              snapshot.targetsByID[params.newTargetId] == nil else {
+        guard params.oldTargetId == nil else {
+            return nil
+        }
+
+        if let newTarget = snapshot.targetsByID[params.newTargetId],
+           newTarget.isProvisional,
+           newTarget.kind == .page,
+           newTarget.parentFrameID == nil,
+           let currentPageTargetID = snapshot.currentPageTargetID,
+           currentPageTargetID != params.newTargetId {
+            return currentPageTargetID
+        }
+
+        guard snapshot.targetsByID[params.newTargetId] == nil else {
             return nil
         }
 
@@ -299,18 +380,28 @@ private struct TargetInfoPayload: Decodable {
     var type: String
     var frameId: DOMFrameIdentifier?
     var parentFrameId: DOMFrameIdentifier?
+    var domains: [String]?
     var isProvisional: Bool?
     var isPaused: Bool?
 
     func record(currentMainFrameID: DOMFrameIdentifier?) -> ProtocolTargetRecord {
-        ProtocolTargetRecord(
+        let kind = targetKind(currentMainFrameID: currentMainFrameID)
+        return ProtocolTargetRecord(
             id: targetId,
-            kind: targetKind(currentMainFrameID: currentMainFrameID),
+            kind: kind,
             frameID: frameId,
             parentFrameID: parentFrameId,
+            capabilities: capabilities(for: kind),
             isProvisional: isProvisional ?? false,
             isPaused: isPaused ?? false
         )
+    }
+
+    private func capabilities(for kind: ProtocolTargetKind) -> ProtocolTargetCapabilities {
+        if let domains {
+            return ProtocolTargetCapabilities(domainNames: domains)
+        }
+        return ProtocolTargetCapabilities.protocolDefault(for: kind)
     }
 
     private func targetKind(currentMainFrameID: DOMFrameIdentifier?) -> ProtocolTargetKind {
@@ -391,6 +482,22 @@ private struct ChildNodeRemovedParams: Decodable {
     var nodeId: DOMProtocolNodeID
 }
 
+private struct ChildNodeCountUpdatedParams: Decodable {
+    var nodeId: DOMProtocolNodeID
+    var childNodeCount: Int
+}
+
+private struct AttributeModifiedParams: Decodable {
+    var nodeId: DOMProtocolNodeID
+    var name: String
+    var value: String
+}
+
+private struct AttributeRemovedParams: Decodable {
+    var nodeId: DOMProtocolNodeID
+    var name: String
+}
+
 private final class DOMNodeWirePayload: Decodable {
     var nodeId: DOMProtocolNodeID
     var nodeType: Int
@@ -398,6 +505,8 @@ private final class DOMNodeWirePayload: Decodable {
     var localName: String?
     var nodeValue: String?
     var frameId: DOMFrameIdentifier?
+    var documentURL: String?
+    var baseURL: String?
     var attributes: [String]?
     var childNodeCount: Int?
     var children: [DOMNodeWirePayload]?
@@ -427,7 +536,9 @@ private final class DOMNodeWirePayload: Decodable {
             nodeName: nodeName,
             localName: localName ?? "",
             nodeValue: nodeValue ?? "",
-            frameID: frameId,
+            ownerFrameID: frameId,
+            documentURL: documentURL,
+            baseURL: baseURL,
             attributes: attributePairs(attributes ?? []),
             regularChildren: regularChildren,
             contentDocument: contentDocument?.payload,

--- a/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
@@ -2,12 +2,6 @@ import Foundation
 import WebInspectorCore
 
 package enum NetworkTransportAdapter {
-#if DEBUG
-    private static func networkTrace(_ message: @autoclosure () -> String) {}
-#else
-    private static func networkTrace(_ message: @autoclosure () -> String) {}
-#endif
-
     package static func command(for intent: NetworkCommandIntent) throws -> ProtocolCommand {
         switch intent {
         case let .getResponseBody(requestKey, backendResourceIdentifier):
@@ -54,9 +48,6 @@ package enum NetworkTransportAdapter {
         switch event.method {
         case "Network.requestWillBeSent":
             let params = try TransportMessageParser.decode(RequestWillBeSentParams.self, from: event.paramsData)
-            if shouldTraceNavigationResource(type: params.type, url: params.request.url, documentURL: params.documentURL) {
-                networkTrace("navigation.request target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId?.rawValue ?? "nil") type=\(params.type ?? "nil") url=\(params.request.url) documentURL=\(params.documentURL ?? "nil") originatingTarget=\(params.targetId?.rawValue ?? "nil")")
-            }
             let existingRequestURL = session.requestSnapshot(
                 for: .init(targetID: targetID, requestID: params.requestId)
             )?.request.url
@@ -77,9 +68,6 @@ package enum NetworkTransportAdapter {
             )
         case "Network.responseReceived":
             let params = try TransportMessageParser.decode(ResponseReceivedParams.self, from: event.paramsData)
-            if shouldTraceNavigationResource(type: params.type, url: params.response.url ?? "", documentURL: nil) {
-                networkTrace("navigation.response target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId?.rawValue ?? "nil") type=\(params.type ?? "nil") url=\(params.response.url ?? "nil") status=\(params.response.status)")
-            }
             session.applyResponseReceived(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -113,7 +101,6 @@ package enum NetworkTransportAdapter {
             )
         case "Network.loadingFailed":
             let params = try TransportMessageParser.decode(LoadingFailedParams.self, from: event.paramsData)
-            networkTrace("failed target=\(targetID.rawValue) request=\(params.requestId.rawValue) error=\(params.errorText) canceled=\(params.canceled ?? false)")
             session.applyLoadingFailed(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -170,9 +157,6 @@ package enum NetworkTransportAdapter {
             session.applyWebSocketClosed(targetID: targetID, requestID: params.requestId, timestamp: params.timestamp)
         case "Network.requestServedFromMemoryCache":
             let params = try TransportMessageParser.decode(RequestServedFromMemoryCacheParams.self, from: event.paramsData)
-            if shouldTraceNavigationResource(type: params.resource.type, url: params.resource.url, documentURL: params.documentURL) {
-                networkTrace("navigation.memoryCache target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId.rawValue) url=\(params.resource.url) documentURL=\(params.documentURL)")
-            }
             _ = session.applyRequestServedFromMemoryCache(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -204,12 +188,6 @@ package enum NetworkTransportAdapter {
         return try JSONSerialization.data(withJSONObject: object, options: [])
     }
 
-    private static func shouldTraceNavigationResource(type: String?, url: String, documentURL: String?) -> Bool {
-        if type == "Document" {
-            return true
-        }
-        return documentURL == url
-    }
 }
 
 private struct ResponseBodyResult: Decodable {

--- a/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
@@ -2,6 +2,12 @@ import Foundation
 import WebInspectorCore
 
 package enum NetworkTransportAdapter {
+#if DEBUG
+    private static func networkTrace(_ message: @autoclosure () -> String) {}
+#else
+    private static func networkTrace(_ message: @autoclosure () -> String) {}
+#endif
+
     package static func command(for intent: NetworkCommandIntent) throws -> ProtocolCommand {
         switch intent {
         case let .getResponseBody(requestKey, backendResourceIdentifier):
@@ -48,6 +54,9 @@ package enum NetworkTransportAdapter {
         switch event.method {
         case "Network.requestWillBeSent":
             let params = try TransportMessageParser.decode(RequestWillBeSentParams.self, from: event.paramsData)
+            if shouldTraceNavigationResource(type: params.type, url: params.request.url, documentURL: params.documentURL) {
+                networkTrace("navigation.request target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId?.rawValue ?? "nil") type=\(params.type ?? "nil") url=\(params.request.url) documentURL=\(params.documentURL ?? "nil") originatingTarget=\(params.targetId?.rawValue ?? "nil")")
+            }
             let existingRequestURL = session.requestSnapshot(
                 for: .init(targetID: targetID, requestID: params.requestId)
             )?.request.url
@@ -68,6 +77,9 @@ package enum NetworkTransportAdapter {
             )
         case "Network.responseReceived":
             let params = try TransportMessageParser.decode(ResponseReceivedParams.self, from: event.paramsData)
+            if shouldTraceNavigationResource(type: params.type, url: params.response.url ?? "", documentURL: nil) {
+                networkTrace("navigation.response target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId?.rawValue ?? "nil") type=\(params.type ?? "nil") url=\(params.response.url ?? "nil") status=\(params.response.status)")
+            }
             session.applyResponseReceived(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -101,6 +113,7 @@ package enum NetworkTransportAdapter {
             )
         case "Network.loadingFailed":
             let params = try TransportMessageParser.decode(LoadingFailedParams.self, from: event.paramsData)
+            networkTrace("failed target=\(targetID.rawValue) request=\(params.requestId.rawValue) error=\(params.errorText) canceled=\(params.canceled ?? false)")
             session.applyLoadingFailed(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -157,6 +170,9 @@ package enum NetworkTransportAdapter {
             session.applyWebSocketClosed(targetID: targetID, requestID: params.requestId, timestamp: params.timestamp)
         case "Network.requestServedFromMemoryCache":
             let params = try TransportMessageParser.decode(RequestServedFromMemoryCacheParams.self, from: event.paramsData)
+            if shouldTraceNavigationResource(type: params.resource.type, url: params.resource.url, documentURL: params.documentURL) {
+                networkTrace("navigation.memoryCache target=\(targetID.rawValue) request=\(params.requestId.rawValue) frame=\(params.frameId.rawValue) url=\(params.resource.url) documentURL=\(params.documentURL)")
+            }
             _ = session.applyRequestServedFromMemoryCache(
                 targetID: targetID,
                 requestID: params.requestId,
@@ -186,6 +202,13 @@ package enum NetworkTransportAdapter {
             ]
         }
         return try JSONSerialization.data(withJSONObject: object, options: [])
+    }
+
+    private static func shouldTraceNavigationResource(type: String?, url: String, documentURL: String?) -> Bool {
+        if type == "Document" {
+            return true
+        }
+        return documentURL == url
     }
 }
 

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -1,6 +1,12 @@
 import Foundation
 import WebInspectorCore
 
+#if DEBUG
+private func transportTrace(_ message: @autoclosure () -> String) {}
+#else
+private func transportTrace(_ message: @autoclosure () -> String) {}
+#endif
+
 package actor TransportSession {
     private struct PendingReply: Sendable {
         var domain: ProtocolDomain
@@ -21,10 +27,12 @@ package actor TransportSession {
     private var targetReplyKeysByRootWrapperID: [UInt64: TargetReplyKey]
     private var mainPageTargetWaiters: [UInt64: ReplyPromise<TransportMainPageTarget>]
     private var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord]
+    private var provisionalTargetMessagesByTargetID: [ProtocolTargetIdentifier: [ParsedProtocolMessage]]
     private var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
     private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
+    private var orderedSubscribers: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]
     private var inboundMessages: [String]
     private var isDrainingInboundMessages: Bool
     private var closed: Bool
@@ -42,9 +50,12 @@ package actor TransportSession {
         targetReplyKeysByRootWrapperID = [:]
         mainPageTargetWaiters = [:]
         targetsByID = [:]
+        provisionalTargetMessagesByTargetID = [:]
         frameTargetIDsByFrameID = [:]
         executionContextsByID = [:]
+        currentMainPageTargetID = nil
         subscribers = [:]
+        orderedSubscribers = [:]
         inboundMessages = []
         isDrainingInboundMessages = false
         closed = false
@@ -58,6 +69,20 @@ package actor TransportSession {
         pair.continuation.onTermination = { [weak self] _ in
             Task {
                 await self?.removeSubscriber(subscriberID, domain: domain)
+            }
+        }
+        return pair.stream
+    }
+
+    package func orderedEvents() -> AsyncStream<ProtocolEventEnvelope> {
+        let pair = AsyncStream<ProtocolEventEnvelope>.makeStream(bufferingPolicy: .unbounded)
+        nextSubscriberID &+= 1
+        let subscriberID = nextSubscriberID
+        orderedSubscribers[subscriberID] = pair.continuation
+        transportTrace("ordered.subscribe id=\(subscriberID)")
+        pair.continuation.onTermination = { [weak self] _ in
+            Task {
+                await self?.removeOrderedSubscriber(subscriberID)
             }
         }
         return pair.stream
@@ -114,12 +139,17 @@ package actor TransportSession {
         targetReplies.removeAll()
         targetReplyKeysByRootWrapperID.removeAll()
         mainPageTargetWaiters.removeAll()
+        provisionalTargetMessagesByTargetID.removeAll()
         for continuations in subscribers.values {
             for continuation in continuations.values {
                 continuation.finish()
             }
         }
+        for continuation in orderedSubscribers.values {
+            continuation.finish()
+        }
         subscribers.removeAll()
+        orderedSubscribers.removeAll()
         await backend.detach()
     }
 
@@ -336,6 +366,7 @@ package actor TransportSession {
            let key = targetReplyKeysByRootWrapperID.removeValue(forKey: id) {
             if parsed.errorMessage != nil,
                let pending = removeTargetReply(for: key) {
+                traceReply(pending, parsed: parsed)
                 await resolve(pending, parsed: parsed)
             }
             return
@@ -343,6 +374,7 @@ package actor TransportSession {
 
         if let id = parsed.id,
            let pending = rootReplies.removeValue(forKey: id) {
+            traceReply(pending, parsed: parsed)
             await resolve(pending, parsed: parsed)
             return
         }
@@ -364,18 +396,35 @@ package actor TransportSession {
 
         await updateRegistryFromRootEvent(method: method, paramsData: parsed.paramsData)
         await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetIDForRootEvent(method: method, paramsData: parsed.paramsData), paramsData: parsed.paramsData)
+        await dispatchCommittedProvisionalTargetMessagesIfNeeded(method: method, paramsData: parsed.paramsData)
     }
 
     private func handleTargetMessage(_ parsed: ParsedProtocolMessage, targetID: ProtocolTargetIdentifier) async {
+        if targetsByID[targetID]?.isProvisional == true {
+            transportTrace("target.buffer provisional target=\(targetID.rawValue) method=\(parsed.method ?? "reply") id=\(String(describing: parsed.id))")
+            provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
+            return
+        }
+
         if let id = parsed.id {
             let key = TargetReplyKey(targetID: targetID, commandID: id)
             if let pending = removeTargetReply(for: key) {
+                traceReply(pending, parsed: parsed)
                 await resolve(pending, parsed: parsed)
                 return
             }
         }
 
         guard let method = parsed.method else {
+            return
+        }
+
+        if method == "Target.dispatchMessageFromTarget" {
+            guard let dispatch = try? TransportMessageParser.decode(TargetDispatchParams.self, from: parsed.paramsData),
+                  let targetMessage = try? await TransportMessageParser.parse(dispatch.message) else {
+                return
+            }
+            await handleTargetMessage(targetMessage, targetID: dispatch.targetId)
             return
         }
 
@@ -469,14 +518,23 @@ package actor TransportSession {
     }
 
     private func record(for targetInfo: TargetInfoPayload) -> ProtocolTargetRecord {
-        ProtocolTargetRecord(
+        let kind = targetKind(for: targetInfo)
+        return ProtocolTargetRecord(
             id: targetInfo.targetId,
-            kind: targetKind(for: targetInfo),
+            kind: kind,
             frameID: targetInfo.frameId,
             parentFrameID: targetInfo.parentFrameId,
+            capabilities: capabilities(for: targetInfo, kind: kind),
             isProvisional: targetInfo.isProvisional ?? false,
             isPaused: targetInfo.isPaused ?? false
         )
+    }
+
+    private func capabilities(for targetInfo: TargetInfoPayload, kind: ProtocolTargetKind) -> ProtocolTargetCapabilities {
+        if let domains = targetInfo.domains {
+            return ProtocolTargetCapabilities(domainNames: domains)
+        }
+        return ProtocolTargetCapabilities.protocolDefault(for: kind)
     }
 
     private func targetKind(for targetInfo: TargetInfoPayload) -> ProtocolTargetKind {
@@ -518,6 +576,7 @@ package actor TransportSession {
 
     private func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) async {
         targetsByID.removeValue(forKey: targetID)
+        provisionalTargetMessagesByTargetID.removeValue(forKey: targetID)
         frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != targetID }
         executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
         let pendingReplies = targetReplies.keys
@@ -586,9 +645,30 @@ package actor TransportSession {
         }
     }
 
+    private func dispatchCommittedProvisionalTargetMessagesIfNeeded(method: String, paramsData: Data) async {
+        guard method == "Target.didCommitProvisionalTarget",
+              let params = try? TransportMessageParser.decode(TargetCommittedParams.self, from: paramsData),
+              let messages = provisionalTargetMessagesByTargetID.removeValue(forKey: params.newTargetId) else {
+            return
+        }
+
+        transportTrace("target.flush provisional target=\(params.newTargetId.rawValue) count=\(messages.count)")
+        for message in messages {
+            await handleTargetMessage(message, targetID: params.newTargetId)
+        }
+    }
+
     private func inferredOldTargetIDForOldlessCommit(
         newTargetID: ProtocolTargetIdentifier
     ) -> ProtocolTargetIdentifier? {
+        if let newRecord = targetsByID[newTargetID],
+           newRecord.isProvisional,
+           newRecord.isTopLevelPage,
+           let currentMainPageTargetID,
+           currentMainPageTargetID != newTargetID {
+            return currentMainPageTargetID
+        }
+
         guard targetsByID[newTargetID] == nil else {
             return nil
         }
@@ -612,6 +692,8 @@ package actor TransportSession {
                 return frameTargetIDsByFrameID[frameID] ?? currentMainPageTargetID
             }
             return currentMainPageTargetID
+        case "DOM.documentUpdated":
+            return nil
         default:
             switch ProtocolDomain(method: method) {
             case .dom, .runtime, .network, .page, .storage:
@@ -642,10 +724,15 @@ package actor TransportSession {
             domain: domain,
             method: method,
             targetID: targetID,
+            receivedDomainSequences: lastSequenceByDomain,
             paramsData: paramsData
         )
         let continuations = subscribers[domain].map { Array($0.values) } ?? []
+        traceEvent(envelope)
         for continuation in continuations {
+            continuation.yield(envelope)
+        }
+        for continuation in orderedSubscribers.values {
             continuation.yield(envelope)
         }
         await notifyMainPageTargetWaitersIfNeeded(receivedSequence: nextSequence)
@@ -676,6 +763,33 @@ package actor TransportSession {
         subscribers[domain]?.removeValue(forKey: subscriberID)
         if subscribers[domain]?.isEmpty == true {
             subscribers.removeValue(forKey: domain)
+        }
+    }
+
+    private func removeOrderedSubscriber(_ subscriberID: UInt64) {
+        transportTrace("ordered.unsubscribe id=\(subscriberID)")
+        orderedSubscribers.removeValue(forKey: subscriberID)
+    }
+
+    private func traceEvent(_ event: ProtocolEventEnvelope) {
+        switch event.domain {
+        case .target:
+            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
+        case .dom where event.method == "DOM.documentUpdated" || event.method == "DOM.inspect":
+            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
+        case .inspector where event.method == "Inspector.inspect":
+            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
+        default:
+            break
+        }
+    }
+
+    private func traceReply(_ pending: PendingReply, parsed: ParsedProtocolMessage) {
+        switch pending.method {
+        case "DOM.getDocument", "DOM.requestNode":
+            transportTrace("reply method=\(pending.method) target=\(pending.targetID?.rawValue ?? "nil") nextSeq=\(nextSequence) domSeq=\(lastSequenceByDomain[.dom] ?? 0) error=\(parsed.errorMessage ?? "nil")")
+        default:
+            break
         }
     }
 
@@ -748,6 +862,7 @@ private struct TargetInfoPayload: Decodable {
     var type: String
     var frameId: DOMFrameIdentifier?
     var parentFrameId: DOMFrameIdentifier?
+    var domains: [String]?
     var isProvisional: Bool?
     var isPaused: Bool?
 

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -391,17 +391,17 @@ package actor TransportSession {
     }
 
     private func handleTargetMessage(_ parsed: ParsedProtocolMessage, targetID: ProtocolTargetIdentifier) async {
-        if targetsByID[targetID]?.isProvisional == true {
-            provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
-            return
-        }
-
         if let id = parsed.id {
             let key = TargetReplyKey(targetID: targetID, commandID: id)
             if let pending = removeTargetReply(for: key) {
                 await resolve(pending, parsed: parsed)
                 return
             }
+        }
+
+        if targetsByID[targetID]?.isProvisional == true {
+            provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
+            return
         }
 
         guard let method = parsed.method else {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -1,12 +1,6 @@
 import Foundation
 import WebInspectorCore
 
-#if DEBUG
-private func transportTrace(_ message: @autoclosure () -> String) {}
-#else
-private func transportTrace(_ message: @autoclosure () -> String) {}
-#endif
-
 package actor TransportSession {
     private struct PendingReply: Sendable {
         var domain: ProtocolDomain
@@ -79,7 +73,6 @@ package actor TransportSession {
         nextSubscriberID &+= 1
         let subscriberID = nextSubscriberID
         orderedSubscribers[subscriberID] = pair.continuation
-        transportTrace("ordered.subscribe id=\(subscriberID)")
         pair.continuation.onTermination = { [weak self] _ in
             Task {
                 await self?.removeOrderedSubscriber(subscriberID)
@@ -366,7 +359,6 @@ package actor TransportSession {
            let key = targetReplyKeysByRootWrapperID.removeValue(forKey: id) {
             if parsed.errorMessage != nil,
                let pending = removeTargetReply(for: key) {
-                traceReply(pending, parsed: parsed)
                 await resolve(pending, parsed: parsed)
             }
             return
@@ -374,7 +366,6 @@ package actor TransportSession {
 
         if let id = parsed.id,
            let pending = rootReplies.removeValue(forKey: id) {
-            traceReply(pending, parsed: parsed)
             await resolve(pending, parsed: parsed)
             return
         }
@@ -401,7 +392,6 @@ package actor TransportSession {
 
     private func handleTargetMessage(_ parsed: ParsedProtocolMessage, targetID: ProtocolTargetIdentifier) async {
         if targetsByID[targetID]?.isProvisional == true {
-            transportTrace("target.buffer provisional target=\(targetID.rawValue) method=\(parsed.method ?? "reply") id=\(String(describing: parsed.id))")
             provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
             return
         }
@@ -409,7 +399,6 @@ package actor TransportSession {
         if let id = parsed.id {
             let key = TargetReplyKey(targetID: targetID, commandID: id)
             if let pending = removeTargetReply(for: key) {
-                traceReply(pending, parsed: parsed)
                 await resolve(pending, parsed: parsed)
                 return
             }
@@ -652,7 +641,6 @@ package actor TransportSession {
             return
         }
 
-        transportTrace("target.flush provisional target=\(params.newTargetId.rawValue) count=\(messages.count)")
         for message in messages {
             await handleTargetMessage(message, targetID: params.newTargetId)
         }
@@ -728,7 +716,6 @@ package actor TransportSession {
             paramsData: paramsData
         )
         let continuations = subscribers[domain].map { Array($0.values) } ?? []
-        traceEvent(envelope)
         for continuation in continuations {
             continuation.yield(envelope)
         }
@@ -767,30 +754,7 @@ package actor TransportSession {
     }
 
     private func removeOrderedSubscriber(_ subscriberID: UInt64) {
-        transportTrace("ordered.unsubscribe id=\(subscriberID)")
         orderedSubscribers.removeValue(forKey: subscriberID)
-    }
-
-    private func traceEvent(_ event: ProtocolEventEnvelope) {
-        switch event.domain {
-        case .target:
-            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
-        case .dom where event.method == "DOM.documentUpdated" || event.method == "DOM.inspect":
-            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
-        case .inspector where event.method == "Inspector.inspect":
-            transportTrace("emit seq=\(event.sequence) domain=\(event.domain) method=\(event.method) target=\(event.targetID?.rawValue ?? "nil") targetSeq=\(event.receivedSequence(for: .target)) domSeq=\(event.receivedSequence(for: .dom))")
-        default:
-            break
-        }
-    }
-
-    private func traceReply(_ pending: PendingReply, parsed: ParsedProtocolMessage) {
-        switch pending.method {
-        case "DOM.getDocument", "DOM.requestNode":
-            transportTrace("reply method=\(pending.method) target=\(pending.targetID?.rawValue ?? "nil") nextSeq=\(nextSequence) domSeq=\(lastSequenceByDomain[.dom] ?? 0) error=\(parsed.errorMessage ?? "nil")")
-        default:
-            break
-        }
     }
 
     private func removePendingReply(_ key: PendingKey) {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -581,6 +581,9 @@ package actor TransportSession {
 
     private func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
         let committedOldTargetID = oldTargetID ?? inferredOldTargetIDForOldlessCommit(newTargetID: newTargetID)
+        if let committedOldTargetID {
+            moveBufferedProvisionalTargetMessages(from: committedOldTargetID, to: newTargetID)
+        }
         if let oldTargetID = committedOldTargetID,
            oldTargetID == currentMainPageTargetID,
            let existingNewRecord = targetsByID[newTargetID],
@@ -632,6 +635,18 @@ package actor TransportSession {
            newRecord.parentFrameID == nil {
             currentMainPageTargetID = newTargetID
         }
+    }
+
+    private func moveBufferedProvisionalTargetMessages(
+        from oldTargetID: ProtocolTargetIdentifier,
+        to newTargetID: ProtocolTargetIdentifier
+    ) {
+        guard oldTargetID != newTargetID,
+              let messages = provisionalTargetMessagesByTargetID.removeValue(forKey: oldTargetID),
+              messages.isEmpty == false else {
+            return
+        }
+        provisionalTargetMessagesByTargetID[newTargetID, default: []].append(contentsOf: messages)
     }
 
     private func dispatchCommittedProvisionalTargetMessagesIfNeeded(method: String, paramsData: Data) async {

--- a/Sources/WebInspectorTransport/TransportTypes.swift
+++ b/Sources/WebInspectorTransport/TransportTypes.swift
@@ -127,6 +127,7 @@ package struct ProtocolEventEnvelope: Equatable, Sendable {
     package var domain: ProtocolDomain
     package var method: String
     package var targetID: ProtocolTargetIdentifier?
+    package var receivedDomainSequences: [ProtocolDomain: UInt64]
     package var paramsData: Data
 
     package init(
@@ -134,13 +135,19 @@ package struct ProtocolEventEnvelope: Equatable, Sendable {
         domain: ProtocolDomain,
         method: String,
         targetID: ProtocolTargetIdentifier?,
+        receivedDomainSequences: [ProtocolDomain: UInt64] = [:],
         paramsData: Data
     ) {
         self.sequence = sequence
         self.domain = domain
         self.method = method
         self.targetID = targetID
+        self.receivedDomainSequences = receivedDomainSequences
         self.paramsData = paramsData
+    }
+
+    package func receivedSequence(for domain: ProtocolDomain) -> UInt64 {
+        receivedDomainSequences[domain] ?? 0
     }
 }
 

--- a/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
@@ -784,12 +784,17 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     }
 
     private func openAncestors(of node: DOMNode) {
-        var current = node.parentID.flatMap { dom.node(for: $0) }
-        while let ancestor = current {
-            if ancestor.nodeType != .document || ancestor.parentID != nil {
+        guard let rootTargetID = dom.currentPageTargetID else {
+            return
+        }
+        let projection = dom.treeProjection(rootTargetID: rootTargetID)
+        for ancestorID in projection.ancestorNodeIDs(of: node.id) {
+            guard let ancestor = dom.node(for: ancestorID) else {
+                continue
+            }
+            if ancestor.nodeType != .document || projection.parent(of: ancestor.id) != nil {
                 openState[ancestor.id] = true
             }
-            current = ancestor.parentID.flatMap { dom.node(for: $0) }
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
@@ -55,7 +55,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     private var openState: [DOMNode.ID: Bool] = [:]
     private var hoveredNodeID: DOMNode.ID?
     private var requestedChildNodeIDs: Set<DOMNode.ID> = []
-    private var childRequestRetryCounts: [DOMNode.ID: Int] = [:]
     private var findFoundRanges: [NSRange] = []
     private var findHighlightedRanges: [NSRange] = []
     private var hoverRowRects: [CGRect] = []
@@ -258,16 +257,18 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     }
 
     @objc private func handleTap(_ recognizer: UITapGestureRecognizer) {
-        guard recognizer.state == .ended,
-              let row = row(at: recognizer.location(in: textContentView))
-        else {
+        guard recognizer.state == .ended else {
             return
         }
+        let location = recognizer.location(in: textContentView)
+        guard let row = row(at: location) else {
+            return
+        }
+        let disclosureHit = isDisclosureHit(at: location, in: row)
 
         dismissDOMMenuAnchor()
         clearTextSelection()
-        let location = recognizer.location(in: textContentView)
-        if isDisclosureHit(at: location, in: row) {
+        if disclosureHit {
             toggle(row: row)
         } else if recognizer.modifierFlags.contains(.shift) {
             extendMultiSelection(to: row)
@@ -559,6 +560,14 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     }
 
     private func scheduleTreeReload(for invalidation: DOMTreeInvalidation) {
+        if invalidation.requiresImmediateReload {
+            pendingTreeInvalidation = nil
+            scheduledTreeReloadTask?.cancel()
+            scheduledTreeReloadTask = nil
+            reloadTree(for: invalidation)
+            return
+        }
+
         if let pending = pendingTreeInvalidation {
             pendingTreeInvalidation = pending.merged(with: invalidation)
         } else {
@@ -568,7 +577,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
             return
         }
         scheduledTreeReloadTask = Task { @MainActor [weak self] in
-            await Task.yield()
             guard let self else {
                 return
             }
@@ -983,12 +991,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
             }
             return dom.hasUnloadedRegularChildren(node)
         }
-        childRequestRetryCounts = childRequestRetryCounts.filter { nodeID, _ in
-            guard let node = dom.node(for: nodeID) else {
-                return false
-            }
-            return dom.hasUnloadedRegularChildren(node)
-        }
     }
 
     private func requestChildrenForOpenRowsIfNeeded() {
@@ -1016,30 +1018,14 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         else {
             return
         }
-        let attempt = childRequestRetryCounts[node.id, default: 0] + 1
-        childRequestRetryCounts[node.id] = attempt
         Task { @MainActor [weak self, requestChildrenAction, nodeID = node.id] in
             guard let self else {
                 return
             }
-            let succeeded = await requestChildrenAction?(nodeID) ?? false
-            self.requestedChildNodeIDs.remove(nodeID)
-            guard let node = self.dom.node(for: nodeID) else {
-                self.childRequestRetryCounts.removeValue(forKey: nodeID)
-                return
+            defer {
+                self.requestedChildNodeIDs.remove(nodeID)
             }
-            if succeeded || !self.dom.hasUnloadedRegularChildren(node) {
-                self.childRequestRetryCounts.removeValue(forKey: nodeID)
-                return
-            }
-            guard attempt < 3 else {
-                return
-            }
-            try? await Task.sleep(nanoseconds: 250_000_000)
-            guard !Task.isCancelled else {
-                return
-            }
-            self.requestChildrenIfNeeded(for: node)
+            _ = await requestChildrenAction?(nodeID) ?? false
         }
     }
 
@@ -2478,7 +2464,7 @@ extension DOMTreeTextView {
             toggleMultiSelection(row: row)
         } else {
             clearMultiSelection(keepingLast: row.node.id)
-            multiSelectionLastNodeID = row.node.id
+            select(row.node)
         }
     }
 
@@ -3282,6 +3268,13 @@ private enum DOMTreeMarkupBuilder {
 }
 
 private extension DOMTreeInvalidation {
+    var requiresImmediateReload: Bool {
+        if case .documentReset = self {
+            return true
+        }
+        return false
+    }
+
     var requiresTextFragmentReset: Bool {
         if case .documentReset = self {
             return true

--- a/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import ObservationBridge
 import UIKit
 import WebInspectorCore
 import WebInspectorRuntime
@@ -6,8 +7,12 @@ import WebInspectorRuntime
 @MainActor
 package final class DOMTreeViewController: UIViewController {
     private let treeView: DOMTreeTextView
+    private weak var session: InspectorSession?
+    private let observationScope = ObservationScope()
+    private var isEnsuringDOMDocumentLoaded = false
 
     package init(session: InspectorSession) {
+        self.session = session
         self.treeView = DOMTreeTextView(
             dom: session.dom,
             requestChildrenAction: { [weak session] nodeID in
@@ -21,9 +26,11 @@ package final class DOMTreeViewController: UIViewController {
             }
         )
         super.init(nibName: nil, bundle: nil)
+        startObservingDOMRoot(session: session)
     }
 
     package init(dom: DOMSession) {
+        self.session = nil
         self.treeView = DOMTreeTextView(dom: dom)
         super.init(nibName: nil, bundle: nil)
     }
@@ -33,10 +40,43 @@ package final class DOMTreeViewController: UIViewController {
         nil
     }
 
+    isolated deinit {
+        observationScope.cancelAll()
+    }
+
     override package func loadView() {
         treeView.backgroundColor = .clear
         treeView.accessibilityIdentifier = "WebInspector.DOM.Tree.NativeTextView"
         view = treeView
+    }
+
+    override package func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        ensureDOMDocumentLoadedIfNeeded()
+    }
+
+    private func startObservingDOMRoot(session: InspectorSession) {
+        session.dom.observe(\.treeRevision) { [weak self] _ in
+            self?.ensureDOMDocumentLoadedIfNeeded()
+        }
+        .store(in: observationScope)
+    }
+
+    private func ensureDOMDocumentLoadedIfNeeded() {
+        guard let session,
+              viewIfLoaded?.window != nil,
+              !isEnsuringDOMDocumentLoaded,
+              session.dom.currentPageRootNode == nil else {
+            return
+        }
+
+        isEnsuringDOMDocumentLoaded = true
+        Task { @MainActor [weak self, weak session] in
+            defer {
+                self?.isEnsuringDOMDocumentLoaded = false
+            }
+            _ = await session?.ensureDOMDocumentLoaded()
+        }
     }
 }
 

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -10,6 +10,8 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     private let detailViewController: NetworkDetailViewController
     private let observationScope = ObservationScope()
     private var isSyncingStack = false
+    private var isStackSyncScheduledAfterTransition = false
+    private var pendingStackSyncAnimates = false
 
     package init(
         model: NetworkPanelModel,
@@ -77,6 +79,10 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func syncStack(with request: NetworkRequest?, animated: Bool) {
+        guard scheduleStackSyncAfterCurrentTransitionIfNeeded(animated: animated) == false else {
+            return
+        }
+
         guard request != nil else {
             popRequestDetailIfNeeded(animated: animated)
             return
@@ -109,6 +115,40 @@ package final class NetworkCompactNavigationController: UINavigationController, 
             return
         }
         setViewControllers([listViewController], animated: animated)
+    }
+
+    private func scheduleStackSyncAfterCurrentTransitionIfNeeded(animated: Bool) -> Bool {
+        guard let transitionCoordinator else {
+            return false
+        }
+
+        pendingStackSyncAnimates = pendingStackSyncAnimates || animated
+        guard isStackSyncScheduledAfterTransition == false else {
+            return true
+        }
+
+        isStackSyncScheduledAfterTransition = true
+        let didSchedule = transitionCoordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.performPendingStackSyncAfterTransition()
+        }
+        if didSchedule {
+            return true
+        }
+
+        isStackSyncScheduledAfterTransition = false
+        pendingStackSyncAnimates = false
+        return false
+    }
+
+    private func performPendingStackSyncAfterTransition() {
+        guard isStackSyncScheduledAfterTransition else {
+            return
+        }
+
+        isStackSyncScheduledAfterTransition = false
+        let shouldAnimate = pendingStackSyncAnimates
+        pendingStackSyncAnimates = false
+        syncStack(with: model.selectedRequest, animated: shouldAnimate)
     }
 }
 #endif

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -1039,6 +1039,42 @@ func staleSelectionRequestIsRejectedAfterFrameDocumentRefresh() async throws {
 }
 
 @Test
+func requestNodeReplyAfterDocumentInvalidationIsRejected() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+
+    let command = await session.beginInspectSelectionRequest(
+        targetID: pageTargetID,
+        objectID: "page-object"
+    )
+    let requestID: SelectionRequestIdentifier
+    guard case let .success(.requestNode(id, _, _)) = command else {
+        Issue.record("Expected pending requestNode selection")
+        return
+    }
+    requestID = id
+
+    await session.invalidateDocument(targetID: pageTargetID)
+    let result = await session.applyRequestNodeResult(
+        selectionRequestID: requestID,
+        targetID: pageTargetID,
+        nodeID: .init(2)
+    )
+    let snapshot = await session.snapshot()
+
+    guard case let .failed(.missingCurrentDocument(targetID)) = result else {
+        Issue.record("Expected missing current document failure")
+        return
+    }
+    #expect(targetID == pageTargetID)
+    #expect(snapshot.selection.selectedNodeID == nil)
+    #expect(snapshot.selection.pendingRequest == nil)
+}
+
+@Test
 func selectionFailureDoesNotMutateTreeFrameOrDocumentModel() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let session = await DOMSession()

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -288,6 +288,9 @@ func pendingFrameOwnerHydrationWalksLoadedDescendants() async throws {
         await session.snapshot().currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(30))]
     )
     #expect(await session.pendingFrameOwnerHydrationIntent() == .requestChildNodes(targetID: pageTargetID, nodeID: .init(30), depth: 1))
+    #expect(await session.pendingFrameOwnerHydrationIntent() == nil)
+    await session.clearOwnerHydrationTransactions(targetID: pageTargetID)
+    #expect(await session.pendingFrameOwnerHydrationIntent() == .requestChildNodes(targetID: pageTargetID, nodeID: .init(30), depth: 1))
 
     await session.applySetChildNodes(
         parent: wrapperID,
@@ -1133,6 +1136,26 @@ func requestNodeReplyAfterDocumentInvalidationIsRejected() async throws {
     #expect(targetID == pageTargetID)
     #expect(snapshot.selection.selectedNodeID == nil)
     #expect(snapshot.selection.pendingRequest == nil)
+}
+
+@Test
+func protocolNodeSelectionAfterDocumentInvalidationIsRejected() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    await session.invalidateDocument(targetID: pageTargetID)
+
+    let result = await session.selectProtocolNode(targetID: pageTargetID, nodeID: .init(2))
+    let snapshot = await session.snapshot()
+
+    guard case let .failure(.missingCurrentDocument(targetID)) = result else {
+        Issue.record("Expected missing current document failure")
+        return
+    }
+    #expect(targetID == pageTargetID)
+    #expect(snapshot.selection.selectedNodeID == nil)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -107,6 +107,7 @@ func provisionalFrameCommitDoesNotResetParentPageDocument() async throws {
     #expect(after.targetsByID[provisionalFrameTargetID] == nil)
     #expect(after.targetsByID[committedFrameTargetID]?.kind == .frame)
     #expect(after.framesByID[frameID]?.targetID == committedFrameTargetID)
+    #expect(after.framesByID[frameID]?.currentDocumentID == nil)
     #expect(after.nodesByID[frameRootID] == nil)
     #expect(after.frameDocumentProjections[committedFrameTargetID]?.state == .pending)
     #expect(after.frameDocumentProjections[committedFrameTargetID]?.ownerNodeID == nil)

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -272,6 +272,67 @@ func iframeOwnerProjectsFrameDocumentWithoutStoringItAsRegularChild() async thro
 }
 
 @Test
+func pendingFrameOwnerHydrationWalksLoadedDescendants() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID, parentFrameID: mainFrameID))
+    _ = await session.replaceDocumentRoot(pageDocumentWithNestedUnloadedOwner(), targetID: pageTargetID)
+    _ = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
+
+    let wrapperID = try #require(
+        await session.snapshot().currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(30))]
+    )
+    #expect(await session.pendingFrameOwnerHydrationIntent() == .requestChildNodes(targetID: pageTargetID, nodeID: .init(30), depth: 1))
+
+    await session.applySetChildNodes(
+        parent: wrapperID,
+        children: [
+            .element(
+                nodeID: 31,
+                name: "iframe",
+                ownerFrameID: mainFrameID,
+                attributes: [.init(name: "src", value: "https://frame.example/ad")]
+            ),
+        ]
+    )
+    let snapshot = await session.snapshot()
+    let iframeID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(31))])
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.state == .attached)
+}
+
+@Test
+func frameOwnerCandidatesAreScopedToParentFrameDocument() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let childFrameTargetID = ProtocolTarget.ID("frame-child-target")
+    let childFrameID = DOMFrame.ID("frame-child")
+    let nestedFrameTargetID = ProtocolTarget.ID("frame-nested-target")
+    let nestedFrameID = DOMFrame.ID("frame-nested")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: childFrameTargetID, kind: .frame, frameID: childFrameID, parentFrameID: mainFrameID))
+    await session.applyTargetCreated(.init(id: nestedFrameTargetID, kind: .frame, frameID: nestedFrameID, parentFrameID: childFrameID))
+    _ = await session.replaceDocumentRoot(pageDocument(iframeFrameID: childFrameID, ownerFrameID: mainFrameID), targetID: pageTargetID)
+    _ = await session.replaceDocumentRoot(pageDocument(iframeFrameID: nestedFrameID, ownerFrameID: childFrameID), targetID: childFrameTargetID)
+    _ = await session.replaceDocumentRoot(frameDocument(rootNodeID: 201), targetID: nestedFrameTargetID)
+
+    let snapshot = await session.snapshot()
+    let childDocumentIframeID = try #require(
+        snapshot.currentNodeIDByKey[.init(targetID: childFrameTargetID, nodeID: .init(20))]
+    )
+
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.ownerNodeID == childDocumentIframeID)
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.state == .attached)
+}
+
+@Test
 func frameDocumentProjectionRemainsPendingWhenURLDoesNotMatch() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")
@@ -1196,6 +1257,36 @@ private func pageDocumentWithoutIframe() -> DOMNodePayload {
                 children: [
                     .element(nodeID: 3, name: "head"),
                     .element(nodeID: 4, name: "body"),
+                ]
+            ),
+        ]
+    )
+}
+
+private func pageDocumentWithNestedUnloadedOwner() -> DOMNodePayload {
+    document(
+        nodeID: 1,
+        documentURL: "https://page.example/",
+        baseURL: "https://page.example/",
+        children: [
+            .element(
+                nodeID: 2,
+                name: "html",
+                children: [
+                    .element(nodeID: 3, name: "head"),
+                    .element(
+                        nodeID: 4,
+                        name: "body",
+                        children: [
+                            DOMNodePayload(
+                                nodeID: .init(30),
+                                nodeType: .element,
+                                nodeName: "div",
+                                localName: "div",
+                                regularChildren: .unrequested(count: 1)
+                            ),
+                        ]
+                    ),
                 ]
             ),
         ]

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -497,6 +497,28 @@ func ambiguousURLFallbackLeavesFrameDocumentPending() async throws {
 }
 
 @Test
+func frameIDMatchDisambiguatesDuplicateURLFrameOwners() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-b-target")
+    let frameID = DOMFrame.ID("frame-b")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID))
+    _ = await session.replaceDocumentRoot(pageDocumentWithDuplicateIframeURLsAndFrameIDs(), targetID: pageTargetID)
+    let frameRootID = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
+
+    let snapshot = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let expectedIframeID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(21))])
+    let projectionState = try #require(snapshot.frameDocumentProjections[frameTargetID])
+
+    #expect(projectionState.ownerNodeID == expectedIframeID)
+    #expect(projectionState.state == .attached)
+    #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: expectedIframeID) })
+}
+
+@Test
 func iframeOwnerSrcMutationReevaluatesFrameDocumentProjection() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")
@@ -1310,6 +1332,40 @@ private func pageDocumentWithDuplicateIframeURLs() -> DOMNodePayload {
                                 nodeID: 21,
                                 name: "iframe",
                                 ownerFrameID: .init("main-frame"),
+                                attributes: [.init(name: "src", value: "https://frame.example/ad")]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+        ]
+    )
+}
+
+private func pageDocumentWithDuplicateIframeURLsAndFrameIDs() -> DOMNodePayload {
+    document(
+        nodeID: 1,
+        documentURL: "https://page.example/",
+        baseURL: "https://page.example/",
+        children: [
+            .element(
+                nodeID: 2,
+                name: "html",
+                children: [
+                    .element(
+                        nodeID: 3,
+                        name: "body",
+                        children: [
+                            .element(
+                                nodeID: 20,
+                                name: "iframe",
+                                ownerFrameID: .init("frame-a"),
+                                attributes: [.init(name: "src", value: "https://frame.example/ad")]
+                            ),
+                            .element(
+                                nodeID: 21,
+                                name: "iframe",
+                                ownerFrameID: .init("frame-b"),
                                 attributes: [.init(name: "src", value: "https://frame.example/ad")]
                             ),
                         ]

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -13,8 +13,8 @@ func pageTargetCreationCreatesCurrentPageAndMainFrame() async throws {
     )
     let snapshot = await session.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == pageTargetID)
-    #expect(snapshot.currentPage?.mainFrameID == mainFrameID)
+    #expect(snapshot.currentPageTargetID == pageTargetID)
+    #expect(snapshot.mainFrameID == mainFrameID)
     #expect(snapshot.targetsByID[pageTargetID]?.kind == .page)
     #expect(snapshot.framesByID[mainFrameID]?.targetID == pageTargetID)
 }
@@ -27,7 +27,7 @@ func pageTargetCreationWithoutMainPageFlagOnlyRegistersTarget() async throws {
     await session.applyTargetCreated(.init(id: pageTargetID, kind: .page))
     let snapshot = await session.snapshot()
 
-    #expect(snapshot.currentPage == nil)
+    #expect(snapshot.currentPageTargetID == nil)
     #expect(snapshot.targetsByID[pageTargetID]?.kind == .page)
 }
 
@@ -69,7 +69,7 @@ func provisionalPageCommitUpdatesMainPageTargetWithoutKeepingOldDocument() async
     await session.applyTargetCommitted(oldTargetID: provisionalTargetID, newTargetID: committedTargetID)
     let after = await session.snapshot()
 
-    #expect(after.currentPage?.mainTargetID == committedTargetID)
+    #expect(after.currentPageTargetID == committedTargetID)
     #expect(after.targetsByID[provisionalTargetID] == nil)
     #expect(after.targetsByID[committedTargetID]?.isProvisional == false)
     #expect(after.framesByID[mainFrameID]?.targetID == committedTargetID)
@@ -108,6 +108,8 @@ func provisionalFrameCommitDoesNotResetParentPageDocument() async throws {
     #expect(after.targetsByID[committedFrameTargetID]?.kind == .frame)
     #expect(after.framesByID[frameID]?.targetID == committedFrameTargetID)
     #expect(after.nodesByID[frameRootID] == nil)
+    #expect(after.frameDocumentProjections[committedFrameTargetID]?.state == .pending)
+    #expect(after.frameDocumentProjections[committedFrameTargetID]?.ownerNodeID == nil)
 }
 
 @Test
@@ -230,13 +232,15 @@ func mainPageNavigationDoesNotMixFrameDocumentsIntoParentDocument() async throws
     _ = await session.replaceDocumentRoot(pageDocument(iframeFrameID: frameID), targetID: pageTargetID)
     let frameRootID = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
     let first = await session.snapshot()
+    let firstPageDocumentID = try #require(first.targetsByID[pageTargetID]?.currentDocumentID)
 
     _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
     let second = await session.snapshot()
+    let secondPageDocumentID = try #require(second.targetsByID[pageTargetID]?.currentDocumentID)
     let projection = await session.treeProjection(rootTargetID: pageTargetID)
 
-    #expect(first.currentPage?.navigationGeneration == 1)
-    #expect(second.currentPage?.navigationGeneration == 2)
+    #expect(firstPageDocumentID.localDocumentLifetimeID == .init(1))
+    #expect(secondPageDocumentID.localDocumentLifetimeID == .init(2))
     #expect(second.nodesByID[frameRootID] != nil)
     #expect(projection.rows.map(\.nodeID).contains(frameRootID) == false)
 }
@@ -257,11 +261,147 @@ func iframeOwnerProjectsFrameDocumentWithoutStoringItAsRegularChild() async thro
     let projection = await session.treeProjection(rootTargetID: pageTargetID)
     let iframeID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(20))])
     let iframe = try #require(snapshot.nodesByID[iframeID])
+    let projectionState = try #require(snapshot.frameDocumentProjections[frameTargetID])
 
+    #expect(iframe.ownerFrameID == DOMFrameIdentifier("main-frame"))
     #expect(iframe.regularChildIDs.isEmpty)
     #expect(snapshot.nodesByID[frameRootID]?.parentID == nil)
-    #expect(snapshot.framesByID[frameID]?.ownerNodeID == iframeID)
+    #expect(projectionState.ownerNodeID == iframeID)
+    #expect(projectionState.state == .attached)
     #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
+}
+
+@Test
+func frameDocumentProjectionRemainsPendingWhenURLDoesNotMatch() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID, parentFrameID: mainFrameID))
+    _ = await session.replaceDocumentRoot(
+        pageDocument(
+            iframeFrameID: frameID,
+            iframeAttributes: [.init(name: "src", value: "https://ads.example/bootstrap")]
+        ),
+        targetID: pageTargetID
+    )
+    let frameRootID = await session.replaceDocumentRoot(
+        frameDocument(rootNodeID: 101, documentURL: "https://redirect.example/final-ad"),
+        targetID: frameTargetID
+    )
+
+    let snapshot = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let projectionState = try #require(snapshot.frameDocumentProjections[frameTargetID])
+
+    #expect(projectionState.ownerNodeID == nil)
+    #expect(projectionState.state == .pending)
+    #expect(projection.rows.map(\.nodeID).contains(frameRootID) == false)
+}
+
+@Test
+func iframeOwnerSetChildNodesDoesNotRemoveAttachedFrameDocumentProjection() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID))
+    _ = await session.replaceDocumentRoot(pageDocument(iframeFrameID: frameID), targetID: pageTargetID)
+    let frameRootID = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
+    let before = await session.snapshot()
+    let iframeID = try #require(before.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(20))])
+
+    await session.applySetChildNodes(
+        parent: iframeID,
+        children: [
+            .element(nodeID: 30, name: "span"),
+        ]
+    )
+
+    let after = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let iframe = try #require(after.nodesByID[iframeID])
+
+    #expect(iframe.regularChildIDs.isEmpty)
+    #expect(after.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(30))] == nil)
+    #expect(after.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    #expect(after.frameDocumentProjections[frameTargetID]?.state == .attached)
+    #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
+}
+
+@Test
+func ambiguousURLFallbackLeavesFrameDocumentPending() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID))
+    _ = await session.replaceDocumentRoot(pageDocumentWithDuplicateIframeURLs(), targetID: pageTargetID)
+    let frameRootID = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
+
+    let snapshot = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let projectionState = try #require(snapshot.frameDocumentProjections[frameTargetID])
+
+    #expect(projectionState.ownerNodeID == nil)
+    #expect(projectionState.state == .ambiguous)
+    #expect(projection.rows.map(\.nodeID).contains(frameRootID) == false)
+}
+
+@Test
+func iframeOwnerSrcMutationReevaluatesFrameDocumentProjection() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID))
+    _ = await session.replaceDocumentRoot(
+        pageDocument(
+            iframeFrameID: frameID,
+            iframeAttributes: [.init(name: "src", value: "about:blank")]
+        ),
+        targetID: pageTargetID
+    )
+    let frameRootID = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
+    let before = await session.snapshot()
+    let iframeID = try #require(before.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(20))])
+
+    #expect(before.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
+    #expect(before.frameDocumentProjections[frameTargetID]?.state == .pending)
+
+    await session.applyAttributeModified(iframeID, name: "src", value: "https://frame.example/ad")
+    let after = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+
+    #expect(after.nodesByID[iframeID]?.attributes.first { $0.name == "src" }?.value == "https://frame.example/ad")
+    #expect(after.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    #expect(after.frameDocumentProjections[frameTargetID]?.state == .attached)
+    #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
+}
+
+@Test
+func getDocumentIntentRequiresDOMCapability() async throws {
+    let session = await DOMSession()
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+
+    await session.applyTargetCreated(
+        .init(id: pageTargetID, kind: .page, capabilities: [.dom]),
+        makeCurrentMainPage: true
+    )
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame))
+
+    #expect(await session.getDocumentIntent(targetID: pageTargetID) == .getDocument(targetID: pageTargetID))
+    #expect(await session.getDocumentIntent(targetID: frameTargetID) == nil)
 }
 
 @Test
@@ -283,7 +423,8 @@ func ownerMissingFrameDocumentProjectsWhenOwnerAppears() async throws {
     let snapshot = await session.snapshot()
 
     #expect(snapshot.framesByID[frameID]?.currentDocumentID == frameRootID.documentID)
-    #expect(snapshot.framesByID[frameID]?.ownerNodeID != nil)
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.state == .attached)
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.ownerNodeID != nil)
     #expect(projection.rows.map(\.nodeID).contains(frameRootID))
 }
 
@@ -305,7 +446,8 @@ func iframeOwnerRemovalDropsProjectionButKeepsFrameTargetMirror() async throws {
     let after = await session.snapshot()
     let projection = await session.treeProjection(rootTargetID: pageTargetID)
 
-    #expect(after.framesByID[frameID]?.ownerNodeID == nil)
+    #expect(after.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
+    #expect(after.frameDocumentProjections[frameTargetID]?.state == .pending)
     #expect(after.nodesByID[frameRootID] != nil)
     #expect(projection.rows.map(\.nodeID).contains(frameRootID) == false)
 }
@@ -341,6 +483,125 @@ func visibleOrderMatchesWebKitDOMTreeOrder() async throws {
         "span",
         "::after",
     ])
+}
+
+@Test
+func setChildNodesPreservesProtocolChildOrderAndSiblingLinks() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(nodeID: 1, children: [.element(nodeID: 2, name: "body")]),
+        targetID: pageTargetID
+    )
+    let bodyID = try #require(await session.snapshot().currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
+
+    await session.applySetChildNodes(
+        parent: bodyID,
+        children: [
+            .element(nodeID: 3, name: "style"),
+            .element(nodeID: 4, name: "script"),
+            .element(nodeID: 5, name: "div"),
+        ],
+        eventSequence: 1
+    )
+
+    let snapshot = await session.snapshot()
+    let childIDs = try [3, 4, 5].map { nodeID in
+        try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(nodeID))])
+    }
+
+    #expect(snapshot.nodesByID[bodyID]?.regularChildren.loadedChildren == childIDs)
+    #expect(snapshot.nodesByID[childIDs[0]]?.previousSiblingID == nil)
+    #expect(snapshot.nodesByID[childIDs[0]]?.nextSiblingID == childIDs[1])
+    #expect(snapshot.nodesByID[childIDs[1]]?.previousSiblingID == childIDs[0])
+    #expect(snapshot.nodesByID[childIDs[1]]?.nextSiblingID == childIDs[2])
+    #expect(snapshot.nodesByID[childIDs[2]]?.previousSiblingID == childIDs[1])
+    #expect(snapshot.nodesByID[childIDs[2]]?.nextSiblingID == nil)
+}
+
+@Test("Regression: detached root cannot overwrite connected page document nodes")
+func detachedRootCannotOverwriteConnectedPageDocumentNodes() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    let before = await session.snapshot()
+
+    let htmlKey = DOMNodeCurrentKey(targetID: pageTargetID, nodeID: .init(2))
+    let headKey = DOMNodeCurrentKey(targetID: pageTargetID, nodeID: .init(3))
+    let bodyKey = DOMNodeCurrentKey(targetID: pageTargetID, nodeID: .init(4))
+    let htmlID = try #require(before.currentNodeIDByKey[htmlKey])
+    let headID = try #require(before.currentNodeIDByKey[headKey])
+    let bodyID = try #require(before.currentNodeIDByKey[bodyKey])
+
+    await session.applyDetachedRoot(
+        targetID: pageTargetID,
+        payload: .element(
+            nodeID: 2,
+            name: "img",
+            children: [
+                .element(nodeID: 3, name: "source"),
+            ]
+        ),
+        eventSequence: 1
+    )
+
+    let after = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+
+    #expect(after.treeRevision == before.treeRevision)
+    #expect(after.currentNodeIDByKey[htmlKey] == htmlID)
+    #expect(after.currentNodeIDByKey[headKey] == headID)
+    #expect(after.currentNodeIDByKey[bodyKey] == bodyID)
+    #expect(after.nodesByID[htmlID]?.nodeName == "html")
+    #expect(after.nodesByID[headID]?.parentID == htmlID)
+    #expect(after.nodesByID[bodyID]?.parentID == htmlID)
+    #expect(projection.rows.map(\.nodeName) == ["#document", "html", "head", "body"])
+}
+
+@Test
+func childNodeInsertedUsesWebKitPreviousSiblingSemantics() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                .element(
+                    nodeID: 2,
+                    name: "body",
+                    children: [
+                        .element(nodeID: 3, name: "a"),
+                        .element(nodeID: 5, name: "c"),
+                    ]
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+    var snapshot = await session.snapshot()
+    let bodyID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
+    let aID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(3))])
+    let cID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(5))])
+
+    let bID = try #require(await session.applyChildInserted(parent: bodyID, previousSibling: aID, child: .element(nodeID: 4, name: "b")))
+    let dID = try #require(await session.applyChildInserted(parent: bodyID, previousSibling: nil, child: .element(nodeID: 6, name: "d")))
+    snapshot = await session.snapshot()
+
+    #expect(snapshot.nodesByID[bodyID]?.regularChildren.loadedChildren == [dID, aID, bID, cID])
+    #expect(snapshot.nodesByID[dID]?.previousSiblingID == nil)
+    #expect(snapshot.nodesByID[dID]?.nextSiblingID == aID)
+    #expect(snapshot.nodesByID[aID]?.previousSiblingID == dID)
+    #expect(snapshot.nodesByID[aID]?.nextSiblingID == bID)
+    #expect(snapshot.nodesByID[bID]?.previousSiblingID == aID)
+    #expect(snapshot.nodesByID[bID]?.nextSiblingID == cID)
+    #expect(snapshot.nodesByID[cID]?.previousSiblingID == bID)
+    #expect(snapshot.nodesByID[cID]?.nextSiblingID == nil)
 }
 
 @Test
@@ -387,7 +648,7 @@ func clearingNodeSelectionCancelsPendingInspectSelection() async throws {
         targetID: pageTargetID,
         nodeID: .init(2)
     )
-    guard case let .failure(.staleSelectionRequest(expected, received)) = result else {
+    guard case let .failed(.staleSelectionRequest(expected, received)) = result else {
         Issue.record("Expected cancelled request to be rejected as stale")
         return
     }
@@ -557,6 +818,48 @@ func requestChildNodesIntentUsesNodeOwningTargetAndDepth() async throws {
 }
 
 @Test
+func setChildNodesAppliesToCurrentDocumentWithoutTransaction() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                DOMNodePayload(
+                    nodeID: .init(4),
+                    nodeType: .element,
+                    nodeName: "BODY",
+                    localName: "body",
+                    regularChildren: .unrequested(count: 1)
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+    let bodyID = try #require(await session.snapshot().currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(4))])
+
+    await session.applySetChildNodes(
+        parent: bodyID,
+        children: [.element(nodeID: 8, name: "style")],
+        eventSequence: 9
+    )
+    var snapshot = await session.snapshot()
+    let styleID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(8))])
+    #expect(snapshot.nodesByID[styleID]?.nodeName == "style")
+
+    await session.invalidateDocument(targetID: pageTargetID)
+    await session.applySetChildNodes(
+        parent: bodyID,
+        children: [.element(nodeID: 9, name: "script")],
+        eventSequence: 11
+    )
+    snapshot = await session.snapshot()
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(9))] == nil)
+}
+
+@Test
 func mainDocumentSelectionRequestsPageTarget() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let session = await DOMSession()
@@ -682,7 +985,7 @@ func staleSelectionRequestIsRejectedAfterFrameDocumentRefresh() async throws {
     )
     let snapshot = await session.snapshot()
 
-    guard case let .failure(.staleDocument(expected, actual)) = result else {
+    guard case let .failed(.staleDocument(expected, actual)) = result else {
         Issue.record("Expected stale document failure")
         return
     }
@@ -720,18 +1023,31 @@ private func iframeDepth(in projection: DOMTreeProjection, iframeID: DOMNode.ID)
     projection.rows.first(where: { $0.nodeID == iframeID })?.depth ?? -1
 }
 
-private func document(nodeID: Int, children: [DOMNodePayload] = []) -> DOMNodePayload {
+private func document(
+    nodeID: Int,
+    documentURL: String? = nil,
+    baseURL: String? = nil,
+    children: [DOMNodePayload] = []
+) -> DOMNodePayload {
     DOMNodePayload(
         nodeID: .init(nodeID),
         nodeType: .document,
         nodeName: "#document",
+        documentURL: documentURL,
+        baseURL: baseURL,
         regularChildren: .loaded(children)
     )
 }
 
-private func pageDocument(iframeFrameID: DOMFrame.ID) -> DOMNodePayload {
+private func pageDocument(
+    iframeFrameID _: DOMFrame.ID,
+    ownerFrameID: DOMFrame.ID = .init("main-frame"),
+    iframeAttributes: [DOMAttribute] = [.init(name: "src", value: "https://frame.example/ad")]
+) -> DOMNodePayload {
     document(
         nodeID: 1,
+        documentURL: "https://page.example/",
+        baseURL: "https://page.example/",
         children: [
             .element(
                 nodeID: 2,
@@ -742,7 +1058,46 @@ private func pageDocument(iframeFrameID: DOMFrame.ID) -> DOMNodePayload {
                         nodeID: 4,
                         name: "body",
                         children: [
-                            .element(nodeID: 20, name: "iframe", frameID: iframeFrameID),
+                            .element(
+                                nodeID: 20,
+                                name: "iframe",
+                                ownerFrameID: ownerFrameID,
+                                attributes: iframeAttributes
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+        ]
+    )
+}
+
+private func pageDocumentWithDuplicateIframeURLs() -> DOMNodePayload {
+    document(
+        nodeID: 1,
+        documentURL: "https://page.example/",
+        baseURL: "https://page.example/",
+        children: [
+            .element(
+                nodeID: 2,
+                name: "html",
+                children: [
+                    .element(
+                        nodeID: 3,
+                        name: "body",
+                        children: [
+                            .element(
+                                nodeID: 20,
+                                name: "iframe",
+                                ownerFrameID: .init("main-frame"),
+                                attributes: [.init(name: "src", value: "https://frame.example/ad")]
+                            ),
+                            .element(
+                                nodeID: 21,
+                                name: "iframe",
+                                ownerFrameID: .init("main-frame"),
+                                attributes: [.init(name: "src", value: "https://frame.example/ad")]
+                            ),
                         ]
                     ),
                 ]
@@ -767,9 +1122,14 @@ private func pageDocumentWithoutIframe() -> DOMNodePayload {
     )
 }
 
-private func frameDocument(rootNodeID: Int, selectedNodeName: String = "img") -> DOMNodePayload {
+private func frameDocument(
+    rootNodeID: Int,
+    documentURL: String = "https://frame.example/ad",
+    selectedNodeName: String = "img"
+) -> DOMNodePayload {
     document(
         nodeID: rootNodeID,
+        documentURL: documentURL,
         children: [
             .element(
                 nodeID: 2,
@@ -796,7 +1156,9 @@ private extension DOMNodePayload {
     static func element(
         nodeID: Int,
         name: String,
-        frameID: DOMFrame.ID? = nil,
+        ownerFrameID: DOMFrame.ID? = nil,
+        documentURL: String? = nil,
+        baseURL: String? = nil,
         attributes: [DOMAttribute] = [],
         children: [DOMNodePayload] = [],
         shadowRoots: [DOMNodePayload] = [],
@@ -811,7 +1173,9 @@ private extension DOMNodePayload {
             nodeType: .element,
             nodeName: name,
             localName: name,
-            frameID: frameID,
+            ownerFrameID: ownerFrameID,
+            documentURL: documentURL,
+            baseURL: baseURL,
             attributes: attributes,
             regularChildren: .loaded(children),
             shadowRoots: shadowRoots,

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -337,6 +337,55 @@ func frameOwnerCandidatesAreScopedToParentFrameDocument() async throws {
 }
 
 @Test
+func nestedFrameProjectionWaitsForParentFrameDocumentBeforeOwnerMatching() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let childFrameTargetID = ProtocolTarget.ID("frame-child-target")
+    let childFrameID = DOMFrame.ID("frame-child")
+    let nestedFrameTargetID = ProtocolTarget.ID("frame-nested-target")
+    let nestedFrameID = DOMFrame.ID("frame-nested")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: childFrameTargetID, kind: .frame, frameID: childFrameID, parentFrameID: mainFrameID))
+    await session.applyTargetCreated(.init(id: nestedFrameTargetID, kind: .frame, frameID: nestedFrameID, parentFrameID: childFrameID))
+    _ = await session.replaceDocumentRoot(
+        pageDocument(
+            iframeFrameID: childFrameID,
+            ownerFrameID: mainFrameID,
+            iframeAttributes: [.init(name: "src", value: "https://frame.example/child")]
+        ),
+        targetID: pageTargetID
+    )
+    let nestedRootID = await session.replaceDocumentRoot(
+        frameDocument(rootNodeID: 201, documentURL: "https://frame.example/nested"),
+        targetID: nestedFrameTargetID
+    )
+
+    var snapshot = await session.snapshot()
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.ownerNodeID == nil)
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.state == .pending)
+
+    _ = await session.replaceDocumentRoot(
+        nestedOwnerFrameDocument(
+            documentURL: "https://frame.example/child",
+            nestedFrameURL: "https://frame.example/nested",
+            ownerFrameID: childFrameID
+        ),
+        targetID: childFrameTargetID
+    )
+    snapshot = await session.snapshot()
+    let childDocumentIframeID = try #require(
+        snapshot.currentNodeIDByKey[.init(targetID: childFrameTargetID, nodeID: .init(20))]
+    )
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.ownerNodeID == childDocumentIframeID)
+    #expect(snapshot.frameDocumentProjections[nestedFrameTargetID]?.state == .attached)
+    #expect(projection.rows.map(\.nodeID).contains(nestedRootID))
+}
+
+@Test
 func frameDocumentProjectionRemainsPendingWhenURLDoesNotMatch() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")
@@ -1281,6 +1330,39 @@ private func pageDocumentWithoutIframe() -> DOMNodePayload {
                 children: [
                     .element(nodeID: 3, name: "head"),
                     .element(nodeID: 4, name: "body"),
+                ]
+            ),
+        ]
+    )
+}
+
+private func nestedOwnerFrameDocument(
+    documentURL: String,
+    nestedFrameURL: String,
+    ownerFrameID: DOMFrame.ID
+) -> DOMNodePayload {
+    document(
+        nodeID: 1,
+        documentURL: documentURL,
+        baseURL: documentURL,
+        children: [
+            .element(
+                nodeID: 2,
+                name: "html",
+                children: [
+                    .element(nodeID: 3, name: "head"),
+                    .element(
+                        nodeID: 4,
+                        name: "body",
+                        children: [
+                            .element(
+                                nodeID: 20,
+                                name: "iframe",
+                                ownerFrameID: ownerFrameID,
+                                attributes: [.init(name: "src", value: nestedFrameURL)]
+                            ),
+                        ]
+                    ),
                 ]
             ),
         ]

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -303,6 +303,33 @@ func frameDocumentProjectionRemainsPendingWhenURLDoesNotMatch() async throws {
 }
 
 @Test
+func srcLessIframeOwnerProjectsAboutBlankFrameDocument() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID))
+    _ = await session.replaceDocumentRoot(
+        pageDocument(iframeFrameID: frameID, iframeAttributes: []),
+        targetID: pageTargetID
+    )
+    let frameRootID = await session.replaceDocumentRoot(
+        frameDocument(rootNodeID: 101, documentURL: "about:blank"),
+        targetID: frameTargetID
+    )
+
+    let snapshot = await session.snapshot()
+    let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let iframeID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(20))])
+
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    #expect(snapshot.frameDocumentProjections[frameTargetID]?.state == .attached)
+    #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
+}
+
+@Test
 func iframeOwnerSetChildNodesDoesNotRemoveAttachedFrameDocumentProjection() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")
@@ -386,6 +413,23 @@ func iframeOwnerSrcMutationReevaluatesFrameDocumentProjection() async throws {
     #expect(after.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
     #expect(after.frameDocumentProjections[frameTargetID]?.state == .attached)
     #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
+
+    await session.applyAttributeModified(iframeID, name: "src", value: "https://other.example/ad")
+    let afterMismatch = await session.snapshot()
+    let mismatchedProjection = await session.treeProjection(rootTargetID: pageTargetID)
+    #expect(afterMismatch.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
+    #expect(afterMismatch.frameDocumentProjections[frameTargetID]?.state == .pending)
+    #expect(mismatchedProjection.rows.map(\.nodeID).contains(frameRootID) == false)
+
+    await session.applyAttributeModified(iframeID, name: "src", value: "https://frame.example/ad")
+    #expect(await session.snapshot().frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+
+    await session.applyAttributeRemoved(iframeID, name: "src")
+    let afterRemoval = await session.snapshot()
+    let removedProjection = await session.treeProjection(rootTargetID: pageTargetID)
+    #expect(afterRemoval.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
+    #expect(afterRemoval.frameDocumentProjections[frameTargetID]?.state == .pending)
+    #expect(removedProjection.rows.map(\.nodeID).contains(frameRootID) == false)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -269,6 +269,8 @@ func iframeOwnerProjectsFrameDocumentWithoutStoringItAsRegularChild() async thro
     #expect(snapshot.nodesByID[frameRootID]?.parentID == nil)
     #expect(projectionState.ownerNodeID == iframeID)
     #expect(projectionState.state == .attached)
+    #expect(projection.parent(of: frameRootID) == iframeID)
+    #expect(projection.children(of: iframeID) == [frameRootID])
     #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
 }
 
@@ -548,6 +550,8 @@ func iframeOwnerSrcMutationReevaluatesFrameDocumentProjection() async throws {
     #expect(after.nodesByID[iframeID]?.attributes.first { $0.name == "src" }?.value == "https://frame.example/ad")
     #expect(after.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
     #expect(after.frameDocumentProjections[frameTargetID]?.state == .attached)
+    #expect(after.nodesByID[frameRootID]?.parentID == nil)
+    #expect(projection.parent(of: frameRootID) == iframeID)
     #expect(projection.rows.contains { $0.nodeID == frameRootID && $0.depth > iframeDepth(in: projection, iframeID: iframeID) })
 
     await session.applyAttributeModified(iframeID, name: "src", value: "https://other.example/ad")
@@ -555,16 +559,22 @@ func iframeOwnerSrcMutationReevaluatesFrameDocumentProjection() async throws {
     let mismatchedProjection = await session.treeProjection(rootTargetID: pageTargetID)
     #expect(afterMismatch.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
     #expect(afterMismatch.frameDocumentProjections[frameTargetID]?.state == .pending)
+    #expect(afterMismatch.nodesByID[frameRootID]?.parentID == nil)
     #expect(mismatchedProjection.rows.map(\.nodeID).contains(frameRootID) == false)
 
     await session.applyAttributeModified(iframeID, name: "src", value: "https://frame.example/ad")
-    #expect(await session.snapshot().frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    let reattached = await session.snapshot()
+    let reattachedProjection = await session.treeProjection(rootTargetID: pageTargetID)
+    #expect(reattached.frameDocumentProjections[frameTargetID]?.ownerNodeID == iframeID)
+    #expect(reattached.nodesByID[frameRootID]?.parentID == nil)
+    #expect(reattachedProjection.parent(of: frameRootID) == iframeID)
 
     await session.applyAttributeRemoved(iframeID, name: "src")
     let afterRemoval = await session.snapshot()
     let removedProjection = await session.treeProjection(rootTargetID: pageTargetID)
     #expect(afterRemoval.frameDocumentProjections[frameTargetID]?.ownerNodeID == nil)
     #expect(afterRemoval.frameDocumentProjections[frameTargetID]?.state == .pending)
+    #expect(afterRemoval.nodesByID[frameRootID]?.parentID == nil)
     #expect(removedProjection.rows.map(\.nodeID).contains(frameRootID) == false)
 }
 
@@ -1131,10 +1141,17 @@ func iframeAdRefreshSelectionUsesNewFrameDocumentGenerationAndSelectedProjection
     ).get()
     let snapshot = await session.snapshot()
     let projection = await session.treeProjection(rootTargetID: pageTargetID)
+    let iframeID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(20))])
 
     #expect(snapshot.framesByID[frameID]?.currentDocumentID == refreshedFrameRootID.documentID)
     #expect(selectedNodeID.documentID == refreshedFrameRootID.documentID)
+    #expect(snapshot.nodesByID[refreshedFrameRootID]?.parentID == nil)
+    #expect(projection.parent(of: refreshedFrameRootID) == iframeID)
+    #expect(projection.ancestorNodeIDs(of: selectedNodeID).contains(iframeID))
+    #expect(projection.ancestorNodeIDs(of: selectedNodeID).contains(refreshedFrameRootID))
     #expect(projection.rows.contains { $0.nodeID == selectedNodeID && $0.isSelected })
+    #expect(await session.selectedNodeCopyText(.selectorPath) == "#ad-node")
+    #expect(await session.selectedNodeCopyText(.xPath) == "/html/body/div")
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -2361,9 +2361,6 @@ func performIsRejectedUntilBootstrapAttaches() async throws {
 @MainActor
 @Test
 func attachInspectabilityPreparationRestoresOriginalValue() throws {
-    guard #available(iOS 16.4, macOS 13.3, *) else {
-        return
-    }
     let webView = WKWebView(frame: .zero)
     let initialValue = webView.isInspectable
     webView.isInspectable = false

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -2091,6 +2091,107 @@ func reloadDOMDocumentDiscardsDeleteUndoHistory() async throws {
 
 @MainActor
 @Test
+func reloadDOMDocumentCancelsQueuedDeleteUndoOperationsBeforeTheySend() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try #require(session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(2))])
+    session.dom.selectNode(htmlID)
+
+    let undoManager = UndoManager()
+    let countBeforeDelete = await backend.sentTargetMessages().count
+    let deleteTask = Task {
+        try await session.deleteSelectedDOMNode(undoManager: undoManager)
+    }
+    let removeNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countBeforeDelete)
+    await receiveTargetReply(
+        transport,
+        targetID: removeNode.targetIdentifier,
+        messageID: try messageID(removeNode.message),
+        result: "{}"
+    )
+    try await deleteTask.value
+    #expect(undoManager.canUndo)
+
+    let countBeforeQueuedOperations = await backend.sentTargetMessages().count
+    let reloadReplyTask = Task {
+        let getDocument = await backend.waitForTargetMessage(method: "DOM.getDocument", after: countBeforeQueuedOperations)
+        await receiveTargetReply(
+            transport,
+            targetID: getDocument.targetIdentifier,
+            messageID: try messageID(getDocument.message),
+            result: mainDocumentResult
+        )
+    }
+
+    undoManager.undo()
+    #expect(undoManager.canRedo)
+    undoManager.redo()
+
+    try await session.reloadDOMDocument()
+    try await reloadReplyTask.value
+    try await Task.sleep(for: .milliseconds(50))
+
+    let methodsAfterReload = await targetMessageMethods(backend).dropFirst(countBeforeQueuedOperations)
+    #expect(methodsAfterReload.contains("DOM.getDocument"))
+    #expect(methodsAfterReload.contains("DOM.undo") == false)
+    #expect(methodsAfterReload.contains("DOM.redo") == false)
+}
+
+@MainActor
+@Test
+func deleteUndoReloadCancellationClearsUndoHistory() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try #require(session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(2))])
+    session.dom.selectNode(htmlID)
+
+    let undoManager = UndoManager()
+    let countBeforeDelete = await backend.sentTargetMessages().count
+    let deleteTask = Task {
+        try await session.deleteSelectedDOMNode(undoManager: undoManager)
+    }
+    let removeNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countBeforeDelete)
+    await receiveTargetReply(
+        transport,
+        targetID: removeNode.targetIdentifier,
+        messageID: try messageID(removeNode.message),
+        result: "{}"
+    )
+    try await deleteTask.value
+    #expect(undoManager.canUndo)
+
+    let countBeforeUndo = await backend.sentTargetMessages().count
+    undoManager.undo()
+    let undo = try await waitForTargetMessage(backend, method: "DOM.undo", after: countBeforeUndo)
+    await receiveTargetReply(
+        transport,
+        targetID: undo.targetIdentifier,
+        messageID: try messageID(undo.message),
+        result: "{}"
+    )
+    _ = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: countBeforeUndo)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+
+    _ = try await waitUntil {
+        await MainActor.run {
+            undoManager.canRedo == false ? session.lastError : nil
+        }
+    }
+    #expect(undoManager.canUndo == false)
+    #expect(undoManager.canRedo == false)
+    #expect(session.lastError == InspectorSessionError(String(describing: CancellationError())))
+}
+
+@MainActor
+@Test
 func reloadDOMDocumentCancelsActiveElementPickerBeforeReplacingDocument() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -256,6 +256,61 @@ func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async thr
     #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID != nil)
 }
 
+@Test
+func provisionalFrameDocumentResolvedBeforeCommitRehydratesCommittedFrame() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let provisionalTargetID = ProtocolTargetIdentifier("frame-provisional")
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":true}}}"#
+    )
+    let firstRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(firstRequest.targetIdentifier == provisionalTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: firstRequest.targetIdentifier,
+        messageID: try messageID(firstRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+    let _: DOMDocumentIdentifier = try await waitUntil {
+        await session.dom.snapshot().targetsByID[provisionalTargetID]?.currentDocumentID
+    }
+
+    let sentCountBeforeCommit = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-ad"}}"#
+    )
+    let committedRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeCommit
+    )
+    #expect(committedRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: committedRequest.targetIdentifier,
+        messageID: try messageID(committedRequest.message),
+        result: secondLazyFrameDocumentResult
+    )
+
+    let snapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.targetsByID[ProtocolTargetIdentifier.frameAd]?.currentDocumentID != nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(snapshot.targetsByID[provisionalTargetID] == nil)
+}
+
 @Test("Regression: frame getDocument request does not block page DOM events")
 func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
     let backend = FakeTransportBackend()
@@ -1134,6 +1189,64 @@ func detachedSetChildNodesRootKeepsRequestNodeSelectable() async throws {
     let selectedNode = try #require(await session.dom.selectedNode)
     #expect(await selectedNode.nodeName == "IMG")
     #expect(await selectedNode.attributes == [DOMAttribute(name: "src", value: "https://ads.example/detached.webp")])
+}
+
+@Test("Regression: detached frame setChildNodes root keeps requestNode selectable")
+func detachedFrameSetChildNodesRootKeepsRequestNodeSelectable() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let frameDocumentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: frameDocumentRequest.targetIdentifier,
+        messageID: try messageID(frameDocumentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[ProtocolTargetIdentifier.frameAd]?.currentDocumentID
+    }
+
+    let intent = await session.dom.beginInspectSelectionRequest(
+        targetID: .frameAd,
+        objectID: "detached-frame-object"
+    )
+    guard case let .success(commandIntent) = intent else {
+        Issue.record("Expected DOM.requestNode intent")
+        return
+    }
+
+    let sentCount = await backend.sentTargetMessages().count
+    let performTask = Task {
+        try await session.perform(commandIntent)
+    }
+    let sent = try await waitForTargetMessage(backend, method: "DOM.requestNode", after: sentCount)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .frameAd,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":0,"nodes":[{"nodeId":300,"nodeType":1,"nodeName":"DIV","localName":"div","children":[{"nodeId":301,"nodeType":1,"nodeName":"IMG","localName":"img"}]}]}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        result: #"{"nodeId":301}"#
+    )
+    _ = try await performTask.value
+
+    let selectedNode = try #require(await session.dom.selectedNode)
+    #expect(await selectedNode.nodeName == "IMG")
+    #expect(await session.dom.selectedNodeID?.documentID.targetID == ProtocolTargetIdentifier.frameAd)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -23,7 +23,7 @@ func connectBootstrapsMainPageDocumentInOrder() async throws {
         "Network.enable",
     ])
     #expect(await session.isAttached)
-    #expect(await session.dom.snapshot().currentPage?.mainTargetID == ProtocolTargetIdentifier.pageMain)
+    #expect(await session.dom.snapshot().currentPageTargetID == ProtocolTargetIdentifier.pageMain)
     #expect(await session.dom.snapshot().documentsByID.count == 1)
 }
 
@@ -130,17 +130,14 @@ func frameDocumentRefreshUpdatesOnlyFrameDocument() async throws {
     try await connect(session, transport: transport, backend: backend)
     let pageDocumentID = try #require(await session.dom.snapshot().currentPageDocumentID)
 
+    let sentCount = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM"],"isProvisional":false}}}"#
     )
     _ = try await waitUntil {
         await session.dom.snapshot().targetsByID[.frameAd]
     }
 
-    let sentCount = await backend.sentTargetMessages().count
-    let performTask = Task {
-        try await session.perform(.getDocument(targetID: .frameAd))
-    }
     let sent = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
     await receiveTargetReply(
         transport,
@@ -148,12 +145,435 @@ func frameDocumentRefreshUpdatesOnlyFrameDocument() async throws {
         messageID: try messageID(sent.message),
         result: ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html"}]}}"##
     )
-    _ = try await performTask.value
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID
+    }
 
     let snapshot = await session.dom.snapshot()
     #expect(snapshot.currentPageDocumentID == pageDocumentID)
     #expect(snapshot.targetsByID[.frameAd]?.currentDocumentID != nil)
     #expect(snapshot.targetsByID[.frameAd]?.currentDocumentID != pageDocumentID)
+}
+
+@Test
+func frameTargetWithoutDOMCapabilityDoesNotHydrateOnCreationOrDocumentUpdated() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":[],"isProvisional":false}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+    await receiveTargetDispatch(
+        transport,
+        targetID: .frameAd,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+
+    #expect(await backend.sentTargetMessages().count == sentCount)
+    #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID == nil)
+}
+
+@Test
+func frameTargetWithoutAdvertisedDomainsUsesWebKitFrameDefaultAndDoesNotHydrateOnCreation() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+
+    #expect(await backend.sentTargetMessages().count == sentCount)
+    #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID == nil)
+}
+
+@Test
+func frameTargetWithAdvertisedDOMCapabilityHydratesOnCreation() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let sent = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
+    #expect(sent.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        result: firstLazyFrameDocumentResult
+    )
+
+    #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID != nil)
+}
+
+@Test("Regression: frame getDocument request does not block page DOM events")
+func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let frameDocumentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(frameDocumentRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: pageHTMLChildrenSetChildNodesMessage
+    )
+    let bodyID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(4)
+    )
+    let snapshotWhileFrameRequestIsPending = await session.dom.snapshot()
+    #expect(snapshotWhileFrameRequestIsPending.nodesByID[bodyID]?.nodeName == "BODY")
+    #expect(snapshotWhileFrameRequestIsPending.targetsByID[.frameAd]?.currentDocumentID == nil)
+
+    await receiveTargetReply(
+        transport,
+        targetID: frameDocumentRequest.targetIdentifier,
+        messageID: try messageID(frameDocumentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+    let finalSnapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.targetsByID[.frameAd]?.currentDocumentID != nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(4))] == bodyID)
+}
+
+@Test
+func pageDocumentUpdatedInvalidatesCurrentPageDocumentWithoutReloading() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageDocumentID = try #require(await session.dom.snapshot().currentPageDocumentID)
+    let sentCount = await backend.sentTargetMessages().count
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let snapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+
+    #expect(snapshot.currentPageDocumentID == nil)
+    #expect(snapshot.documentsByID[pageDocumentID]?.lifecycle == .invalidated)
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(1))] == nil)
+    #expect(await backend.sentTargetMessages().count == sentCount)
+}
+
+@Test
+func ensureDOMDocumentLoadedReloadsInvalidatedPageDocument() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let invalidatedSnapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(invalidatedSnapshot.currentPageDocumentID == nil)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let ensureTask = Task {
+        await session.ensureDOMDocumentLoaded()
+    }
+    let reload = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCount
+    )
+    #expect(reload.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: reload.targetIdentifier,
+        messageID: try messageID(reload.message),
+        result: manualReloadDocumentResult
+    )
+
+    #expect(await ensureTask.value)
+    let finalSnapshot = await session.dom.snapshot()
+    #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
+}
+
+@Test("Regression: documentUpdated reopens document request gate while previous getDocument is pending")
+func documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let _: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+
+    let sentCount = await backend.sentTargetMessages().count
+    let ensureTask = Task {
+        await session.ensureDOMDocumentLoaded()
+    }
+    let firstRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCount
+    )
+    let afterFirstRequest = await backend.sentTargetMessages().count
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let secondRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: afterFirstRequest
+    )
+
+    #expect(secondRequest.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(try messageID(secondRequest.message) != messageID(firstRequest.message))
+
+    await receiveTargetReply(
+        transport,
+        targetID: secondRequest.targetIdentifier,
+        messageID: try messageID(secondRequest.message),
+        result: manualReloadDocumentResult
+    )
+    #expect(await ensureTask.value)
+
+    await receiveTargetReply(
+        transport,
+        targetID: firstRequest.targetIdentifier,
+        messageID: try messageID(firstRequest.message),
+        result: staleReloadDocumentResult
+    )
+    try await Task.sleep(for: .milliseconds(25))
+
+    let finalSnapshot = await session.dom.snapshot()
+    #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
+    #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(50))] == nil)
+}
+
+@Test("Regression: stale setChildNodes from previous page does not move head children into new body")
+func staleSetChildNodesAfterPageNavigationDoesNotMoveHeadChildrenIntoNewBody() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let countBeforeOldDocumentReload = await backend.sentTargetMessages().count
+    let oldDocumentReloadTask = Task {
+        try await session.reloadDOMDocument()
+    }
+    let oldDocumentReload = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: countBeforeOldDocumentReload
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: oldDocumentReload.targetIdentifier,
+        messageID: try messageID(oldDocumentReload.message),
+        result: oldDocumentWithHeadNodeFourResult
+    )
+    try await oldDocumentReloadTask.value
+
+    let oldHeadID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(4)
+    )
+    let requestIntent = try #require(await session.dom.requestChildNodesIntent(for: oldHeadID))
+    let countBeforeRequest = await backend.sentTargetMessages().count
+    let requestTask = Task {
+        try await session.perform(requestIntent)
+    }
+    let oldHeadRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestChildNodes",
+        after: countBeforeRequest
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: oldHeadRequest.targetIdentifier,
+        messageID: try messageID(oldHeadRequest.message),
+        result: "{}"
+    )
+    _ = try await requestTask.value
+
+    let countBeforeNavigation = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":4,"nodes":[{"nodeId":8,"nodeType":1,"nodeName":"STYLE","localName":"style"}]}}"#
+    )
+    let _: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(await backend.sentTargetMessages().count == countBeforeNavigation)
+
+    let countBeforeManualReload = await backend.sentTargetMessages().count
+    let manualReloadTask = Task {
+        try await session.reloadDOMDocument()
+    }
+    let newDocumentReload = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: countBeforeManualReload
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: newDocumentReload.targetIdentifier,
+        messageID: try messageID(newDocumentReload.message),
+        result: newDocumentWithBodyNodeFourResult
+    )
+    try await manualReloadTask.value
+
+    let newBodyID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(4)
+    )
+
+    let snapshot = await session.dom.snapshot()
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(8))] == nil)
+    #expect(snapshot.nodesByID[newBodyID]?.regularChildIDs.isEmpty == true)
+}
+
+@Test("Regression: targetless iframe DOM update does not invalidate parent page selection")
+func targetlessIframeDocumentUpdateDoesNotInvalidateParentPageSelection() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let mainNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(5)
+    )
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let frameDocumentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(frameDocumentRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameDocumentRequest.targetIdentifier,
+        messageID: try messageID(frameDocumentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"IFRAME","localName":"iframe","frameId":"main-frame","attributes":["src","https://frame.example/ad"]}}}"#
+    )
+    let iframeNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(6)
+    )
+
+    let beforeUpdate = await session.dom.snapshot()
+    let pageDocumentID = try #require(beforeUpdate.currentPageDocumentID)
+    let frameDocumentID = try #require(beforeUpdate.targetsByID[.frameAd]?.currentDocumentID)
+    let frameRootID = try #require(beforeUpdate.documentsByID[frameDocumentID]?.rootNodeID)
+    await session.dom.selectNode(mainNodeID)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: frameRootID
+    )
+
+    let sentCountBeforeTargetlessUpdate = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
+    try await Task.sleep(for: .milliseconds(25))
+
+    let afterUpdate = await session.dom.snapshot()
+    #expect(afterUpdate.currentPageDocumentID == pageDocumentID)
+    #expect(afterUpdate.targetsByID[.frameAd]?.currentDocumentID == frameDocumentID)
+    #expect(afterUpdate.selection.selectedNodeID == mainNodeID)
+    #expect(afterUpdate.nodesByID[mainNodeID] != nil)
+    #expect(afterUpdate.nodesByID[iframeNodeID] != nil)
+    #expect(await backend.sentTargetMessages().count == sentCountBeforeTargetlessUpdate)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: frameRootID
+    )
 }
 
 @Test("Lazy iframe insertion and frame document update keep the parent page tree intact")
@@ -163,43 +583,21 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
     let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
 
-    await receiveTargetDispatch(
-        transport,
-        targetID: .pageMain,
-        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":5,"nodeType":1,"nodeName":"MAIN","localName":"main","attributes":["id","content"]}]}]}}"#
-    )
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
     let mainNodeID = try await waitForCurrentNode(
         in: session,
         targetID: .pageMain,
         protocolNodeID: .init(5)
     )
 
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
-        await session.dom.snapshot().targetsByID[.frameAd]
-    }
-
-    await receiveTargetDispatch(
-        transport,
-        targetID: .pageMain,
-        message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"IFRAME","localName":"iframe","frameId":"ad-frame","attributes":["src","https://frame.example/ad"]}}}"#
-    )
-    let iframeNodeID = try await waitForCurrentNode(
-        in: session,
-        targetID: .pageMain,
-        protocolNodeID: .init(6)
-    )
-
-    let sentCountBeforeFirstFrameDocument = await backend.sentTargetMessages().count
-    let firstFrameDocumentTask = Task {
-        try await session.perform(.getDocument(targetID: .frameAd))
-    }
     let firstFrameDocumentRequest = try await waitForTargetMessage(
         backend,
         method: "DOM.getDocument",
-        after: sentCountBeforeFirstFrameDocument
+        after: sentCountBeforeFrameTarget
     )
     #expect(firstFrameDocumentRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
     await receiveTargetReply(
@@ -208,7 +606,20 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
         messageID: try messageID(firstFrameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    _ = try await firstFrameDocumentTask.value
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"IFRAME","localName":"iframe","frameId":"main-frame","attributes":["src","https://frame.example/ad"]}}}"#
+    )
+    let iframeNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(6)
+    )
 
     let beforeUpdate = await session.dom.snapshot()
     let pageDocumentID = try #require(beforeUpdate.currentPageDocumentID)
@@ -217,6 +628,36 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
     assertProjectionContainsFrameDocument(
         in: await session.dom.treeProjection(rootTargetID: .pageMain),
         iframeNodeID: iframeNodeID,
+        frameRootNodeID: firstFrameRootID
+    )
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":6,"nodes":[{"nodeId":7,"nodeType":1,"nodeName":"SPAN","localName":"span"}]}}"#
+    )
+    let afterIframeOwnerUpdate = await session.dom.snapshot()
+    #expect(afterIframeOwnerUpdate.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(7))] == nil)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: firstFrameRootID
+    )
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":4,"nodes":[{"nodeId":5,"nodeType":1,"nodeName":"MAIN","localName":"main","attributes":["id","content"]},{"nodeId":6,"nodeType":1,"nodeName":"IFRAME","localName":"iframe","frameId":"main-frame","attributes":["src","https://frame.example/ad"]}]}}"#
+    )
+    let refreshedIframeNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(6)
+    )
+    #expect(refreshedIframeNodeID == iframeNodeID)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: refreshedIframeNodeID,
         frameRootNodeID: firstFrameRootID
     )
 
@@ -241,7 +682,8 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
 
     let afterUpdate: DOMSessionSnapshot = try await waitUntil {
         let snapshot = await session.dom.snapshot()
-        guard snapshot.targetsByID[.frameAd]?.currentDocumentID != firstFrameDocumentID else {
+        guard let currentDocumentID = snapshot.targetsByID[.frameAd]?.currentDocumentID,
+              currentDocumentID != firstFrameDocumentID else {
             return nil
         }
         return snapshot
@@ -260,13 +702,87 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
     )
 }
 
-// Expected-failing regression guard for the pending frame-owner modeling fix.
+@Test("Pending frame document hydrates page owner path before projection")
+func pendingFrameDocumentHydratesPageOwnerPathBeforeProjection() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let frameDocumentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(frameDocumentRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameDocumentRequest.targetIdentifier,
+        messageID: try messageID(frameDocumentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+
+    let htmlHydrationRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestChildNodes",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(htmlHydrationRequest.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(try integerParameter("nodeId", in: htmlHydrationRequest.message) == 2)
+    let sentCountAfterHTMLHydrationRequest = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body","childNodeCount":2}]}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: htmlHydrationRequest.targetIdentifier,
+        messageID: try messageID(htmlHydrationRequest.message),
+        result: "{}"
+    )
+
+    let bodyHydrationRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestChildNodes",
+        after: sentCountAfterHTMLHydrationRequest
+    )
+    #expect(bodyHydrationRequest.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(try integerParameter("nodeId", in: bodyHydrationRequest.message) == 4)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":4,"nodes":[{"nodeId":5,"nodeType":1,"nodeName":"MAIN","localName":"main","attributes":["id","content"]},{"nodeId":6,"nodeType":1,"nodeName":"IFRAME","localName":"iframe","frameId":"main-frame","attributes":["src","https://frame.example/ad"]}]}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: bodyHydrationRequest.targetIdentifier,
+        messageID: try messageID(bodyHydrationRequest.message),
+        result: "{}"
+    )
+
+    let iframeNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(6)
+    )
+    let snapshot = await session.dom.snapshot()
+    let frameDocumentID = try #require(snapshot.targetsByID[.frameAd]?.currentDocumentID)
+    let frameRootID = try #require(snapshot.documentsByID[frameDocumentID]?.rootNodeID)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: frameRootID
+    )
+}
+
 // WebKit reports DOM.Node.frameId as the frame that owns the node's document.
 // For an iframe element in the page DOM that is the page frame, not the
 // cross-origin child frame whose document arrives through a separate target.
-// The current model still treats this value as child frame identity in one path;
-// keep this test failing until owner-frame identity and child-frame projection
-// are separated in the DOM model.
 @Test("Regression: DOM.Node.frameId on an iframe owner is the owner frame, not the child frame identity")
 func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
     let backend = FakeTransportBackend()
@@ -274,11 +790,7 @@ func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
     let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
 
-    await receiveTargetDispatch(
-        transport,
-        targetID: .pageMain,
-        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":5,"nodeType":1,"nodeName":"MAIN","localName":"main","attributes":["id","content"]}]}]}}"#
-    )
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
     _ = try await waitForCurrentNode(
         in: session,
         targetID: .pageMain,
@@ -320,45 +832,63 @@ func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
     )
     _ = try await frameDocumentTask.value
     let firstFrameDocumentID = try #require(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID)
+    let firstFrameRootID = try #require(await session.dom.snapshot().documentsByID[firstFrameDocumentID]?.rootNodeID)
 
-    let sentCountBeforeFrameUpdate = await backend.sentTargetMessages().count
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: firstFrameRootID
+    )
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":6,"nodes":[{"nodeId":7,"nodeType":1,"nodeName":"SPAN","localName":"span"}]}}"#
+    )
+    #expect(await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(7))] == nil)
+    assertProjectionContainsFrameDocument(
+        in: await session.dom.treeProjection(rootTargetID: .pageMain),
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: firstFrameRootID
+    )
+
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
     await receiveTargetDispatch(
         transport,
         targetID: .frameAd,
-        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+        message: #"{"method":"DOM.inspect","params":{"nodeId":104}}"#
     )
-    let frameDocumentReload = try await waitForTargetMessage(
+    let disable = try await waitForTargetMessage(
         backend,
-        method: "DOM.getDocument",
-        after: sentCountBeforeFrameUpdate
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeInspect
     )
-    #expect(frameDocumentReload.targetIdentifier == ProtocolTargetIdentifier.frameAd)
     await receiveTargetReply(
         transport,
-        targetID: frameDocumentReload.targetIdentifier,
-        messageID: try messageID(frameDocumentReload.message),
-        result: secondLazyFrameDocumentResult
+        targetID: disable.targetIdentifier,
+        messageID: try messageID(disable.message),
+        result: "{}"
     )
-
-    let snapshot: DOMSessionSnapshot = try await waitUntil {
-        let snapshot = await session.dom.snapshot()
-        guard snapshot.targetsByID[.frameAd]?.currentDocumentID != firstFrameDocumentID else {
-            return nil
-        }
-        return snapshot
+    let selectedNode = try await waitUntil {
+        await session.dom.selectedNode
     }
-    let frameDocumentID = try #require(snapshot.targetsByID[.frameAd]?.currentDocumentID)
-    let frameRootID = try #require(snapshot.documentsByID[frameDocumentID]?.rootNodeID)
-    let projectionRows = await session.dom.treeProjection(rootTargetID: .pageMain).rows.map(\.nodeID)
+    #expect(await selectedNode.nodeName == "CANVAS")
+    let snapshot = await session.dom.snapshot()
+    let projection = await session.dom.treeProjection(rootTargetID: .pageMain)
 
-    #expect(snapshot.framesByID[DOMFrameIdentifier("main-frame")]?.ownerNodeID == nil)
-    #expect(snapshot.framesByID[DOMFrameIdentifier("ad-frame")]?.ownerNodeID == nil)
+    #expect(snapshot.framesByID[DOMFrameIdentifier("main-frame")]?.currentDocumentID == snapshot.currentPageDocumentID)
+    #expect(snapshot.framesByID[DOMFrameIdentifier("ad-frame")]?.currentDocumentID == firstFrameDocumentID)
     #expect(snapshot.nodesByID[iframeNodeID] != nil)
-    #expect(projectionRows.contains(frameRootID) == false)
+    assertProjectionContainsFrameDocument(
+        in: projection,
+        iframeNodeID: iframeNodeID,
+        frameRootNodeID: firstFrameRootID
+    )
 }
 
 @Test
-func targetCommitBootstrapsCommittedMainPageDocument() async throws {
+func targetCommitBootstrapsCommittedMainPageTarget() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -375,14 +905,63 @@ func targetCommitBootstrapsCommittedMainPageDocument() async throws {
     let bootstrapMessages = try await completeBootstrap(
         transport: transport,
         backend: backend,
-        after: sentCountBeforeCommit
+        after: sentCountBeforeCommit,
+        documentResult: manualReloadDocumentResult
     )
 
     let snapshot = await session.dom.snapshot()
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier.pageNext)
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier.pageNext)
     #expect(snapshot.targetsByID[.pageNext]?.currentDocumentID != nil)
     #expect(snapshot.targetsByID[.pageMain] == nil)
-    #expect(bootstrapMessages.map { $0.targetIdentifier } == Array(repeating: ProtocolTargetIdentifier.pageNext, count: 5))
+    #expect(bootstrapMessages.map(\.targetIdentifier).allSatisfy { $0 == .pageNext })
+    #expect(bootstrapMessages.compactMap { try? messageMethod($0.message) } == [
+        "Inspector.enable",
+        "Inspector.initialized",
+        "Runtime.enable",
+        "DOM.getDocument",
+        "Network.enable",
+    ])
+}
+
+@Test("Regression: provisional DOM events from link navigation are ignored before committed document reload")
+func linkNavigationBuffersProvisionalDOMEventsUntilCommit() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeNavigation = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+    )
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageNext,
+        message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":0}}"#
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
+    )
+
+    let bootstrapMessages = try await completeBootstrap(
+        transport: transport,
+        backend: backend,
+        after: sentCountBeforeNavigation,
+        documentResult: newDocumentWithHeadChildCountResult
+    )
+
+    let snapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageTargetID == .pageNext,
+              snapshot.currentNodeIDByKey[.init(targetID: .pageNext, nodeID: .init(3))] != nil else {
+            return nil
+        }
+        return snapshot
+    }
+    let headID = try #require(snapshot.currentNodeIDByKey[.init(targetID: .pageNext, nodeID: .init(3))])
+    #expect(bootstrapMessages.map(\.targetIdentifier).allSatisfy { $0 == .pageNext })
+    #expect(snapshot.nodesByID[headID]?.nodeName == "HEAD")
+    #expect(snapshot.nodesByID[headID]?.regularChildren.knownCount == 2)
 }
 
 @Test
@@ -434,12 +1013,101 @@ func requestNodeWaitsForPathPushBeforeSelectingNode() async throws {
     #expect(attributes == [DOMAttribute(name: "id", value: "selected")])
 }
 
+@Test("Regression: backend setChildNodes without explicit hydration keeps requestNode selectable")
+func backendSetChildNodesWithoutExplicitHydrationKeepsRequestNodeSelectable() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":164,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","picked"]}]}]}}"#
+    )
+
+    let expectedNodeID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(164)
+    )
+    let intent = await session.dom.beginInspectSelectionRequest(
+        targetID: .pageMain,
+        objectID: "selected-object"
+    )
+    guard case let .success(commandIntent) = intent else {
+        Issue.record("Expected DOM.requestNode intent")
+        return
+    }
+
+    let sentCount = await backend.sentTargetMessages().count
+    let performTask = Task {
+        try await session.perform(commandIntent)
+    }
+    let sent = try await waitForTargetMessage(backend, method: "DOM.requestNode", after: sentCount)
+    await receiveTargetReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        result: #"{"nodeId":164}"#
+    )
+    _ = try await performTask.value
+
+    #expect(await session.dom.selectedNodeID == expectedNodeID)
+    let selectedNode = try #require(await session.dom.selectedNode)
+    #expect(await selectedNode.attributes == [DOMAttribute(name: "id", value: "picked")])
+}
+
+@Test("Regression: detached setChildNodes root keeps requestNode selectable")
+func detachedSetChildNodesRootKeepsRequestNodeSelectable() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let intent = await session.dom.beginInspectSelectionRequest(
+        targetID: .pageMain,
+        objectID: "detached-selected-object"
+    )
+    guard case let .success(commandIntent) = intent else {
+        Issue.record("Expected DOM.requestNode intent")
+        return
+    }
+
+    let sentCount = await backend.sentTargetMessages().count
+    let performTask = Task {
+        try await session.perform(commandIntent)
+    }
+    let sent = try await waitForTargetMessage(backend, method: "DOM.requestNode", after: sentCount)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":0,"nodes":[{"nodeId":200,"nodeType":1,"nodeName":"DIV","localName":"div","children":[{"nodeId":201,"nodeType":1,"nodeName":"IMG","localName":"img"}]}]}}"#
+    )
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.attributeModified","params":{"nodeId":201,"name":"src","value":"https://ads.example/detached.webp"}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        result: #"{"nodeId":201}"#
+    )
+    _ = try await performTask.value
+
+    let selectedNode = try #require(await session.dom.selectedNode)
+    #expect(await selectedNode.nodeName == "IMG")
+    #expect(await selectedNode.attributes == [DOMAttribute(name: "src", value: "https://ads.example/detached.webp")])
+}
+
 @Test
-func requestNodeFailureDoesNotMutateDOMTree() async throws {
+func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(
-        configuration: .init(responseTimeout: .seconds(1), bootstrapTimeout: .seconds(1), eventApplicationTimeout: .milliseconds(1))
+        configuration: .init(responseTimeout: .seconds(1), bootstrapTimeout: .seconds(1))
     )
     try await connect(session, transport: transport, backend: backend)
     let snapshotBeforeSelection = await session.dom.snapshot()
@@ -478,7 +1146,31 @@ func requestNodeFailureDoesNotMutateDOMTree() async throws {
     #expect(snapshot.documentsByID.keys == snapshotBeforeSelection.documentsByID.keys)
     #expect(snapshot.nodesByID.keys == snapshotBeforeSelection.nodesByID.keys)
     #expect(snapshot.selection.selectedNodeID == nil)
-    #expect(snapshot.selection.failure == .unresolvedNode(.init(targetID: .pageMain, nodeID: .init(999))))
+    #expect(snapshot.selection.failure == nil)
+    let pendingRequest = try #require(snapshot.selection.pendingRequest)
+    #expect(pendingRequest.targetID == .pageMain)
+    #expect(snapshot.transactions.contains { transaction in
+        transaction.targetID == .pageMain
+            && transaction.documentID == pendingRequest.documentID
+            && transaction.kind == .requestNode(selectionRequestID: pendingRequest.id, objectID: "missing-object")
+            && transaction.requestedProtocolNodeID == .init(999)
+    })
+    #expect(await session.lastError == nil)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-path"]}]}}"#
+    )
+
+    let selectedNode = try await waitUntil {
+        await session.dom.selectedNode
+    }
+    #expect(await selectedNode.nodeName == "DIV")
+    #expect(await selectedNode.attributes == [DOMAttribute(name: "id", value: "late-path")])
+    let resolvedSnapshot = await session.dom.snapshot()
+    #expect(resolvedSnapshot.selection.pendingRequest == nil)
+    #expect(resolvedSnapshot.selection.failure == nil)
 }
 
 @Test
@@ -521,6 +1213,170 @@ func elementPickerBeginAndCancelToggleInspectMode() async throws {
     )
     await cancelTask.value
 
+    #expect(await session.isSelectingElement == false)
+}
+
+@Test
+func targetDestroyedClearsActiveElementPicker() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    #expect(await session.isSelectingElement)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetDestroyed","params":{"targetId":"page-main"}}"#
+    )
+    _ = try await waitUntil {
+        await session.isSelectingElement == false ? true : nil
+    }
+}
+
+@Test
+func targetCommitClearsElementPickerForOldTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    #expect(await session.isSelectingElement)
+
+    let sentCountBeforeNavigation = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
+    )
+
+    _ = try await waitUntil {
+        await session.isSelectingElement == false ? true : nil
+    }
+
+    let bootstrapMessages = try await completeBootstrap(
+        transport: transport,
+        backend: backend,
+        after: sentCountBeforeNavigation,
+        documentResult: manualReloadDocumentResult
+    )
+    #expect(bootstrapMessages.map(\.targetIdentifier).allSatisfy { $0 == .pageNext })
+}
+
+@Test
+func elementPickerUsesBootstrappedTargetAfterTargetCommit() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeNavigation = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
+    )
+    try await completeBootstrap(
+        transport: transport,
+        backend: backend,
+        after: sentCountBeforeNavigation,
+        documentResult: manualReloadDocumentResult
+    )
+
+    let sentCountBeforePicker = await backend.sentTargetMessages().count
+    let beginTask = Task {
+        try await session.beginElementPicker()
+    }
+
+    let enableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforePicker
+    )
+    #expect(enableMessage.targetIdentifier == ProtocolTargetIdentifier.pageNext)
+    await receiveTargetReply(
+        transport,
+        targetID: enableMessage.targetIdentifier,
+        messageID: try messageID(enableMessage.message),
+        result: "{}"
+    )
+    try await beginTask.value
+    #expect(await session.isSelectingElement)
+}
+
+@Test
+func elementPickerAcceptsInspectEventBeforeInspectModeReply() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+    }
+
+    let sentCount = await backend.sentTargetMessages().count
+    let beginTask = Task {
+        try await session.beginElementPicker()
+    }
+    let enableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCount
+    )
+    #expect(try boolParameter("enabled", in: enableMessage.message) == true)
+    #expect(await session.isSelectingElement)
+
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeInspect
+    )
+    #expect(requestNode.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","selected"]}]}}"#
+    )
+    let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":3}"#
+    )
+    let disableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRequestReply
+    )
+    #expect(try boolParameter("enabled", in: disableMessage.message) == false)
+    await receiveTargetReply(
+        transport,
+        targetID: disableMessage.targetIdentifier,
+        messageID: try messageID(disableMessage.message),
+        result: "{}"
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: enableMessage.targetIdentifier,
+        messageID: try messageID(enableMessage.message),
+        result: "{}"
+    )
+    try await beginTask.value
+
+    let selectedNode = try await waitUntil {
+        await session.dom.selectedNode
+    }
+    #expect(await selectedNode.nodeName == "DIV")
     #expect(await session.isSelectingElement == false)
 }
 
@@ -576,6 +1432,66 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
         await session.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
+    #expect(await session.isSelectingElement == false)
+}
+
+@Test
+func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(
+        configuration: .init(
+            responseTimeout: .seconds(1),
+            bootstrapTimeout: .seconds(1)
+        )
+    )
+    try await connect(session, transport: transport, backend: backend)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+    }
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
+
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeInspect
+    )
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","selected-after-path-push"]}]}}"#
+    )
+    let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":3}"#
+    )
+    let disable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRequestReply
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: disable.targetIdentifier,
+        messageID: try messageID(disable.message),
+        result: "{}"
+    )
+
+    let selectedNode = try await waitUntil {
+        await session.dom.selectedNode
+    }
+    #expect(await selectedNode.attributes == [DOMAttribute(name: "id", value: "selected-after-path-push")])
     #expect(await session.isSelectingElement == false)
 }
 
@@ -1367,7 +2283,7 @@ func detachCancelsPumpsAndClearsModelState() async throws {
 
     #expect(await backend.isDetached())
     #expect(await session.isAttached == false)
-    #expect(await session.dom.snapshot().currentPage == nil)
+    #expect(await session.dom.snapshot().currentPageTargetID == nil)
     #expect(await session.network.snapshot().orderedRequestIDs.isEmpty)
 }
 
@@ -1402,8 +2318,7 @@ func bootstrapFailureClearsSeededModelState() async throws {
     let session = await InspectorSession(
         configuration: .init(
             responseTimeout: .milliseconds(20),
-            bootstrapTimeout: .seconds(1),
-            eventApplicationTimeout: .milliseconds(25)
+            bootstrapTimeout: .seconds(1)
         )
     )
     await transport.receiveRootMessage(
@@ -1414,7 +2329,7 @@ func bootstrapFailureClearsSeededModelState() async throws {
         try await session.connect(transport: transport)
     }
 
-    #expect(await session.dom.snapshot().currentPage == nil)
+    #expect(await session.dom.snapshot().currentPageTargetID == nil)
     #expect(await session.network.snapshot().orderedRequestIDs.isEmpty)
     #expect(await session.isAttached == false)
     #expect(await session.lastError != nil)
@@ -1464,16 +2379,6 @@ func attachInspectabilityPreparationRestoresOriginalValue() throws {
     webView.isInspectable = initialValue
 }
 
-@MainActor
-@Test
-func eventPumpTimeoutRemovesWaiter() async {
-    let pump = DomainEventPump()
-
-    await pump.waitUntilApplied(10, timeout: .milliseconds(1))
-
-    #expect(pump.pendingWaiterCount == 0)
-}
-
 private func connect(
     _ session: InspectorSession,
     transport: TransportSession,
@@ -1506,7 +2411,8 @@ private func testTransport(_ backend: FakeTransportBackend) -> TransportSession 
 private func completeBootstrap(
     transport: TransportSession,
     backend: FakeTransportBackend,
-    after initialSentCount: Int = 0
+    after initialSentCount: Int = 0,
+    documentResult: String = mainDocumentResult
 ) async throws -> [SentTargetMessage] {
     var sentCount = initialSentCount
     var sentMessages: [SentTargetMessage] = []
@@ -1530,7 +2436,7 @@ private func completeBootstrap(
         transport,
         targetID: documentMessage.targetIdentifier,
         messageID: try messageID(documentMessage.message),
-        result: mainDocumentResult
+        result: documentResult
     )
 
     let networkMessage = try await waitForTargetMessage(backend, method: "Network.enable", after: sentCount)
@@ -1563,10 +2469,45 @@ private func beginPicker(
     try await beginTask.value
 }
 
-private let mainDocumentResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[]}]}}"##
+private func hydratePageHTMLChildren(
+    session: InspectorSession,
+    transport: TransportSession,
+    backend: FakeTransportBackend
+) async throws {
+    let htmlID = try await waitForCurrentNode(
+        in: session,
+        targetID: .pageMain,
+        protocolNodeID: .init(2)
+    )
+    let sentCount = await backend.sentTargetMessages().count
+    let requestTask = Task {
+        await session.requestChildNodes(for: htmlID)
+    }
+    let request = try await waitForTargetMessage(backend, method: "DOM.requestChildNodes", after: sentCount)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: pageHTMLChildrenSetChildNodesMessage
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: request.targetIdentifier,
+        messageID: try messageID(request.message),
+        result: "{}"
+    )
+    #expect(await requestTask.value)
+}
+
+private let mainDocumentResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","childNodeCount":2}]}}"##
+private let pageHTMLChildrenSetChildNodesMessage = #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":5,"nodeType":1,"nodeName":"MAIN","localName":"main","attributes":["id","content"]}]}]}}"#
 private let nestedDocumentResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":4,"nodeType":1,"nodeName":"DIV","localName":"div"}]}]}]}}"##
-private let firstLazyFrameDocumentResult = ##"{"root":{"nodeId":101,"nodeType":9,"nodeName":"#document","children":[{"nodeId":102,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":103,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":104,"nodeType":1,"nodeName":"CANVAS","localName":"canvas"}]}]}]}}"##
-private let secondLazyFrameDocumentResult = ##"{"root":{"nodeId":201,"nodeType":9,"nodeName":"#document","children":[{"nodeId":202,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":203,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":204,"nodeType":1,"nodeName":"VIDEO","localName":"video"}]}]}]}}"##
+private let manualReloadDocumentResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":40,"nodeType":1,"nodeName":"MAIN","localName":"main"}]}]}]}}"##
+private let staleReloadDocumentResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":50,"nodeType":1,"nodeName":"SECTION","localName":"section"}]}]}]}}"##
+private let oldDocumentWithHeadNodeFourResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":4,"nodeType":1,"nodeName":"HEAD","localName":"head","childNodeCount":1},{"nodeId":5,"nodeType":1,"nodeName":"BODY","localName":"body"}]}]}}"##
+private let newDocumentWithBodyNodeFourResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head"},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body"}]}]}}"##
+private let newDocumentWithHeadChildCountResult = ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"HEAD","localName":"head","childNodeCount":2},{"nodeId":4,"nodeType":1,"nodeName":"BODY","localName":"body"}]}]}}"##
+private let firstLazyFrameDocumentResult = ##"{"root":{"nodeId":101,"nodeType":9,"nodeName":"#document","documentURL":"https://frame.example/ad","baseURL":"https://frame.example/ad","children":[{"nodeId":102,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":103,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":104,"nodeType":1,"nodeName":"CANVAS","localName":"canvas"}]}]}]}}"##
+private let secondLazyFrameDocumentResult = ##"{"root":{"nodeId":201,"nodeType":9,"nodeName":"#document","documentURL":"https://frame.example/ad","baseURL":"https://frame.example/ad","children":[{"nodeId":202,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":203,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":204,"nodeType":1,"nodeName":"VIDEO","localName":"video"}]}]}]}}"##
 
 private func targetMessageMethods(_ backend: FakeTransportBackend) async -> [String?] {
     await backend.sentTargetMessages().map { try? messageMethod($0.message) }
@@ -1577,18 +2518,27 @@ private func waitForTargetMessage(
     method: String,
     after count: Int = 0
 ) async throws -> SentTargetMessage {
-    await backend.waitForTargetMessage(method: method, after: count)
+    try await waitUntil(timeoutError: TransportError.replyTimeout(method: method, targetID: nil)) {
+        let messages = await backend.sentTargetMessages()
+        return messages.dropFirst(count).first { sent in
+            (try? messageMethod(sent.message)) == method
+        }
+    }
 }
 
-private func waitUntil<Value: Sendable>(_ body: @escaping @Sendable () async -> Value?) async throws -> Value {
-    let deadline = ContinuousClock.now + .seconds(1)
+private func waitUntil<Value: Sendable>(
+    timeout: Duration = .seconds(1),
+    timeoutError: any Error = TransportError.replyTimeout(method: "test wait", targetID: nil),
+    _ body: @escaping @Sendable () async -> Value?
+) async throws -> Value {
+    let deadline = ContinuousClock.now + timeout
     while ContinuousClock.now < deadline {
         if let value = await body() {
             return value
         }
         try await Task.sleep(for: .milliseconds(5))
     }
-    throw TransportError.replyTimeout(method: "test wait", targetID: nil)
+    throw timeoutError
 }
 
 private func waitForCurrentNode(
@@ -1716,16 +2666,15 @@ private extension ProtocolTargetIdentifier {
 private extension InspectorSessionConfiguration {
     static let test = InspectorSessionConfiguration(
         responseTimeout: .seconds(1),
-        bootstrapTimeout: .seconds(1),
-        eventApplicationTimeout: .milliseconds(25)
+        bootstrapTimeout: .seconds(1)
     )
 }
 
 private extension DOMSessionSnapshot {
     var currentPageDocumentID: DOMDocumentIdentifier? {
-        guard let currentPage else {
+        guard let currentPageTargetID else {
             return nil
         }
-        return targetsByID[currentPage.mainTargetID]?.currentDocumentID
+        return targetsByID[currentPageTargetID]?.currentDocumentID
     }
 }

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -897,6 +897,86 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
     )
 }
 
+@Test("Regression: repeated frame documentUpdated reissues an in-flight frame reload")
+func repeatedFrameDocumentUpdatedReissuesInFlightFrameReload() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+    let initialFrameDocumentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(initialFrameDocumentRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: initialFrameDocumentRequest.targetIdentifier,
+        messageID: try messageID(initialFrameDocumentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID
+    }
+
+    let sentCountBeforeFirstUpdate = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .frameAd,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let firstReload = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFirstUpdate
+    )
+    #expect(firstReload.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+
+    let sentCountBeforeSecondUpdate = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .frameAd,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let secondReload = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeSecondUpdate
+    )
+    #expect(secondReload.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    #expect(try messageID(secondReload.message) != messageID(firstReload.message))
+
+    await receiveTargetReply(
+        transport,
+        targetID: firstReload.targetIdentifier,
+        messageID: try messageID(firstReload.message),
+        result: firstLazyFrameDocumentResult
+    )
+    try await Task.sleep(for: .milliseconds(25))
+    #expect(await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(101))] == nil)
+
+    await receiveTargetReply(
+        transport,
+        targetID: secondReload.targetIdentifier,
+        messageID: try messageID(secondReload.message),
+        result: secondLazyFrameDocumentResult
+    )
+
+    let snapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))] != nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(101))] == nil)
+}
+
 @Test("Pending frame document hydrates page owner path before projection")
 func pendingFrameDocumentHydratesPageOwnerPathBeforeProjection() async throws {
     let backend = FakeTransportBackend()
@@ -1558,8 +1638,8 @@ func elementPickerUsesBootstrappedTargetAfterTargetCommit() async throws {
     #expect(await session.isSelectingElement)
 }
 
-@Test
-func elementPickerAcceptsInspectEventBeforeInspectModeReply() async throws {
+@Test("Regression: element picker ignores inspect events before inspect-mode enable completes")
+func elementPickerIgnoresInspectEventBeforeInspectModeReply() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -1587,10 +1667,25 @@ func elementPickerAcceptsInspectEventBeforeInspectModeReply() async throws {
 
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    try await Task.sleep(for: .milliseconds(25))
+    let messagesBeforeEnableReply = await backend.sentTargetMessages().dropFirst(sentCountBeforeInspect)
+    #expect(messagesBeforeEnableReply.allSatisfy { (try? messageMethod($0.message)) != "DOM.requestNode" })
+    #expect(await session.isSelectingElement)
+
+    await receiveTargetReply(
+        transport,
+        targetID: enableMessage.targetIdentifier,
+        messageID: try messageID(enableMessage.message),
+        result: "{}"
+    )
+    try await beginTask.value
+
+    let sentCountBeforeAcceptedInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
     let requestNode = try await waitForTargetMessage(
         backend,
         method: "DOM.requestNode",
-        after: sentCountBeforeInspect
+        after: sentCountBeforeAcceptedInspect
     )
     #expect(requestNode.targetIdentifier == ProtocolTargetIdentifier.pageMain)
 
@@ -1618,13 +1713,127 @@ func elementPickerAcceptsInspectEventBeforeInspectModeReply() async throws {
         messageID: try messageID(disableMessage.message),
         result: "{}"
     )
+
+    let selectedNode = try await waitUntil {
+        await session.dom.selectedNode
+    }
+    #expect(await selectedNode.nodeName == "DIV")
+    #expect(await session.isSelectingElement == false)
+}
+
+@Test("Regression: restarted picker ignores stale inspect event while enable is pending")
+func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+    }
+
+    let sentCountBeforeFirstBegin = await backend.sentTargetMessages().count
+    let firstBeginTask = Task {
+        try await session.beginElementPicker()
+    }
+    let firstEnable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeFirstBegin
+    )
+    #expect(try boolParameter("enabled", in: firstEnable.message) == true)
+
+    let sentCountBeforeCancel = await backend.sentTargetMessages().count
+    let cancelTask = Task {
+        await session.cancelElementPicker()
+    }
+    let cancelDisable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeCancel
+    )
+    #expect(try boolParameter("enabled", in: cancelDisable.message) == false)
     await receiveTargetReply(
         transport,
-        targetID: enableMessage.targetIdentifier,
-        messageID: try messageID(enableMessage.message),
+        targetID: cancelDisable.targetIdentifier,
+        messageID: try messageID(cancelDisable.message),
         result: "{}"
     )
-    try await beginTask.value
+    await cancelTask.value
+
+    let sentCountBeforeRestart = await backend.sentTargetMessages().count
+    let restartTask = Task {
+        try await session.beginElementPicker()
+    }
+    let restartEnable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRestart
+    )
+    #expect(try boolParameter("enabled", in: restartEnable.message) == true)
+    #expect(await session.isSelectingElement)
+
+    let sentCountBeforeStaleInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    try await Task.sleep(for: .milliseconds(25))
+    let messagesAfterStaleInspect = await backend.sentTargetMessages().dropFirst(sentCountBeforeStaleInspect)
+    #expect(messagesAfterStaleInspect.allSatisfy { (try? messageMethod($0.message)) != "DOM.requestNode" })
+    #expect(messagesAfterStaleInspect.allSatisfy { (try? messageMethod($0.message)) != "DOM.setInspectModeEnabled" })
+    #expect(await session.isSelectingElement)
+
+    await receiveTargetReply(
+        transport,
+        targetID: firstEnable.targetIdentifier,
+        messageID: try messageID(firstEnable.message),
+        result: "{}"
+    )
+    try await firstBeginTask.value
+    #expect(await session.isSelectingElement)
+
+    await receiveTargetReply(
+        transport,
+        targetID: restartEnable.targetIdentifier,
+        messageID: try messageID(restartEnable.message),
+        result: "{}"
+    )
+    try await restartTask.value
+
+    let sentCountBeforeAcceptedInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeAcceptedInspect
+    )
+    #expect(requestNode.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","selected"]}]}}"#
+    )
+    let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":3}"#
+    )
+    let disable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRequestReply
+    )
+    #expect(try boolParameter("enabled", in: disable.message) == false)
+    await receiveTargetReply(
+        transport,
+        targetID: disable.targetIdentifier,
+        messageID: try messageID(disable.message),
+        result: "{}"
+    )
 
     let selectedNode = try await waitUntil {
         await session.dom.selectedNode

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -221,6 +221,41 @@ func frameTargetWithAdvertisedDOMCapabilityHydratesOnCreation() async throws {
     #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID != nil)
 }
 
+@Test
+func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
+    )
+
+    let connectTask = Task {
+        try await session.connect(transport: transport)
+    }
+    let bootstrapMessages = try await completeBootstrap(transport: transport, backend: backend)
+    try await connectTask.value
+
+    let frameRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: bootstrapMessages.count
+    )
+    #expect(frameRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameRequest.targetIdentifier,
+        messageID: try messageID(frameRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+
+    #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID != nil)
+}
+
 @Test("Regression: frame getDocument request does not block page DOM events")
 func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
     let backend = FakeTransportBackend()
@@ -502,8 +537,8 @@ func staleSetChildNodesAfterPageNavigationDoesNotMoveHeadChildrenIntoNewBody() a
     #expect(snapshot.nodesByID[newBodyID]?.regularChildIDs.isEmpty == true)
 }
 
-@Test("Regression: targetless iframe DOM update does not invalidate parent page selection")
-func targetlessIframeDocumentUpdateDoesNotInvalidateParentPageSelection() async throws {
+@Test("Regression: root-scoped documentUpdated invalidates the current page document")
+func rootScopedDocumentUpdatedInvalidatesCurrentPageDocument() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -548,7 +583,7 @@ func targetlessIframeDocumentUpdateDoesNotInvalidateParentPageSelection() async 
     )
 
     let beforeUpdate = await session.dom.snapshot()
-    let pageDocumentID = try #require(beforeUpdate.currentPageDocumentID)
+    _ = try #require(beforeUpdate.currentPageDocumentID)
     let frameDocumentID = try #require(beforeUpdate.targetsByID[.frameAd]?.currentDocumentID)
     let frameRootID = try #require(beforeUpdate.documentsByID[frameDocumentID]?.rootNodeID)
     await session.dom.selectNode(mainNodeID)
@@ -560,20 +595,19 @@ func targetlessIframeDocumentUpdateDoesNotInvalidateParentPageSelection() async 
 
     let sentCountBeforeTargetlessUpdate = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
-    try await Task.sleep(for: .milliseconds(25))
 
-    let afterUpdate = await session.dom.snapshot()
-    #expect(afterUpdate.currentPageDocumentID == pageDocumentID)
-    #expect(afterUpdate.targetsByID[.frameAd]?.currentDocumentID == frameDocumentID)
-    #expect(afterUpdate.selection.selectedNodeID == mainNodeID)
-    #expect(afterUpdate.nodesByID[mainNodeID] != nil)
-    #expect(afterUpdate.nodesByID[iframeNodeID] != nil)
+    let afterUpdate: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(afterUpdate.currentPageDocumentID == nil)
+    #expect(afterUpdate.targetsByID[ProtocolTargetIdentifier.frameAd]?.currentDocumentID == frameDocumentID)
+    #expect(afterUpdate.selection.selectedNodeID == nil)
     #expect(await backend.sentTargetMessages().count == sentCountBeforeTargetlessUpdate)
-    assertProjectionContainsFrameDocument(
-        in: await session.dom.treeProjection(rootTargetID: .pageMain),
-        iframeNodeID: iframeNodeID,
-        frameRootNodeID: frameRootID
-    )
+    #expect((await session.dom.treeProjection(rootTargetID: .pageMain)).rows.map(\.nodeID).contains(frameRootID) == false)
 }
 
 @Test("Lazy iframe insertion and frame document update keep the parent page tree intact")

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -364,6 +364,59 @@ func provisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydrating() asy
     #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(101))] == nil)
 }
 
+@Test
+func oldlessProvisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydrating() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let provisionalTargetID = ProtocolTargetIdentifier("frame-provisional")
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":true}}}"#
+    )
+    let firstRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(firstRequest.targetIdentifier == provisionalTargetID)
+    let firstRequestMessageID = try messageID(firstRequest.message)
+
+    let sentCountBeforeCommit = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"newTargetId":"frame-ad"}}"#
+    )
+    let committedRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeCommit
+    )
+    #expect(committedRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: committedRequest.targetIdentifier,
+        messageID: try messageID(committedRequest.message),
+        result: secondLazyFrameDocumentResult
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))]
+    }
+
+    await receiveTargetReply(
+        transport,
+        targetID: .frameAd,
+        messageID: firstRequestMessageID,
+        result: firstLazyFrameDocumentResult
+    )
+    try await Task.sleep(for: .milliseconds(25))
+
+    let snapshot = await session.dom.snapshot()
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))] != nil)
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(101))] == nil)
+}
+
 @Test("Regression: frame getDocument request does not block page DOM events")
 func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
     let backend = FakeTransportBackend()

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -311,6 +311,59 @@ func provisionalFrameDocumentResolvedBeforeCommitRehydratesCommittedFrame() asyn
     #expect(snapshot.targetsByID[provisionalTargetID] == nil)
 }
 
+@Test
+func provisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydrating() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let provisionalTargetID = ProtocolTargetIdentifier("frame-provisional")
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":true}}}"#
+    )
+    let firstRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(firstRequest.targetIdentifier == provisionalTargetID)
+    let firstRequestMessageID = try messageID(firstRequest.message)
+
+    let sentCountBeforeCommit = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-ad"}}"#
+    )
+    let committedRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCountBeforeCommit
+    )
+    #expect(committedRequest.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: committedRequest.targetIdentifier,
+        messageID: try messageID(committedRequest.message),
+        result: secondLazyFrameDocumentResult
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))]
+    }
+
+    await receiveTargetReply(
+        transport,
+        targetID: .frameAd,
+        messageID: firstRequestMessageID,
+        result: firstLazyFrameDocumentResult
+    )
+    try await Task.sleep(for: .milliseconds(25))
+
+    let snapshot = await session.dom.snapshot()
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))] != nil)
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(101))] == nil)
+}
+
 @Test("Regression: frame getDocument request does not block page DOM events")
 func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
     let backend = FakeTransportBackend()
@@ -1525,6 +1578,86 @@ func elementPickerAcceptsInspectEventBeforeInspectModeReply() async throws {
     }
     #expect(await selectedNode.nodeName == "DIV")
     #expect(await session.isSelectingElement == false)
+}
+
+@Test
+func staleInspectEventCompletionDoesNotCancelRestartedPicker() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+    }
+    try await beginPicker(session: session, transport: transport, backend: backend)
+
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"{\"injectedScriptId\":7,\"id\":99}"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeInspect
+    )
+
+    let sentCountBeforeCancel = await backend.sentTargetMessages().count
+    let cancelTask = Task {
+        await session.cancelElementPicker()
+    }
+    let cancelDisable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeCancel
+    )
+    #expect(try boolParameter("enabled", in: cancelDisable.message) == false)
+    await receiveTargetReply(
+        transport,
+        targetID: cancelDisable.targetIdentifier,
+        messageID: try messageID(cancelDisable.message),
+        result: "{}"
+    )
+    await cancelTask.value
+
+    let sentCountBeforeRestart = await backend.sentTargetMessages().count
+    let restartTask = Task {
+        try await session.beginElementPicker()
+    }
+    let restartEnable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRestart
+    )
+    #expect(try boolParameter("enabled", in: restartEnable.message) == true)
+    await receiveTargetReply(
+        transport,
+        targetID: restartEnable.targetIdentifier,
+        messageID: try messageID(restartEnable.message),
+        result: "{}"
+    )
+    try await restartTask.value
+    #expect(await session.isSelectingElement)
+
+    let sentCountBeforeStaleReply = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":3,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","old-picker"]}]}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":3}"#
+    )
+    try await Task.sleep(for: .milliseconds(25))
+
+    let messagesAfterStaleReply = await backend.sentTargetMessages().dropFirst(sentCountBeforeStaleReply)
+    #expect(await session.isSelectingElement)
+    #expect(messagesAfterStaleReply.allSatisfy { (try? messageMethod($0.message)) != "DOM.setInspectModeEnabled" })
 }
 
 @Test

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -444,6 +444,35 @@ func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws
 }
 
 @Test
+func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
+
+    let targetStream = await session.events(for: .target)
+    let domStream = await session.events(for: .dom)
+    let targetTask = firstEvent(from: targetStream)
+    let domTask = firstEvent(from: domStream)
+
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-provisional"),
+        message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":1}}"#
+    )
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
+
+    let targetEvent = try #require(await targetTask.value)
+    let domEvent = try #require(await domTask.value)
+
+    #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
+    #expect(domEvent.method == "DOM.childNodeCountUpdated")
+    #expect(domEvent.targetID == ProtocolTargetIdentifier("frame-committed"))
+    #expect(domEvent.sequence > targetEvent.sequence)
+    #expect(domEvent.receivedSequence(for: .target) == targetEvent.sequence)
+}
+
+@Test
 func retargetedPendingReplyStillTimesOutAfterCommit() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -360,6 +360,31 @@ func targetCommitRetargetsPendingRepliesToCommittedTarget() async throws {
 }
 
 @Test
+func provisionalTargetReplyResolvesBeforeBufferedEvents() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
+
+    let sendTask = Task {
+        try await session.send(
+            ProtocolCommand(domain: .dom, method: "DOM.getDocument", routing: .target(.init("frame-provisional")))
+        )
+    }
+    let sent = try await waitForTargetMessage(backend)
+    let innerID = try messageID(sent.message)
+
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-provisional"),
+        message: ##"{"id":\##(innerID),"result":{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document"}}}"##
+    )
+    let result = try await sendTask.value
+
+    #expect(result.targetID == ProtocolTargetIdentifier("frame-provisional"))
+    #expect(await session.snapshot().pendingTargetReplyKeys.isEmpty)
+}
+
+@Test
 func oldlessTargetCommitInfersSoleProvisionalTarget() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .seconds(1))

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -389,6 +389,36 @@ func oldlessTargetCommitInfersSoleProvisionalTarget() async throws {
 }
 
 @Test
+func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","frameId":"main-frame","isProvisional":true}}}"#)
+
+    let targetStream = await session.events(for: .target)
+    let domStream = await session.events(for: .dom)
+    let targetTask = firstEvent(from: targetStream)
+    let domTask = firstEvent(from: domStream)
+
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("page-next"),
+        message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":0}}"#
+    )
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#)
+
+    let targetEvent = try #require(await targetTask.value)
+    let domEvent = try #require(await domTask.value)
+
+    #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
+    #expect(domEvent.method == "DOM.childNodeCountUpdated")
+    #expect(domEvent.targetID == ProtocolTargetIdentifier("page-next"))
+    #expect(domEvent.sequence > targetEvent.sequence)
+    #expect(domEvent.receivedSequence(for: .target) == targetEvent.sequence)
+}
+
+@Test
 func retargetedPendingReplyStillTimesOutAfterCommit() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
@@ -425,7 +455,7 @@ func ambiguousTargetCommitPreservesExistingMetadataAndDoesNotInventTarget() asyn
 }
 
 @Test
-func rootScopedRuntimeAndDOMEventsResolveToCurrentPageTarget() async throws {
+func rootScopedRuntimeAndDOMMutationEventsResolveToCurrentPageTarget() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let runtimeStream = await session.events(for: .runtime)
@@ -435,12 +465,25 @@ func rootScopedRuntimeAndDOMEventsResolveToCurrentPageTarget() async throws {
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":11,"frameId":"main-frame"}}}"#)
-    await session.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
+    await session.receiveRootMessage(#"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":1,"childNodeCount":2}}"#)
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByID[ExecutionContextID(11)]?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await runtimeTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await domTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
+}
+
+@Test
+func rootScopedDocumentUpdatedRemainsTargetless() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+    let domStream = await session.events(for: .dom)
+    let domTask = firstEvent(from: domStream)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
+
+    #expect(await domTask.value?.targetID == nil)
 }
 
 @Test
@@ -514,6 +557,28 @@ func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
     #expect(await cssTask.value?.method == "CSS.styleSheetChanged")
     #expect(await consoleTask.value?.method == "Console.messageAdded")
     #expect(await networkTask.value?.method == "Network.requestWillBeSent")
+}
+
+@Test
+func orderedStreamReceivesTargetEventsAcrossDomainsInTransportOrder() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+    let stream = await session.orderedEvents()
+    let eventsTask = firstEvents(4, from: stream)
+
+    await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"DOM.documentUpdated","params":{}}"#)
+    await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"r1","request":{"url":"https://example.com"},"timestamp":1}}"#)
+    await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7}}}"#)
+    await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":2}}"#)
+
+    let events = await eventsTask.value
+    #expect(events.map(\.method) == [
+        "DOM.documentUpdated",
+        "Network.requestWillBeSent",
+        "Runtime.executionContextCreated",
+        "DOM.childNodeCountUpdated",
+    ])
+    #expect(events.map(\.sequence) == [1, 2, 3, 4])
 }
 
 @Test
@@ -704,7 +769,7 @@ func domAdapterCompletesInspectSelectionThroughRequestNodeResult() async throws 
         selectionRequestID: selectionRequestID,
         to: dom
     )
-    guard case let .success(selectedNodeID) = result else {
+    guard case let .resolved(selectedNodeID) = result else {
         Issue.record("Expected selected node")
         return
     }
@@ -808,7 +873,7 @@ func domAdapterAmbiguousTargetCommitDoesNotOverwriteExistingTargetMetadata() asy
 
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("frame-ad")]?.kind == .frame)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("frame-ad")]?.frameID == DOMFrameIdentifier("ad-frame"))
-    #expect(snapshot.currentPage == nil)
+    #expect(snapshot.currentPageTargetID == nil)
 }
 
 @Test
@@ -827,7 +892,7 @@ func domAdapterPageTargetWithParentFrameIsClassifiedAsFrame() async throws {
     let snapshot = await dom.snapshot()
 
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("iframe-page")]?.kind == .frame)
-    #expect(snapshot.currentPage == nil)
+    #expect(snapshot.currentPageTargetID == nil)
     #expect(snapshot.framesByID[DOMFrameIdentifier("child-frame")]?.targetID == ProtocolTargetIdentifier("iframe-page"))
 }
 
@@ -856,7 +921,7 @@ func domAdapterPageTargetWithKnownNonMainFrameIsClassifiedAsFrame() async throws
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier("page-main"))
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("iframe-page")]?.kind == .frame)
     #expect(snapshot.framesByID[DOMFrameIdentifier("child-frame")]?.targetID == ProtocolTargetIdentifier("iframe-page"))
 }
@@ -896,7 +961,7 @@ func domAdapterPageTargetWithoutFrameIDCanCommitAsCurrentPage() async throws {
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier("page-new"))
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier("page-new"))
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-new")]?.kind == .page)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-new")]?.isProvisional == false)
 }
@@ -925,7 +990,7 @@ func domAdapterCommittedTopLevelProvisionalPageBecomesCurrentPage() async throws
         ),
         to: dom
     )
-    #expect(await dom.snapshot().currentPage?.mainTargetID == ProtocolTargetIdentifier("page-old"))
+    #expect(await dom.snapshot().currentPageTargetID == ProtocolTargetIdentifier("page-old"))
 
     try await DOMTransportAdapter.applyTargetEvent(
         ProtocolEventEnvelope(
@@ -939,8 +1004,8 @@ func domAdapterCommittedTopLevelProvisionalPageBecomesCurrentPage() async throws
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier("page-main"))
-    #expect(snapshot.currentPage?.mainFrameID == DOMFrameIdentifier("main-frame"))
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(snapshot.mainFrameID == DOMFrameIdentifier("main-frame"))
 }
 
 @Test
@@ -956,7 +1021,7 @@ func domAdapterOldlessCommittedProvisionalPageWithoutMainContextStaysFrameScoped
         ),
         to: dom
     )
-    #expect(await dom.snapshot().currentPage == nil)
+    #expect(await dom.snapshot().currentPageTargetID == nil)
 
     try await DOMTransportAdapter.applyTargetEvent(
         ProtocolEventEnvelope(
@@ -970,7 +1035,7 @@ func domAdapterOldlessCommittedProvisionalPageWithoutMainContextStaysFrameScoped
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage == nil)
+    #expect(snapshot.currentPageTargetID == nil)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-main")]?.kind == .frame)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-main")]?.isProvisional == false)
 }
@@ -1001,7 +1066,7 @@ func domAdapterOldlessCommitInfersSoleProvisionalFrameTarget() async throws {
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage == nil)
+    #expect(snapshot.currentPageTargetID == nil)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-provisional")] == nil)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-main")]?.kind == .frame)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-main")]?.frameID == DOMFrameIdentifier("main-frame"))
@@ -1044,7 +1109,7 @@ func domAdapterCommittedSecondaryPageDoesNotReplaceCurrentPage() async throws {
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier("page-main"))
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-popup")]?.frameID == DOMFrameIdentifier("popup-frame"))
 }
 
@@ -1084,7 +1149,7 @@ func domAdapterSubframeCommitDoesNotConsumeCurrentMainPage() async throws {
     )
     let snapshot = await dom.snapshot()
 
-    #expect(snapshot.currentPage?.mainTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(snapshot.currentPageTargetID == ProtocolTargetIdentifier("page-main"))
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("page-main")]?.kind == .page)
     #expect(snapshot.targetsByID[ProtocolTargetIdentifier("frame-committed")]?.isProvisional == false)
 }
@@ -1242,10 +1307,55 @@ func domAdapterDecodesOuterHTMLResultAndInspectEvents() throws {
     ))
 }
 
-private func firstEvent(from stream: AsyncStream<ProtocolEventEnvelope>) -> Task<ProtocolEventEnvelope?, Never> {
+private func firstEvent(
+    from stream: AsyncStream<ProtocolEventEnvelope>,
+    timeout: Duration = .seconds(1)
+) -> Task<ProtocolEventEnvelope?, Never> {
     Task {
-        var iterator = stream.makeAsyncIterator()
-        return await iterator.next()
+        await withTaskGroup(of: ProtocolEventEnvelope?.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                return await iterator.next()
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
+private func firstEvents(
+    _ count: Int,
+    from stream: AsyncStream<ProtocolEventEnvelope>,
+    timeout: Duration = .seconds(1)
+) -> Task<[ProtocolEventEnvelope], Never> {
+    Task {
+        await withTaskGroup(of: [ProtocolEventEnvelope].self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                var events: [ProtocolEventEnvelope] = []
+                while events.count < count {
+                    guard let event = await iterator.next() else {
+                        break
+                    }
+                    events.append(event)
+                }
+                return events
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return []
+            }
+
+            let result = await group.next() ?? []
+            group.cancelAll()
+            return result
+        }
     }
 }
 

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -6,6 +6,7 @@ import UIKit
 @testable import WebInspectorUI
 
 @MainActor
+@Suite(.serialized)
 struct DOMContainerTests {
     @Test
     func elementPlaceholderTracksCoreSelection() async throws {

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -80,6 +80,39 @@ struct DOMTreeTextViewTests {
         #expect(requestedNodeID.flatMap { session.node(for: $0) }?.localName == "article")
     }
 
+    @Test
+    func selectingProjectedFrameNodeOpensComposedAncestors() async throws {
+        let pageTargetID = ProtocolTargetIdentifier("page-main")
+        let frameTargetID = ProtocolTargetIdentifier("frame-ad-target")
+        let frameID = DOMFrameIdentifier("frame-ad")
+        let session = DOMSession()
+
+        session.applyTargetCreated(
+            ProtocolTargetRecord(id: pageTargetID, kind: .page, frameID: DOMFrameIdentifier("main-frame")),
+            makeCurrentMainPage: true
+        )
+        session.applyTargetCreated(
+            ProtocolTargetRecord(id: frameTargetID, kind: .frame, frameID: frameID)
+        )
+        _ = session.replaceDocumentRoot(projectedPageDocument(frameID: frameID), targetID: pageTargetID)
+        let frameRootID = session.replaceDocumentRoot(projectedFrameDocument(), targetID: frameTargetID)
+        let selectedNodeID = try #require(
+            session.snapshot().currentNodeIDByKey[DOMNodeCurrentKey(targetID: frameTargetID, nodeID: .init(8))]
+        )
+        let view = makeTreeView(session: session)
+
+        session.selectNode(selectedNodeID)
+        await waitForObservationDelivery()
+        view.layoutIfNeeded()
+
+        let projection = session.treeProjection(rootTargetID: pageTargetID)
+        #expect(session.snapshot().nodesByID[frameRootID]?.parentID == nil)
+        #expect(projection.ancestorNodeIDs(of: selectedNodeID).contains(frameRootID))
+        #expect(view.renderedTextForTesting.contains("#document"))
+        #expect(view.renderedTextForTesting.contains("<img id=\"ad-node\">"))
+        #expect(view.selectedRowRectsForTesting().count == 1)
+    }
+
     private func makeTreeView(root: DOMNodePayload = documentNode()) -> DOMTreeTextView {
         makeTreeView(session: makeDOMSession(root: root))
     }
@@ -173,6 +206,74 @@ private func documentWithDeferredArticle() -> DOMNodePayload {
                             localName: "article",
                             regularChildren: .unrequested(count: 1)
                         )
+                    ),
+                ])
+            ),
+        ])
+    )
+}
+
+private func projectedPageDocument(frameID: DOMFrame.ID) -> DOMNodePayload {
+    DOMNodePayload(
+        nodeID: .init(1),
+        nodeType: .document,
+        nodeName: "#document",
+        regularChildren: .loaded([
+            DOMNodePayload(
+                nodeID: .init(2),
+                nodeType: .element,
+                nodeName: "HTML",
+                localName: "html",
+                regularChildren: .loaded([
+                    DOMNodePayload(
+                        nodeID: .init(3),
+                        nodeType: .element,
+                        nodeName: "BODY",
+                        localName: "body",
+                        regularChildren: .loaded([
+                            DOMNodePayload(
+                                nodeID: .init(20),
+                                nodeType: .element,
+                                nodeName: "IFRAME",
+                                localName: "iframe",
+                                ownerFrameID: frameID,
+                                attributes: [DOMAttribute(name: "src", value: "https://frame.example/ad")]
+                            ),
+                        ])
+                    ),
+                ])
+            ),
+        ])
+    )
+}
+
+private func projectedFrameDocument() -> DOMNodePayload {
+    DOMNodePayload(
+        nodeID: .init(101),
+        nodeType: .document,
+        nodeName: "#document",
+        documentURL: "https://frame.example/ad",
+        regularChildren: .loaded([
+            DOMNodePayload(
+                nodeID: .init(2),
+                nodeType: .element,
+                nodeName: "HTML",
+                localName: "html",
+                regularChildren: .loaded([
+                    DOMNodePayload(
+                        nodeID: .init(3),
+                        nodeType: .element,
+                        nodeName: "BODY",
+                        localName: "body",
+                        regularChildren: .loaded([
+                            DOMNodePayload(
+                                nodeID: .init(8),
+                                nodeType: .element,
+                                nodeName: "IMG",
+                                localName: "img",
+                                attributes: [DOMAttribute(name: "id", value: "ad-node")]
+                            ),
+                        ])
                     ),
                 ])
             ),

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -36,6 +36,18 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func primaryClickingRowUpdatesCoreSelection() throws {
+        let session = makeDOMSession()
+        let view = makeTreeView(session: session)
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.layoutIfNeeded()
+
+        #expect(session.selectedNode?.localName == "input")
+        #expect(view.selectedRowRectsForTesting().count == 1)
+    }
+
+    @Test
     func expandedElementRendersChildrenAndClosingTag() throws {
         let view = makeTreeView()
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -5,6 +5,7 @@ import UIKit
 @testable import WebInspectorUI
 
 @MainActor
+@Suite(.serialized)
 struct NetworkDetailViewControllerTests {
     @Test
     func detailShowsEmptyStateWithoutSelection() {
@@ -141,7 +142,7 @@ struct NetworkDetailViewControllerTests {
         #expect(didPush)
 
         model.selectRequest(nil)
-        let didPop = await waitUntil {
+        let didPop = await waitUntilAllowingAnimations {
             navigationController.viewControllers == [listViewController]
         }
         #expect(didPop)
@@ -251,6 +252,20 @@ struct NetworkDetailViewControllerTests {
                 return true
             }
             await Task.yield()
+        }
+        return false
+    }
+
+    private func waitUntilAllowingAnimations(
+        maxTicks: Int = 256,
+        _ condition: @MainActor () -> Bool
+    ) async -> Bool {
+        for _ in 0..<maxTicks {
+            if condition() {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
         return false
     }

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -6,6 +6,7 @@ import UIKit
 @testable import WebInspectorUI
 
 @MainActor
+@Suite(.serialized)
 struct ParentContainerTests {
     @Test
     func sessionAndViewControllerUseDOMAndNetworkTabsByDefault() {


### PR DESCRIPTION
## Purpose

Repair the DOM/frame ownership flow for iframe documents and tighten the runtime/UI behavior around the V2 inspector model.

## Changes

- Reworks DOM model/projection handling for frame-owned documents, pending frame hydration, document identity, and target-scoped DOM actions.
- Splits DOM target graph, document storage, frame-document projection indexing, and composed-tree projection building into focused internal components.
- Keeps raw `DOMNode.parentID` document-local while representing iframe owner -> frame document root edges only in `DOMTreeProjection` parent/child metadata.
- Uses composed-tree ancestors for DOM tree selection reveal so frame-root selection opens the iframe owner path without mutating protocol DOM parents.
- Tightens frame owner discovery for nested frames, src-less/about:blank iframe documents, duplicate iframe URLs, and parent-frame document scoping.
- Updates runtime transport handling for target-scoped commands, document reload cancellation, element picker state, provisional target commits, and delete undo/redo serialization.
- Adds regression coverage across DOM model, transport, runtime session, and UI container behavior.
- Adds a GitHub Actions package test workflow with stable and optional simulator matrix entries.
- Documents the default Xcode validation command in `AGENTS.md`.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` uncommitted changes: clean (`6D54A6AA-1B22-4658-94A1-BD3F3666F269`)
- `codex-review` against `codex/remove-v1-drop-v2-prefix`: clean (`61FB9E9F-4C34-4DA3-AB60-13EAC1BEC294`)

## Screenshots

- Not applicable; no user-visible layout change intended.