### PR TITLE
fix(transport): align target command routing

### DIFF
--- a/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/NetworkTransportAdapter.swift
@@ -8,7 +8,7 @@ package enum NetworkTransportAdapter {
             return ProtocolCommand(
                 domain: .network,
                 method: "Network.getResponseBody",
-                routing: .octopus(pageTarget: nil),
+                routing: .target(requestKey.targetID),
                 parametersData: try parameters(
                     requestKey: requestKey,
                     backendResourceIdentifier: backendResourceIdentifier
@@ -18,7 +18,7 @@ package enum NetworkTransportAdapter {
             return ProtocolCommand(
                 domain: .network,
                 method: "Network.getSerializedCertificate",
-                routing: .octopus(pageTarget: nil),
+                routing: .target(requestKey.targetID),
                 parametersData: try parameters(
                     requestKey: requestKey,
                     backendResourceIdentifier: backendResourceIdentifier

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -7,6 +7,7 @@ package actor TransportSession {
         var method: String
         var targetID: ProtocolTargetIdentifier?
         var promise: ReplyPromise<ProtocolCommandResult>
+        var hasBufferedProvisionalResponse: Bool
     }
 
     private let backend: any TransportBackend
@@ -93,7 +94,7 @@ package actor TransportSession {
             guard targetsByID[targetID] != nil else {
                 throw TransportError.missingTarget(targetID)
             }
-            if let result = compatibilityResult(for: command, targetID: targetID) {
+            if let result = transportLocalResult(for: command, targetID: targetID) {
                 return result
             }
             return try await sendTarget(command, targetID: targetID)
@@ -102,7 +103,7 @@ package actor TransportSession {
             guard targetsByID[resolvedTarget] != nil else {
                 throw TransportError.missingTarget(resolvedTarget)
             }
-            if let result = compatibilityResult(for: command, targetID: resolvedTarget) {
+            if let result = transportLocalResult(for: command, targetID: resolvedTarget) {
                 return result
             }
             return try await sendTarget(command, targetID: resolvedTarget)
@@ -215,7 +216,8 @@ package actor TransportSession {
             domain: command.domain,
             method: command.method,
             targetID: nil,
-            promise: promise
+            promise: promise,
+            hasBufferedProvisionalResponse: false
         )
         do {
             let message = try TransportMessageParser.makeCommandString(
@@ -249,7 +251,8 @@ package actor TransportSession {
             domain: command.domain,
             method: command.method,
             targetID: targetID,
-            promise: promise
+            promise: promise,
+            hasBufferedProvisionalResponse: false
         )
         targetReplyKeysByRootWrapperID[outerCommandID] = key
         do {
@@ -282,23 +285,21 @@ package actor TransportSession {
         case target(TargetReplyKey)
     }
 
-    private func compatibilityResult(
+    private func transportLocalResult(
         for command: ProtocolCommand,
         targetID: ProtocolTargetIdentifier
     ) -> ProtocolCommandResult? {
-        switch command.method {
-        case "DOM.enable", "CSS.enable":
-            ProtocolCommandResult(
-                domain: command.domain,
-                method: command.method,
-                targetID: targetID,
-                receivedSequence: nextSequence,
-                receivedDomainSequences: lastSequenceByDomain,
-                resultData: Data("{}".utf8)
-            )
-        default:
-            nil
+        guard command.method == "DOM.enable" else {
+            return nil
         }
+        return ProtocolCommandResult(
+            domain: command.domain,
+            method: command.method,
+            targetID: targetID,
+            receivedSequence: nextSequence,
+            receivedDomainSequences: lastSequenceByDomain,
+            resultData: Data("{}".utf8)
+        )
     }
 
     private func drainInboundMessages() async {
@@ -333,7 +334,7 @@ package actor TransportSession {
                 } catch {
                     return
                 }
-                await self.failPendingReply(
+                await self.failPendingReplyFromTimeout(
                     key,
                     error: TransportError.replyTimeout(method: method, targetID: targetID)
                 )
@@ -393,17 +394,18 @@ package actor TransportSession {
     }
 
     private func handleTargetMessage(_ parsed: ParsedProtocolMessage, targetID: ProtocolTargetIdentifier) async {
+        if targetsByID[targetID]?.isProvisional == true {
+            markTargetReplyAsBufferedIfNeeded(parsed, targetID: targetID)
+            provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
+            return
+        }
+
         if let id = parsed.id {
             let key = TargetReplyKey(targetID: targetID, commandID: id)
             if let pending = removeTargetReply(for: key) {
                 await resolve(pending, parsed: parsed)
                 return
             }
-        }
-
-        if targetsByID[targetID]?.isProvisional == true {
-            provisionalTargetMessagesByTargetID[targetID, default: []].append(parsed)
-            return
         }
 
         guard let method = parsed.method else {
@@ -795,12 +797,55 @@ package actor TransportSession {
         await pending?.promise.fulfill(.failure(error))
     }
 
+    private func failPendingReplyFromTimeout(_ key: PendingKey, error: any Error) async {
+        let pending: PendingReply?
+        switch key {
+        case let .root(commandID):
+            pending = rootReplies.removeValue(forKey: commandID)
+        case let .target(targetReplyKey):
+            pending = removeTargetReplyForTimeout(targetReplyKey)
+        }
+        await pending?.promise.fulfill(.failure(error))
+    }
+
     private func removeTargetReply(for key: TargetReplyKey) -> PendingReply? {
         let pending = targetReplies.removeValue(forKey: key)
         if let wrapperID = targetReplyKeysByRootWrapperID.first(where: { $0.value == key })?.key {
             targetReplyKeysByRootWrapperID.removeValue(forKey: wrapperID)
         }
         return pending
+    }
+
+    private func removeTargetReplyForTimeout(_ key: TargetReplyKey) -> PendingReply? {
+        if let pending = targetReplies[key] {
+            guard !pending.hasBufferedProvisionalResponse else {
+                return nil
+            }
+            return removeTargetReply(for: key)
+        }
+
+        guard let retargetedKey = targetReplies.keys.first(where: { $0.commandID == key.commandID }) else {
+            return nil
+        }
+        guard targetReplies[retargetedKey]?.hasBufferedProvisionalResponse != true else {
+            return nil
+        }
+        return removeTargetReply(for: retargetedKey)
+    }
+
+    private func markTargetReplyAsBufferedIfNeeded(
+        _ parsed: ParsedProtocolMessage,
+        targetID: ProtocolTargetIdentifier
+    ) {
+        guard let commandID = parsed.id else {
+            return
+        }
+        let key = TargetReplyKey(targetID: targetID, commandID: commandID)
+        guard var pending = targetReplies[key] else {
+            return
+        }
+        pending.hasBufferedProvisionalResponse = true
+        targetReplies[key] = pending
     }
 
     private func removeRetargetedReply(commandID: UInt64) -> PendingReply? {

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -17,7 +17,6 @@ func connectBootstrapsMainPageDocumentInOrder() async throws {
     #expect(methods == [
         "Inspector.enable",
         "Inspector.initialized",
-        // DOM.enable is resolved by TransportSession compatibility and is not routed to the backend.
         "Runtime.enable",
         "DOM.getDocument",
         "Network.enable",
@@ -48,11 +47,14 @@ func domainPumpsApplyNetworkEventsToNetworkSession() async throws {
 }
 
 @Test
-func networkLazyFetchReturnsCommandResultFromPageTarget() async throws {
+func networkLazyFetchReturnsCommandResultFromRequestTarget() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","domains":["Network"],"isProvisional":false}}}"#
+    )
 
     let sentCount = await backend.sentTargetMessages().count
     let performTask = Task {
@@ -65,7 +67,7 @@ func networkLazyFetchReturnsCommandResultFromPageTarget() async throws {
     }
     let sent = try await waitForTargetMessage(backend, method: "Network.getResponseBody", after: sentCount)
 
-    #expect(sent.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(sent.targetIdentifier == ProtocolTargetIdentifier.frameAd)
     #expect(String(data: Data(sent.message.utf8), encoding: .utf8)?.contains(#""requestId":"request-1""#) == true)
 
     await receiveTargetReply(
@@ -77,7 +79,7 @@ func networkLazyFetchReturnsCommandResultFromPageTarget() async throws {
     let result = try await performTask.value
 
     #expect(result.method == "Network.getResponseBody")
-    #expect(result.targetID == ProtocolTargetIdentifier.pageMain)
+    #expect(result.targetID == ProtocolTargetIdentifier.frameAd)
     #expect(String(data: result.resultData, encoding: .utf8)?.contains(#""body":"hello""#) == true)
 }
 
@@ -258,7 +260,7 @@ func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async thr
 }
 
 @Test
-func provisionalFrameDocumentResolvedBeforeCommitRehydratesCommittedFrame() async throws {
+func provisionalFrameDocumentReplyBeforeCommitRehydratesCommittedFrame() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -281,9 +283,7 @@ func provisionalFrameDocumentResolvedBeforeCommitRehydratesCommittedFrame() asyn
         messageID: try messageID(firstRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    let _: DOMDocumentIdentifier = try await waitUntil {
-        await session.dom.snapshot().targetsByID[provisionalTargetID]?.currentDocumentID
-    }
+    #expect(await session.dom.snapshot().targetsByID[provisionalTargetID]?.currentDocumentID == nil)
 
     let sentCountBeforeCommit = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
@@ -3174,7 +3174,6 @@ private func completeBootstrap(
 ) async throws -> [SentTargetMessage] {
     var sentCount = initialSentCount
     var sentMessages: [SentTargetMessage] = []
-    // DOM.enable is resolved by TransportSession compatibility, so this helper only replies to backend-routed commands.
     for method in ["Inspector.enable", "Inspector.initialized", "Runtime.enable"] {
         let sent = try await waitForTargetMessage(backend, method: method, after: sentCount)
         sentMessages.append(sent)

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -53,7 +53,7 @@ func targetCommandUsesNestedReplyKey() async throws {
 }
 
 @Test
-func targetScopedCompatibilityCommandsResolveWithoutBackendSend() async throws {
+func domEnableIsTransportLocalWhileCSSEnableRoutesToTargetBackend() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
@@ -61,15 +61,29 @@ func targetScopedCompatibilityCommandsResolveWithoutBackendSend() async throws {
     let domResult = try await session.send(
         ProtocolCommand(domain: .dom, method: "DOM.enable", routing: .target(.init("page-main")))
     )
-    let cssResult = try await session.send(
-        ProtocolCommand(domain: .css, method: "CSS.enable", routing: .octopus(pageTarget: .init("page-main")))
+    #expect(await backend.sentTargetMessages().isEmpty)
+
+    let cssTask = Task {
+        try await session.send(
+            ProtocolCommand(domain: .css, method: "CSS.enable", routing: .octopus(pageTarget: .init("page-main")))
+        )
+    }
+    let cssSent = try await waitUntil {
+        let messages = await backend.sentTargetMessages()
+        return messages.last
+    }
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("page-main"),
+        message: #"{"id":\#(try messageID(cssSent.message)),"result":{}}"#
     )
+    let cssResult = try await cssTask.value
 
     #expect(domResult.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(cssResult.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(String(data: domResult.resultData, encoding: .utf8) == "{}")
     #expect(String(data: cssResult.resultData, encoding: .utf8) == "{}")
-    #expect(await backend.sentMessages().isEmpty)
+    #expect(cssSent.targetIdentifier == ProtocolTargetIdentifier("page-main"))
 }
 
 @Test
@@ -360,7 +374,7 @@ func targetCommitRetargetsPendingRepliesToCommittedTarget() async throws {
 }
 
 @Test
-func provisionalTargetReplyResolvesBeforeBufferedEvents() async throws {
+func provisionalTargetReplyIsBufferedUntilCommit() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
@@ -378,9 +392,46 @@ func provisionalTargetReplyResolvesBeforeBufferedEvents() async throws {
         targetID: .init("frame-provisional"),
         message: ##"{"id":\##(innerID),"result":{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document"}}}"##
     )
+    #expect(await session.snapshot().pendingTargetReplyKeys == [
+        TargetReplyKey(targetID: .init("frame-provisional"), commandID: innerID),
+    ])
+
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
     let result = try await sendTask.value
 
-    #expect(result.targetID == ProtocolTargetIdentifier("frame-provisional"))
+    #expect(result.targetID == ProtocolTargetIdentifier("frame-committed"))
+    #expect(await session.snapshot().pendingTargetReplyKeys.isEmpty)
+}
+
+@Test
+func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
+
+    let sendTask = Task {
+        try await session.send(
+            ProtocolCommand(domain: .dom, method: "DOM.getDocument", routing: .target(.init("frame-provisional")))
+        )
+    }
+    let sent = try await waitForTargetMessage(backend)
+    let innerID = try messageID(sent.message)
+
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-provisional"),
+        message: ##"{"id":\##(innerID),"result":{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document"}}}"##
+    )
+    try await Task.sleep(for: .milliseconds(50))
+
+    #expect(await session.snapshot().pendingTargetReplyKeys == [
+        TargetReplyKey(targetID: .init("frame-provisional"), commandID: innerID),
+    ])
+
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
+    let result = try await sendTask.value
+
+    #expect(result.targetID == ProtocolTargetIdentifier("frame-committed"))
     #expect(await session.snapshot().pendingTargetReplyKeys.isEmpty)
 }
 
@@ -1209,7 +1260,7 @@ func domAdapterSubframeCommitDoesNotConsumeCurrentMainPage() async throws {
 }
 
 @Test
-func networkCommandIntentRoutesThroughCurrentPageOctopusTarget() throws {
+func networkCommandIntentRoutesThroughRequestTarget() throws {
     let requestKey = NetworkRequestIdentifierKey(
         targetID: .init("frame-ad"),
         requestID: .init("request-1")
@@ -1222,9 +1273,9 @@ func networkCommandIntentRoutesThroughCurrentPageOctopusTarget() throws {
     )
 
     #expect(bodyCommand.method == "Network.getResponseBody")
-    #expect(bodyCommand.routing == .octopus(pageTarget: nil))
+    #expect(bodyCommand.routing == .target(.init("frame-ad")))
     #expect(certificateCommand.method == "Network.getSerializedCertificate")
-    #expect(certificateCommand.routing == .octopus(pageTarget: nil))
+    #expect(certificateCommand.routing == .target(.init("frame-ad")))
     #expect(String(data: bodyCommand.parametersData, encoding: .utf8)?.contains(#""requestId":"request-1""#) == true)
 }
 


### PR DESCRIPTION
## Summary
- Treat `DOM.enable` as transport-local while routing `CSS.enable` through the backend target path.
- Buffer provisional target replies until commit, including replies received before the commit event and after the normal response timeout window.
- Route network lazy commands through the request target and update Runtime/Transport tests for the corrected target ownership behavior.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorTransportTests`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review clean: FAA7C17A-3CCC-40A4-A125-BB96DB97099A