### PR TITLE
feat(css): add element style core transport support

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -1,0 +1,441 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+package final class CSSNodeStyles {
+    package let identity: CSSNodeStyleIdentity
+    package var state: CSSNodeStylesState
+    package var sections: [CSSStyleSection]
+    package var computedProperties: [CSSComputedStyleProperty]
+    package var revision: UInt64
+
+    package init(
+        identity: CSSNodeStyleIdentity,
+        state: CSSNodeStylesState = .loading,
+        sections: [CSSStyleSection] = [],
+        computedProperties: [CSSComputedStyleProperty] = [],
+        revision: UInt64 = 0
+    ) {
+        self.identity = identity
+        self.state = state
+        self.sections = sections
+        self.computedProperties = computedProperties
+        self.revision = revision
+    }
+}
+
+@MainActor
+@Observable
+package final class CSSSession {
+    package private(set) var selectedNodeStyles: CSSNodeStyles?
+    package private(set) var selectedState: CSSNodeStylesState
+    package private(set) var revision: UInt64
+
+    @ObservationIgnored private var stylesByNodeID: [DOMNodeIdentifier: CSSNodeStyles]
+    @ObservationIgnored private var activeRefreshRevisionByNodeID: [DOMNodeIdentifier: UInt64]
+    @ObservationIgnored private var nextRevision: UInt64
+
+    package init() {
+        selectedNodeStyles = nil
+        selectedState = .unavailable(.noSelection)
+        revision = 0
+        stylesByNodeID = [:]
+        activeRefreshRevisionByNodeID = [:]
+        nextRevision = 0
+    }
+
+    package func reset() {
+        selectedNodeStyles = nil
+        selectedState = .unavailable(.noSelection)
+        revision = 0
+        stylesByNodeID.removeAll()
+        activeRefreshRevisionByNodeID.removeAll()
+        nextRevision = 0
+    }
+
+    package func markSelectedNodeUnavailable(_ reason: CSSNodeStylesUnavailableReason) {
+        selectedNodeStyles = nil
+        selectedState = .unavailable(reason)
+        revision &+= 1
+    }
+
+    package func beginRefresh(identity: CSSNodeStyleIdentity) -> CSSStyleRefreshToken? {
+        guard identity.targetCapabilities.contains(.css) else {
+            markSelectedNodeUnavailable(.cssUnavailableForTarget(identity.targetID))
+            return nil
+        }
+
+        nextRevision &+= 1
+        let nodeStyles = stylesByNodeID[identity.nodeID] ?? CSSNodeStyles(identity: identity)
+        stylesByNodeID[identity.nodeID] = nodeStyles
+        nodeStyles.state = .loading
+        nodeStyles.revision = nextRevision
+        selectedNodeStyles = nodeStyles
+        selectedState = .loading
+        revision &+= 1
+        activeRefreshRevisionByNodeID[identity.nodeID] = nextRevision
+        return CSSStyleRefreshToken(identity: identity, revision: nextRevision)
+    }
+
+    package func applyRefresh(
+        token: CSSStyleRefreshToken,
+        matched: CSSMatchedStylesPayload,
+        inline: CSSInlineStylesPayload,
+        computed: [CSSComputedStyleProperty]
+    ) {
+        guard activeRefreshRevisionByNodeID[token.identity.nodeID] == token.revision,
+              selectedNodeStyles?.identity == token.identity,
+              let nodeStyles = stylesByNodeID[token.identity.nodeID] else {
+            return
+        }
+
+        nodeStyles.sections = Self.makeSections(
+            identity: token.identity,
+            matched: matched,
+            inline: inline
+        )
+        nodeStyles.computedProperties = computed
+        nodeStyles.state = .loaded
+        nodeStyles.revision = token.revision
+        selectedState = .loaded
+        activeRefreshRevisionByNodeID.removeValue(forKey: token.identity.nodeID)
+        revision &+= 1
+    }
+
+    package func markRefreshFailed(_ token: CSSStyleRefreshToken, message: String) {
+        guard activeRefreshRevisionByNodeID[token.identity.nodeID] == token.revision,
+              selectedNodeStyles?.identity == token.identity,
+              let nodeStyles = stylesByNodeID[token.identity.nodeID] else {
+            return
+        }
+        nodeStyles.state = .failed(message)
+        selectedState = .failed(message)
+        activeRefreshRevisionByNodeID.removeValue(forKey: token.identity.nodeID)
+        revision &+= 1
+    }
+
+    package func markNeedsRefresh(targetID: ProtocolTargetIdentifier) {
+        var changed = false
+        for nodeStyles in stylesByNodeID.values where nodeStyles.identity.targetID == targetID {
+            guard !(nodeStyles.state == .loading && activeRefreshRevisionByNodeID[nodeStyles.identity.nodeID] != nil) else {
+                continue
+            }
+            nodeStyles.state = .needsRefresh
+            nodeStyles.revision &+= 1
+            activeRefreshRevisionByNodeID.removeValue(forKey: nodeStyles.identity.nodeID)
+            changed = true
+            if selectedNodeStyles === nodeStyles {
+                selectedState = .needsRefresh
+            }
+        }
+        if changed {
+            revision &+= 1
+        }
+    }
+
+    package func markNeedsRefresh(targetID: ProtocolTargetIdentifier, nodeID: DOMProtocolNodeID) {
+        guard let current = stylesByNodeID.values.first(where: {
+            $0.identity.targetID == targetID && $0.identity.protocolNodeID == nodeID
+        }) else {
+            return
+        }
+        guard !(current.state == .loading && activeRefreshRevisionByNodeID[current.identity.nodeID] != nil) else {
+            return
+        }
+        current.state = .needsRefresh
+        current.revision &+= 1
+        activeRefreshRevisionByNodeID.removeValue(forKey: current.identity.nodeID)
+        if selectedNodeStyles === current {
+            selectedState = .needsRefresh
+        }
+        revision &+= 1
+    }
+
+    package func removeStyles(targetID: ProtocolTargetIdentifier) {
+        let removedIDs = stylesByNodeID
+            .filter { $0.value.identity.targetID == targetID }
+            .map(\.key)
+        guard !removedIDs.isEmpty else {
+            return
+        }
+        for nodeID in removedIDs {
+            stylesByNodeID.removeValue(forKey: nodeID)
+            activeRefreshRevisionByNodeID.removeValue(forKey: nodeID)
+        }
+        if let removedSelectedNodeID = selectedNodeStyles?.identity.nodeID,
+           selectedNodeStyles?.identity.targetID == targetID {
+            selectedNodeStyles = nil
+            selectedState = .unavailable(.staleNode(removedSelectedNodeID))
+        }
+        revision &+= 1
+    }
+
+    package func setStyleTextIntent(for propertyID: CSSPropertyIdentifier, enabled: Bool) -> CSSCommandIntent? {
+        guard let nodeStyles = selectedNodeStyles,
+              case .loaded = selectedState,
+              case .loaded = nodeStyles.state,
+              let (sectionIndex, propertyIndex) = Self.locateProperty(propertyID, in: nodeStyles.sections),
+              nodeStyles.sections[sectionIndex].isEditable else {
+            return nil
+        }
+
+        let style = nodeStyles.sections[sectionIndex].style
+        guard style.isEditable,
+              style.id == propertyID.styleID,
+              style.cssProperties.indices.contains(propertyIndex) else {
+            return nil
+        }
+        let property = style.cssProperties[propertyIndex]
+        guard property.isEditable,
+              property.isEnabled != enabled,
+              let text = Self.rewrittenStyleText(style: style, propertyIndex: propertyIndex, enabled: enabled) else {
+            return nil
+        }
+        return .setStyleText(targetID: nodeStyles.identity.targetID, styleID: propertyID.styleID, text: text)
+    }
+
+    package func applySetStyleTextResult(
+        _ style: CSSStyle,
+        styleID: CSSStyleIdentifier,
+        targetID: ProtocolTargetIdentifier
+    ) {
+        var changed = false
+        for nodeStyles in stylesByNodeID.values where nodeStyles.identity.targetID == targetID {
+            for sectionIndex in nodeStyles.sections.indices where nodeStyles.sections[sectionIndex].style.id == styleID {
+                var section = nodeStyles.sections[sectionIndex]
+                let normalizedStyle = Self.normalizedStyle(
+                    style,
+                    isEditable: section.isEditable,
+                    ruleOrigin: section.rule?.origin
+                )
+                section.style = normalizedStyle
+                if var rule = section.rule {
+                    rule.style = normalizedStyle
+                    section.rule = rule
+                }
+                nodeStyles.sections[sectionIndex] = section
+                nodeStyles.state = .needsRefresh
+                changed = true
+                if selectedNodeStyles === nodeStyles {
+                    selectedState = .needsRefresh
+                }
+            }
+        }
+        if changed {
+            revision &+= 1
+        }
+    }
+
+    private static func locateProperty(
+        _ propertyID: CSSPropertyIdentifier,
+        in sections: [CSSStyleSection]
+    ) -> (sectionIndex: Int, propertyIndex: Int)? {
+        for sectionIndex in sections.indices {
+            let style = sections[sectionIndex].style
+            guard style.id == propertyID.styleID,
+                  style.cssProperties.indices.contains(propertyID.propertyIndex) else {
+                continue
+            }
+            return (sectionIndex, propertyID.propertyIndex)
+        }
+        return nil
+    }
+
+    private static func makeSections(
+        identity: CSSNodeStyleIdentity,
+        matched: CSSMatchedStylesPayload,
+        inline: CSSInlineStylesPayload
+    ) -> [CSSStyleSection] {
+        var sections: [CSSStyleSection] = []
+        var ordinal = 0
+
+        if let inlineStyle = inline.inlineStyle {
+            appendSection(
+                &sections,
+                identity: identity,
+                ordinal: &ordinal,
+                kind: .inlineStyle,
+                title: "element.style",
+                style: inlineStyle,
+                isEditable: inlineStyle.id != nil
+            )
+        }
+
+        for match in matched.matchedRules.reversed() {
+            appendRuleSection(&sections, identity: identity, ordinal: &ordinal, match: match, kind: .rule)
+        }
+
+        if let attributesStyle = inline.attributesStyle {
+            appendSection(
+                &sections,
+                identity: identity,
+                ordinal: &ordinal,
+                kind: .attributesStyle,
+                title: "Attributes",
+                style: attributesStyle,
+                isEditable: false
+            )
+        }
+
+        for pseudo in matched.pseudoElements {
+            for match in pseudo.matches.reversed() {
+                appendRuleSection(
+                    &sections,
+                    identity: identity,
+                    ordinal: &ordinal,
+                    match: match,
+                    kind: .pseudoElement(pseudo.pseudoID)
+                )
+            }
+        }
+
+        for (ancestorIndex, inherited) in matched.inherited.enumerated() {
+            if let inlineStyle = inherited.inlineStyle {
+                appendSection(
+                    &sections,
+                    identity: identity,
+                    ordinal: &ordinal,
+                    kind: .inheritedInlineStyle(ancestorIndex: ancestorIndex),
+                    title: "Inherited element.style",
+                    style: inlineStyle,
+                    isEditable: inlineStyle.id != nil
+                )
+            }
+            for match in inherited.matchedRules.reversed() {
+                appendRuleSection(
+                    &sections,
+                    identity: identity,
+                    ordinal: &ordinal,
+                    match: match,
+                    kind: .inheritedRule(ancestorIndex: ancestorIndex)
+                )
+            }
+        }
+
+        return sections
+    }
+
+    private static func appendRuleSection(
+        _ sections: inout [CSSStyleSection],
+        identity: CSSNodeStyleIdentity,
+        ordinal: inout Int,
+        match: CSSRuleMatch,
+        kind: CSSStyleSectionKind
+    ) {
+        let isEditable = match.rule.origin != .userAgent && match.rule.style.id != nil
+        var rule = match.rule
+        rule.style = normalizedStyle(rule.style, isEditable: isEditable, ruleOrigin: rule.origin)
+        sections.append(
+            CSSStyleSection(
+                id: .init(nodeID: identity.nodeID, kind: kind, ordinal: ordinal),
+                kind: kind,
+                title: rule.selectorList.text,
+                subtitle: rule.sourceURL,
+                rule: rule,
+                style: rule.style,
+                isEditable: isEditable
+            )
+        )
+        ordinal += 1
+    }
+
+    private static func appendSection(
+        _ sections: inout [CSSStyleSection],
+        identity: CSSNodeStyleIdentity,
+        ordinal: inout Int,
+        kind: CSSStyleSectionKind,
+        title: String,
+        style: CSSStyle,
+        isEditable: Bool
+    ) {
+        sections.append(
+            CSSStyleSection(
+                id: .init(nodeID: identity.nodeID, kind: kind, ordinal: ordinal),
+                kind: kind,
+                title: title,
+                style: normalizedStyle(style, isEditable: isEditable, ruleOrigin: nil),
+                isEditable: isEditable
+            )
+        )
+        ordinal += 1
+    }
+
+    private static func normalizedStyle(
+        _ style: CSSStyle,
+        isEditable: Bool,
+        ruleOrigin: CSSStyleOrigin?
+    ) -> CSSStyle {
+        let styleID = style.id
+        let effectiveEditable = isEditable && styleID != nil && ruleOrigin != .userAgent
+        let canSafelyRewriteStyleText = effectiveEditable && style.cssProperties.allSatisfy { $0.text != nil }
+        var normalized = style
+        normalized.isEditable = effectiveEditable
+        normalized.cssProperties = style.cssProperties.enumerated().map { index, property in
+            var normalizedProperty = property
+            if let styleID {
+                normalizedProperty.id = CSSPropertyIdentifier(styleID: styleID, propertyIndex: index)
+            } else {
+                normalizedProperty.id = nil
+            }
+            normalizedProperty.isEditable = canSafelyRewriteStyleText
+                && normalizedProperty.text != nil
+                && canTogglePropertyText(normalizedProperty)
+            return normalizedProperty
+        }
+        return normalized
+    }
+
+    private static func rewrittenStyleText(style: CSSStyle, propertyIndex: Int, enabled: Bool) -> String? {
+        guard style.cssProperties.indices.contains(propertyIndex) else {
+            return nil
+        }
+        let property = style.cssProperties[propertyIndex]
+        guard property.isEditable,
+              style.cssProperties.allSatisfy({ $0.text != nil }),
+              let toggledText = toggledPropertyText(property, enabled: enabled) else {
+            return nil
+        }
+
+        var texts: [String] = []
+        for index in style.cssProperties.indices {
+            if index == propertyIndex {
+                texts.append(toggledText)
+                continue
+            }
+            guard let text = style.cssProperties[index].text else {
+                return nil
+            }
+            texts.append(text)
+        }
+        return texts.joined(separator: "\n")
+    }
+
+    private static func canTogglePropertyText(_ property: CSSProperty) -> Bool {
+        toggledPropertyText(property, enabled: !property.isEnabled) != nil
+    }
+
+    private static func toggledPropertyText(_ property: CSSProperty, enabled: Bool) -> String? {
+        guard let text = property.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty,
+              property.isEnabled != enabled else {
+            return nil
+        }
+
+        if enabled {
+            guard text.hasPrefix("/*"),
+                  text.hasSuffix("*/") else {
+                return nil
+            }
+            let inner = String(text.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            return inner.isEmpty ? nil : inner
+        }
+
+        guard !text.contains("/*"),
+              !text.contains("*/") else {
+            return nil
+        }
+        return "/* \(text) */"
+    }
+
+}

--- a/Sources/WebInspectorCore/CSS/CSSProtocol.swift
+++ b/Sources/WebInspectorCore/CSS/CSSProtocol.swift
@@ -1,0 +1,626 @@
+import Foundation
+
+package struct CSSStyleSheetIdentifier: RawRepresentable, Hashable, Codable, Sendable, CustomStringConvertible {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package var description: String {
+        rawValue
+    }
+}
+
+package struct CSSStyleIdentifier: Hashable, Codable, Sendable {
+    package var styleSheetID: CSSStyleSheetIdentifier
+    package var ordinal: Int
+
+    package init(styleSheetID: CSSStyleSheetIdentifier, ordinal: Int) {
+        self.styleSheetID = styleSheetID
+        self.ordinal = ordinal
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case styleSheetID = "styleSheetId"
+        case ordinal
+    }
+}
+
+package struct CSSRuleIdentifier: Hashable, Codable, Sendable {
+    package var styleSheetID: CSSStyleSheetIdentifier
+    package var ordinal: Int
+
+    package init(styleSheetID: CSSStyleSheetIdentifier, ordinal: Int) {
+        self.styleSheetID = styleSheetID
+        self.ordinal = ordinal
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case styleSheetID = "styleSheetId"
+        case ordinal
+    }
+}
+
+package struct CSSSourceRange: Equatable, Codable, Sendable {
+    package var startLine: Int
+    package var startColumn: Int
+    package var endLine: Int
+    package var endColumn: Int
+
+    package init(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int) {
+        self.startLine = startLine
+        self.startColumn = startColumn
+        self.endLine = endLine
+        self.endColumn = endColumn
+    }
+}
+
+package enum CSSStyleOrigin: Equatable, Sendable {
+    case user
+    case userAgent
+    case author
+    case inspector
+    case other(String)
+
+    package init(rawValue: String) {
+        switch rawValue {
+        case "user":
+            self = .user
+        case "user-agent":
+            self = .userAgent
+        case "author":
+            self = .author
+        case "inspector":
+            self = .inspector
+        default:
+            self = .other(rawValue)
+        }
+    }
+}
+
+extension CSSStyleOrigin: Codable {
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(rawValue: try container.decode(String.self))
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    package var rawValue: String {
+        switch self {
+        case .user:
+            "user"
+        case .userAgent:
+            "user-agent"
+        case .author:
+            "author"
+        case .inspector:
+            "inspector"
+        case let .other(value):
+            value
+        }
+    }
+}
+
+package enum CSSPropertyStatus: Equatable, Sendable {
+    case active
+    case inactive
+    case disabled
+    case style
+    case other(String)
+
+    package init(rawValue: String) {
+        switch rawValue {
+        case "active":
+            self = .active
+        case "inactive":
+            self = .inactive
+        case "disabled":
+            self = .disabled
+        case "style":
+            self = .style
+        default:
+            self = .other(rawValue)
+        }
+    }
+}
+
+extension CSSPropertyStatus: Codable {
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(rawValue: try container.decode(String.self))
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    package var rawValue: String {
+        switch self {
+        case .active:
+            "active"
+        case .inactive:
+            "inactive"
+        case .disabled:
+            "disabled"
+        case .style:
+            "style"
+        case let .other(value):
+            value
+        }
+    }
+}
+
+package struct CSSNodeStyleIdentity: Equatable, Hashable, Sendable {
+    package var nodeID: DOMNodeIdentifier
+    package var targetID: ProtocolTargetIdentifier
+    package var documentID: DOMDocumentIdentifier
+    package var protocolNodeID: DOMProtocolNodeID
+    package var targetCapabilities: ProtocolTargetCapabilities
+
+    package init(
+        nodeID: DOMNodeIdentifier,
+        targetID: ProtocolTargetIdentifier,
+        documentID: DOMDocumentIdentifier,
+        protocolNodeID: DOMProtocolNodeID,
+        targetCapabilities: ProtocolTargetCapabilities
+    ) {
+        self.nodeID = nodeID
+        self.targetID = targetID
+        self.documentID = documentID
+        self.protocolNodeID = protocolNodeID
+        self.targetCapabilities = targetCapabilities
+    }
+}
+
+package enum CSSNodeStylesUnavailableReason: Error, Equatable, Sendable {
+    case noSelection
+    case nonElementNode(DOMNodeType)
+    case staleNode(DOMNodeIdentifier)
+    case cssUnavailableForTarget(ProtocolTargetIdentifier)
+}
+
+package enum CSSCommandIntent: Equatable, Sendable {
+    case enable(targetID: ProtocolTargetIdentifier)
+    case getMatchedStyles(identity: CSSNodeStyleIdentity, includePseudo: Bool = true, includeInherited: Bool = true)
+    case getInlineStyles(identity: CSSNodeStyleIdentity)
+    case getComputedStyle(identity: CSSNodeStyleIdentity)
+    case setStyleText(targetID: ProtocolTargetIdentifier, styleID: CSSStyleIdentifier, text: String)
+}
+
+package struct CSSPropertyIdentifier: Hashable, Codable, Sendable {
+    package var styleID: CSSStyleIdentifier
+    package var propertyIndex: Int
+
+    package init(styleID: CSSStyleIdentifier, propertyIndex: Int) {
+        self.styleID = styleID
+        self.propertyIndex = propertyIndex
+    }
+}
+
+package struct CSSSelector: Equatable, Codable, Sendable {
+    package var text: String
+    package var specificity: [Int]?
+    package var dynamic: Bool?
+
+    package init(text: String, specificity: [Int]? = nil, dynamic: Bool? = nil) {
+        self.text = text
+        self.specificity = specificity
+        self.dynamic = dynamic
+    }
+}
+
+package struct CSSSelectorList: Equatable, Codable, Sendable {
+    package var selectors: [CSSSelector]
+    package var text: String
+    package var range: CSSSourceRange?
+
+    package init(selectors: [CSSSelector], text: String, range: CSSSourceRange? = nil) {
+        self.selectors = selectors
+        self.text = text
+        self.range = range
+    }
+}
+
+package struct CSSGrouping: Equatable, Codable, Sendable {
+    package var type: String
+    package var ruleID: CSSRuleIdentifier?
+    package var text: String?
+    package var sourceURL: String?
+    package var range: CSSSourceRange?
+
+    package init(
+        type: String,
+        ruleID: CSSRuleIdentifier? = nil,
+        text: String? = nil,
+        sourceURL: String? = nil,
+        range: CSSSourceRange? = nil
+    ) {
+        self.type = type
+        self.ruleID = ruleID
+        self.text = text
+        self.sourceURL = sourceURL
+        self.range = range
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case ruleID = "ruleId"
+        case text
+        case sourceURL
+        case range
+    }
+}
+
+package struct CSSShorthandEntry: Equatable, Codable, Sendable {
+    package var name: String
+    package var value: String
+
+    package init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}
+
+package struct CSSProperty: Equatable, Codable, Sendable {
+    package var id: CSSPropertyIdentifier?
+    package var name: String
+    package var value: String
+    package var priority: String
+    package var text: String?
+    package var parsedOk: Bool
+    package var status: CSSPropertyStatus
+    package var implicit: Bool
+    package var range: CSSSourceRange?
+    package var isEditable: Bool
+
+    package init(
+        id: CSSPropertyIdentifier? = nil,
+        name: String,
+        value: String,
+        priority: String = "",
+        text: String? = nil,
+        parsedOk: Bool = true,
+        status: CSSPropertyStatus = .style,
+        implicit: Bool = false,
+        range: CSSSourceRange? = nil,
+        isEditable: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.value = value
+        self.priority = priority
+        self.text = text
+        self.parsedOk = parsedOk
+        self.status = status
+        self.implicit = implicit
+        self.range = range
+        self.isEditable = isEditable
+    }
+
+    package var isEnabled: Bool {
+        status != .disabled
+    }
+
+    package var isOverridden: Bool {
+        status == .inactive
+    }
+
+    package var isParsed: Bool {
+        parsedOk
+    }
+
+    package var isImplicit: Bool {
+        implicit
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case value
+        case priority
+        case text
+        case parsedOk
+        case status
+        case implicit
+        case range
+        case isEditable
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(CSSPropertyIdentifier.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        value = try container.decode(String.self, forKey: .value)
+        priority = try container.decodeIfPresent(String.self, forKey: .priority) ?? ""
+        text = try container.decodeIfPresent(String.self, forKey: .text)
+        parsedOk = try container.decodeIfPresent(Bool.self, forKey: .parsedOk) ?? true
+        status = try container.decodeIfPresent(CSSPropertyStatus.self, forKey: .status) ?? .style
+        implicit = try container.decodeIfPresent(Bool.self, forKey: .implicit) ?? false
+        range = try container.decodeIfPresent(CSSSourceRange.self, forKey: .range)
+        isEditable = try container.decodeIfPresent(Bool.self, forKey: .isEditable) ?? false
+    }
+}
+
+package struct CSSStyle: Equatable, Codable, Sendable {
+    package var id: CSSStyleIdentifier?
+    package var cssProperties: [CSSProperty]
+    package var shorthandEntries: [CSSShorthandEntry]
+    package var cssText: String?
+    package var range: CSSSourceRange?
+    package var width: String?
+    package var height: String?
+    package var isEditable: Bool
+
+    package init(
+        id: CSSStyleIdentifier? = nil,
+        cssProperties: [CSSProperty],
+        shorthandEntries: [CSSShorthandEntry] = [],
+        cssText: String? = nil,
+        range: CSSSourceRange? = nil,
+        width: String? = nil,
+        height: String? = nil,
+        isEditable: Bool = false
+    ) {
+        self.id = id
+        self.cssProperties = cssProperties
+        self.shorthandEntries = shorthandEntries
+        self.cssText = cssText
+        self.range = range
+        self.width = width
+        self.height = height
+        self.isEditable = isEditable
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "styleId"
+        case cssProperties
+        case shorthandEntries
+        case cssText
+        case range
+        case width
+        case height
+        case isEditable
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(CSSStyleIdentifier.self, forKey: .id)
+        cssProperties = try container.decode([CSSProperty].self, forKey: .cssProperties)
+        shorthandEntries = try container.decodeIfPresent([CSSShorthandEntry].self, forKey: .shorthandEntries) ?? []
+        cssText = try container.decodeIfPresent(String.self, forKey: .cssText)
+        range = try container.decodeIfPresent(CSSSourceRange.self, forKey: .range)
+        width = try container.decodeIfPresent(String.self, forKey: .width)
+        height = try container.decodeIfPresent(String.self, forKey: .height)
+        isEditable = try container.decodeIfPresent(Bool.self, forKey: .isEditable) ?? false
+    }
+}
+
+package struct CSSRule: Equatable, Codable, Sendable {
+    package var id: CSSRuleIdentifier?
+    package var selectorList: CSSSelectorList
+    package var sourceURL: String?
+    package var sourceLine: Int
+    package var origin: CSSStyleOrigin
+    package var style: CSSStyle
+    package var groupings: [CSSGrouping]
+    package var isImplicitlyNested: Bool
+
+    package init(
+        id: CSSRuleIdentifier? = nil,
+        selectorList: CSSSelectorList,
+        sourceURL: String? = nil,
+        sourceLine: Int,
+        origin: CSSStyleOrigin,
+        style: CSSStyle,
+        groupings: [CSSGrouping] = [],
+        isImplicitlyNested: Bool = false
+    ) {
+        self.id = id
+        self.selectorList = selectorList
+        self.sourceURL = sourceURL
+        self.sourceLine = sourceLine
+        self.origin = origin
+        self.style = style
+        self.groupings = groupings
+        self.isImplicitlyNested = isImplicitlyNested
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "ruleId"
+        case selectorList
+        case sourceURL
+        case sourceLine
+        case origin
+        case style
+        case groupings
+        case isImplicitlyNested
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(CSSRuleIdentifier.self, forKey: .id)
+        selectorList = try container.decode(CSSSelectorList.self, forKey: .selectorList)
+        sourceURL = try container.decodeIfPresent(String.self, forKey: .sourceURL)
+        sourceLine = try container.decodeIfPresent(Int.self, forKey: .sourceLine) ?? 0
+        origin = try container.decode(CSSStyleOrigin.self, forKey: .origin)
+        style = try container.decode(CSSStyle.self, forKey: .style)
+        groupings = try container.decodeIfPresent([CSSGrouping].self, forKey: .groupings) ?? []
+        isImplicitlyNested = try container.decodeIfPresent(Bool.self, forKey: .isImplicitlyNested) ?? false
+    }
+}
+
+package struct CSSRuleMatch: Equatable, Codable, Sendable {
+    package var rule: CSSRule
+    package var matchingSelectors: [Int]
+
+    package init(rule: CSSRule, matchingSelectors: [Int]) {
+        self.rule = rule
+        self.matchingSelectors = matchingSelectors
+    }
+}
+
+package struct CSSPseudoIdMatches: Equatable, Codable, Sendable {
+    package var pseudoID: String
+    package var matches: [CSSRuleMatch]
+
+    package init(pseudoID: String, matches: [CSSRuleMatch]) {
+        self.pseudoID = pseudoID
+        self.matches = matches
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case pseudoID = "pseudoId"
+        case matches
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let pseudoID = try? container.decode(String.self, forKey: .pseudoID) {
+            self.pseudoID = pseudoID
+        } else {
+            self.pseudoID = try String(container.decode(Int.self, forKey: .pseudoID))
+        }
+        matches = try container.decodeIfPresent([CSSRuleMatch].self, forKey: .matches) ?? []
+    }
+}
+
+package struct CSSInheritedStyleEntry: Equatable, Codable, Sendable {
+    package var inlineStyle: CSSStyle?
+    package var matchedRules: [CSSRuleMatch]
+
+    package init(inlineStyle: CSSStyle? = nil, matchedRules: [CSSRuleMatch]) {
+        self.inlineStyle = inlineStyle
+        self.matchedRules = matchedRules
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case inlineStyle
+        case matchedRules = "matchedCSSRules"
+    }
+}
+
+package struct CSSMatchedStylesPayload: Equatable, Codable, Sendable {
+    package var matchedRules: [CSSRuleMatch]
+    package var pseudoElements: [CSSPseudoIdMatches]
+    package var inherited: [CSSInheritedStyleEntry]
+
+    package init(
+        matchedRules: [CSSRuleMatch] = [],
+        pseudoElements: [CSSPseudoIdMatches] = [],
+        inherited: [CSSInheritedStyleEntry] = []
+    ) {
+        self.matchedRules = matchedRules
+        self.pseudoElements = pseudoElements
+        self.inherited = inherited
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case matchedRules = "matchedCSSRules"
+        case pseudoElements
+        case inherited
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        matchedRules = try container.decodeIfPresent([CSSRuleMatch].self, forKey: .matchedRules) ?? []
+        pseudoElements = try container.decodeIfPresent([CSSPseudoIdMatches].self, forKey: .pseudoElements) ?? []
+        inherited = try container.decodeIfPresent([CSSInheritedStyleEntry].self, forKey: .inherited) ?? []
+    }
+}
+
+package struct CSSInlineStylesPayload: Equatable, Codable, Sendable {
+    package var inlineStyle: CSSStyle?
+    package var attributesStyle: CSSStyle?
+
+    package init(inlineStyle: CSSStyle? = nil, attributesStyle: CSSStyle? = nil) {
+        self.inlineStyle = inlineStyle
+        self.attributesStyle = attributesStyle
+    }
+}
+
+package struct CSSComputedStyleProperty: Equatable, Codable, Sendable {
+    package var name: String
+    package var value: String
+
+    package init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}
+
+package enum CSSNodeStylesState: Equatable, Sendable {
+    case loading
+    case loaded
+    case unavailable(CSSNodeStylesUnavailableReason)
+    case failed(String)
+    case needsRefresh
+}
+
+package enum CSSStyleSectionKind: Equatable, Hashable, Sendable {
+    case inlineStyle
+    case rule
+    case attributesStyle
+    case pseudoElement(String)
+    case inheritedInlineStyle(ancestorIndex: Int)
+    case inheritedRule(ancestorIndex: Int)
+}
+
+package struct CSSStyleSectionIdentifier: Hashable, Sendable {
+    package var nodeID: DOMNodeIdentifier
+    package var kind: CSSStyleSectionKind
+    package var ordinal: Int
+
+    package init(nodeID: DOMNodeIdentifier, kind: CSSStyleSectionKind, ordinal: Int) {
+        self.nodeID = nodeID
+        self.kind = kind
+        self.ordinal = ordinal
+    }
+}
+
+package struct CSSStyleSection: Equatable, Sendable {
+    package var id: CSSStyleSectionIdentifier
+    package var kind: CSSStyleSectionKind
+    package var title: String
+    package var subtitle: String?
+    package var rule: CSSRule?
+    package var style: CSSStyle
+    package var isEditable: Bool
+
+    package init(
+        id: CSSStyleSectionIdentifier,
+        kind: CSSStyleSectionKind,
+        title: String,
+        subtitle: String? = nil,
+        rule: CSSRule? = nil,
+        style: CSSStyle,
+        isEditable: Bool
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.subtitle = subtitle
+        self.rule = rule
+        self.style = style
+        self.isEditable = isEditable
+    }
+}
+
+package struct CSSStyleRefreshToken: Equatable, Sendable {
+    package var identity: CSSNodeStyleIdentity
+    package var revision: UInt64
+
+    package init(identity: CSSNodeStyleIdentity, revision: UInt64) {
+        self.identity = identity
+        self.revision = revision
+    }
+}

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -410,8 +410,8 @@ package final class DOMSession {
     package func reset() {
         currentPageTargetID = nil
         mainFrameID = nil
-        treeRevision = 0
-        selectionRevision = 0
+        treeRevision &+= 1
+        selectionRevision &+= 1
         targetGraph.reset()
         documentStore.reset()
         frameDocumentProjectionIndex.removeAll()

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -829,6 +829,38 @@ package final class DOMSession {
         return node(for: selectedNodeID)
     }
 
+    package func selectedCSSNodeStyleIdentity() -> Result<CSSNodeStyleIdentity, CSSNodeStylesUnavailableReason> {
+        guard let selectedNodeID = selection.selectedNodeID else {
+            return .failure(.noSelection)
+        }
+        return cssNodeStyleIdentity(for: selectedNodeID)
+    }
+
+    package func cssNodeStyleIdentity(
+        for nodeID: DOMNode.ID
+    ) -> Result<CSSNodeStyleIdentity, CSSNodeStylesUnavailableReason> {
+        guard let node = node(for: nodeID) else {
+            return .failure(.staleNode(nodeID))
+        }
+        guard node.nodeType == .element else {
+            return .failure(.nonElementNode(node.nodeType))
+        }
+        let targetID = nodeID.documentID.targetID
+        let capabilities = targetCapabilities(for: targetID)
+        guard capabilities.contains(.css) else {
+            return .failure(.cssUnavailableForTarget(targetID))
+        }
+        return .success(
+            CSSNodeStyleIdentity(
+                nodeID: nodeID,
+                targetID: targetID,
+                documentID: nodeID.documentID,
+                protocolNodeID: node.protocolNodeID,
+                targetCapabilities: capabilities
+            )
+        )
+    }
+
     package var currentPageRootNode: DOMNode? {
         guard let targetID = currentPageTargetID,
               let document = documentStore.currentDocument(forTargetID: targetID),

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -65,7 +65,7 @@ package enum ProtocolTargetKind: Equatable, Sendable {
     }
 }
 
-package struct ProtocolTargetCapabilities: OptionSet, Equatable, Sendable {
+package struct ProtocolTargetCapabilities: OptionSet, Equatable, Hashable, Sendable {
     package let rawValue: UInt8
 
     package init(rawValue: UInt8) {
@@ -77,8 +77,9 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Sendable {
     package static let target = Self(rawValue: 1 << 2)
     package static let inspector = Self(rawValue: 1 << 3)
     package static let network = Self(rawValue: 1 << 4)
+    package static let css = Self(rawValue: 1 << 5)
 
-    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network]
+    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network, .css]
     package static let frameDefault: Self = []
     package static let workerDefault: Self = [.runtime]
     package static let serviceWorkerDefault: Self = [.runtime, .network]
@@ -112,6 +113,8 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Sendable {
                 capabilities.insert(.inspector)
             case "network":
                 capabilities.insert(.network)
+            case "css":
+                capabilities.insert(.css)
             default:
                 break
             }

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -79,7 +79,7 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Hashable, Senda
     package static let network = Self(rawValue: 1 << 4)
     package static let css = Self(rawValue: 1 << 5)
 
-    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network, .css]
+    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network]
     package static let frameDefault: Self = []
     package static let workerDefault: Self = [.runtime]
     package static let serviceWorkerDefault: Self = [.runtime, .network]

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -507,6 +507,7 @@ package final class InspectorSession {
         try await perform(intent)
         dom.applyNodeRemoved(nodeID)
         dom.selectNode(nil)
+        css.removeStyles(targetID: documentID.targetID)
         lastError = nil
 
         return DOMDeleteUndoState(

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -116,6 +116,7 @@ private final class InspectorConnection {
     let originalInspectability: Bool?
     var eventPump: DomainEventPump?
     var bootstrappedTargetIDs: Set<ProtocolTargetIdentifier>
+    var cssEnabledTargetIDs: Set<ProtocolTargetIdentifier>
 
     init(
         transport: TransportSession,
@@ -127,6 +128,7 @@ private final class InspectorConnection {
         self.originalInspectability = originalInspectability
         eventPump = nil
         bootstrappedTargetIDs = []
+        cssEnabledTargetIDs = []
     }
 }
 
@@ -155,6 +157,7 @@ private struct TargetDestroyedEventParams: Decodable {
 @Observable
 package final class InspectorSession {
     package let dom: DOMSession
+    package let css: CSSSession
     package let network: NetworkSession
     package private(set) var isAttached: Bool
     package private(set) var lastError: InspectorSessionError?
@@ -175,10 +178,12 @@ package final class InspectorSession {
     package init(
         configuration: InspectorSessionConfiguration = .init(),
         dom: DOMSession = DOMSession(),
+        css: CSSSession = CSSSession(),
         network: NetworkSession = NetworkSession()
     ) {
         self.configuration = configuration
         self.dom = dom
+        self.css = css
         self.network = network
         isAttached = false
         lastError = nil
@@ -280,6 +285,7 @@ package final class InspectorSession {
             await transport.detach()
             restoreInspectabilityIfNeeded(for: nextConnection)
             dom.reset()
+            css.reset()
             network.reset()
             let sessionError = InspectorSessionError(String(describing: error))
             lastError = sessionError
@@ -309,6 +315,7 @@ package final class InspectorSession {
             restoreInspectabilityIfNeeded(for: previousPendingConnection)
         }
         dom.reset()
+        css.reset()
         network.reset()
         cancelDOMDocumentRequests()
         highlightedDOMTargetID = nil
@@ -564,6 +571,7 @@ package final class InspectorSession {
         await cancelElementPicker()
         clearDeleteUndoHistory()
         dom.reset()
+        css.reset()
         network.reset()
         cancelDOMDocumentRequests()
         if let connection {
@@ -676,6 +684,82 @@ package final class InspectorSession {
         return result
     }
 
+    @discardableResult
+    package func perform(_ intent: CSSCommandIntent) async throws -> ProtocolCommandResult {
+        let connection = try activeConnection()
+        let transport = connection.transport
+        let result = try await transport.send(CSSTransportAdapter.command(for: intent))
+        try ensureCurrentConnection(connection)
+        return result
+    }
+
+    package func refreshStylesForSelectedNode() async {
+        do {
+            try await refreshSelectedNodeStyles()
+            lastError = nil
+        } catch {
+            lastError = InspectorSessionError(String(describing: error))
+        }
+    }
+
+    package func setCSSProperty(_ propertyID: CSSPropertyIdentifier, enabled: Bool) async throws {
+        guard let intent = css.setStyleTextIntent(for: propertyID, enabled: enabled) else {
+            throw InspectorSessionError("CSS property is not editable.")
+        }
+        let result = try await perform(intent)
+        guard case let .setStyleText(targetID, styleID, _) = intent else {
+            throw InspectorSessionError("Unexpected CSS command intent.")
+        }
+        let style = try CSSTransportAdapter.setStyleTextResult(from: result)
+        css.applySetStyleTextResult(style, styleID: styleID, targetID: targetID)
+        try await refreshSelectedNodeStyles()
+        lastError = nil
+    }
+
+    private func refreshSelectedNodeStyles() async throws {
+        switch dom.selectedCSSNodeStyleIdentity() {
+        case let .success(identity):
+            try await refreshStyles(for: identity)
+        case let .failure(reason):
+            css.markSelectedNodeUnavailable(reason)
+        }
+    }
+
+    private func refreshStyles(for identity: CSSNodeStyleIdentity) async throws {
+        let connection = try activeConnection()
+        try await ensureCSSEnabled(targetID: identity.targetID, connection: connection)
+        guard let token = css.beginRefresh(identity: identity) else {
+            return
+        }
+        let transport = connection.transport
+        let matchedCommand = try CSSTransportAdapter.command(for: .getMatchedStyles(identity: identity))
+        let inlineCommand = try CSSTransportAdapter.command(for: .getInlineStyles(identity: identity))
+        let computedCommand = try CSSTransportAdapter.command(for: .getComputedStyle(identity: identity))
+
+        do {
+            async let matchedResult = transport.send(matchedCommand)
+            async let inlineResult = transport.send(inlineCommand)
+            async let computedResult = transport.send(computedCommand)
+
+            let results = try await (matchedResult, inlineResult, computedResult)
+            try ensureCurrentConnection(connection)
+            guard case let .success(currentIdentity) = dom.selectedCSSNodeStyleIdentity(),
+                  currentIdentity == identity else {
+                return
+            }
+
+            css.applyRefresh(
+                token: token,
+                matched: try CSSTransportAdapter.matchedStyles(from: results.0),
+                inline: try CSSTransportAdapter.inlineStyles(from: results.1),
+                computed: try CSSTransportAdapter.computedStyles(from: results.2)
+            )
+        } catch {
+            css.markRefreshFailed(token, message: String(describing: error))
+            throw error
+        }
+    }
+
     package func fetchResponseBody(for id: NetworkRequest.ID) async {
         guard let request = network.request(for: id) else {
             return
@@ -705,6 +789,7 @@ package final class InspectorSession {
         try ensureCurrentConnection(connection)
         _ = try await sendTargetCommand(domain: .dom, method: "DOM.enable", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
+        try await ensureCSSEnabled(targetID: mainTargetID, connection: connection)
         _ = try await sendTargetCommand(domain: .runtime, method: "Runtime.enable", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
 
@@ -738,6 +823,46 @@ package final class InspectorSession {
         )
     }
 
+    private func ensureCSSEnabled(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection
+    ) async throws {
+        guard dom.targetCapabilities(for: targetID).contains(.css),
+              !connection.cssEnabledTargetIDs.contains(targetID) else {
+            return
+        }
+        _ = try await connection.transport.send(try CSSTransportAdapter.command(for: .enable(targetID: targetID)))
+        try ensureCurrentConnection(connection)
+        connection.cssEnabledTargetIDs.insert(targetID)
+    }
+
+    private func startCSSEnableIfNeeded(targetID: ProtocolTargetIdentifier) {
+        guard isAttached,
+              let connection,
+              dom.targetCapabilities(for: targetID).contains(.css),
+              !connection.cssEnabledTargetIDs.contains(targetID) else {
+            return
+        }
+        let targetKind = dom.targetKind(for: targetID)
+        Task { @MainActor [weak self, connection, targetKind] in
+            guard let self else {
+                return
+            }
+            do {
+                try await ensureCSSEnabled(targetID: targetID, connection: connection)
+            } catch {
+                guard isCurrentConnection(connection) else {
+                    return
+                }
+                if targetKind == .frame,
+                   shouldIgnoreFrameTargetLifecycleError(error) {
+                    return
+                }
+                lastError = InspectorSessionError(String(describing: error))
+            }
+        }
+    }
+
     private func startPumps(connection: InspectorConnection) async {
         stopPumps(connection)
         let transport = connection.transport
@@ -760,6 +885,10 @@ package final class InspectorSession {
             await handleInspectorEvent(event)
         case .dom:
             await handleDOMEvent(event)
+        case .css:
+            applyEvent(event) {
+                try CSSTransportAdapter.applyCSSEvent(event, to: $0.css)
+            }
         case .network:
             applyEvent(event) {
                 try NetworkTransportAdapter.applyNetworkEvent(event, to: $0.network)
@@ -787,6 +916,7 @@ package final class InspectorSession {
             let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
             if let destroyedTargetID {
                 cancelDOMDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
+                css.removeStyles(targetID: destroyedTargetID)
             }
             applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
             if isAttached,
@@ -794,6 +924,9 @@ package final class InspectorSession {
                createdTarget.kind == .frame {
                 if createdTarget.capabilities.contains(.dom) {
                     startDOMDocumentRequest(targetID: createdTarget.id, reason: "frameTargetCreated")
+                }
+                if createdTarget.capabilities.contains(.css) {
+                    startCSSEnableIfNeeded(targetID: createdTarget.id)
                 }
             }
             if event.method == "Target.didCommitProvisionalTarget",
@@ -806,8 +939,12 @@ package final class InspectorSession {
                let targetCommit {
                 if let oldTargetID = targetCommit.oldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
+                    css.removeStyles(targetID: oldTargetID)
                 }
                 startFrameTargetDocumentRequestAfterCommit(targetID: targetCommit.newTargetID)
+                if dom.targetKind(for: targetCommit.newTargetID) == .frame {
+                    startCSSEnableIfNeeded(targetID: targetCommit.newTargetID)
+                }
             }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -820,6 +957,11 @@ package final class InspectorSession {
             && target.capabilities.contains(.dom)
             && target.currentDocumentID == nil {
             startDOMDocumentRequest(targetID: target.id, reason: "attachedFrameTarget")
+        }
+        for target in dom.snapshot().targetsByID.values
+        where target.kind == .frame
+            && target.capabilities.contains(.css) {
+            startCSSEnableIfNeeded(targetID: target.id)
         }
     }
 
@@ -841,10 +983,24 @@ package final class InspectorSession {
                 return
             }
             if event.method == "DOM.documentUpdated" {
+                if let targetID = event.targetID ?? dom.currentPageTargetID {
+                    css.removeStyles(targetID: targetID)
+                }
                 refreshDOMDocumentAfterBackendUpdate(event)
                 return
             }
+            let selectedStyleNodeID = css.selectedNodeStyles?.identity.nodeID
             try DOMTransportAdapter.applyDOMEvent(event, to: dom)
+            if cssInvalidatingDOMEventMethods.contains(event.method),
+               let targetID = event.targetID {
+                if let selectedStyleNodeID,
+                   selectedStyleNodeID.documentID.targetID == targetID,
+                   dom.selectedNodeID != selectedStyleNodeID {
+                    css.removeStyles(targetID: targetID)
+                } else {
+                    css.markNeedsRefresh(targetID: targetID)
+                }
+            }
             if event.method == "DOM.setChildNodes" {
                 startPendingFrameOwnerHydration()
             }
@@ -869,6 +1025,17 @@ package final class InspectorSession {
                 lastError = InspectorSessionError(String(describing: error))
             }
         }
+    }
+
+    private var cssInvalidatingDOMEventMethods: Set<String> {
+        [
+            "DOM.setChildNodes",
+            "DOM.childNodeInserted",
+            "DOM.childNodeRemoved",
+            "DOM.childNodeCountUpdated",
+            "DOM.attributeModified",
+            "DOM.attributeRemoved",
+        ]
     }
 
     private func handleInspectEvent(_ event: DOMInspectEvent) async {
@@ -1097,7 +1264,7 @@ package final class InspectorSession {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
-                if handle.targetKind == .frame, shouldIgnoreFrameDocumentRequestError(error) {
+                if handle.targetKind == .frame, shouldIgnoreFrameTargetLifecycleError(error) {
                     return
                 }
                 InspectorRuntimeLog.error("getDocument.failed target=\(targetID.rawValue) reason=\(reason) error=\(error)")
@@ -1185,7 +1352,7 @@ package final class InspectorSession {
         dom.clearOwnerHydrationTransactions(targetID: targetID)
     }
 
-    private func shouldIgnoreFrameDocumentRequestError(_ error: any Error) -> Bool {
+    private func shouldIgnoreFrameTargetLifecycleError(_ error: any Error) -> Bool {
         switch error {
         case is CancellationError:
             return true
@@ -1209,6 +1376,7 @@ package final class InspectorSession {
             return
         }
         try DOMTransportAdapter.applyGetDocumentResult(result, to: dom)
+        css.removeStyles(targetID: targetID)
         startPendingFrameOwnerHydration()
         lastError = nil
     }
@@ -1450,9 +1618,13 @@ package final class InspectorSession {
     }
 
     private func ensureCurrentConnection(_ candidate: InspectorConnection) throws {
-        guard connection === candidate || pendingConnection === candidate else {
+        guard isCurrentConnection(candidate) else {
             throw TransportError.transportClosed
         }
+    }
+
+    private func isCurrentConnection(_ candidate: InspectorConnection) -> Bool {
+        connection === candidate || pendingConnection === candidate
     }
 
     package static func prepareInspectability(for webView: WKWebView) -> Bool {

--- a/Sources/WebInspectorTransport/CSSTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/CSSTransportAdapter.swift
@@ -1,0 +1,112 @@
+import Foundation
+import WebInspectorCore
+
+package enum CSSTransportAdapter {
+    package static func command(for intent: CSSCommandIntent) throws -> ProtocolCommand {
+        switch intent {
+        case let .enable(targetID):
+            return ProtocolCommand(
+                domain: .css,
+                method: "CSS.enable",
+                routing: .target(targetID)
+            )
+        case let .getMatchedStyles(identity, includePseudo, includeInherited):
+            return ProtocolCommand(
+                domain: .css,
+                method: "CSS.getMatchedStylesForNode",
+                routing: .target(identity.targetID),
+                parametersData: try data([
+                    "nodeId": identity.protocolNodeID.rawValue,
+                    "includePseudo": includePseudo,
+                    "includeInherited": includeInherited,
+                ])
+            )
+        case let .getInlineStyles(identity):
+            return ProtocolCommand(
+                domain: .css,
+                method: "CSS.getInlineStylesForNode",
+                routing: .target(identity.targetID),
+                parametersData: try data(["nodeId": identity.protocolNodeID.rawValue])
+            )
+        case let .getComputedStyle(identity):
+            return ProtocolCommand(
+                domain: .css,
+                method: "CSS.getComputedStyleForNode",
+                routing: .target(identity.targetID),
+                parametersData: try data(["nodeId": identity.protocolNodeID.rawValue])
+            )
+        case let .setStyleText(targetID, styleID, text):
+            return ProtocolCommand(
+                domain: .css,
+                method: "CSS.setStyleText",
+                routing: .target(targetID),
+                parametersData: try data([
+                    "styleId": styleIDPayload(styleID),
+                    "text": text,
+                ])
+            )
+        }
+    }
+
+    package static func matchedStyles(from result: ProtocolCommandResult) throws -> CSSMatchedStylesPayload {
+        try TransportMessageParser.decode(CSSMatchedStylesPayload.self, from: result.resultData)
+    }
+
+    package static func inlineStyles(from result: ProtocolCommandResult) throws -> CSSInlineStylesPayload {
+        try TransportMessageParser.decode(CSSInlineStylesPayload.self, from: result.resultData)
+    }
+
+    package static func computedStyles(from result: ProtocolCommandResult) throws -> [CSSComputedStyleProperty] {
+        let payload = try TransportMessageParser.decode(ComputedStyleResult.self, from: result.resultData)
+        return payload.computedStyle
+    }
+
+    package static func setStyleTextResult(from result: ProtocolCommandResult) throws -> CSSStyle {
+        let payload = try TransportMessageParser.decode(SetStyleTextResult.self, from: result.resultData)
+        return payload.style
+    }
+
+    @MainActor
+    package static func applyCSSEvent(_ event: ProtocolEventEnvelope, to session: CSSSession) throws {
+        guard event.domain == .css,
+              let targetID = event.targetID else {
+            return
+        }
+
+        switch event.method {
+        case "CSS.styleSheetChanged",
+             "CSS.styleSheetAdded",
+             "CSS.styleSheetRemoved",
+             "CSS.mediaQueryResultChanged":
+            session.markNeedsRefresh(targetID: targetID)
+        case "CSS.nodeLayoutFlagsChanged":
+            let params = try TransportMessageParser.decode(NodeLayoutFlagsChangedParams.self, from: event.paramsData)
+            session.markNeedsRefresh(targetID: targetID, nodeID: params.nodeId)
+        default:
+            break
+        }
+    }
+
+    private static func data(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [])
+    }
+
+    private static func styleIDPayload(_ styleID: CSSStyleIdentifier) -> [String: Any] {
+        [
+            "styleSheetId": styleID.styleSheetID.rawValue,
+            "ordinal": styleID.ordinal,
+        ]
+    }
+}
+
+private struct ComputedStyleResult: Decodable {
+    var computedStyle: [CSSComputedStyleProperty]
+}
+
+private struct SetStyleTextResult: Decodable {
+    var style: CSSStyle
+}
+
+private struct NodeLayoutFlagsChangedParams: Decodable {
+    var nodeId: DOMProtocolNodeID
+}

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -24,6 +24,8 @@ package actor TransportSession {
     private var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord]
     private var provisionalTargetMessagesByTargetID: [ProtocolTargetIdentifier: [ParsedProtocolMessage]]
     private var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
+    private var styleSheetTargetIDsByStyleSheetID: [CSSStyleSheetIdentifier: ProtocolTargetIdentifier]
+    private var unresolvedStyleSheetFrameIDsByStyleSheetID: [CSSStyleSheetIdentifier: DOMFrameIdentifier]
     private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
@@ -47,6 +49,8 @@ package actor TransportSession {
         targetsByID = [:]
         provisionalTargetMessagesByTargetID = [:]
         frameTargetIDsByFrameID = [:]
+        styleSheetTargetIDsByStyleSheetID = [:]
+        unresolvedStyleSheetFrameIDsByStyleSheetID = [:]
         executionContextsByID = [:]
         currentMainPageTargetID = nil
         subscribers = [:]
@@ -388,8 +392,9 @@ package actor TransportSession {
             return
         }
 
-        await updateRegistryFromRootEvent(method: method, paramsData: parsed.paramsData)
-        await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetIDForRootEvent(method: method, paramsData: parsed.paramsData), paramsData: parsed.paramsData)
+        let targetID = targetIDForRootEvent(method: method, paramsData: parsed.paramsData)
+        await updateRegistryFromRootEvent(method: method, targetID: targetID, paramsData: parsed.paramsData)
+        await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetID, paramsData: parsed.paramsData)
         await dispatchCommittedProvisionalTargetMessagesIfNeeded(method: method, paramsData: parsed.paramsData)
     }
 
@@ -452,7 +457,11 @@ package actor TransportSession {
         )
     }
 
-    private func updateRegistryFromRootEvent(method: String, paramsData: Data) async {
+    private func updateRegistryFromRootEvent(
+        method: String,
+        targetID: ProtocolTargetIdentifier?,
+        paramsData: Data
+    ) async {
         switch method {
         case "Target.targetCreated":
             guard let params = try? TransportMessageParser.decode(TargetCreatedParams.self, from: paramsData) else {
@@ -470,15 +479,23 @@ package actor TransportSession {
             }
             applyTargetCommitted(oldTargetID: params.oldTargetId, newTargetID: params.newTargetId)
         case "Runtime.executionContextCreated":
-            updateRegistryFromTargetEvent(method: method, targetID: targetIDForRootEvent(method: method, paramsData: paramsData), paramsData: paramsData)
+            updateRegistryFromTargetEvent(method: method, targetID: targetID, paramsData: paramsData)
+        case "CSS.styleSheetAdded", "CSS.styleSheetRemoved":
+            updateCSSStyleSheetRegistry(method: method, targetID: targetID, paramsData: paramsData)
         default:
             break
         }
     }
 
     private func updateRegistryFromTargetEvent(method: String, targetID: ProtocolTargetIdentifier?, paramsData: Data) {
+        guard let targetID else {
+            return
+        }
+        if method == "CSS.styleSheetAdded" || method == "CSS.styleSheetRemoved" {
+            updateCSSStyleSheetRegistry(method: method, targetID: targetID, paramsData: paramsData)
+            return
+        }
         guard method == "Runtime.executionContextCreated",
-              let targetID,
               let params = try? TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: paramsData) else {
             return
         }
@@ -501,6 +518,7 @@ package actor TransportSession {
         targetsByID[record.id] = record
         if let frameID = record.frameID {
             frameTargetIDsByFrameID[frameID] = record.id
+            resolvePendingStyleSheets(frameID: frameID, targetID: record.id)
         }
         if currentMainPageTargetID == nil,
            record.kind == .page,
@@ -571,6 +589,7 @@ package actor TransportSession {
         targetsByID.removeValue(forKey: targetID)
         provisionalTargetMessagesByTargetID.removeValue(forKey: targetID)
         frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != targetID }
+        styleSheetTargetIDsByStyleSheetID = styleSheetTargetIDsByStyleSheetID.filter { $0.value != targetID }
         executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
         let pendingReplies = targetReplies.keys
             .filter { $0.targetID == targetID }
@@ -597,6 +616,7 @@ package actor TransportSession {
             targetsByID[newTargetID] = committedSubframeRecord
             if let frameID = committedSubframeRecord.frameID {
                 frameTargetIDsByFrameID[frameID] = newTargetID
+                resolvePendingStyleSheets(frameID: frameID, targetID: newTargetID)
             }
             return
         }
@@ -616,10 +636,14 @@ package actor TransportSession {
         if let oldTargetID = committedOldTargetID {
             retargetPendingReplies(from: oldTargetID, to: newTargetID)
             frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != oldTargetID }
+            for (styleSheetID, targetID) in styleSheetTargetIDsByStyleSheetID where targetID == oldTargetID {
+                styleSheetTargetIDsByStyleSheetID[styleSheetID] = newTargetID
+            }
         }
 
         if let frameID = newRecord.frameID {
             frameTargetIDsByFrameID[frameID] = newTargetID
+            resolvePendingStyleSheets(frameID: frameID, targetID: newTargetID)
         }
         if let oldTargetID = committedOldTargetID {
             for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
@@ -699,15 +723,88 @@ package actor TransportSession {
                 return frameTargetIDsByFrameID[frameID] ?? currentMainPageTargetID
             }
             return currentMainPageTargetID
+        case "CSS.styleSheetAdded":
+            return targetIDForCSSStyleSheetAdded(paramsData: paramsData)
+        case "CSS.styleSheetChanged", "CSS.styleSheetRemoved":
+            return targetIDForCSSStyleSheetID(paramsData: paramsData)
         case "DOM.documentUpdated":
             return nil
         default:
             switch ProtocolDomain(method: method) {
-            case .dom, .runtime, .network, .page, .storage:
+            case .dom, .runtime, .css, .network, .page, .storage:
                 return currentMainPageTargetID
             default:
                 return nil
             }
+        }
+    }
+
+    private func targetIDForCSSStyleSheetAdded(paramsData: Data) -> ProtocolTargetIdentifier? {
+        guard let params = try? TransportMessageParser.decode(CSSStyleSheetAddedParams.self, from: paramsData) else {
+            return nil
+        }
+        if let frameID = params.header.frameID,
+           frameTargetIDsByFrameID[frameID] == nil {
+            return nil
+        }
+        if let frameID = params.header.frameID {
+            return frameTargetIDsByFrameID[frameID]
+        }
+        return styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] ?? currentMainPageTargetID
+    }
+
+    private func targetIDForCSSStyleSheetID(paramsData: Data) -> ProtocolTargetIdentifier? {
+        guard let params = try? TransportMessageParser.decode(CSSStyleSheetIDParams.self, from: paramsData) else {
+            return nil
+        }
+        if unresolvedStyleSheetFrameIDsByStyleSheetID[params.styleSheetID] != nil {
+            return nil
+        }
+        return styleSheetTargetIDsByStyleSheetID[params.styleSheetID] ?? currentMainPageTargetID
+    }
+
+    private func updateCSSStyleSheetRegistry(
+        method: String,
+        targetID: ProtocolTargetIdentifier?,
+        paramsData: Data
+    ) {
+        switch method {
+        case "CSS.styleSheetAdded":
+            guard let params = try? TransportMessageParser.decode(CSSStyleSheetAddedParams.self, from: paramsData) else {
+                return
+            }
+            if let frameID = params.header.frameID {
+                if let resolvedTargetID = frameTargetIDsByFrameID[frameID] {
+                    styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] = resolvedTargetID
+                    unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
+                } else {
+                    styleSheetTargetIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
+                    unresolvedStyleSheetFrameIDsByStyleSheetID[params.header.styleSheetID] = frameID
+                }
+                return
+            }
+            if let resolvedTargetID = targetID {
+                styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] = resolvedTargetID
+                unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
+            }
+        case "CSS.styleSheetRemoved":
+            guard let params = try? TransportMessageParser.decode(CSSStyleSheetIDParams.self, from: paramsData) else {
+                return
+            }
+            styleSheetTargetIDsByStyleSheetID.removeValue(forKey: params.styleSheetID)
+            unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.styleSheetID)
+        default:
+            return
+        }
+    }
+
+    private func resolvePendingStyleSheets(frameID: DOMFrameIdentifier, targetID: ProtocolTargetIdentifier) {
+        let styleSheetIDs = unresolvedStyleSheetFrameIDsByStyleSheetID
+            .filter { $0.value == frameID }
+            .map(\.key)
+        for styleSheetID in styleSheetIDs {
+            styleSheetTargetIDsByStyleSheetID[styleSheetID] = targetID
+            unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: styleSheetID)
         }
     }
 
@@ -910,6 +1007,28 @@ private struct RuntimeExecutionContextCreatedParams: Decodable {
     }
 
     var context: Context
+}
+
+private struct CSSStyleSheetAddedParams: Decodable {
+    var header: CSSStyleSheetHeaderPayload
+}
+
+private struct CSSStyleSheetHeaderPayload: Decodable {
+    var styleSheetID: CSSStyleSheetIdentifier
+    var frameID: DOMFrameIdentifier?
+
+    private enum CodingKeys: String, CodingKey {
+        case styleSheetID = "styleSheetId"
+        case frameID = "frameId"
+    }
+}
+
+private struct CSSStyleSheetIDParams: Decodable {
+    var styleSheetID: CSSStyleSheetIdentifier
+
+    private enum CodingKeys: String, CodingKey {
+        case styleSheetID = "styleSheetId"
+    }
 }
 
 private extension ProtocolTargetRecord {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -760,7 +760,7 @@ package actor TransportSession {
         if unresolvedStyleSheetFrameIDsByStyleSheetID[params.styleSheetID] != nil {
             return nil
         }
-        return styleSheetTargetIDsByStyleSheetID[params.styleSheetID] ?? currentMainPageTargetID
+        return styleSheetTargetIDsByStyleSheetID[params.styleSheetID]
     }
 
     private func updateCSSStyleSheetRegistry(

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -2,9 +2,9 @@ import Testing
 @testable import WebInspectorCore
 
 @Test
-func protocolTargetCapabilitiesIncludeCSSForPageTargetsAndDomainParsing() {
-    #expect(ProtocolTargetCapabilities.pageDefault.contains(.css))
-    #expect(ProtocolTargetCapabilities.protocolDefault(for: .page).contains(.css))
+func protocolTargetCapabilitiesRequireExplicitCSSDomainParsing() {
+    #expect(ProtocolTargetCapabilities.pageDefault.contains(.css) == false)
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .page).contains(.css) == false)
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.css) == false)
     #expect(ProtocolTargetCapabilities(domainNames: ["DOM", "CSS"]).contains(.css))
 }

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -1,0 +1,470 @@
+import Testing
+@testable import WebInspectorCore
+
+@Test
+func protocolTargetCapabilitiesIncludeCSSForPageTargetsAndDomainParsing() {
+    #expect(ProtocolTargetCapabilities.pageDefault.contains(.css))
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .page).contains(.css))
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.css) == false)
+    #expect(ProtocolTargetCapabilities(domainNames: ["DOM", "CSS"]).contains(.css))
+}
+
+@Test
+func selectedCSSNodeStyleIdentityRequiresElementCurrentNodeAndCSSTarget() async throws {
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let session = await DOMSession()
+    await session.applyTargetCreated(
+        .init(id: pageTargetID, kind: .page, capabilities: [.dom, .css]),
+        makeCurrentMainPage: true
+    )
+    let rootID = await session.replaceDocumentRoot(
+        DOMNodePayload(
+            nodeID: .init(1),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                DOMNodePayload(nodeID: .init(2), nodeType: .element, nodeName: "BODY", localName: "body"),
+            ])
+        ),
+        targetID: pageTargetID
+    )
+    let snapshot = await session.snapshot()
+    let bodyID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
+
+    await session.selectNode(bodyID)
+    let identity = try #require(await session.selectedCSSNodeStyleIdentity().successValue)
+    #expect(identity.targetID == pageTargetID)
+    #expect(identity.protocolNodeID == .init(2))
+
+    await session.selectNode(rootID)
+    #expect(await session.selectedCSSNodeStyleIdentity().failureValue == .nonElementNode(.document))
+
+    await session.applyTargetCreated(.init(id: .init("plain"), kind: .page, capabilities: [.dom]))
+    let plainRootID = await session.replaceDocumentRoot(
+        DOMNodePayload(
+            nodeID: .init(1),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                DOMNodePayload(nodeID: .init(2), nodeType: .element, nodeName: "BODY", localName: "body"),
+            ])
+        ),
+        targetID: .init("plain")
+    )
+    let plainDocumentID = plainRootID.documentID
+    let plainBodyID = DOMNodeIdentifier(documentID: plainDocumentID, nodeID: .init(2))
+    await session.selectNode(plainBodyID)
+    #expect(await session.selectedCSSNodeStyleIdentity().failureValue == .cssUnavailableForTarget(.init("plain")))
+
+    let staleNodeID = DOMNodeIdentifier(documentID: plainDocumentID, nodeID: .init(999))
+    #expect(await session.cssNodeStyleIdentity(for: staleNodeID).failureValue == .staleNode(staleNodeID))
+}
+
+@Test
+func cssSessionBuildsOrderedSectionsAndPropertyRowState() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(await css.beginRefresh(identity: identity))
+
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(
+            matchedRules: [
+                CSSRuleMatch(
+                    rule: rule(
+                        selector: "body",
+                        properties: [
+                            CSSProperty(name: "margin", value: "0", text: "margin: 0;", status: .active),
+                            CSSProperty(name: "color", value: "red", text: "color: red;", status: .inactive),
+                            CSSProperty(name: "display", value: "block", text: "/* display: block; */", status: .disabled),
+                            CSSProperty(name: "box-sizing", value: "border-box", text: "box-sizing: border-box;"),
+                        ]
+                    ),
+                    matchingSelectors: [0]
+                ),
+            ]
+        ),
+        inline: CSSInlineStylesPayload(
+            inlineStyle: style(
+                id: CSSStyleIdentifier(styleSheetID: .init("inline"), ordinal: 0),
+                properties: [
+                    CSSProperty(name: "padding", value: "4px", text: "padding: 4px;"),
+                ]
+            ),
+            attributesStyle: style(properties: [
+                CSSProperty(name: "width", value: "100", text: "width: 100;"),
+            ])
+        ),
+        computed: [
+            CSSComputedStyleProperty(name: "display", value: "block"),
+        ]
+    )
+
+    let selected = try #require(await css.selectedNodeStyles)
+    #expect(await css.selectedState == .loaded)
+    #expect(await selected.sections.map(\.kind) == [.inlineStyle, .rule, .attributesStyle])
+    #expect(await selected.sections[0].title == "element.style")
+    #expect(await selected.sections[1].title == "body")
+    #expect(await selected.sections[2].isEditable == false)
+    #expect(await selected.computedProperties == [CSSComputedStyleProperty(name: "display", value: "block")])
+
+    let properties = await selected.sections[1].style.cssProperties
+    #expect(properties[0].isEnabled)
+    #expect(properties[0].isOverridden == false)
+    #expect(properties[1].isOverridden)
+    #expect(properties[2].isEnabled == false)
+    #expect(properties[3].isEnabled)
+    #expect(properties[0].isEditable)
+    #expect(properties[2].isEditable)
+}
+
+@Test
+func cssSessionRendersMatchedRulesInCascadeOrder() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(
+            matchedRules: [
+                CSSRuleMatch(
+                    rule: rule(selector: ".base", styleID: .init(styleSheetID: .init("base"), ordinal: 0), properties: [
+                        CSSProperty(name: "color", value: "black", text: "color: black;"),
+                    ]),
+                    matchingSelectors: [0]
+                ),
+                CSSRuleMatch(
+                    rule: rule(selector: ".specific", styleID: .init(styleSheetID: .init("specific"), ordinal: 1), properties: [
+                        CSSProperty(name: "color", value: "red", text: "color: red;"),
+                    ]),
+                    matchingSelectors: [0]
+                ),
+            ],
+            inherited: [
+                CSSInheritedStyleEntry(matchedRules: [
+                    CSSRuleMatch(
+                        rule: rule(selector: ".ancestor-base", styleID: .init(styleSheetID: .init("ancestor-base"), ordinal: 0), properties: [
+                            CSSProperty(name: "font", value: "inherit", text: "font: inherit;"),
+                        ]),
+                        matchingSelectors: [0]
+                    ),
+                    CSSRuleMatch(
+                        rule: rule(selector: ".ancestor-specific", styleID: .init(styleSheetID: .init("ancestor-specific"), ordinal: 1), properties: [
+                            CSSProperty(name: "font", value: "system", text: "font: system;"),
+                        ]),
+                        matchingSelectors: [0]
+                    ),
+                ]),
+            ]
+        ),
+        inline: .init(),
+        computed: []
+    )
+
+    let styles = try #require(await css.selectedNodeStyles)
+    #expect(await styles.sections.map(\.title) == [
+        ".specific",
+        ".base",
+        ".ancestor-specific",
+        ".ancestor-base",
+    ])
+}
+
+@Test
+func cssSessionBuildsSetStyleTextIntentByCommentingAndUncommentingPropertyText() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let styleID = CSSStyleIdentifier(styleSheetID: .init("inline"), ordinal: 0)
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: .init(),
+        inline: CSSInlineStylesPayload(
+            inlineStyle: style(
+                id: styleID,
+                properties: [
+                    CSSProperty(name: "margin", value: "0", text: "margin: 0;", status: .active),
+                    CSSProperty(name: "box-sizing", value: "border-box", text: "box-sizing: border-box;"),
+                ]
+            )
+        ),
+        computed: []
+    )
+
+    let disabledIntent = try #require(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: styleID, propertyIndex: 0),
+        enabled: false
+    ))
+    #expect(disabledIntent == .setStyleText(
+        targetID: identity.targetID,
+        styleID: styleID,
+        text: "/* margin: 0; */\nbox-sizing: border-box;"
+    ))
+
+    let disabledStyleID = CSSStyleIdentifier(styleSheetID: .init("rule"), ordinal: 0)
+    let disabledToken = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: disabledToken,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: disabledStyleID,
+                    properties: [
+                        CSSProperty(name: "margin", value: "0", text: "/* margin: 0; */", status: .disabled),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let enabledIntent = try #require(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: disabledStyleID, propertyIndex: 0),
+        enabled: true
+    ))
+    #expect(enabledIntent == .setStyleText(targetID: identity.targetID, styleID: disabledStyleID, text: "margin: 0;"))
+}
+
+@Test
+func cssSessionRejectsNonEditableToggleTargets() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let styleID = CSSStyleIdentifier(styleSheetID: .init("ua"), ordinal: 0)
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: styleID,
+                    origin: .userAgent,
+                    properties: [
+                        CSSProperty(name: "display", value: "block", text: "display: block;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: CSSInlineStylesPayload(attributesStyle: style(properties: [
+            CSSProperty(name: "width", value: "100", text: "width: 100;"),
+        ])),
+        computed: []
+    )
+
+    #expect(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: styleID, propertyIndex: 0),
+        enabled: false
+    ) == nil)
+}
+
+@Test
+func cssSessionDoesNotSynthesizeStyleTextWhenOtherPropertiesHaveNoAuthoredText() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let styleID = CSSStyleIdentifier(styleSheetID: .init("sheet"), ordinal: 0)
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: styleID,
+                    properties: [
+                        CSSProperty(name: "margin", value: "0", text: "margin: 0;"),
+                        CSSProperty(name: "margin-top", value: "0", implicit: true),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let styles = try #require(await css.selectedNodeStyles)
+    #expect(await styles.sections[0].style.cssProperties[0].isEditable == false)
+    #expect(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: styleID, propertyIndex: 0),
+        enabled: false
+    ) == nil)
+}
+
+@Test
+func cssSessionInFlightRefreshWinsOverInvalidation() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(await css.beginRefresh(identity: identity))
+
+    await css.markNeedsRefresh(targetID: identity.targetID)
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    properties: [
+                        CSSProperty(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    #expect(await css.selectedState == .loaded)
+    #expect(await css.selectedNodeStyles?.sections.map(\.title) == ["body"])
+}
+
+@Test
+func cssSessionRejectsEditIntentWhenSelectedStylesNeedRefresh() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let styleID = CSSStyleIdentifier(styleSheetID: .init("sheet"), ordinal: 0)
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: styleID,
+                    properties: [
+                        CSSProperty(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+    #expect(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: styleID, propertyIndex: 0),
+        enabled: false
+    ) != nil)
+
+    await css.markNeedsRefresh(targetID: identity.targetID)
+
+    #expect(await css.setStyleTextIntent(
+        for: CSSPropertyIdentifier(styleID: styleID, propertyIndex: 0),
+        enabled: false
+    ) == nil)
+}
+
+@Test
+func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() async throws {
+    let css = await CSSSession()
+    let sharedStyleID = CSSStyleIdentifier(styleSheetID: .init("sheet"), ordinal: 0)
+    let pageIdentity = cssIdentity(targetID: .init("page"), nodeRawID: 2)
+    let frameIdentity = cssIdentity(targetID: .init("frame"), nodeRawID: 2)
+
+    let pageToken = try #require(await css.beginRefresh(identity: pageIdentity))
+    await css.applyRefresh(
+        token: pageToken,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: sharedStyleID,
+                    properties: [
+                        CSSProperty(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let frameToken = try #require(await css.beginRefresh(identity: frameIdentity))
+    await css.applyRefresh(
+        token: frameToken,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatch(
+                rule: rule(
+                    selector: "body",
+                    styleID: sharedStyleID,
+                    properties: [
+                        CSSProperty(name: "margin", value: "10px", text: "margin: 10px;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    await css.applySetStyleTextResult(
+        CSSStyle(id: sharedStyleID, cssProperties: [
+            CSSProperty(name: "margin", value: "0", text: "/* margin: 0; */", status: .disabled),
+        ]),
+        styleID: sharedStyleID,
+        targetID: pageIdentity.targetID
+    )
+
+    let selectedFrameStyles = try #require(await css.selectedNodeStyles)
+    #expect(await css.selectedState == .loaded)
+    #expect(await selectedFrameStyles.identity.targetID == frameIdentity.targetID)
+    #expect(await selectedFrameStyles.sections[0].style.cssProperties[0].value == "10px")
+}
+
+private func cssIdentity(
+    targetID: ProtocolTargetIdentifier = ProtocolTargetIdentifier("page"),
+    nodeRawID: Int = 2
+) -> CSSNodeStyleIdentity {
+    let documentID = DOMDocumentIdentifier(targetID: targetID, localDocumentLifetimeID: .init(1))
+    return CSSNodeStyleIdentity(
+        nodeID: DOMNodeIdentifier(documentID: documentID, nodeID: .init(nodeRawID)),
+        targetID: targetID,
+        documentID: documentID,
+        protocolNodeID: .init(nodeRawID),
+        targetCapabilities: [.css, .dom]
+    )
+}
+
+private func rule(
+    selector: String,
+    styleID: CSSStyleIdentifier = CSSStyleIdentifier(styleSheetID: .init("sheet"), ordinal: 0),
+    origin: CSSStyleOrigin = .author,
+    properties: [CSSProperty]
+) -> CSSRule {
+    CSSRule(
+        id: CSSRuleIdentifier(styleSheetID: styleID.styleSheetID, ordinal: styleID.ordinal),
+        selectorList: CSSSelectorList(selectors: [CSSSelector(text: selector)], text: selector),
+        sourceLine: 1,
+        origin: origin,
+        style: style(id: styleID, properties: properties)
+    )
+}
+
+private func style(
+    id: CSSStyleIdentifier? = nil,
+    properties: [CSSProperty]
+) -> CSSStyle {
+    CSSStyle(id: id, cssProperties: properties)
+}
+
+private extension Result {
+    var successValue: Success? {
+        if case let .success(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var failureValue: Failure? {
+        if case let .failure(value) = self {
+            return value
+        }
+        return nil
+    }
+}

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -258,8 +258,12 @@ func resetDoesNotReuseDocumentLifetimeForSameTargetID() async throws {
     )
     _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
     let firstDocumentID = try #require(await session.snapshot().targetsByID[pageTargetID]?.currentDocumentID)
+    let revisionBeforeReset = await session.treeRevision
+    let selectionRevisionBeforeReset = await session.selectionRevision
 
     await session.reset()
+    #expect(await session.treeRevision > revisionBeforeReset)
+    #expect(await session.selectionRevision > selectionRevisionBeforeReset)
     await session.applyTargetCreated(
         .init(id: pageTargetID, kind: .page, frameID: mainFrameID),
         makeCurrentMainPage: true

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -274,6 +274,9 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
     try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
     let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
     await session.dom.selectNode(bodyID)
+    await transport.receiveRootMessage(
+        #"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-body"}}}"#
+    )
 
     let sentCount = await backend.sentTargetMessages().count
     let refreshTask = Task {
@@ -422,6 +425,43 @@ func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
         await session.dom.selectedNodeID == nil ? true : nil
     }
 
+    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
+}
+
+@Test
+func localDOMDeleteClearsSelectedCSSNodeStylesWithoutBackendMutationEvent() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
+    await refreshTask.value
+    #expect(await session.css.selectedState == .loaded)
+
+    let countBeforeDelete = await backend.sentTargetMessages().count
+    let deleteTask = Task {
+        try await session.deleteDOMNode(bodyID, undoManager: nil)
+    }
+    let removeNode = try await waitForTargetMessage(backend, method: "DOM.removeNode", after: countBeforeDelete)
+    await receiveTargetReply(
+        transport,
+        targetID: removeNode.targetIdentifier,
+        messageID: try messageID(removeNode.message),
+        result: "{}"
+    )
+    try await deleteTask.value
+
+    #expect(await session.dom.selectedNodeID == nil)
     #expect(await session.css.selectedNodeStyles == nil)
     #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
 }
@@ -620,7 +660,7 @@ func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async thr
     let session = await InspectorSession(configuration: .test)
 
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
     )
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime"],"isProvisional":false}}}"#
@@ -1577,7 +1617,7 @@ func targetCommitBootstrapsCommittedMainPageTarget() async throws {
 
     let sentCountBeforeCommit = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-next", isProvisional: true)
     )
     await transport.receiveRootMessage(
         #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
@@ -1614,7 +1654,7 @@ func linkNavigationBuffersProvisionalDOMEventsUntilCommit() async throws {
 
     let sentCountBeforeNavigation = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-next", isProvisional: true)
     )
     await receiveTargetDispatch(
         transport,
@@ -1985,7 +2025,7 @@ func targetCommitClearsElementPickerForOldTarget() async throws {
 
     let sentCountBeforeNavigation = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-next", isProvisional: true)
     )
     await transport.receiveRootMessage(
         #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
@@ -2013,7 +2053,7 @@ func elementPickerUsesBootstrappedTargetAfterTargetCommit() async throws {
 
     let sentCountBeforeNavigation = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","isProvisional":true}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-next", isProvisional: true)
     )
     await transport.receiveRootMessage(
         #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
@@ -3444,7 +3484,7 @@ func detachDuringConnectKeepsSessionDetached() async throws {
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
     )
 
     let connectTask = Task {
@@ -3492,7 +3532,7 @@ func performIsRejectedUntilBootstrapAttaches() async throws {
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
     )
 
     let connectTask = Task {
@@ -3533,7 +3573,7 @@ private func connect(
     backend: FakeTransportBackend
 ) async throws {
     await transport.receiveRootMessage(
-        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
     )
     let connectTask = Task {
         try await session.connect(transport: transport)
@@ -3553,6 +3593,15 @@ private func connect(
 
 private func testTransport(_ backend: FakeTransportBackend) -> TransportSession {
     TransportSession(backend: backend, responseTimeout: nil)
+}
+
+private func cssCapablePageTargetCreatedMessage(
+    targetID: String,
+    frameID: String? = nil,
+    isProvisional: Bool
+) -> String {
+    let framePair = frameID.map { #","frameId":"\#($0)""# } ?? ""
+    return #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"\#(targetID)","type":"page"\#(framePair),"domains":["DOM","Runtime","Target","Inspector","Network","CSS"],"isProvisional":\#(isProvisional)}}}"#
 }
 
 @discardableResult

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -17,6 +17,7 @@ func connectBootstrapsMainPageDocumentInOrder() async throws {
     #expect(methods == [
         "Inspector.enable",
         "Inspector.initialized",
+        "CSS.enable",
         "Runtime.enable",
         "DOM.getDocument",
         "Network.enable",
@@ -126,6 +127,306 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
 }
 
 @Test
+func selectedElementStyleRefreshLoadsCSSSession() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: messages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+    await refreshTask.value
+
+    let styles = try #require(await session.css.selectedNodeStyles)
+    #expect(await session.css.selectedState == .loaded)
+    #expect(await styles.identity.nodeID == bodyID)
+    #expect(await styles.sections.map(\.title) == ["element.style", "body"])
+    #expect(await styles.sections[1].style.cssProperties.first?.name == "margin")
+    #expect(await styles.computedProperties == [CSSComputedStyleProperty(name: "display", value: "block")])
+}
+
+@Test
+func selectedElementStyleRefreshDropsResultsWhenSelectionChanges() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let firstSentCount = await backend.sentTargetMessages().count
+    let firstRefresh = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let firstMessages = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
+
+    await session.dom.selectNode(htmlID)
+    let secondSentCount = await backend.sentTargetMessages().count
+    let secondRefresh = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: firstMessages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: secondMessages,
+        selector: "html",
+        styleSheetID: "sheet-html"
+    )
+    await firstRefresh.value
+    await secondRefresh.value
+
+    let styles = try #require(await session.css.selectedNodeStyles)
+    #expect(await styles.identity.nodeID == htmlID)
+    #expect(await styles.sections.map(\.title) == ["element.style", "html"])
+}
+
+@Test
+func cssPropertyToggleSendsSetStyleTextAndRefreshesStyles() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let refreshCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let initialRefreshMessages = try await waitForCSSRefreshMessages(backend, after: refreshCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: initialRefreshMessages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+    await refreshTask.value
+
+    let propertyID = CSSPropertyIdentifier(
+        styleID: CSSStyleIdentifier(styleSheetID: .init("sheet-body"), ordinal: 1),
+        propertyIndex: 0
+    )
+    let toggleSentCount = await backend.sentTargetMessages().count
+    let toggleTask = Task {
+        try await session.setCSSProperty(propertyID, enabled: false)
+    }
+    let setStyleText = try await waitForTargetMessage(backend, method: "CSS.setStyleText", after: toggleSentCount)
+    #expect(setStyleText.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(try messageParameters(setStyleText.message)["text"] as? String == "/* margin: 0; */")
+    let refreshAfterToggleCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: setStyleText.targetIdentifier,
+        messageID: try messageID(setStyleText.message),
+        result: #"{"style":{"styleId":{"styleSheetId":"sheet-body","ordinal":1},"cssProperties":[{"name":"margin","value":"0","text":"/* margin: 0; */","status":"disabled"}]}}"#
+    )
+
+    let refreshMessages = try await waitForCSSRefreshMessages(
+        backend,
+        after: refreshAfterToggleCount
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-body"}}"#
+    )
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: refreshMessages,
+        selector: "body",
+        styleSheetID: "sheet-body",
+        marginStatus: "disabled",
+        marginText: "/* margin: 0; */"
+    )
+    try await toggleTask.value
+
+    let styles = try #require(await session.css.selectedNodeStyles)
+    #expect(await session.css.selectedState == .loaded)
+    #expect(await styles.sections[1].style.cssProperties[0].isEnabled == false)
+}
+
+@Test
+func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
+    await refreshTask.value
+    #expect(await session.css.selectedState == .loaded)
+
+    await transport.receiveRootMessage(
+        #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-body"}}"#
+    )
+    _ = try await waitUntil {
+        await session.css.selectedState == .needsRefresh ? true : nil
+    }
+
+    let refreshAgainCount = await backend.sentTargetMessages().count
+    let refreshAgain = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messagesAgain = try await waitForCSSRefreshMessages(backend, after: refreshAgainCount)
+    try await replyCSSRefresh(transport: transport, messages: messagesAgain, selector: "body", styleSheetID: "sheet-body")
+    await refreshAgain.value
+    #expect(await session.css.selectedState == .loaded)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.attributeModified","params":{"nodeId":4,"name":"class","value":"featured"}}"#
+    )
+    _ = try await waitUntil {
+        await session.css.selectedState == .needsRefresh ? true : nil
+    }
+
+    let refreshAfterAttributeCount = await backend.sentTargetMessages().count
+    let refreshAfterAttribute = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messagesAfterAttribute = try await waitForCSSRefreshMessages(backend, after: refreshAfterAttributeCount)
+    try await replyCSSRefresh(transport: transport, messages: messagesAfterAttribute, selector: "body", styleSheetID: "sheet-body")
+    await refreshAfterAttribute.value
+    #expect(await session.css.selectedState == .loaded)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"ASIDE","localName":"aside"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.css.selectedState == .needsRefresh ? true : nil
+    }
+}
+
+@Test
+func documentUpdatedClearsSelectedCSSNodeStylesForInvalidatedDocument() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
+    await refreshTask.value
+    #expect(await session.css.selectedNodeStyles != nil)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    _ = try await waitUntil {
+        await session.css.selectedNodeStyles == nil ? true : nil
+    }
+    #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
+}
+
+@Test
+func explicitDOMReloadClearsSelectedCSSNodeStylesForReplacedDocument() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
+    await refreshTask.value
+    #expect(await session.css.selectedNodeStyles != nil)
+
+    let reloadSentCount = await backend.sentTargetMessages().count
+    let reloadTask = Task {
+        try await session.reloadDOMDocument()
+    }
+    let reload = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: reloadSentCount)
+    await receiveTargetReply(
+        transport,
+        targetID: reload.targetIdentifier,
+        messageID: try messageID(reload.message),
+        result: manualReloadDocumentResult
+    )
+    try await reloadTask.value
+
+    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
+}
+
+@Test
+func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    await session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let refreshTask = Task {
+        await session.refreshStylesForSelectedNode()
+    }
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
+    await refreshTask.value
+    #expect(await session.css.selectedState == .loaded)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.childNodeRemoved","params":{"nodeId":4}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.selectedNodeID == nil ? true : nil
+    }
+
+    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
+}
+
+@Test
 func frameDocumentRefreshUpdatesOnlyFrameDocument() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -222,6 +523,94 @@ func frameTargetWithAdvertisedDOMCapabilityHydratesOnCreation() async throws {
     )
 
     #expect(await session.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID != nil)
+}
+
+@Test
+func frameTargetWithAdvertisedCSSCapabilityIsEnabledOnCreation() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let frameTargetID = ProtocolTargetIdentifier("frame-css")
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-css","type":"frame","frameId":"css-frame","parentFrameId":"main-frame","domains":["DOM","CSS"],"isProvisional":false}}}"#
+    )
+
+    let cssEnable = try await waitForTargetMessage(backend, method: "CSS.enable", after: sentCount)
+    #expect(cssEnable.targetIdentifier == frameTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: cssEnable.targetIdentifier,
+        messageID: try messageID(cssEnable.message),
+        result: "{}"
+    )
+
+    let documentRequest = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
+    #expect(documentRequest.targetIdentifier == frameTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: documentRequest.targetIdentifier,
+        messageID: try messageID(documentRequest.message),
+        result: firstLazyFrameDocumentResult
+    )
+}
+
+@Test
+func frameTargetCSSCapabilityEnableIgnoresDestroyedTargetRace() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let frameTargetID = ProtocolTargetIdentifier("frame-css-race")
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-css-race","type":"frame","frameId":"css-frame-race","parentFrameId":"main-frame","domains":["CSS"],"isProvisional":false}}}"#
+    )
+
+    let cssEnable = try await waitForTargetMessage(backend, method: "CSS.enable", after: sentCount)
+    #expect(cssEnable.targetIdentifier == frameTargetID)
+    let pendingKey = TargetReplyKey(
+        targetID: frameTargetID,
+        commandID: try messageID(cssEnable.message)
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetDestroyed","params":{"targetId":"frame-css-race"}}"#
+    )
+    _ = try await waitUntil {
+        await pendingTargetReplyKeys(transport).contains(pendingKey) == false ? true : nil
+    }
+
+    #expect(await session.lastError == nil)
+}
+
+@Test
+func frameTargetCSSCapabilityEnableIgnoresStaleConnectionAfterDetach() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let frameTargetID = ProtocolTargetIdentifier("frame-css-stale")
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-css-stale","type":"frame","frameId":"css-frame-stale","parentFrameId":"main-frame","domains":["CSS"],"isProvisional":false}}}"#
+    )
+
+    let cssEnable = try await waitForTargetMessage(backend, method: "CSS.enable", after: sentCount)
+    let pendingKey = TargetReplyKey(
+        targetID: frameTargetID,
+        commandID: try messageID(cssEnable.message)
+    )
+    await session.detach()
+    _ = try await waitUntil {
+        await pendingTargetReplyKeys(transport).contains(pendingKey) == false ? true : nil
+    }
+    try await Task.sleep(for: .milliseconds(5))
+
+    #expect(await session.lastError == nil)
 }
 
 @Test
@@ -1209,6 +1598,7 @@ func targetCommitBootstrapsCommittedMainPageTarget() async throws {
     #expect(bootstrapMessages.compactMap { try? messageMethod($0.message) } == [
         "Inspector.enable",
         "Inspector.initialized",
+        "CSS.enable",
         "Runtime.enable",
         "DOM.getDocument",
         "Network.enable",
@@ -3174,7 +3564,7 @@ private func completeBootstrap(
 ) async throws -> [SentTargetMessage] {
     var sentCount = initialSentCount
     var sentMessages: [SentTargetMessage] = []
-    for method in ["Inspector.enable", "Inspector.initialized", "Runtime.enable"] {
+    for method in ["Inspector.enable", "Inspector.initialized", "CSS.enable", "Runtime.enable"] {
         let sent = try await waitForTargetMessage(backend, method: method, after: sentCount)
         sentMessages.append(sent)
         sentCount = await backend.sentTargetMessages().count
@@ -3302,6 +3692,66 @@ private func waitForTargetMessage(
     }
 }
 
+private struct CSSRefreshMessages {
+    var matched: SentTargetMessage
+    var inline: SentTargetMessage
+    var computed: SentTargetMessage
+}
+
+private func waitForCSSRefreshMessages(
+    _ backend: FakeTransportBackend,
+    after count: Int
+) async throws -> CSSRefreshMessages {
+    async let matched = waitForTargetMessage(backend, method: "CSS.getMatchedStylesForNode", after: count)
+    async let inline = waitForTargetMessage(backend, method: "CSS.getInlineStylesForNode", after: count)
+    async let computed = waitForTargetMessage(backend, method: "CSS.getComputedStyleForNode", after: count)
+    return try await CSSRefreshMessages(matched: matched, inline: inline, computed: computed)
+}
+
+private func replyCSSRefresh(
+    transport: TransportSession,
+    messages: CSSRefreshMessages,
+    selector: String,
+    styleSheetID: String,
+    marginStatus: String = "active",
+    marginText: String = "margin: 0;"
+) async throws {
+    await receiveTargetReply(
+        transport,
+        targetID: messages.matched.targetIdentifier,
+        messageID: try messageID(messages.matched.message),
+        result: cssMatchedStylesResult(
+            selector: selector,
+            styleSheetID: styleSheetID,
+            marginStatus: marginStatus,
+            marginText: marginText
+        )
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: messages.inline.targetIdentifier,
+        messageID: try messageID(messages.inline.message),
+        result: #"{"inlineStyle":{"styleId":{"styleSheetId":"inline","ordinal":0},"cssProperties":[{"name":"box-sizing","value":"border-box","text":"box-sizing: border-box;","status":"active"}]}}"#
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: messages.computed.targetIdentifier,
+        messageID: try messageID(messages.computed.message),
+        result: #"{"computedStyle":[{"name":"display","value":"block"}]}"#
+    )
+}
+
+private func cssMatchedStylesResult(
+    selector: String,
+    styleSheetID: String,
+    marginStatus: String,
+    marginText: String
+) -> String {
+    """
+    {"matchedCSSRules":[{"rule":{"ruleId":{"styleSheetId":"\(styleSheetID)","ordinal":1},"selectorList":{"selectors":[{"text":"\(selector)"}],"text":"\(selector)"},"origin":"author","style":{"styleId":{"styleSheetId":"\(styleSheetID)","ordinal":1},"cssProperties":[{"name":"margin","value":"0","text":"\(jsonEscapedString(marginText))","status":"\(marginStatus)"}]}},"matchingSelectors":[0]}]}
+    """
+}
+
 private func waitUntil<Value: Sendable>(
     timeout: Duration = .seconds(1),
     timeoutError: any Error = TransportError.replyTimeout(method: "test wait", targetID: nil),
@@ -3419,6 +3869,12 @@ private func messageMethod(_ message: String) throws -> String? {
     let data = try #require(message.data(using: .utf8))
     let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     return object["method"] as? String
+}
+
+private func messageParameters(_ message: String) throws -> [String: Any] {
+    let data = try #require(message.data(using: .utf8))
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    return try #require(object["params"] as? [String: Any])
 }
 
 private func boolParameter(_ name: String, in message: String) throws -> Bool? {

--- a/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import WebInspectorCore
+@testable import WebInspectorTransport
+
+@Test
+func cssTransportAdapterBuildsReadCommands() throws {
+    let identity = cssIdentity()
+
+    let matched = try CSSTransportAdapter.command(for: .getMatchedStyles(identity: identity))
+    #expect(matched.method == "CSS.getMatchedStylesForNode")
+    #expect(matched.routing == .target(identity.targetID))
+    let matchedParams = try JSONObject(matched.parametersData)
+    #expect(matchedParams["nodeId"] as? Int == 2)
+    #expect(matchedParams["includePseudo"] as? Bool == true)
+    #expect(matchedParams["includeInherited"] as? Bool == true)
+
+    let inline = try CSSTransportAdapter.command(for: .getInlineStyles(identity: identity))
+    #expect(inline.method == "CSS.getInlineStylesForNode")
+    #expect(try JSONObject(inline.parametersData)["nodeId"] as? Int == 2)
+
+    let computed = try CSSTransportAdapter.command(for: .getComputedStyle(identity: identity))
+    #expect(computed.method == "CSS.getComputedStyleForNode")
+    #expect(try JSONObject(computed.parametersData)["nodeId"] as? Int == 2)
+}
+
+@Test
+func cssTransportAdapterBuildsSetStyleTextCommand() throws {
+    let styleID = CSSStyleIdentifier(styleSheetID: .init("sheet-1"), ordinal: 7)
+    let command = try CSSTransportAdapter.command(for: .setStyleText(
+        targetID: .init("page"),
+        styleID: styleID,
+        text: "/* margin: 0; */"
+    ))
+
+    #expect(command.method == "CSS.setStyleText")
+    #expect(command.routing == .target(.init("page")))
+    let params = try JSONObject(command.parametersData)
+    let encodedStyleID = try #require(params["styleId"] as? [String: Any])
+    #expect(encodedStyleID["styleSheetId"] as? String == "sheet-1")
+    #expect(encodedStyleID["ordinal"] as? Int == 7)
+    #expect(params["text"] as? String == "/* margin: 0; */")
+}
+
+@Test
+func cssTransportAdapterDecodesReadAndSetStyleTextResults() throws {
+    let matched = try CSSTransportAdapter.matchedStyles(from: ProtocolCommandResult(
+        domain: .css,
+        method: "CSS.getMatchedStylesForNode",
+        targetID: .init("page"),
+        resultData: Data("""
+        {
+          "matchedCSSRules": [
+            {
+              "rule": {
+                "ruleId": {"styleSheetId": "sheet", "ordinal": 1},
+                "selectorList": {"selectors": [{"text": "body"}], "text": "body"},
+                "origin": "author",
+                "style": {
+                  "styleId": {"styleSheetId": "sheet", "ordinal": 1},
+                  "cssProperties": [{"name": "margin", "value": "0", "text": "margin: 0;"}]
+                }
+              },
+              "matchingSelectors": [0]
+            }
+          ]
+        }
+        """.utf8)
+    ))
+    #expect(matched.matchedRules.first?.rule.selectorList.text == "body")
+    #expect(matched.matchedRules.first?.rule.style.cssProperties.first?.status == .style)
+
+    let inline = try CSSTransportAdapter.inlineStyles(from: ProtocolCommandResult(
+        domain: .css,
+        method: "CSS.getInlineStylesForNode",
+        targetID: .init("page"),
+        resultData: Data("""
+        {
+          "inlineStyle": {
+            "styleId": {"styleSheetId": "inline", "ordinal": 0},
+            "cssProperties": [{"name": "padding", "value": "4px", "text": "padding: 4px;"}]
+          }
+        }
+        """.utf8)
+    ))
+    #expect(inline.inlineStyle?.cssProperties.first?.name == "padding")
+
+    let computed = try CSSTransportAdapter.computedStyles(from: ProtocolCommandResult(
+        domain: .css,
+        method: "CSS.getComputedStyleForNode",
+        targetID: .init("page"),
+        resultData: Data(#"{"computedStyle":[{"name":"display","value":"block"}]}"#.utf8)
+    ))
+    #expect(computed == [CSSComputedStyleProperty(name: "display", value: "block")])
+
+    let setStyle = try CSSTransportAdapter.setStyleTextResult(from: ProtocolCommandResult(
+        domain: .css,
+        method: "CSS.setStyleText",
+        targetID: .init("page"),
+        resultData: Data("""
+        {
+          "style": {
+            "styleId": {"styleSheetId": "inline", "ordinal": 0},
+            "cssProperties": [{"name": "margin", "value": "0", "text": "/* margin: 0; */", "status": "disabled"}]
+          }
+        }
+        """.utf8)
+    ))
+    #expect(setStyle.cssProperties.first?.status == .disabled)
+}
+
+@Test
+func cssTransportAdapterAppliesTargetScopedInvalidationEvents() async throws {
+    let css = await CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(await css.beginRefresh(identity: identity))
+    await css.applyRefresh(
+        token: token,
+        matched: .init(),
+        inline: CSSInlineStylesPayload(inlineStyle: CSSStyle(
+            id: CSSStyleIdentifier(styleSheetID: .init("inline"), ordinal: 0),
+            cssProperties: [
+                CSSProperty(name: "margin", value: "0", text: "margin: 0;"),
+            ]
+        )),
+        computed: []
+    )
+
+    try await CSSTransportAdapter.applyCSSEvent(
+        ProtocolEventEnvelope(
+            sequence: 1,
+            domain: .css,
+            method: "CSS.styleSheetChanged",
+            targetID: identity.targetID,
+            paramsData: Data(#"{"styleSheetId":"sheet"}"#.utf8)
+        ),
+        to: css
+    )
+    #expect(await css.selectedState == .needsRefresh)
+}
+
+private func cssIdentity() -> CSSNodeStyleIdentity {
+    let targetID = ProtocolTargetIdentifier("page")
+    let documentID = DOMDocumentIdentifier(targetID: targetID, localDocumentLifetimeID: .init(1))
+    return CSSNodeStyleIdentity(
+        nodeID: DOMNodeIdentifier(documentID: documentID, nodeID: .init(2)),
+        targetID: targetID,
+        documentID: documentID,
+        protocolNodeID: .init(2),
+        targetCapabilities: [.css, .dom]
+    )
+}
+
+private func JSONObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -669,20 +669,22 @@ func rootCSSStyleSheetEventsResolveFrameTargetFromFrameIDAndStyleSheetOwnership(
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let cssStream = await session.events(for: .css)
-    let eventsTask = firstEvents(3, from: cssStream)
+    let eventsTask = firstEvents(4, from: cssStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","parentFrameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-frame","frameId":"frame-A"}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-frame"}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetRemoved","params":{"styleSheetId":"sheet-frame"}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-frame"}}"#)
 
     let events = await eventsTask.value
-    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged", "CSS.styleSheetRemoved"])
+    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged", "CSS.styleSheetRemoved", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         ProtocolTargetIdentifier("frame-A"),
         ProtocolTargetIdentifier("frame-A"),
         ProtocolTargetIdentifier("frame-A"),
+        nil,
     ])
 }
 

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -665,6 +665,48 @@ func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
 }
 
 @Test
+func rootCSSStyleSheetEventsResolveFrameTargetFromFrameIDAndStyleSheetOwnership() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+    let cssStream = await session.events(for: .css)
+    let eventsTask = firstEvents(3, from: cssStream)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","parentFrameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-frame","frameId":"frame-A"}}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-frame"}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetRemoved","params":{"styleSheetId":"sheet-frame"}}"#)
+
+    let events = await eventsTask.value
+    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged", "CSS.styleSheetRemoved"])
+    #expect(events.map(\.targetID) == [
+        ProtocolTargetIdentifier("frame-A"),
+        ProtocolTargetIdentifier("frame-A"),
+        ProtocolTargetIdentifier("frame-A"),
+    ])
+}
+
+@Test
+func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+    let cssStream = await session.events(for: .css)
+    let eventsTask = firstEvents(2, from: cssStream)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-late-frame","frameId":"late-frame"}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-late","type":"frame","frameId":"late-frame","parentFrameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-late-frame"}}"#)
+
+    let events = await eventsTask.value
+    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged"])
+    #expect(events.map(\.targetID) == [
+        nil,
+        ProtocolTargetIdentifier("frame-late"),
+    ])
+}
+
+@Test
 func orderedStreamReceivesTargetEventsAcrossDomainsInTransportOrder() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)


### PR DESCRIPTION
## Summary
- Add a CSS core model for selected element styles, style sections, properties, computed styles, unavailable/loading/refresh states, and safe property toggle intents.
- Add CSS transport commands, decoders, event invalidation, and frame-aware stylesheet event routing.
- Wire CSS into `InspectorSession` bootstrap, selected-node style refresh, property toggles, DOM/CSS invalidation, detach/reload cleanup, and frame target lifecycle handling.
- Add Core, Transport, and Runtime tests for CSS payload mapping, toggle behavior, refresh races, DOM invalidation, and target-scoped routing.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` clean before commit