### PR TITLE
chore(deps): update UIHostingMenu to 0.1.6

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/UIHostingMenu.git",
       "state" : {
-        "revision" : "eb453ff2ce1eb238f0fc17515db84690e5c3db63",
-        "version" : "0.1.4"
+        "revision" : "434a962f1592d15ef77ae27e247ff92a45044a6c",
+        "version" : "0.1.6"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "904549e4966658820801bbe0d5fc19577f635aa10a535e69f3c8f3236310c8a1",
+  "originHash" : "d0b0bdfefbed11d16b78868c9851d36e5df3f3ba92e91f3dd09c41103e26c585",
   "pins" : [
     {
       "identity" : "machokit",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/UIHostingMenu.git",
       "state" : {
-        "revision" : "eb453ff2ce1eb238f0fc17515db84690e5c3db63",
-        "version" : "0.1.4"
+        "revision" : "434a962f1592d15ef77ae27e247ff92a45044a6c",
+        "version" : "0.1.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/UIHostingMenu.git",
-            exact: "0.1.4"
+            exact: "0.1.6"
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "354e71237289c65de87b7414f23ea553bf99a3626719534df513ad066a2529eb",
+  "originHash" : "57818082fb8ec508fcbc6faffc8e6501542e1d0a30d4dee5189f5d1b107eedfd",
   "pins" : [
     {
       "identity" : "machokit",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/UIHostingMenu.git",
       "state" : {
-        "revision" : "eb453ff2ce1eb238f0fc17515db84690e5c3db63",
-        "version" : "0.1.4"
+        "revision" : "434a962f1592d15ef77ae27e247ff92a45044a6c",
+        "version" : "0.1.6"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Bump the SwiftPM `UIHostingMenu` dependency from `0.1.4` to `0.1.6`.
- Refresh the root, workspace, and Monocly SwiftPM resolved package pins to the `v0.1.6` revision.

## Testing
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -project Monocly/Monocly.xcodeproj -scheme Monocly`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` on uncommitted changes: no findings
- `codex-review` against `main`: no findings