### PR TITLE
Fix DOM navigation menu undo and reload behavior

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -56,20 +56,10 @@ private extension UnicodeScalar {
 package final class DOMTargetState {
     package let targetID: ProtocolTarget.ID
     package var currentDocument: DOMDocumentState?
-    package var nextDocumentLifetimeID: UInt64
 
     package init(targetID: ProtocolTarget.ID) {
         self.targetID = targetID
         currentDocument = nil
-        nextDocumentLifetimeID = 0
-    }
-
-    package func nextDocumentID() -> DOMDocument.ID {
-        nextDocumentLifetimeID &+= 1
-        return DOMDocument.ID(
-            targetID: targetID,
-            localDocumentLifetimeID: DOMDocumentLifetimeIdentifier(nextDocumentLifetimeID)
-        )
     }
 }
 
@@ -564,7 +554,7 @@ package final class DOMSession {
         let targetState = state(for: targetID)
         removeDocuments(for: targetID)
 
-        let documentID = targetState.nextDocumentID()
+        let documentID = documentStore.nextDocumentID(for: targetID)
         var nodesByID: [DOMNode.ID: DOMNode] = [:]
         var currentNodeIDByProtocolNodeID: [DOMProtocolNodeID: DOMNode.ID] = [:]
         let rootNodeID = buildSubtree(

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -306,13 +306,25 @@ package final class DOMTargetGraph {
 @MainActor
 package final class DOMDocumentStore {
     private var targetStatesByID: [ProtocolTarget.ID: DOMTargetState]
+    private var lastDocumentLifetimeIDByTargetID: [ProtocolTarget.ID: UInt64]
 
     package init() {
         targetStatesByID = [:]
+        lastDocumentLifetimeIDByTargetID = [:]
     }
 
     package func reset() {
+        // Document identifiers are scoped to the DOMSession lifetime; reset only drops current document state.
         targetStatesByID.removeAll()
+    }
+
+    package func nextDocumentID(for targetID: ProtocolTarget.ID) -> DOMDocument.ID {
+        let nextDocumentLifetimeID = (lastDocumentLifetimeIDByTargetID[targetID] ?? 0) + 1
+        lastDocumentLifetimeIDByTargetID[targetID] = nextDocumentLifetimeID
+        return DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: DOMDocumentLifetimeIdentifier(nextDocumentLifetimeID)
+        )
     }
 
     package func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {

--- a/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
@@ -25,9 +25,10 @@ package final class DOMCompactNavigationController: UINavigationController {
         navigationBar.prefersLargeTitles = false
         webInspectorApplyClearNavigationBarStyle(to: self)
         rootViewController.navigationItem.style = .browser
+        let treeViewController = rootViewController as? DOMTreeViewController
         let navigationItems = DOMNavigationItems(session: session)
-        navigationItems.install(on: rootViewController.navigationItem) { [weak self] in
-            self?.undoManager
+        navigationItems.install(on: rootViewController.navigationItem) { [weak self, weak treeViewController] in
+            treeViewController?.domTreeUndoManager ?? self?.undoManager
         }
         domNavigationItems = navigationItems
     }

--- a/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
+++ b/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
@@ -1,14 +1,15 @@
 #if canImport(UIKit)
 import ObservationBridge
 import UIKit
-import WebInspectorCore
 import WebInspectorRuntime
 
 @MainActor
 package final class DOMNavigationItems: NSObject {
+    private typealias UndoManagerProvider = @MainActor () -> UndoManager?
+
     private let session: InspectorSession
     private let observationScope = ObservationScope()
-    private var undoManagerProvider: (@MainActor () -> UndoManager?)?
+    private var undoManagerProvider: UndoManagerProvider = { nil }
 
     private lazy var pickItem: UIBarButtonItem = {
         let item = UIBarButtonItem(
@@ -63,83 +64,84 @@ package final class DOMNavigationItems: NSObject {
                 completion([])
                 return
             }
-            completion(makeOverflowMenu(undoManager: undoManagerProvider?()).children)
+            completion(makeOverflowMenu(undoManagerProvider: undoManagerProvider).children)
         }
     }
 
-    private func makeOverflowMenu(undoManager: UndoManager?) -> UIMenu {
+    private func makeOverflowMenu(undoManagerProvider: @escaping UndoManagerProvider) -> UIMenu {
         UIMenu(children: [
-            makeCopyMenu(),
-            makeReloadMenu(),
-            makeDeleteAction(undoManager: undoManager),
+            UIMenu(options: .displayInline, children: [
+                makeUndoAction(undoManagerProvider: undoManagerProvider),
+                makeRedoAction(undoManagerProvider: undoManagerProvider),
+            ]),
+            UIMenu(options: .displayInline, children: [
+                makeReloadAction(),
+            ]),
+            UIMenu(options: .displayInline, children: [
+                makeDeleteAction(undoManagerProvider: undoManagerProvider),
+            ]),
         ])
     }
 
-    private func makeCopyMenu() -> UIMenu {
-        UIMenu(
-            title: webInspectorLocalized("Copy", default: "Copy"),
-            image: UIImage(systemName: "document.on.document"),
-            children: [
-                copyAction(title: "HTML", kind: .html),
-                copyAction(
-                    title: webInspectorLocalized("dom.element.copy.selector_path", default: "Selector Path"),
-                    kind: .selectorPath
-                ),
-                copyAction(title: "XPath", kind: .xPath),
-            ]
-        )
+    private func makeUndoAction(undoManagerProvider: @escaping UndoManagerProvider) -> UIAction {
+        let undoManager = undoManagerProvider()
+        return UIAction(
+            title: webInspectorLocalized("undo", default: "Undo"),
+            image: UIImage(systemName: "arrow.uturn.backward"),
+            attributes: undoManager?.canUndo == true ? [] : [.disabled]
+        ) { _ in
+            Task { @MainActor in
+                guard let undoManager = undoManagerProvider(), undoManager.canUndo else {
+                    return
+                }
+                undoManager.undo()
+            }
+        }
     }
 
-    private func makeReloadMenu() -> UIMenu {
-        UIMenu(
+    private func makeRedoAction(undoManagerProvider: @escaping UndoManagerProvider) -> UIAction {
+        let undoManager = undoManagerProvider()
+        return UIAction(
+            title: webInspectorLocalized("redo", default: "Redo"),
+            image: UIImage(systemName: "arrow.uturn.forward"),
+            attributes: undoManager?.canRedo == true ? [] : [.disabled]
+        ) { _ in
+            Task { @MainActor in
+                guard let undoManager = undoManagerProvider(), undoManager.canRedo else {
+                    return
+                }
+                undoManager.redo()
+            }
+        }
+    }
+
+    private func makeReloadAction() -> UIAction {
+        UIAction(
             title: webInspectorLocalized("reload", default: "Reload"),
             image: UIImage(systemName: "arrow.clockwise"),
-            children: [
-                UIAction(
-                    title: webInspectorLocalized("reload.target.inspector", default: "Reload Inspector"),
-                    image: UIImage(systemName: "arrow.clockwise"),
-                    attributes: session.canReloadDOMDocument ? [] : [.disabled]
-                ) { [weak session] _ in
-                    Task { @MainActor in
-                        try? await session?.reloadDOMDocument()
-                    }
-                },
-                UIAction(
-                    title: webInspectorLocalized("reload.target.page", default: "Reload Page"),
-                    image: UIImage(systemName: "arrow.clockwise"),
-                    attributes: session.hasInspectablePageWebView ? [] : [.disabled]
-                ) { [weak session] _ in
-                    Task { @MainActor in
-                        try? await session?.reloadPage()
-                    }
-                },
-            ]
-        )
+            attributes: (session.hasInspectablePageWebView || session.canReloadDOMDocument) ? [] : [.disabled]
+        ) { [weak session] _ in
+            Task { @MainActor in
+                guard let session else {
+                    return
+                }
+                if session.hasInspectablePageWebView {
+                    try? await session.reloadPage()
+                } else {
+                    try? await session.reloadDOMDocument()
+                }
+            }
+        }
     }
 
-    private func makeDeleteAction(undoManager: UndoManager?) -> UIAction {
+    private func makeDeleteAction(undoManagerProvider: @escaping UndoManagerProvider) -> UIAction {
         UIAction(
             title: webInspectorLocalized("inspector.delete_node", default: "Delete Node"),
             image: UIImage(systemName: "trash"),
             attributes: session.canDeleteSelectedDOMNode ? [.destructive] : [.disabled, .destructive]
         ) { [weak session] _ in
             Task { @MainActor in
-                try? await session?.deleteSelectedDOMNode(undoManager: undoManager)
-            }
-        }
-    }
-
-    private func copyAction(title: String, kind: DOMNodeCopyTextKind) -> UIAction {
-        UIAction(
-            title: title,
-            attributes: session.canCopySelectedDOMNodeText ? [] : [.disabled]
-        ) { [weak session] _ in
-            Task { @MainActor in
-                guard let text = try? await session?.copySelectedDOMNodeText(kind),
-                      text.isEmpty == false else {
-                    return
-                }
-                UIPasteboard.general.string = text
+                try? await session?.deleteSelectedDOMNode(undoManager: undoManagerProvider())
             }
         }
     }
@@ -164,7 +166,7 @@ extension DOMNavigationItems {
     }
 
     package func overflowMenuForTesting(undoManager: UndoManager? = nil) -> UIMenu {
-        makeOverflowMenu(undoManager: undoManager)
+        makeOverflowMenu(undoManagerProvider: { undoManager })
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
@@ -75,7 +75,7 @@ package final class DOMSplitViewController: UISplitViewController {
         }
         let navigationItems = DOMNavigationItems(session: session)
         navigationItems.install(on: navigationItem) { [weak self] in
-            self?.undoManager
+            self?.treeViewController.domTreeUndoManager ?? self?.undoManager
         }
         domNavigationItems = navigationItems
     }

--- a/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeTextView.swift
@@ -72,6 +72,7 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     private var measuredTextWidth: CGFloat = 0
     private var lastBoundsSize: CGSize = .zero
     private var rowIndexByNodeID: [DOMNode.ID: Int] = [:]
+    private var lastRenderedDocumentRootID: DOMNode.ID?
     private var lastObservedSelectedNodeID: DOMNode.ID?
     private var pendingRevealSelectedNodeID: DOMNode.ID?
     private var pendingTreeInvalidation: DOMTreeInvalidation?
@@ -617,6 +618,7 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
             reloadTreeCallCount += 1
         }
 #endif
+        resetLocalDocumentStateIfNeeded()
         let previousRows = rows
         let previousText = renderedText
         if resetFragments {
@@ -651,6 +653,32 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         updateContentDecorations()
         setNeedsLayout()
         revealPendingSelectedNodeIfPossible()
+    }
+
+    private func resetLocalDocumentStateIfNeeded() {
+        let rootID = dom.currentPageRootNode?.id
+        defer {
+            lastRenderedDocumentRootID = rootID
+        }
+        guard rootID == nil
+                || (lastRenderedDocumentRootID != nil && lastRenderedDocumentRootID != rootID) else {
+            return
+        }
+
+        openState.removeAll(keepingCapacity: true)
+        hoveredNodeID = nil
+        requestedChildNodeIDs.removeAll(keepingCapacity: true)
+        hoverRowRects.removeAll(keepingCapacity: true)
+        selectedRowRects.removeAll(keepingCapacity: true)
+        multiSelectedRowRects.removeAll(keepingCapacity: true)
+        lastObservedSelectedNodeID = nil
+        pendingRevealSelectedNodeID = nil
+        multiSelectedNodeIDs.removeAll(keepingCapacity: true)
+        multiSelectionLastNodeID = nil
+        multiSelectionShiftAnchorNodeID = nil
+        multiSelectionShiftRangeNodeIDs.removeAll(keepingCapacity: true)
+        dismissDOMMenuAnchor()
+        clearTextSelection()
     }
 
     private func applyContentInvalidation(affectedKeys: Set<DOMNode.ID>) -> Bool {

--- a/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTreeViewController.swift
@@ -11,6 +11,10 @@ package final class DOMTreeViewController: UIViewController {
     private let observationScope = ObservationScope()
     private var isEnsuringDOMDocumentLoaded = false
 
+    package var domTreeUndoManager: UndoManager? {
+        treeView.undoManager
+    }
+
     package init(session: InspectorSession) {
         self.session = session
         self.treeView = DOMTreeTextView(

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -247,6 +247,33 @@ func mainPageNavigationDoesNotMixFrameDocumentsIntoParentDocument() async throws
 }
 
 @Test
+func resetDoesNotReuseDocumentLifetimeForSameTargetID() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(
+        .init(id: pageTargetID, kind: .page, frameID: mainFrameID),
+        makeCurrentMainPage: true
+    )
+    _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    let firstDocumentID = try #require(await session.snapshot().targetsByID[pageTargetID]?.currentDocumentID)
+
+    await session.reset()
+    await session.applyTargetCreated(
+        .init(id: pageTargetID, kind: .page, frameID: mainFrameID),
+        makeCurrentMainPage: true
+    )
+    _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    let secondDocumentID = try #require(await session.snapshot().targetsByID[pageTargetID]?.currentDocumentID)
+
+    #expect(firstDocumentID.targetID == pageTargetID)
+    #expect(secondDocumentID.targetID == pageTargetID)
+    #expect(firstDocumentID.localDocumentLifetimeID == .init(1))
+    #expect(secondDocumentID.localDocumentLifetimeID == .init(2))
+}
+
+@Test
 func iframeOwnerProjectsFrameDocumentWithoutStoringItAsRegularChild() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -108,20 +108,42 @@ struct DOMContainerTests {
     }
 
     @Test
-    func overflowMenuDisablesActionsWhenSessionIsDetached() throws {
+    func overflowMenuUsesPageReloadAndDeleteOnlyWhenSessionIsDetached() throws {
         let dom = makeDOMSession()
         let session = InspectorSession(dom: dom)
         let navigationItems = DOMNavigationItems(session: session)
 
         let emptyMenu = navigationItems.overflowMenuForTesting()
-        #expect(action(titled: "HTML", in: emptyMenu)?.attributes.contains(.disabled) == true)
+        #expect(inlineSectionCount(in: emptyMenu) == 3)
+        #expect(action(titled: "Undo", in: emptyMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "Redo", in: emptyMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "HTML", in: emptyMenu) == nil)
+        #expect(action(titled: "Selector Path", in: emptyMenu) == nil)
+        #expect(action(titled: "XPath", in: emptyMenu) == nil)
+        #expect(action(titled: "Reload", in: emptyMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "Reload Inspector", in: emptyMenu) == nil)
+        #expect(action(titled: "Reload Page", in: emptyMenu) == nil)
 
         let selectedNode = try #require(firstElement(named: "input", in: dom))
         dom.selectNode(selectedNode.id)
 
         let selectedMenu = navigationItems.overflowMenuForTesting()
-        #expect(action(titled: "HTML", in: selectedMenu)?.attributes.contains(.disabled) == true)
+        #expect(inlineSectionCount(in: selectedMenu) == 3)
+        #expect(action(titled: "Undo", in: selectedMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "Redo", in: selectedMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "HTML", in: selectedMenu) == nil)
+        #expect(action(titled: "Selector Path", in: selectedMenu) == nil)
+        #expect(action(titled: "XPath", in: selectedMenu) == nil)
+        #expect(action(titled: "Reload", in: selectedMenu)?.attributes.contains(.disabled) == true)
+        #expect(action(titled: "Reload Inspector", in: selectedMenu) == nil)
+        #expect(action(titled: "Reload Page", in: selectedMenu) == nil)
         #expect(destructiveAction(in: selectedMenu)?.attributes.contains(.disabled) == true)
+
+        let undoManager = UndoManager()
+        undoManager.registerUndo(withTarget: UndoTarget()) { _ in }
+        let undoableMenu = navigationItems.overflowMenuForTesting(undoManager: undoManager)
+        #expect(action(titled: "Undo", in: undoableMenu)?.attributes.contains(.disabled) == false)
+        #expect(action(titled: "Redo", in: undoableMenu)?.attributes.contains(.disabled) == true)
     }
 
     private func makeDOMSession() -> DOMSession {
@@ -215,6 +237,13 @@ struct DOMContainerTests {
         return nil
     }
 
+    private func inlineSectionCount(in menu: UIMenu) -> Int {
+        menu.children
+            .compactMap { $0 as? UIMenu }
+            .filter { $0.options.contains(.displayInline) }
+            .count
+    }
+
     private func destructiveAction(in menu: UIMenu) -> UIAction? {
         for child in menu.children {
             if let action = child as? UIAction,
@@ -242,4 +271,6 @@ struct DOMContainerTests {
         return false
     }
 }
+
+private final class UndoTarget {}
 #endif

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -61,6 +61,33 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func documentResetClearsLocalExpansionStateEvenWhenNodeIDsRepeat() async throws {
+        let session = makeDOMSession()
+        let view = makeTreeView(session: session)
+
+        view.toggleRowForTesting(containing: "<article")
+        #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
+
+        let targetID = ProtocolTargetIdentifier("page-main")
+        session.reset()
+        session.applyTargetCreated(
+            ProtocolTargetRecord(
+                id: targetID,
+                kind: .page,
+                frameID: DOMFrameIdentifier("main-frame")
+            ),
+            makeCurrentMainPage: true
+        )
+        _ = session.replaceDocumentRoot(documentNode(), targetID: targetID)
+        await waitForObservationDelivery()
+        view.layoutIfNeeded()
+
+        let text = view.renderedTextForTesting
+        #expect(text.contains("<article>…</article>"))
+        #expect(!text.contains("<span id=\"nested-child\"></span>"))
+    }
+
+    @Test
     func openingUnloadedRowRequestsChildrenThroughInjectedAction() async throws {
         let session = makeDOMSession(root: documentWithDeferredArticle())
         var requestedNodeID: DOMNode.ID?


### PR DESCRIPTION
## Purpose

Fix the DOM navigation overflow menu so it matches the current WebView-backed DOM flow while preserving transport-only inspector behavior and shared delete undo support.

## Changes

- Replaced the DOM navigation copy/reload submenu with inline sections for Undo/Redo, Reload, and Delete.
- Wired DOM navigation delete to the DOM tree text view undo manager so deletes can be undone from either entry point.
- Kept one Reload action: WebView-backed sessions reload the page, while transport-only sessions fall back to DOM document reload.
- Moved DOM document lifetime allocation into DOMDocumentStore so reset does not reuse document identities for the same target.
- Cleared DOM tree text view local expansion/selection state when the rendered document identity changes.

## Testing

- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- codex-review uncommitted changes: clean

## UI

- No screenshots captured; menu structure only.