### PR TITLE
test(native): speed up native CI fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,22 +174,18 @@ jobs:
       - name: Run package tests
         if: env.SKIP_TESTS != '1'
         run: |
-          test_arguments=()
+          test_scheme="WebInspectorKit"
           if [[ "${TEST_SCOPE}" == "native" ]]; then
-            test_arguments+=(
-              "-only-testing:WebInspectorNativeBridgeTests"
-              "-only-testing:WebInspectorNativeSymbolsTests"
-            )
+            test_scheme="WebInspectorNativeTests"
           fi
 
           xcodebuild test \
             -workspace WebInspectorKit.xcworkspace \
-            -scheme WebInspectorKit \
+            -scheme "${test_scheme}" \
             -destination "${DESTINATION}" \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            -maximum-concurrent-test-simulator-destinations 1 \
-            "${test_arguments[@]}"
+            -maximum-concurrent-test-simulator-destinations 1
 
       - name: Report optional skip
         if: env.SKIP_TESTS == '1'

--- a/Package.swift
+++ b/Package.swift
@@ -142,10 +142,16 @@ let package = Package(
             path: "Tests/WebInspectorTransportTests",
             swiftSettings: strictSwiftSettings
         ),
+        .target(
+            name: "WebInspectorNativeSymbolFixtures",
+            path: "Tests/WebInspectorNativeSymbolFixtures",
+            publicHeadersPath: "include"
+        ),
         .testTarget(
             name: "WebInspectorNativeSymbolsTests",
             dependencies: [
-                "WebInspectorNativeSymbols"
+                "WebInspectorNativeSymbols",
+                "WebInspectorNativeSymbolFixtures"
             ],
             path: "Tests/WebInspectorNativeSymbolsTests",
             swiftSettings: strictSwiftSettings

--- a/Sources/WebInspectorNativeSymbols/MachOKitSymbolLookup.swift
+++ b/Sources/WebInspectorNativeSymbols/MachOKitSymbolLookup.swift
@@ -17,12 +17,24 @@ import MachOKit
     }
 
     static func loadedImage(matching pathSuffixes: [String]) -> MachOImage? {
-        MachOImage.images.first { image in
-            guard let path = image.path else {
-                return false
+        let imageCount = _dyld_image_count()
+        for index in 0..<imageCount {
+            guard let header = unsafe _dyld_get_image_header(index) else {
+                continue
             }
-            return pathSuffixes.contains { path.hasSuffix($0) }
+            let image = unsafe MachOImage(ptr: header)
+            let dyldImagePath: String?
+            if let dyldImageName = unsafe _dyld_get_image_name(index) {
+                dyldImagePath = unsafe String(cString: dyldImageName)
+            } else {
+                dyldImagePath = nil
+            }
+            let paths = [image.path, dyldImagePath].compactMap { $0 }
+            if paths.contains(where: { path in pathSuffixes.contains { path.hasSuffix($0) } }) {
+                return image
+            }
         }
+        return nil
     }
 
     static func image(containingAddress address: UInt64) -> MachOImage? {

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheResolution.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheResolution.swift
@@ -9,6 +9,7 @@ extension NativeInspectorSymbolResolverCore {
         imagePathSuffixes: [String],
         loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
         javaScriptCorePathSuffixes: [String],
+        webCorePathSuffixes: [String] = webCoreImagePathSuffixes,
         loadedImageSymbols: NativeInspectorResolvedSymbolSet,
         symbols: NativeInspectorSymbols
     ) -> NativeInspectorSymbolLookupResult {
@@ -22,7 +23,7 @@ extension NativeInspectorSymbolResolverCore {
         guard let javaScriptCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: javaScriptCorePathSuffixes) }) else {
             return failure(.supportImageMissing)
         }
-        let webCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: webCoreImagePathSuffixes) })
+        let webCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: webCorePathSuffixes) })
         guard webKitImage.is64Bit, let text = textSegment(in: webKitImage) else {
             return failure(.inspectorImageMissing)
         }

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolutionFlow.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolutionFlow.swift
@@ -7,6 +7,8 @@ extension NativeInspectorSymbolResolverCore {
     static func resolve(
         imagePathSuffixes: [String],
         javaScriptCorePathSuffixes: [String],
+        webCorePathSuffixes: [String] = webCoreImagePathSuffixes,
+        allowSharedCacheFallback: Bool = true,
         symbols: NativeInspectorSymbols
     ) -> NativeInspectorSymbolLookupResult {
         guard let loadedImage = loadedWebKitImage(pathSuffixes: imagePathSuffixes) else {
@@ -15,7 +17,7 @@ extension NativeInspectorSymbolResolverCore {
         guard let loadedJavaScriptCoreImage = loadedWebKitImage(pathSuffixes: javaScriptCorePathSuffixes) else {
             return failure(.supportImageMissing)
         }
-        let loadedWebCoreImage = loadedWebKitImage(pathSuffixes: webCoreImagePathSuffixes)
+        let loadedWebCoreImage = loadedWebKitImage(pathSuffixes: webCorePathSuffixes)
 
         let image = unsafe MachOImage(ptr: loadedImage.header)
         guard image.is64Bit, let text = textSegment(in: image) else {
@@ -72,6 +74,10 @@ extension NativeInspectorSymbolResolverCore {
             return loadedImageResolution
         }
 
+        guard allowSharedCacheFallback else {
+            return loadedImageResolution
+        }
+
         #if DEBUG
         logResolutionAttemptIncomplete(
             loadedImageResolution,
@@ -84,6 +90,7 @@ extension NativeInspectorSymbolResolverCore {
             imagePathSuffixes: imagePathSuffixes,
             loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
             javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            webCorePathSuffixes: webCorePathSuffixes,
             loadedImageSymbols: loadedImageResultsWithFallback.symbols,
             symbols: symbols
         )

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolver.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolver.swift
@@ -8,6 +8,9 @@ package enum NativeInspectorSymbolResolver {
 
     static func resolveForTesting(
         imagePathSuffixes: [String] = NativeInspectorSymbolResolverCore.webKitImagePathSuffixes,
+        javaScriptCorePathSuffixes: [String] = NativeInspectorSymbolResolverCore.javaScriptCoreImagePathSuffixes,
+        webCorePathSuffixes: [String] = NativeInspectorSymbolResolverCore.webCoreImagePathSuffixes,
+        allowSharedCacheFallback: Bool = true,
         connectSymbol: ObfuscatedSymbolName = NativeInspectorSymbolResolverCore.connectFrontendSymbol,
         disconnectSymbol: ObfuscatedSymbolName = NativeInspectorSymbolResolverCore.disconnectFrontendSymbol,
         alternateConnectSymbols: [ObfuscatedSymbolName] = [],
@@ -20,6 +23,9 @@ package enum NativeInspectorSymbolResolver {
         makeAttachResolution(
             from: NativeInspectorSymbolResolverCore.resolveForTesting(
                 imagePathSuffixes: imagePathSuffixes,
+                javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+                webCorePathSuffixes: webCorePathSuffixes,
+                allowSharedCacheFallback: allowSharedCacheFallback,
                 connectSymbol: connectSymbol,
                 disconnectSymbol: disconnectSymbol,
                 alternateConnectSymbols: alternateConnectSymbols,
@@ -131,6 +137,9 @@ package enum NativeInspectorSymbolResolver {
 
     static func resolveForTesting(
         imagePathSuffixes: [String] = [],
+        javaScriptCorePathSuffixes: [String] = [],
+        webCorePathSuffixes: [String] = [],
+        allowSharedCacheFallback: Bool = true,
         connectSymbol: String = "",
         disconnectSymbol: String = "",
         alternateConnectSymbols: [String] = [],

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolverCore.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolverCore.swift
@@ -78,6 +78,9 @@ enum NativeInspectorSymbolResolverCore {
     
     static func resolveForTesting(
         imagePathSuffixes: [String] = webKitImagePathSuffixes,
+        javaScriptCorePathSuffixes: [String] = javaScriptCoreImagePathSuffixes,
+        webCorePathSuffixes: [String] = webCoreImagePathSuffixes,
+        allowSharedCacheFallback: Bool = true,
         connectSymbol: ObfuscatedSymbolName = connectFrontendSymbol,
         disconnectSymbol: ObfuscatedSymbolName = disconnectFrontendSymbol,
         alternateConnectSymbols: [ObfuscatedSymbolName] = [],
@@ -89,7 +92,9 @@ enum NativeInspectorSymbolResolverCore {
     ) -> NativeInspectorSymbolLookupResult {
         resolve(
             imagePathSuffixes: imagePathSuffixes,
-            javaScriptCorePathSuffixes: javaScriptCoreImagePathSuffixes,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            webCorePathSuffixes: webCorePathSuffixes,
+            allowSharedCacheFallback: allowSharedCacheFallback,
             symbols: NativeInspectorSymbols(
                 connectFrontend: NativeInspectorRequiredSymbol(
                     role: .connectFrontend,

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -10,8 +10,11 @@ package actor TransportSession {
         var hasBufferedProvisionalResponse: Bool
     }
 
+    package typealias ResponseTimeoutSleep = @Sendable (Duration) async throws -> Void
+
     private let backend: any TransportBackend
     private let responseTimeout: Duration?
+    private let responseTimeoutSleep: ResponseTimeoutSleep
     private var nextCommandID: UInt64
     private var nextSequence: UInt64
     private var lastSequenceByDomain: [ProtocolDomain: UInt64]
@@ -35,9 +38,14 @@ package actor TransportSession {
     private var isDrainingInboundMessages: Bool
     private var closed: Bool
 
-    package init(backend: any TransportBackend, responseTimeout: Duration? = .seconds(5)) {
+    package init(
+        backend: any TransportBackend,
+        responseTimeout: Duration? = .seconds(5),
+        responseTimeoutSleep: ResponseTimeoutSleep? = nil
+    ) {
         self.backend = backend
         self.responseTimeout = responseTimeout
+        self.responseTimeoutSleep = responseTimeoutSleep ?? { try await Task.sleep(for: $0) }
         nextCommandID = 0
         nextSequence = 0
         lastSequenceByDomain = [:]
@@ -356,9 +364,10 @@ package actor TransportSession {
         targetID: ProtocolTargetIdentifier?
     ) async throws -> ProtocolCommandResult {
         let timeoutTask: Task<Void, Never>? = responseTimeout.map { responseTimeout in
-            Task {
+            let responseTimeoutSleep = self.responseTimeoutSleep
+            return Task {
                 do {
-                    try await Task.sleep(for: responseTimeout)
+                    try await responseTimeoutSleep(responseTimeout)
                 } catch {
                     return
                 }

--- a/Tests/WebInspectorNativeSymbolFixtures/WebInspectorNativeSymbolFixtures.c
+++ b/Tests/WebInspectorNativeSymbolFixtures/WebInspectorNativeSymbolFixtures.c
@@ -1,0 +1,63 @@
+#include "WebInspectorNativeSymbolFixtures.h"
+
+#define WIK_FIXTURE_SYMBOL(name, symbol) \
+    void name(void) __asm__(symbol); \
+    __attribute__((visibility("default"), used, noinline)) void name(void) {}
+
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebKitConnectFrontend,
+    "__ZN6WebKit26WebPageInspectorController15connectFrontendERN9Inspector15FrontendChannelEbb"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebKitDisconnectFrontend,
+    "__ZN6WebKit26WebPageInspectorController18disconnectFrontendERN9Inspector15FrontendChannelE"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWTFStringFromUTF8,
+    "__ZN3WTF6String8fromUTF8ENSt3__14spanIKDuLm18446744073709551615EEE"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWTFStringImplToNSString,
+    "__ZN3WTF10StringImplcvP8NSStringEv"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWTFDestroyStringImpl,
+    "__ZN3WTF10StringImpl7destroyEPS0_"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureBackendDispatcherDispatch,
+    "__ZN9Inspector17BackendDispatcher8dispatchERKN3WTF6StringE"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebCorePageInspectorConnect,
+    "__ZN7WebCore23PageInspectorController15connectFrontendERN9Inspector15FrontendChannelEbb"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebCorePageInspectorDisconnect,
+    "__ZN7WebCore23PageInspectorController18disconnectFrontendERN9Inspector15FrontendChannelE"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebCoreFrameInspectorConnect,
+    "__ZN7WebCore24FrameInspectorController15connectFrontendERN9Inspector15FrontendChannelEbb"
+)
+WIK_FIXTURE_SYMBOL(
+    WebInspectorNativeFixtureWebCoreFrameInspectorDisconnect,
+    "__ZN7WebCore24FrameInspectorController18disconnectFrontendERN9Inspector15FrontendChannelE"
+)
+
+static void (*volatile WebInspectorNativeSymbolFixtureReference)(void);
+
+__attribute__((visibility("default"), used, noinline))
+void WebInspectorNativeSymbolFixtureAnchor(void)
+{
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebKitConnectFrontend;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebKitDisconnectFrontend;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWTFStringFromUTF8;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWTFStringImplToNSString;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWTFDestroyStringImpl;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureBackendDispatcherDispatch;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebCorePageInspectorConnect;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebCorePageInspectorDisconnect;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebCoreFrameInspectorConnect;
+    WebInspectorNativeSymbolFixtureReference = WebInspectorNativeFixtureWebCoreFrameInspectorDisconnect;
+}

--- a/Tests/WebInspectorNativeSymbolFixtures/include/WebInspectorNativeSymbolFixtures.h
+++ b/Tests/WebInspectorNativeSymbolFixtures/include/WebInspectorNativeSymbolFixtures.h
@@ -1,0 +1,14 @@
+#ifndef WEB_INSPECTOR_NATIVE_SYMBOL_FIXTURES_H
+#define WEB_INSPECTOR_NATIVE_SYMBOL_FIXTURES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void WebInspectorNativeSymbolFixtureAnchor(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
+++ b/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
@@ -1,31 +1,22 @@
 #if os(iOS) || os(macOS)
+import Darwin
 import Foundation
 import Testing
 import WebKit
+import WebInspectorNativeSymbolFixtures
 @testable import WebInspectorNativeSymbols
 
 struct NativeInspectorSymbolResolverTests {
     @Test
-    @MainActor
-    func machOKitLookupProvidesSharedCacheAndLoadedImages() throws {
-        #if os(iOS) && !targetEnvironment(simulator)
-        throw Skip("The runtime smoke test is covered separately on device-backed flows.")
-        #else
-        let (currentSharedCache, webKitImage, javaScriptCoreImage) = withWebKitLoaded {
-            (
-                unsafe MachOKitSymbolLookup.currentSharedCache,
-                unsafe MachOKitSymbolLookup.loadedImage(
-                    matching: NativeInspectorSymbolResolver.imagePathSuffixesForTesting().webKit
-                ),
-                unsafe MachOKitSymbolLookup.loadedImage(
-                    matching: NativeInspectorSymbolResolver.imagePathSuffixesForTesting().javaScriptCore
-                )
-            )
-        }
-        #expect(currentSharedCache != nil)
-        #expect(webKitImage != nil)
-        #expect(javaScriptCoreImage != nil)
-        #endif
+    func fixtureImageResolvesCompleteAddressSet() throws {
+        let fixture = try nativeSymbolFixture()
+        let resolution = try NativeInspectorSymbolResolver.resolveUsingFixture(fixture)
+
+        #expect(resolution.failureReason == nil)
+        #expect(resolution.addresses.isComplete)
+        #expect(resolution.isSupported)
+        #expect(resolution.source == "loaded-image")
+        #expect(!resolution.usedConnectDisconnectFallback)
     }
 
     @Test
@@ -45,13 +36,12 @@ struct NativeInspectorSymbolResolverTests {
     }
 
     @Test
-    @MainActor
-    func resolveForTestingReportsOnlyMissingSymbolState() {
-        let resolution = withWebKitLoaded {
-            NativeInspectorSymbolResolver.resolveForTesting(
-                stringFromUTF8Symbol: obfuscated(["Ev", "27definitelyMissingFromUTF8Foo", "6String", "3WTF", "__ZN"])
-            )
-        }
+    func resolveForTestingReportsOnlyMissingSymbolState() throws {
+        let fixture = try nativeSymbolFixture()
+        let resolution = try NativeInspectorSymbolResolver.resolveUsingFixture(
+            fixture,
+            stringFromUTF8Symbol: obfuscated(["Ev", "27definitelyMissingFromUTF8Foo", "6String", "3WTF", "__ZN"])
+        )
         let failureReason = resolution.failureReason
 
         #expect(failureReason != nil)
@@ -78,27 +68,22 @@ struct NativeInspectorSymbolResolverTests {
     }
 
     @Test
-    @MainActor
     func resolveForTestingUsesAlternateConnectDisconnectCandidates() throws {
+        let fixture = try nativeSymbolFixture()
         let primaryConnect = try #require(NativeInspectorSymbolResolver.connectSymbolsForTesting().first)
         let primaryDisconnect = try #require(NativeInspectorSymbolResolver.disconnectSymbolsForTesting().first)
 
-        let resolution = withWebKitLoaded {
-            NativeInspectorSymbolResolver.resolveForTesting(
-                connectSymbol: obfuscated(["Ev", "26DefinitelyWrongConnectName", "7Missing", "__ZN"]),
-                disconnectSymbol: obfuscated(["Ev", "29DefinitelyWrongDisconnectName", "7Missing", "__ZN"]),
-                alternateConnectSymbols: [primaryConnect],
-                alternateDisconnectSymbols: [primaryDisconnect]
-            )
-        }
+        let resolution = try NativeInspectorSymbolResolver.resolveUsingFixture(
+            fixture,
+            connectSymbol: obfuscated(["Ev", "26DefinitelyWrongConnectName", "7Missing", "__ZN"]),
+            disconnectSymbol: obfuscated(["Ev", "29DefinitelyWrongDisconnectName", "7Missing", "__ZN"]),
+            alternateConnectSymbols: [primaryConnect],
+            alternateDisconnectSymbols: [primaryDisconnect]
+        )
 
-        #if os(iOS) && !targetEnvironment(simulator)
-        throw Skip("The runtime smoke test is covered separately on device-backed flows.")
-        #else
         #expect(resolution.isSupported)
         #expect(resolution.connectFrontendAddress != 0)
         #expect(resolution.disconnectFrontendAddress != 0)
-        #endif
     }
 
     @Test
@@ -232,13 +217,12 @@ struct NativeInspectorSymbolResolverTests {
     }
 
     @Test
-    @MainActor
-    func diagnosticsDoNotExposeDecodedMangledSymbols() {
-        let resolution = withWebKitLoaded {
-            NativeInspectorSymbolResolver.resolveForTesting(
-                stringFromUTF8Symbol: obfuscated(["Ev", "27definitelyMissingFromUTF8Foo", "6String", "3WTF", "__ZN"])
-            )
-        }
+    func diagnosticsDoNotExposeDecodedMangledSymbols() throws {
+        let fixture = try nativeSymbolFixture()
+        let resolution = try NativeInspectorSymbolResolver.resolveUsingFixture(
+            fixture,
+            stringFromUTF8Symbol: obfuscated(["Ev", "27definitelyMissingFromUTF8Foo", "6String", "3WTF", "__ZN"])
+        )
         let diagnostics = [
             resolution.failureReason,
             resolution.failureKind,
@@ -254,6 +238,69 @@ struct NativeInspectorSymbolResolverTests {
         #expect(!diagnostics.contains("definitelyMissingFromUTF8Foo"))
     }
 
+}
+
+private struct NativeSymbolFixture {
+    let pathSuffixes: [String]
+}
+
+private enum NativeSymbolFixtureError: Error {
+    case missingImagePath
+}
+
+private func nativeSymbolFixture() throws -> NativeSymbolFixture {
+    var info = unsafe Dl_info()
+    let anchor = unsafe unsafeBitCast(
+        WebInspectorNativeSymbolFixtureAnchor as @convention(c) () -> Void,
+        to: UnsafeRawPointer.self
+    )
+    let didResolveImagePath = unsafe dladdr(anchor, &info) != 0
+    try #require(didResolveImagePath)
+    guard let imagePath = unsafe info.dli_fname else {
+        throw NativeSymbolFixtureError.missingImagePath
+    }
+    let path = unsafe String(cString: imagePath)
+    let imageURL = URL(fileURLWithPath: path)
+    return NativeSymbolFixture(
+        pathSuffixes: [
+            path,
+            "\(imageURL.deletingLastPathComponent().lastPathComponent)/\(imageURL.lastPathComponent)",
+            imageURL.lastPathComponent,
+        ]
+    )
+}
+
+private extension NativeInspectorSymbolResolver {
+    static func resolveUsingFixture(
+        _ fixture: NativeSymbolFixture,
+        allowSharedCacheFallback: Bool = false,
+        connectSymbol: ObfuscatedSymbolName? = nil,
+        disconnectSymbol: ObfuscatedSymbolName? = nil,
+        alternateConnectSymbols: [ObfuscatedSymbolName] = [],
+        alternateDisconnectSymbols: [ObfuscatedSymbolName] = [],
+        stringFromUTF8Symbol: ObfuscatedSymbolName? = nil,
+        stringImplToNSStringSymbol: ObfuscatedSymbolName? = nil,
+        destroyStringImplSymbol: ObfuscatedSymbolName? = nil,
+        backendDispatcherDispatchSymbol: ObfuscatedSymbolName? = nil
+    ) throws -> NativeInspectorSymbolResolution {
+        let primaryConnect = try #require(connectSymbol ?? connectSymbolsForTesting().first)
+        let primaryDisconnect = try #require(disconnectSymbol ?? disconnectSymbolsForTesting().first)
+
+        return resolveForTesting(
+            imagePathSuffixes: fixture.pathSuffixes,
+            javaScriptCorePathSuffixes: fixture.pathSuffixes,
+            webCorePathSuffixes: fixture.pathSuffixes,
+            allowSharedCacheFallback: allowSharedCacheFallback,
+            connectSymbol: primaryConnect,
+            disconnectSymbol: primaryDisconnect,
+            alternateConnectSymbols: alternateConnectSymbols,
+            alternateDisconnectSymbols: alternateDisconnectSymbols,
+            stringFromUTF8Symbol: stringFromUTF8Symbol,
+            stringImplToNSStringSymbol: stringImplToNSStringSymbol,
+            destroyStringImplSymbol: destroyStringImplSymbol,
+            backendDispatcherDispatchSymbol: backendDispatcherDispatchSymbol
+        )
+    }
 }
 
 @MainActor

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -188,25 +188,42 @@ func targetDestroyFailsPendingTargetReplies() async throws {
 
 @Test
 func remoteErrorAndTimeoutFailPendingReplies() async throws {
-    let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
+    let errorBackend = FakeTransportBackend()
+    let errorSession = TransportSession(backend: errorBackend, responseTimeout: nil)
 
     let errorTask = Task {
-        try await session.send(
+        try await errorSession.send(
             ProtocolCommand(domain: .target, method: "Target.resume", routing: .root)
         )
     }
-    let sent = try await waitForRootMessage(backend)
+    let sent = try await waitForRootMessage(errorBackend)
     let id = try messageID(sent)
-    await session.receiveRootMessage(#"{"id":\#(id),"error":{"message":"nope"}}"#)
+    await errorSession.receiveRootMessage(#"{"id":\#(id),"error":{"message":"nope"}}"#)
     await #expect(throws: TransportError.remoteError(method: "Target.resume", targetID: nil, message: "nope")) {
         try await errorTask.value
     }
 
-    await #expect(throws: TransportError.replyTimeout(method: "Target.setPauseOnStart", targetID: nil)) {
-        _ = try await session.send(
+    let timeoutBackend = FakeTransportBackend()
+    let responseTimeout = ManualResponseTimeout()
+    let timeoutSession = TransportSession(
+        backend: timeoutBackend,
+        responseTimeout: .milliseconds(20),
+        responseTimeoutSleep: { duration in
+            try await responseTimeout.sleep(for: duration)
+        }
+    )
+    let timeoutTask = Task {
+        try await timeoutSession.send(
             ProtocolCommand(domain: .target, method: "Target.setPauseOnStart", routing: .root)
         )
+    }
+    _ = try await waitForRootMessage(timeoutBackend)
+    _ = try await waitUntil {
+        await responseTimeout.hasPendingSleep ? true : nil
+    }
+    await responseTimeout.fireNext()
+    await #expect(throws: TransportError.replyTimeout(method: "Target.setPauseOnStart", targetID: nil)) {
+        _ = try await timeoutTask.value
     }
 }
 
@@ -1551,6 +1568,44 @@ private func waitUntil<Value: Sendable>(_ body: @escaping @Sendable () async -> 
         try await Task.sleep(for: .milliseconds(5))
     }
     throw TransportError.replyTimeout(method: "test wait", targetID: nil)
+}
+
+private actor ManualResponseTimeout {
+    private var nextSleepID: UInt64 = 0
+    private var continuations: [UInt64: CheckedContinuation<Void, Error>] = [:]
+
+    var hasPendingSleep: Bool {
+        !continuations.isEmpty
+    }
+
+    func sleep(for _: Duration) async throws {
+        nextSleepID &+= 1
+        let sleepID = nextSleepID
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                continuations[sleepID] = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancel(sleepID)
+            }
+        }
+    }
+
+    func fireNext() {
+        guard let sleepID = continuations.keys.sorted().first,
+              let continuation = continuations.removeValue(forKey: sleepID) else {
+            return
+        }
+        continuation.resume()
+    }
+
+    private func cancel(_ sleepID: UInt64) {
+        guard let continuation = continuations.removeValue(forKey: sleepID) else {
+            return
+        }
+        continuation.resume(throwing: CancellationError())
+    }
 }
 
 private func receiveTargetDispatch(

--- a/WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorNativeTests.xcscheme
+++ b/WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorNativeTests.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebInspectorNativeBridgeTests"
+               BuildableName = "WebInspectorNativeBridgeTests"
+               BlueprintName = "WebInspectorNativeBridgeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebInspectorNativeSymbolsTests"
+               BuildableName = "WebInspectorNativeSymbolsTests"
+               BlueprintName = "WebInspectorNativeSymbolsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "NO">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebInspectorNativeBridgeTests"
+               BuildableName = "WebInspectorNativeBridgeTests"
+               BlueprintName = "WebInspectorNativeBridgeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WebInspectorNativeSymbolsTests"
+               BuildableName = "WebInspectorNativeSymbolsTests"
+               BlueprintName = "WebInspectorNativeSymbolsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Add a shared `WebInspectorNativeTests` scheme and route native CI runs through it instead of filtering the aggregate `WebInspectorKit` scheme.
- Add a native symbol fixture target and move most native symbol resolver tests off real WebKit/shared-cache images.
- Add internal testing controls for JavaScriptCore/WebCore suffixes and shared-cache fallback while preserving default runtime behavior.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorNativeTests -destination 'platform=iOS Simulator,id=046A2D47-D6AC-4FE1-BF48-EB60E616E9F4' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1` (`real 9.39s`)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,id=046A2D47-D6AC-4FE1-BF48-EB60E616E9F4'` (`real 17.92s`)
- `codex-review` on uncommitted changes before commit: 0 findings