### PR TITLE
Restore DOM selection menus

### DIFF
--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -51,15 +51,18 @@ private final class DOMDeleteUndoState {
     let documentTargetID: ProtocolTargetIdentifier
     let commandTargetID: ProtocolTargetIdentifier
     var documentID: DOMDocumentIdentifier
+    var actionName: String
 
     init(
         documentTargetID: ProtocolTargetIdentifier,
         commandTargetID: ProtocolTargetIdentifier,
-        documentID: DOMDocumentIdentifier
+        documentID: DOMDocumentIdentifier,
+        actionName: String = "Delete Node"
     ) {
         self.documentTargetID = documentTargetID
         self.commandTargetID = commandTargetID
         self.documentID = documentID
+        self.actionName = actionName
     }
 }
 
@@ -421,17 +424,31 @@ package final class InspectorSession {
         guard let nodeID = dom.selectedNodeID else {
             throw InspectorSessionError("No DOM node is selected.")
         }
+        return try await copyDOMNodeText(kind, for: nodeID)
+    }
 
+    package func copyDOMNodeText(_ kind: DOMNodeCopyTextKind, for nodeID: WebInspectorCore.DOMNode.ID) async throws -> String {
+        guard isAttached else {
+            throw InspectorSessionError("Inspector session is not attached.")
+        }
         switch kind {
         case .html:
             let commandTargetID = try currentPageTargetForDOMAction()
             guard let intent = dom.outerHTMLIntent(for: nodeID, commandTargetID: commandTargetID) else {
-                throw InspectorSessionError("Selected DOM node is no longer available.")
+                throw InspectorSessionError("DOM node is no longer available.")
             }
             let result = try await perform(intent)
             return try DOMTransportAdapter.outerHTML(from: result)
-        case .selectorPath, .xPath:
-            return dom.selectedNodeCopyText(kind) ?? ""
+        case .selectorPath:
+            guard let node = dom.node(for: nodeID) else {
+                throw InspectorSessionError("DOM node is no longer available.")
+            }
+            return dom.selectorPath(for: node)
+        case .xPath:
+            guard let node = dom.node(for: nodeID) else {
+                throw InspectorSessionError("DOM node is no longer available.")
+            }
+            return dom.xPath(for: node)
         }
     }
 
@@ -442,27 +459,65 @@ package final class InspectorSession {
         guard let nodeID = dom.selectedNodeID else {
             throw InspectorSessionError("No DOM node is selected.")
         }
+        try await deleteDOMNode(nodeID, undoManager: undoManager)
+    }
+
+    package func deleteDOMNodes(_ nodeIDs: [WebInspectorCore.DOMNode.ID], undoManager: UndoManager?) async throws {
+        var seenNodeIDs: Set<WebInspectorCore.DOMNode.ID> = []
+        let uniqueNodeIDs = nodeIDs.filter { seenNodeIDs.insert($0).inserted }
+        let actionName = uniqueNodeIDs.count > 1 ? "Delete Nodes" : "Delete Node"
+        var undoStates: [DOMDeleteUndoState] = []
+
+        do {
+            for nodeID in uniqueNodeIDs.sorted(by: { depthFromRoot(for: $0) > depthFromRoot(for: $1) }) {
+                undoStates.append(try await performDeleteDOMNode(nodeID))
+            }
+        } catch {
+            registerUndoDeletes(undoStates, undoManager: undoManager, actionName: actionName)
+            throw error
+        }
+        registerUndoDeletes(undoStates, undoManager: undoManager, actionName: actionName)
+    }
+
+    package func deleteDOMNode(_ nodeID: WebInspectorCore.DOMNode.ID, undoManager: UndoManager?) async throws {
+        let undoState = try await performDeleteDOMNode(nodeID)
+        if let undoManager {
+            registerUndoDelete(undoState, undoManager: undoManager)
+        }
+    }
+
+    private func performDeleteDOMNode(_ nodeID: WebInspectorCore.DOMNode.ID) async throws -> DOMDeleteUndoState {
+        guard isAttached else {
+            throw InspectorSessionError("Inspector session is not attached.")
+        }
         let commandTargetID = try currentPageTargetForDOMAction()
         guard let identity = dom.actionIdentity(for: nodeID, commandTargetID: commandTargetID),
               let intent = dom.removeNodeIntent(for: nodeID, commandTargetID: identity.commandTargetID) else {
-            throw InspectorSessionError("Selected DOM node is no longer available.")
+            throw InspectorSessionError("DOM node is no longer available.")
         }
         let documentID = nodeID.documentID
 
         try await perform(intent)
         dom.applyNodeRemoved(nodeID)
+        dom.selectNode(nil)
         lastError = nil
 
-        if let undoManager {
-            registerUndoDelete(
-                DOMDeleteUndoState(
-                    documentTargetID: identity.documentTargetID,
-                    commandTargetID: identity.commandTargetID,
-                    documentID: documentID
-                ),
-                undoManager: undoManager
-            )
+        return DOMDeleteUndoState(
+            documentTargetID: identity.documentTargetID,
+            commandTargetID: identity.commandTargetID,
+            documentID: documentID
+        )
+    }
+
+    private func depthFromRoot(for nodeID: WebInspectorCore.DOMNode.ID) -> Int {
+        var depth = 0
+        var currentNode = dom.node(for: nodeID)
+        while let parentID = currentNode?.parentID,
+              let parent = dom.node(for: parentID) {
+            depth += 1
+            currentNode = parent
         }
+        return depth
     }
 
     package func reloadDOMDocument() async throws {
@@ -1199,7 +1254,7 @@ package final class InspectorSession {
                 await target?.performUndoDelete(state, undoManager: undoManager, generation: generation)
             }
         }
-        undoManager.setActionName("Delete Node")
+        undoManager.setActionName(state.actionName)
     }
 
     private func registerRedoDelete(_ state: DOMDeleteUndoState, undoManager: UndoManager) {
@@ -1211,7 +1266,34 @@ package final class InspectorSession {
                 await target?.performRedoDelete(state, undoManager: undoManager, generation: generation)
             }
         }
-        undoManager.setActionName("Delete Node")
+        undoManager.setActionName(state.actionName)
+    }
+
+    private func registerUndoDeletes(
+        _ states: [DOMDeleteUndoState],
+        undoManager: UndoManager?,
+        actionName: String
+    ) {
+        guard let undoManager, !states.isEmpty else {
+            return
+        }
+        for state in states {
+            state.actionName = actionName
+        }
+
+        guard states.count > 1 else {
+            registerUndoDelete(states[0], undoManager: undoManager)
+            return
+        }
+
+        undoManager.beginUndoGrouping()
+        defer {
+            undoManager.setActionName(actionName)
+            undoManager.endUndoGrouping()
+        }
+        for state in states {
+            registerUndoDelete(state, undoManager: undoManager)
+        }
     }
 
     private func enqueueDeleteUndoOperation(_ operation: @escaping @MainActor (UInt64) async -> Void) {

--- a/Sources/WebInspectorUI/DOM/DOMTreeMenu.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeMenu.swift
@@ -5,7 +5,7 @@ import UIKit
 import WebInspectorCore
 
 typealias DOMTreeMenuCopyNodeTextAction = @MainActor (DOMNode.ID, DOMNodeCopyTextKind) async -> String?
-typealias DOMTreeMenuDeleteNodesAction = @MainActor ([DOMNode.ID], UndoManager?) async -> Void
+typealias DOMTreeMenuDeleteNodesAction = @MainActor ([DOMNode.ID], UndoManager?) async -> Bool
 
 @MainActor
 @Observable
@@ -110,7 +110,8 @@ final class DOMTreeMenuModel {
         copy(.xPath, for: nodeID)
     }
 
-    func deleteSelection() {
+    @discardableResult
+    func deleteSelection() -> Task<Void, Never>? {
         delete(deleteNodeIDs)
     }
 
@@ -158,14 +159,20 @@ final class DOMTreeMenuModel {
         }
     }
 
-    private func delete(_ nodeIDs: [DOMNode.ID]) {
+    @discardableResult
+    private func delete(_ nodeIDs: [DOMNode.ID]) -> Task<Void, Never>? {
         guard let deleteNodesAction else {
-            return
+            return nil
         }
         let sortedNodeIDs = uniqueNodeIDsInOrder(nodeIDs)
             .sorted { depthFromRoot(for: $0) > depthFromRoot(for: $1) }
-        Task { @MainActor in
-            await deleteNodesAction(sortedNodeIDs, undoManager)
+        guard !sortedNodeIDs.isEmpty else {
+            return nil
+        }
+        return Task { @MainActor in
+            guard await deleteNodesAction(sortedNodeIDs, undoManager) else {
+                return
+            }
             clearLocalSelection()
         }
     }

--- a/Sources/WebInspectorUI/DOM/DOMTreeMenu.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeMenu.swift
@@ -1,0 +1,270 @@
+#if canImport(UIKit)
+import Observation
+import SwiftUI
+import UIKit
+import WebInspectorCore
+
+typealias DOMTreeMenuCopyNodeTextAction = @MainActor (DOMNode.ID, DOMNodeCopyTextKind) async -> String?
+typealias DOMTreeMenuDeleteNodesAction = @MainActor ([DOMNode.ID], UndoManager?) async -> Void
+
+@MainActor
+@Observable
+final class DOMTreeMenuModel {
+    let dom: DOMSession
+    var nodeIDs: [DOMNode.ID] = []
+    var selectedText: String?
+    var localMarkupTextByNodeID: [DOMNode.ID: String] = [:]
+
+    @ObservationIgnored private var undoManager: UndoManager?
+    @ObservationIgnored private var clearLocalSelection: (@MainActor () -> Void) = {}
+
+    private let copyNodeTextAction: DOMTreeMenuCopyNodeTextAction?
+    private let deleteNodesAction: DOMTreeMenuDeleteNodesAction?
+
+    init(
+        dom: DOMSession,
+        copyNodeTextAction: DOMTreeMenuCopyNodeTextAction?,
+        deleteNodesAction: DOMTreeMenuDeleteNodesAction?
+    ) {
+        self.dom = dom
+        self.copyNodeTextAction = copyNodeTextAction
+        self.deleteNodesAction = deleteNodesAction
+    }
+
+    func configure(
+        nodeIDs: [DOMNode.ID],
+        selectedText: String?,
+        undoManager: UndoManager?,
+        localMarkupTextByNodeID: [DOMNode.ID: String],
+        clearLocalSelection: @escaping @MainActor () -> Void
+    ) {
+        self.nodeIDs = uniqueNodeIDsInOrder(nodeIDs)
+        self.selectedText = selectedText
+        self.undoManager = undoManager
+        self.localMarkupTextByNodeID = localMarkupTextByNodeID
+        self.clearLocalSelection = clearLocalSelection
+    }
+
+    var isMultiNodeMenu: Bool {
+        nodeIDs.count > 1
+    }
+
+    var availableNodeIDs: [DOMNode.ID] {
+        nodeIDs.filter { dom.node(for: $0) != nil }
+    }
+
+    var showsSelectedTextCopy: Bool {
+        selectedText != nil
+    }
+
+    var canCopySelectedText: Bool {
+        !(selectedText?.isEmpty ?? true)
+    }
+
+    var showsSingleNodeCopyActions: Bool {
+        singleNodeID != nil
+    }
+
+    var canCopyHTML: Bool {
+        copyHTMLNodeIDs.contains { canCopyText(.html, for: $0) }
+    }
+
+    var canCopySelectorPath: Bool {
+        singleNodeID.map { canCopyText(.selectorPath, for: $0) } ?? false
+    }
+
+    var canCopyXPath: Bool {
+        singleNodeID.map { canCopyText(.xPath, for: $0) } ?? false
+    }
+
+    var deleteTitle: String {
+        isMultiNodeMenu ? "Delete Nodes" : "Delete Node"
+    }
+
+    var canDelete: Bool {
+        deleteNodesAction != nil && !deleteNodeIDs.isEmpty
+    }
+
+    func copySelectedText() {
+        guard let selectedText, !selectedText.isEmpty else {
+            return
+        }
+        UIPasteboard.general.string = selectedText
+    }
+
+    func copyHTML() {
+        copyHTML(copyHTMLNodeIDs)
+    }
+
+    func copySelectorPath() {
+        guard let nodeID = singleNodeID else {
+            return
+        }
+        copy(.selectorPath, for: nodeID)
+    }
+
+    func copyXPath() {
+        guard let nodeID = singleNodeID else {
+            return
+        }
+        copy(.xPath, for: nodeID)
+    }
+
+    func deleteSelection() {
+        delete(deleteNodeIDs)
+    }
+
+    private var singleNodeID: DOMNode.ID? {
+        guard !isMultiNodeMenu,
+              let nodeID = nodeIDs.first,
+              dom.node(for: nodeID) != nil else {
+            return nil
+        }
+        return nodeID
+    }
+
+    private var copyHTMLNodeIDs: [DOMNode.ID] {
+        isMultiNodeMenu ? availableNodeIDs : singleNodeID.map { [$0] } ?? []
+    }
+
+    private var deleteNodeIDs: [DOMNode.ID] {
+        copyHTMLNodeIDs
+    }
+
+    private func copy(_ kind: DOMNodeCopyTextKind, for nodeID: DOMNode.ID) {
+        Task { @MainActor in
+            guard let text = await copyText(kind, for: nodeID),
+                  !text.isEmpty else {
+                return
+            }
+            UIPasteboard.general.string = text
+        }
+    }
+
+    private func copyHTML(_ nodeIDs: [DOMNode.ID]) {
+        Task { @MainActor in
+            var fragments: [String] = []
+            for nodeID in nodeIDs {
+                guard let text = await copyText(.html, for: nodeID),
+                      !text.isEmpty else {
+                    continue
+                }
+                fragments.append(text)
+            }
+            guard !fragments.isEmpty else {
+                return
+            }
+            UIPasteboard.general.string = fragments.joined(separator: "\n")
+        }
+    }
+
+    private func delete(_ nodeIDs: [DOMNode.ID]) {
+        guard let deleteNodesAction else {
+            return
+        }
+        let sortedNodeIDs = uniqueNodeIDsInOrder(nodeIDs)
+            .sorted { depthFromRoot(for: $0) > depthFromRoot(for: $1) }
+        Task { @MainActor in
+            await deleteNodesAction(sortedNodeIDs, undoManager)
+            clearLocalSelection()
+        }
+    }
+
+    func canCopyText(_ kind: DOMNodeCopyTextKind, for nodeID: DOMNode.ID) -> Bool {
+        guard let node = dom.node(for: nodeID) else {
+            return false
+        }
+        switch kind {
+        case .html:
+            return copyNodeTextAction != nil || !(localMarkupTextByNodeID[nodeID]?.isEmpty ?? true)
+        case .selectorPath:
+            return !dom.selectorPath(for: node).isEmpty
+        case .xPath:
+            return !dom.xPath(for: node).isEmpty
+        }
+    }
+
+    private func copyText(_ kind: DOMNodeCopyTextKind, for nodeID: DOMNode.ID) async -> String? {
+        if let copyNodeTextAction {
+            return await copyNodeTextAction(nodeID, kind)
+        }
+        guard let node = dom.node(for: nodeID) else {
+            return nil
+        }
+        switch kind {
+        case .html:
+            return localMarkupTextByNodeID[nodeID]
+        case .selectorPath:
+            return dom.selectorPath(for: node)
+        case .xPath:
+            return dom.xPath(for: node)
+        }
+    }
+
+    private func depthFromRoot(for nodeID: DOMNode.ID) -> Int {
+        var depth = 0
+        var currentNode = dom.node(for: nodeID)
+        while let parentID = currentNode?.parentID,
+              let parent = dom.node(for: parentID) {
+            depth += 1
+            currentNode = parent
+        }
+        return depth
+    }
+
+    private func uniqueNodeIDsInOrder(_ nodeIDs: [DOMNode.ID]) -> [DOMNode.ID] {
+        var seenNodeIDs: Set<DOMNode.ID> = []
+        return nodeIDs.filter { seenNodeIDs.insert($0).inserted }
+    }
+}
+
+@MainActor
+struct DOMTreeMenuView: View {
+    var model: DOMTreeMenuModel
+
+    var body: some View {
+        Section {
+            if model.showsSelectedTextCopy {
+                Button {
+                    model.copySelectedText()
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .disabled(!model.canCopySelectedText)
+            }
+
+            Button {
+                model.copyHTML()
+            } label: {
+                Text("Copy HTML")
+            }
+            .disabled(!model.canCopyHTML)
+
+            if model.showsSingleNodeCopyActions {
+                Button {
+                    model.copySelectorPath()
+                } label: {
+                    Text("Copy Selector Path")
+                }
+                .disabled(!model.canCopySelectorPath)
+
+                Button {
+                    model.copyXPath()
+                } label: {
+                    Text("Copy XPath")
+                }
+                .disabled(!model.canCopyXPath)
+            }
+        }
+
+        Section {
+            Button(role: .destructive) {
+                model.deleteSelection()
+            } label: {
+                Label(model.deleteTitle, systemImage: "trash")
+            }
+            .disabled(!model.canDelete)
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import ObservationBridge
+import UIHostingMenu
 import UIKit
 import WebInspectorCore
 
@@ -8,6 +9,8 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     typealias RequestChildrenAction = @MainActor (DOMNode.ID) async -> Bool
     typealias HighlightNodeAction = @MainActor (DOMNode.ID) async -> Void
     typealias HideHighlightAction = @MainActor () async -> Void
+    typealias CopyNodeTextAction = DOMTreeMenuCopyNodeTextAction
+    typealias DeleteNodesAction = DOMTreeMenuDeleteNodesAction
 
     fileprivate static let font = UIFont.monospacedSystemFont(ofSize: 13, weight: .regular)
     private static let lineSpacing: CGFloat = 2
@@ -34,6 +37,7 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         return paragraphStyle
     }()
     private let dom: DOMSession
+    private let menuModel: DOMTreeMenuModel
     private let observationScope = ObservationScope()
     private let textContentStorage = NSTextContentStorage()
     private let layoutManager = NSTextLayoutManager()
@@ -49,6 +53,9 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         return interaction
     }()
     private lazy var textInputTokenizer = UITextInputStringTokenizer(textInput: self)
+    private lazy var domMenuHostingMenu = UIHostingMenu(
+        rootView: DOMTreeMenuView(model: menuModel)
+    )
 
     private var rows: [DOMTreeLine] = []
     private var renderedText = ""
@@ -87,7 +94,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     private let hideHighlightAction: HideHighlightAction?
     weak var inputDelegate: UITextInputDelegate?
 #if DEBUG
-    private var lastPresentedDOMMenuTitles: [String] = []
     private var reloadTreeCallCount = 0
     private var buildRenderedRowsCallCount = 0
     private var rebuildTextStorageCallCount = 0
@@ -114,12 +120,19 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         dom: DOMSession,
         requestChildrenAction: RequestChildrenAction? = nil,
         highlightNodeAction: HighlightNodeAction? = nil,
-        hideHighlightAction: HideHighlightAction? = nil
+        hideHighlightAction: HideHighlightAction? = nil,
+        copyNodeTextAction: CopyNodeTextAction? = nil,
+        deleteNodesAction: DeleteNodesAction? = nil
     ) {
         self.dom = dom
         self.requestChildrenAction = requestChildrenAction
         self.highlightNodeAction = highlightNodeAction
         self.hideHighlightAction = hideHighlightAction
+        self.menuModel = DOMTreeMenuModel(
+            dom: dom,
+            copyNodeTextAction: copyNodeTextAction,
+            deleteNodesAction: deleteNodesAction
+        )
         super.init(frame: .zero)
         configureTextSystem()
         configureInteractions()
@@ -1231,9 +1244,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
 
     private func presentDOMMenu(for nodes: [DOMNode], at location: CGPoint) {
         let menu = makeDOMMenu(for: nodes)
-#if DEBUG
-        lastPresentedDOMMenuTitles = menu.children.compactMap { ($0 as? UIAction)?.title }
-#endif
 
         dismissDOMMenuAnchor()
         let button = UIButton(type: .system)
@@ -1263,14 +1273,11 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         menuAnchorButton = nil
     }
 
-    private func makeDOMMenu(for nodes: [DOMNode]) -> UIMenu {
-        if nodes.count > 1 {
-            makeMultiNodeMenu(for: nodes)
-        } else if let node = nodes.first {
-            makeContextMenu(for: node)
-        } else {
-            UIMenu(children: [])
-        }
+    private func makeDOMMenu(for nodes: [DOMNode], selectedText: String? = nil) -> UIMenu {
+        makeMenu(
+            for: uniqueNodeIDsInDisplayOrder(for: nodes),
+            selectedText: selectedText
+        )
     }
 
     private func makeTextSelectionEditMenu(for range: NSRange) -> UIMenu {
@@ -1279,25 +1286,8 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         guard !nodes.isEmpty else {
             return UIMenu(children: [])
         }
-
-        if selectedRows.count > 1 {
-            return makeMultiNodeMenu(for: nodes)
-        }
-
-        let copyText = UIAction(
-            title: "Copy",
-            image: UIImage(systemName: "doc.on.doc")
-        ) { [weak self] _ in
-            guard let self,
-                  let text = self.text(in: DOMTreeTextRange(range: range)),
-                  !text.isEmpty
-            else {
-                return
-            }
-            UIPasteboard.general.string = text
-        }
-
-        return UIMenu(children: [copyText] + makeDOMMenu(for: nodes).children)
+        let selectedText = selectedRows.count == 1 ? text(in: DOMTreeTextRange(range: range)) : nil
+        return makeDOMMenu(for: nodes, selectedText: selectedText)
     }
 
     private func rowsIntersectingTextRange(_ range: NSRange) -> [DOMTreeLine] {
@@ -1319,37 +1309,38 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         }
     }
 
-    private func makeMultiNodeMenu(for nodes: [DOMNode]) -> UIMenu {
-        let copyMarkup = UIAction(title: "Copy Markup") { [weak self] _ in
-            guard let self else {
-                return
+    private func makeMenu(for nodeIDs: [DOMNode.ID], selectedText: String?) -> UIMenu {
+        menuModel.configure(
+            nodeIDs: nodeIDs,
+            selectedText: selectedText,
+            undoManager: undoManager,
+            localMarkupTextByNodeID: localMarkupTextByNodeID(for: nodeIDs),
+            clearLocalSelection: { [weak self] in
+                self?.clearTextSelection()
+                self?.clearMultiSelection(keepingLast: nil)
             }
-            let nodeIDs = Set(nodes.map(\.id))
-            let text = self.rows
-                .filter { !$0.isClosingTag && nodeIDs.contains($0.node.id) }
-                .map(\.text)
-                .joined(separator: "\n")
-            guard !text.isEmpty else {
-                return
-            }
-            UIPasteboard.general.string = text
-        }
-
-        return UIMenu(children: [copyMarkup])
+        )
+        domMenuHostingMenu.setNeedsUpdate()
+        return (try? domMenuHostingMenu.menu()) ?? UIMenu(children: [])
     }
 
-    private func makeContextMenu(for node: DOMNode) -> UIMenu {
-        let copyMarkup = UIAction(title: "Copy Markup") { [weak self, weak node] _ in
-            guard let self, let node else {
-                return
-            }
-            guard let row = self.rows.first(where: { !$0.isClosingTag && $0.node.id == node.id }) else {
-                return
-            }
-            UIPasteboard.general.string = row.text
-        }
+    private func localMarkupText(for nodeID: DOMNode.ID) -> String? {
+        rows.first { !$0.isClosingTag && $0.node.id == nodeID }?.text
+    }
 
-        return UIMenu(children: [copyMarkup])
+    private func uniqueNodeIDsInDisplayOrder(for nodes: [DOMNode]) -> [DOMNode.ID] {
+        var seenNodeIDs: Set<DOMNode.ID> = []
+        return nodes.compactMap { node in
+            seenNodeIDs.insert(node.id).inserted ? node.id : nil
+        }
+    }
+
+    private func localMarkupTextByNodeID(for nodeIDs: [DOMNode.ID]) -> [DOMNode.ID: String] {
+        Dictionary(
+            uniqueKeysWithValues: nodeIDs.compactMap { nodeID in
+                localMarkupText(for: nodeID).map { (nodeID, $0) }
+            }
+        )
     }
 
     private func applyRowAttributes(to attributedText: NSMutableAttributedString) {
@@ -2473,72 +2464,6 @@ extension DOMTreeTextView {
         }
     }
 
-    func secondaryClickMenuTitlesForTesting(containing text: String) -> [String] {
-        guard let row = rows.first(where: { $0.text.contains(text) }) else {
-            return []
-        }
-        let nodes: [DOMNode]
-        if multiSelectedNodeIDs.count > 1, multiSelectedNodeIDs.contains(row.node.id) {
-            nodes = multiSelectedNodesInDisplayOrder()
-        } else {
-            clearMultiSelection(keepingLast: row.node.id)
-            nodes = [row.node]
-        }
-        let menu = makeDOMMenu(for: nodes)
-        let titles = menu.children.compactMap { ($0 as? UIAction)?.title }
-        lastPresentedDOMMenuTitles = titles
-        return titles
-    }
-
-    var multiSelectedNodeIDsForTesting: [UInt64] {
-        rows.compactMap { row in
-            !row.isClosingTag && multiSelectedNodeIDs.contains(row.node.id) ? UInt64(row.node.protocolNodeID.rawValue) : nil
-        }
-    }
-
-    var lastPresentedDOMMenuTitlesForTesting: [String] {
-        lastPresentedDOMMenuTitles
-    }
-
-    func selectTextForTesting(_ text: String) {
-        let nsText = renderedText as NSString
-        let range = nsText.range(of: text)
-        guard range.location != NSNotFound else {
-            return
-        }
-        setSelectedTextRange(DOMTreeTextRange(range: range))
-    }
-
-    func selectTextForTesting(from startText: String, through endText: String) {
-        let nsText = renderedText as NSString
-        let startRange = nsText.range(of: startText)
-        let endRange = nsText.range(of: endText)
-        guard startRange.location != NSNotFound,
-              endRange.location != NSNotFound
-        else {
-            return
-        }
-
-        let lowerBound = min(startRange.location, endRange.location)
-        let upperBound = max(NSMaxRange(startRange), NSMaxRange(endRange))
-        setSelectedTextRange(DOMTreeTextRange(range: NSRange(location: lowerBound, length: upperBound - lowerBound)))
-    }
-
-    var selectedTextForTesting: String {
-        text(in: DOMTreeTextRange(range: selectedTextNSRange)) ?? ""
-    }
-
-    func editMenuTitlesForSelectedTextForTesting() -> [String] {
-        let suggestedActions = [
-            UIAction(title: "Translate") { _ in },
-            UIAction(title: "Share...") { _ in },
-        ]
-        return editMenu(
-            for: DOMTreeTextRange(range: selectedTextNSRange),
-            suggestedActions: suggestedActions
-        )?.children.compactMap { ($0 as? UIAction)?.title } ?? []
-    }
-
     func decorateFindTextForTesting(query: String) {
         clearFindDecorations()
         for range in DOMTreeFindCoordinator.searchRanges(in: renderedText, queryString: query) {
@@ -2551,17 +2476,6 @@ extension DOMTreeTextView {
 
     func decorateStaleFindTextForTesting(query: String) {
         findCoordinator.decorateStaleFoundTextForTesting(queryString: query)
-    }
-
-    func contextMenuForTesting(containing text: String) -> UIMenu? {
-        guard let row = rows.first(where: { $0.text.contains(text) }) else {
-            return nil
-        }
-        return makeDOMMenu(for: [row.node])
-    }
-
-    func contextMenuTitlesForTesting(containing text: String) -> [String] {
-        contextMenuForTesting(containing: text)?.children.compactMap { ($0 as? UIAction)?.title } ?? []
     }
 
     func synchronizeDocumentForTesting() {

--- a/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
@@ -23,6 +23,15 @@ package final class DOMTreeViewController: UIViewController {
             },
             hideHighlightAction: { [weak session] in
                 await session?.hideNodeHighlight()
+            },
+            copyNodeTextAction: { [weak session] nodeID, kind in
+                guard let session else {
+                    return nil
+                }
+                return try? await session.copyDOMNodeText(kind, for: nodeID)
+            },
+            deleteNodesAction: { [weak session] nodeIDs, undoManager in
+                try? await session?.deleteDOMNodes(nodeIDs, undoManager: undoManager)
             }
         )
         super.init(nibName: nil, bundle: nil)

--- a/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
@@ -31,7 +31,15 @@ package final class DOMTreeViewController: UIViewController {
                 return try? await session.copyDOMNodeText(kind, for: nodeID)
             },
             deleteNodesAction: { [weak session] nodeIDs, undoManager in
-                try? await session?.deleteDOMNodes(nodeIDs, undoManager: undoManager)
+                guard let session else {
+                    return false
+                }
+                do {
+                    try await session.deleteDOMNodes(nodeIDs, undoManager: undoManager)
+                    return true
+                } catch {
+                    return false
+                }
             }
         )
         super.init(nibName: nil, bundle: nil)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -2438,6 +2438,107 @@ func domNavigationCopyDeleteAndReloadUseRuntimeAPIs() async throws {
 }
 
 @Test
+func deletingDOMNodeClearsExistingSelectionEvenWhenDeletingAnotherNode() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+
+    let htmlID = try #require(await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(2))])
+    let bodyID = try #require(await session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(4))])
+    await session.dom.selectNode(htmlID)
+
+    let countBeforeDelete = await backend.sentTargetMessages().count
+    let deleteTask = Task {
+        try await session.deleteDOMNode(bodyID, undoManager: nil)
+    }
+    let removeNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countBeforeDelete)
+    await receiveTargetReply(
+        transport,
+        targetID: removeNode.targetIdentifier,
+        messageID: try messageID(removeNode.message),
+        result: "{}"
+    )
+    try await deleteTask.value
+
+    #expect(await session.dom.selectedNodeID == nil)
+}
+
+@MainActor
+@Test
+func multiNodeDeleteRegistersSingleUndoGroup() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+
+    let headID = try #require(session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(3))])
+    let bodyID = try #require(session.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(4))])
+    let undoManager = UndoManager()
+
+    let countBeforeDelete = await backend.sentTargetMessages().count
+    let deleteTask = Task {
+        try await session.deleteDOMNodes([headID, bodyID], undoManager: undoManager)
+    }
+    let firstRemoveNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countBeforeDelete)
+    await receiveTargetReply(
+        transport,
+        targetID: firstRemoveNode.targetIdentifier,
+        messageID: try messageID(firstRemoveNode.message),
+        result: "{}"
+    )
+    let countAfterFirstRemove = await backend.sentTargetMessages().count
+    let secondRemoveNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countAfterFirstRemove)
+    await receiveTargetReply(
+        transport,
+        targetID: secondRemoveNode.targetIdentifier,
+        messageID: try messageID(secondRemoveNode.message),
+        result: "{}"
+    )
+    try await deleteTask.value
+
+    #expect(undoManager.canUndo)
+    #expect(undoManager.undoActionName == "Delete Nodes")
+
+    let countBeforeUndo = await backend.sentTargetMessages().count
+    undoManager.undo()
+    #expect(undoManager.canUndo == false)
+    #expect(undoManager.canRedo)
+
+    let firstUndo = try await waitForTargetMessage(backend, method: "DOM.undo", after: countBeforeUndo)
+    await receiveTargetReply(
+        transport,
+        targetID: firstUndo.targetIdentifier,
+        messageID: try messageID(firstUndo.message),
+        result: "{}"
+    )
+    let firstDocumentReload = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: countBeforeUndo)
+    await receiveTargetReply(
+        transport,
+        targetID: firstDocumentReload.targetIdentifier,
+        messageID: try messageID(firstDocumentReload.message),
+        result: mainDocumentResult
+    )
+
+    let secondUndo = try await waitForTargetMessage(backend, method: "DOM.undo", ordinal: 1, after: countBeforeUndo)
+    await receiveTargetReply(
+        transport,
+        targetID: secondUndo.targetIdentifier,
+        messageID: try messageID(secondUndo.message),
+        result: "{}"
+    )
+    let secondDocumentReload = try await waitForTargetMessage(backend, method: "DOM.getDocument", ordinal: 1, after: countBeforeUndo)
+    await receiveTargetReply(
+        transport,
+        targetID: secondDocumentReload.targetIdentifier,
+        messageID: try messageID(secondDocumentReload.message),
+        result: mainDocumentResult
+    )
+}
+
+@Test
 func frameDOMNodeCopyDeleteRouteThroughPageTargetWithScopedNodeID() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -3163,6 +3264,25 @@ private func waitForTargetMessage(
         return messages.dropFirst(count).first { sent in
             (try? messageMethod(sent.message)) == method
         }
+    }
+}
+
+private func waitForTargetMessage(
+    _ backend: FakeTransportBackend,
+    method: String,
+    ordinal: Int,
+    after count: Int = 0
+) async throws -> SentTargetMessage {
+    try await waitUntil(timeoutError: TransportError.replyTimeout(method: method, targetID: nil)) {
+        let matches = await backend.sentTargetMessages()
+            .dropFirst(count)
+            .filter { sent in
+                (try? messageMethod(sent.message)) == method
+            }
+        guard matches.indices.contains(ordinal) else {
+            return nil
+        }
+        return matches[ordinal]
     }
 }
 

--- a/Tests/WebInspectorUITests/DOMTreeMenuModelTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeMenuModelTests.swift
@@ -1,0 +1,174 @@
+#if canImport(UIKit)
+import Testing
+import UIKit
+@testable import WebInspectorCore
+@testable import WebInspectorUI
+
+@MainActor
+struct DOMTreeMenuModelTests {
+    @Test
+    func singleNodeSelectionEnablesTextAndNodeActions() throws {
+        let fixture = try makeMenuFixture()
+        let model = DOMTreeMenuModel(
+            dom: fixture.session,
+            copyNodeTextAction: { _, kind in
+                switch kind {
+                case .html:
+                    return "<div></div>"
+                case .selectorPath:
+                    return "html > body > div"
+                case .xPath:
+                    return "/html/body/div"
+                }
+            },
+            deleteNodesAction: { _, _ in }
+        )
+
+        model.configure(
+            nodeIDs: [fixture.divID],
+            selectedText: "data-testid",
+            undoManager: nil,
+            localMarkupTextByNodeID: [fixture.divID: "<div id=\"start-of-content\"></div>"],
+            clearLocalSelection: {}
+        )
+
+        #expect(model.showsSelectedTextCopy)
+        #expect(model.canCopySelectedText)
+        #expect(model.canCopyHTML)
+        #expect(model.showsSingleNodeCopyActions)
+        #expect(model.canCopySelectorPath)
+        #expect(model.canCopyXPath)
+        #expect(model.deleteTitle == "Delete Node")
+        #expect(model.canDelete)
+    }
+
+    @Test
+    func singleNodeSelectionDisablesDeleteWhenHandlerIsMissing() throws {
+        let fixture = try makeMenuFixture()
+        let model = DOMTreeMenuModel(
+            dom: fixture.session,
+            copyNodeTextAction: nil,
+            deleteNodesAction: nil
+        )
+
+        model.configure(
+            nodeIDs: [fixture.divID],
+            selectedText: nil,
+            undoManager: nil,
+            localMarkupTextByNodeID: [fixture.divID: "<div id=\"start-of-content\"></div>"],
+            clearLocalSelection: {}
+        )
+
+        #expect(!model.showsSelectedTextCopy)
+        #expect(model.canCopyHTML)
+        #expect(model.showsSingleNodeCopyActions)
+        #expect(model.canCopySelectorPath)
+        #expect(model.canCopyXPath)
+        #expect(model.deleteTitle == "Delete Node")
+        #expect(!model.canDelete)
+    }
+
+    @Test
+    func multiNodeSelectionUsesSharedHTMLCopyAndMultiDeleteState() throws {
+        let fixture = try makeMenuFixture()
+        let model = DOMTreeMenuModel(
+            dom: fixture.session,
+            copyNodeTextAction: { _, kind in
+                kind == .html ? "<node></node>" : nil
+            },
+            deleteNodesAction: { _, _ in }
+        )
+
+        model.configure(
+            nodeIDs: [fixture.divID, fixture.inputID],
+            selectedText: nil,
+            undoManager: nil,
+            localMarkupTextByNodeID: [
+                fixture.divID: "<div id=\"start-of-content\"></div>",
+                fixture.inputID: "<input disabled>",
+            ],
+            clearLocalSelection: {}
+        )
+
+        #expect(!model.showsSelectedTextCopy)
+        #expect(model.canCopyHTML)
+        #expect(!model.showsSingleNodeCopyActions)
+        #expect(!model.canCopySelectorPath)
+        #expect(!model.canCopyXPath)
+        #expect(model.deleteTitle == "Delete Nodes")
+        #expect(model.canDelete)
+    }
+}
+
+private struct DOMTreeMenuModelFixture {
+    var session: DOMSession
+    var divID: DOMNode.ID
+    var inputID: DOMNode.ID
+}
+
+@MainActor
+private func makeMenuFixture() throws -> DOMTreeMenuModelFixture {
+    let targetID = ProtocolTargetIdentifier("page-main")
+    let session = DOMSession()
+    session.applyTargetCreated(
+        ProtocolTargetRecord(
+            id: targetID,
+            kind: .page,
+            frameID: DOMFrameIdentifier("main-frame")
+        ),
+        makeCurrentMainPage: true
+    )
+    _ = session.replaceDocumentRoot(menuFixtureDocument(), targetID: targetID)
+
+    let divID = try #require(
+        session.snapshot().currentNodeIDByKey[DOMNodeCurrentKey(targetID: targetID, nodeID: .init(7))]
+    )
+    let inputID = try #require(
+        session.snapshot().currentNodeIDByKey[DOMNodeCurrentKey(targetID: targetID, nodeID: .init(12))]
+    )
+    return DOMTreeMenuModelFixture(session: session, divID: divID, inputID: inputID)
+}
+
+private func menuFixtureDocument() -> DOMNodePayload {
+    DOMNodePayload(
+        nodeID: .init(1),
+        nodeType: .document,
+        nodeName: "#document",
+        regularChildren: .loaded([
+            DOMNodePayload(
+                nodeID: .init(3),
+                nodeType: .element,
+                nodeName: "HTML",
+                localName: "html",
+                regularChildren: .loaded([
+                    DOMNodePayload(
+                        nodeID: .init(6),
+                        nodeType: .element,
+                        nodeName: "BODY",
+                        localName: "body",
+                        regularChildren: .loaded([
+                            DOMNodePayload(
+                                nodeID: .init(7),
+                                nodeType: .element,
+                                nodeName: "DIV",
+                                localName: "div",
+                                attributes: [
+                                    DOMAttribute(name: "id", value: "start-of-content"),
+                                    DOMAttribute(name: "data-testid", value: "cellInnerDiv"),
+                                ]
+                            ),
+                            DOMNodePayload(
+                                nodeID: .init(12),
+                                nodeType: .element,
+                                nodeName: "INPUT",
+                                localName: "input",
+                                attributes: [DOMAttribute(name: "disabled", value: "")]
+                            ),
+                        ])
+                    ),
+                ])
+            ),
+        ])
+    )
+}
+#endif

--- a/Tests/WebInspectorUITests/DOMTreeMenuModelTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeMenuModelTests.swift
@@ -21,7 +21,7 @@ struct DOMTreeMenuModelTests {
                     return "/html/body/div"
                 }
             },
-            deleteNodesAction: { _, _ in }
+            deleteNodesAction: { _, _ in true }
         )
 
         model.configure(
@@ -76,7 +76,7 @@ struct DOMTreeMenuModelTests {
             copyNodeTextAction: { _, kind in
                 kind == .html ? "<node></node>" : nil
             },
-            deleteNodesAction: { _, _ in }
+            deleteNodesAction: { _, _ in true }
         )
 
         model.configure(
@@ -97,6 +97,56 @@ struct DOMTreeMenuModelTests {
         #expect(!model.canCopyXPath)
         #expect(model.deleteTitle == "Delete Nodes")
         #expect(model.canDelete)
+    }
+
+    @Test
+    func deleteSelectionClearsLocalSelectionOnlyAfterSuccessfulAction() async throws {
+        let fixture = try makeMenuFixture()
+        var clearCount = 0
+        let failingModel = DOMTreeMenuModel(
+            dom: fixture.session,
+            copyNodeTextAction: nil,
+            deleteNodesAction: { _, _ in false }
+        )
+
+        failingModel.configure(
+            nodeIDs: [fixture.divID],
+            selectedText: nil,
+            undoManager: nil,
+            localMarkupTextByNodeID: [:],
+            clearLocalSelection: {
+                clearCount += 1
+            }
+        )
+
+        let failingTask = try #require(failingModel.deleteSelection())
+        await failingTask.value
+        #expect(clearCount == 0)
+
+        var deletedNodeIDs: [DOMNode.ID] = []
+        let successfulModel = DOMTreeMenuModel(
+            dom: fixture.session,
+            copyNodeTextAction: nil,
+            deleteNodesAction: { nodeIDs, _ in
+                deletedNodeIDs = nodeIDs
+                return true
+            }
+        )
+
+        successfulModel.configure(
+            nodeIDs: [fixture.divID],
+            selectedText: nil,
+            undoManager: nil,
+            localMarkupTextByNodeID: [:],
+            clearLocalSelection: {
+                clearCount += 1
+            }
+        )
+
+        let successfulTask = try #require(successfulModel.deleteSelection())
+        await successfulTask.value
+        #expect(deletedNodeIDs == [fixture.divID])
+        #expect(clearCount == 1)
     }
 }
 


### PR DESCRIPTION
## Purpose
Restore the DOM tree contextual menu behavior for node and text selections while keeping the menu implementation readable SwiftUI backed by Observation.

## Changes
- Added a `UIHostingMenu`-backed `DOMTreeMenuView` and `DOMTreeMenuModel` so menu visibility, labels, and disabled state are driven by Observable model state.
- Restored different menu behavior for single-line text selection, multi-line selection, single node selection, and multi-node selection.
- Routed copy/delete actions through node-ID based `InspectorSession` APIs and cleared DOM selection after successful node deletion.
- Preserved local selection when the delete action fails or the backing session is gone, so failed deletes are not treated as successful UI updates.
- Grouped multi-node delete undo registration into a single undo action.
- Added runtime tests for delete selection clearing and grouped undo, plus model-only tests for menu state and delete failure handling.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` clean: `7DBE87C5-B86B-41ED-ADD5-B13C755CEBAE`
- `codex-review` clean after PR feedback fix: `2FF4343A-C0B9-486B-85EB-4FD2536061C7`

## Screenshots
- Not included. This changes contextual menu behavior and runtime state handling without a stable screenshot target.

## Related Issues
- None