### PR TITLE
build(monocly): update WKViewportCoordinator to 0.5.0

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.pbxproj
+++ b/Monocly/Monocly.xcodeproj/project.pbxproj
@@ -578,8 +578,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/lynnswap/WKViewportCoordinator.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				kind = exactVersion;
+				version = 0.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/WKViewportCoordinator.git",
       "state" : {
-        "revision" : "230b9b9b8651f5a368ecca126768f28455598f49",
-        "version" : "0.4.0"
+        "revision" : "0c21dcdec94dc9c62c620016c6569e55a2139ef0",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -91,7 +91,7 @@ final class BrowserPageViewController: UIViewController {
         viewportCoordinator = BrowserViewportCoordinator(webView: store.webView)
         viewportCoordinator?.hostViewController = self
         (store.webView as? BrowserViewportWebView)?.viewportCoordinator = viewportCoordinator
-        viewportCoordinator?.handleWebViewHierarchyDidChange()
+        viewportCoordinator?.webViewHierarchyDidChange()
 
         storeObserverID = store.addStateObserver { [weak self] in
             self?.renderState()
@@ -121,8 +121,8 @@ final class BrowserPageViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        viewportCoordinator?.handleWebViewHierarchyDidChange()
-        viewportCoordinator?.handleViewDidAppear()
+        viewportCoordinator?.webViewHierarchyDidChange()
+        viewportCoordinator?.hostViewDidAppear()
         refreshChromeControls()
         store.loadInitialRequestIfNeeded()
         maybeAutoPresentInspectorIfNeeded()
@@ -130,7 +130,7 @@ final class BrowserPageViewController: UIViewController {
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        viewportCoordinator?.handleWebViewSafeAreaInsetsDidChange()
+        viewportCoordinator?.webViewSafeAreaInsetsDidChange()
     }
 
     @objc

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -65,7 +65,7 @@ final class BrowserViewportCoordinator {
         webView.scrollView.horizontalScrollIndicatorInsets = .zero
     }
 
-    func handleWebViewHierarchyDidChange() {
+    func webViewHierarchyDidChange() {
         if let currentWindowIdentity = webView?.window.map(ObjectIdentifier.init) {
             if let lastKnownWindowIdentity, lastKnownWindowIdentity != currentWindowIdentity {
                 keyboardFrameInScreen = .null
@@ -75,11 +75,11 @@ final class BrowserViewportCoordinator {
         updateViewport()
     }
 
-    func handleViewDidAppear() {
+    func hostViewDidAppear() {
         updateViewport()
     }
 
-    func handleWebViewSafeAreaInsetsDidChange() {
+    func webViewSafeAreaInsetsDidChange() {
         updateViewport()
     }
 
@@ -248,17 +248,17 @@ final class BrowserViewportWebView: WKWebView {
 
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
-        viewportCoordinator?.handleWebViewHierarchyDidChange()
+        viewportCoordinator?.webViewHierarchyDidChange()
     }
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        viewportCoordinator?.handleWebViewHierarchyDidChange()
+        viewportCoordinator?.webViewHierarchyDidChange()
     }
 
     override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
-        viewportCoordinator?.handleWebViewSafeAreaInsetsDidChange()
+        viewportCoordinator?.webViewSafeAreaInsetsDidChange()
     }
 }
 #elseif canImport(AppKit)
@@ -378,6 +378,9 @@ private enum BrowserStoreSPI {
 
 #if canImport(UIKit)
         webView = BrowserViewportWebView(frame: .zero, configuration: configuration)
+#if os(iOS)
+        webView.scrollView.contentInsetAdjustmentBehavior = .always
+#endif
 #else
         webView = WKWebView(frame: .zero, configuration: configuration)
 #endif

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/WKViewportCoordinator.git",
       "state" : {
-        "revision" : "230b9b9b8651f5a368ecca126768f28455598f49",
-        "version" : "0.4.0"
+        "revision" : "0c21dcdec94dc9c62c620016c6569e55a2139ef0",
+        "version" : "0.5.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Pin Monocly's WKViewportCoordinator package requirement to exact 0.5.0.
- Refresh the WebInspectorKit workspace and Monocly project package resolutions to revision 0c21dcdec94dc9c62c620016c6569e55a2139ef0.
- Rename Monocly viewport lifecycle calls to the v0.5.0 API and preserve the previous iOS `.always` content inset adjustment behavior explicitly.

## Testing
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `xcodebuild -resolvePackageDependencies -project Monocly/Monocly.xcodeproj -scheme Monocly`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review: no findings for `main` base review.