### PR TITLE
fix(ui): migrate observation rendering dependencies

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "ba3b94adc34467dfa53836292c88f6d43095802e",
-        "version" : "0.8.0"
+        "revision" : "a5962525799eaf4b4202cabedac0947f89417b36",
+        "version" : "0.9.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
-        "version" : "0.5.1"
+        "revision" : "1c7c673844ed45d84e1d31929dac0493b145c2ba",
+        "version" : "0.8.1"
       }
     },
     {
@@ -166,10 +166,10 @@
     {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
+      "location" : "https://github.com/lynnswap/tree-sitter-swift",
       "state" : {
-        "revision" : "277b583bbb024f20ba88b95c48bf5a6a0b4f2287",
-        "version" : "0.7.1-with-generated-files"
+        "revision" : "60941d667d0bd58f7d5b83dcd59fe22a9865f200",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe19de627c0f3a74665a9ab9edc28569d3393a4933a094518e6473bc295c1dd7",
+  "originHash" : "12825184504d6bd25624262a8f1e30ab567f2b96c5d34a8f18bc98b06a2b1918",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "ba3b94adc34467dfa53836292c88f6d43095802e",
-        "version" : "0.8.0"
+        "revision" : "a5962525799eaf4b4202cabedac0947f89417b36",
+        "version" : "0.9.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
-        "version" : "0.5.1"
+        "revision" : "1c7c673844ed45d84e1d31929dac0493b145c2ba",
+        "version" : "0.8.1"
       }
     },
     {
@@ -166,10 +166,10 @@
     {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
+      "location" : "https://github.com/lynnswap/tree-sitter-swift",
       "state" : {
-        "revision" : "277b583bbb024f20ba88b95c48bf5a6a0b4f2287",
-        "version" : "0.7.1-with-generated-files"
+        "revision" : "60941d667d0bd58f7d5b83dcd59fe22a9865f200",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/lynnswap/ObservationBridge.git",
-            exact: "0.8.0"
+            exact: "0.9.1"
         ),
         .package(
             url: "https://github.com/lynnswap/UIHostingMenu.git",
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.5.1"
+            exact: "0.8.1"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
+++ b/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
@@ -54,34 +54,38 @@ package final class CompactTabBarController: UITabBarController, UITabBarControl
     }
 
     private func bindInterface() {
-        session.interface.observe(\.tabs) { [weak self] _ in
-            self?.renderTabsAndSelection(animated: true)
+        observationScope.observe(session.interface) { [weak self] event, interface in
+            self?.renderInterface(interface, animated: event.kind != .initial)
         }
-        .store(in: observationScope)
-
-        session.interface.observe(\.selectedItemID) { [weak self] _ in
-            self?.renderSelection()
-        }
-        .store(in: observationScope)
     }
 
     private func renderTabsAndSelection(animated: Bool) {
-        let displayItems = session.interface.displayItems(for: .compact)
+        renderInterface(session.interface, animated: animated)
+    }
+
+    private func renderInterface(_ interface: InterfaceModel, animated: Bool) {
+        let displayItems = interface.displayItems(for: .compact)
+        let selectedDisplayItem = interface.resolvedSelection(for: .compact)
         renderSelectionFromInterface {
-            setTabs(nativeTabs(for: displayItems), animated: animated)
-            renderSelection()
+            setTabsIfNeeded(for: displayItems, animated: animated)
+            renderSelection(selectedDisplayItem)
         }
     }
 
-    private func renderSelection() {
-        let selectedDisplayItem = session.interface.resolvedSelection(for: .compact)
+    private func setTabsIfNeeded(for displayItems: [TabDisplayItem], animated: Bool) {
+        let nextItemIDs = displayItems.map(\.id)
+        guard tabs.map(\.identifier) != nextItemIDs else {
+            return
+        }
+        setTabs(nativeTabs(for: displayItems), animated: animated)
+    }
+
+    private func renderSelection(_ selectedDisplayItem: TabDisplayItem?) {
         let nextSelectedTab = tabs.first { $0.identifier == selectedDisplayItem?.id }
         guard selectedTab?.identifier != nextSelectedTab?.identifier else {
             return
         }
-        renderSelectionFromInterface {
-            selectedTab = nextSelectedTab
-        }
+        selectedTab = nextSelectedTab
     }
 
     private func renderSelectionFromInterface(_ render: () -> Void) {

--- a/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
+++ b/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
@@ -33,7 +33,7 @@ package final class RegularTabContentViewController: UINavigationController {
         navigationBar.prefersLargeTitles = false
         webInspectorApplyClearNavigationBarStyle(to: self)
 
-        renderTabsAndSelection(animated: false)
+        renderTabsAndSelection()
         bindInterface()
     }
 
@@ -63,30 +63,34 @@ package final class RegularTabContentViewController: UINavigationController {
     }
 
     private func bindInterface() {
-        session.interface.observe(\.tabs) { [weak self] _ in
-            self?.renderTabsAndSelection(animated: true)
+        observationScope.observe(session.interface) { [weak self] _, interface in
+            self?.renderInterface(interface)
         }
-        .store(in: observationScope)
-
-        session.interface.observe(\.selectedItemID) { [weak self] _ in
-            self?.renderSelection(animated: false)
-        }
-        .store(in: observationScope)
     }
 
-    private func renderTabsAndSelection(animated: Bool) {
-        let displayItems = session.interface.displayItems(for: .regular)
+    private func renderTabsAndSelection() {
+        renderInterface(session.interface)
+    }
+
+    private func renderInterface(_ interface: InterfaceModel) {
+        let displayItems = interface.displayItems(for: .regular)
+        let selectedDisplayItem = interface.resolvedSelection(for: .regular)
         let activeItemIDs = Set(displayItems.map(\.id))
         if let displayedDisplayItemID,
            activeItemIDs.contains(displayedDisplayItemID) == false {
             self.displayedDisplayItemID = nil
         }
         setSegments(for: displayItems)
-        renderSelection(animated: false)
+        renderSelection(selectedDisplayItem)
     }
 
     private func setSegments(for displayItems: [TabDisplayItem]) {
-        segmentDisplayItemIDs = displayItems.map(\.id)
+        let nextItemIDs = displayItems.map(\.id)
+        guard segmentDisplayItemIDs != nextItemIDs else {
+            return
+        }
+
+        segmentDisplayItemIDs = nextItemIDs
         segmentedControl.removeAllSegments()
         for (index, displayItem) in displayItems.enumerated() {
             segmentedControl.insertSegment(
@@ -97,8 +101,7 @@ package final class RegularTabContentViewController: UINavigationController {
         }
     }
 
-    private func renderSelection(animated: Bool) {
-        let selectedDisplayItem = session.interface.resolvedSelection(for: .regular)
+    private func renderSelection(_ selectedDisplayItem: TabDisplayItem?) {
         segmentedControl.selectedSegmentIndex = selectedDisplayItem.flatMap {
             segmentDisplayItemIDs.firstIndex(of: $0.id)
         } ?? UISegmentedControl.noSegment
@@ -116,7 +119,7 @@ package final class RegularTabContentViewController: UINavigationController {
             displayedDisplayItemID = selectedDisplayItem.id
             return
         }
-        setViewControllers([viewController], animated: animated)
+        setViewControllers([viewController], animated: false)
         displayedDisplayItemID = selectedDisplayItem.id
     }
 

--- a/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
+++ b/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
@@ -48,14 +48,9 @@ package final class DOMNavigationItems: NSObject {
     }
 
     private func startObservingSession() {
-        session.observe([\.isAttached, \.isSelectingElement]) { [weak self] in
-            self?.updatePickItemAppearance()
+        observationScope.observe(session) { [weak self] _, session in
+            self?.renderPickItem(session: session)
         }
-        .store(in: observationScope)
-        session.dom.observe([\.treeRevision, \.selectionRevision]) { [weak self] in
-            self?.updatePickItemAppearance()
-        }
-        .store(in: observationScope)
     }
 
     private func makeDeferredOverflowItems() -> UIDeferredMenuElement {
@@ -154,6 +149,10 @@ package final class DOMNavigationItems: NSObject {
     }
 
     private func updatePickItemAppearance() {
+        renderPickItem(session: session)
+    }
+
+    private func renderPickItem(session: InspectorSession) {
         pickItem.isEnabled = session.canSelectElement
         pickItem.tintColor = session.isSelectingElement ? .tintColor : .label
     }

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
@@ -32,12 +32,10 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
 
     override package func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
-
-        var background = defaultBackgroundConfiguration().updated(for: state)
-        if property?.isModifiedByInspector == true {
-            background.backgroundColor = Self.modifiedBackgroundColor
-        }
-        backgroundConfiguration = background
+        renderBackground(
+            isModifiedByInspector: property?.isModifiedByInspector == true,
+            state: state
+        )
     }
 
     package func bind(
@@ -51,11 +49,15 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
         )
         setNeedsUpdateConfiguration()
 
-        observationScope.update {
-            property.observe(\.isModifiedByInspector) { [weak self] in
-                self?.setNeedsUpdateConfiguration()
+        observationScope.cancelAll()
+        observationScope.observe(property) { [weak self] _, property in
+            guard let self else {
+                return
             }
-            .store(in: observationScope)
+            self.renderBackground(
+                isModifiedByInspector: property.isModifiedByInspector,
+                state: self.configurationState
+            )
         }
     }
 
@@ -78,6 +80,17 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
             propertyView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             propertyView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
+    }
+
+    private func renderBackground(
+        isModifiedByInspector: Bool,
+        state: UICellConfigurationState
+    ) {
+        var background = defaultBackgroundConfiguration().updated(for: state)
+        if isModifiedByInspector {
+            background.backgroundColor = Self.modifiedBackgroundColor
+        }
+        backgroundConfiguration = background
     }
 }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
@@ -36,14 +36,9 @@ package final class DOMElementStylePropertyView: UIView {
 
         renderAll(from: property)
 
-        observationScope.update {
-            property.observe([\.name, \.value, \.priority, \.text, \.status, \.isEditable]) { [weak self, weak property] in
-                guard let self, let property else {
-                    return
-                }
-                self.renderAll(from: property)
-            }
-            .store(in: observationScope)
+        observationScope.cancelAll()
+        observationScope.observe(property) { [weak self] _, property in
+            self?.renderAll(from: property)
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -32,14 +32,9 @@ final class DOMElementStyleSectionHeaderView: UICollectionReusableView {
     func bind(_ section: CSSStyleSection) {
         render(section)
 
-        observationScope.update {
-            section.observe([\.title, \.subtitle]) { [weak self, weak section] in
-                guard let self, let section else {
-                    return
-                }
-                self.render(section)
-            }
-            .store(in: observationScope)
+        observationScope.cancelAll()
+        observationScope.observe(section) { [weak self] _, section in
+            self?.render(section)
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -69,7 +69,6 @@ package final class DOMElementViewController: UIViewController {
         self.css = css
         self.session = session
         super.init(nibName: nil, bundle: nil)
-        startObservingState()
     }
 
     @available(*, unavailable)
@@ -86,6 +85,7 @@ package final class DOMElementViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .clear
         configureCollectionView()
+        startObservingState()
         render()
     }
 
@@ -202,40 +202,53 @@ package final class DOMElementViewController: UIViewController {
     }
 
     private func startObservingState() {
-        dom.observe([\.treeRevision, \.selectionRevision]) { [weak self] in
+        observationScope.observe(dom) { [weak self] _, _ in
             self?.render()
         }
-        .store(in: observationScope)
 
-        css.observe([\.selectedNodeStyles, \.selectedState]) { [weak self] in
+        observationScope.observe(css) { [weak self] _, _ in
             self?.observeSelectedNodeStyles()
             self?.render()
         }
-        .store(in: observationScope)
 
-        session?.observe(\.isAttached) { [weak self] _ in
-            self?.render()
+        if let session {
+            observationScope.observe(session) { [weak self] _, session in
+                self?.render(session: session)
+            }
         }
-        .store(in: observationScope)
 
         observeSelectedNodeStyles()
     }
 
     private func observeSelectedNodeStyles() {
-        selectedStylesObservationScope.update {
-            guard let selectedNodeStyles = css.selectedNodeStyles else {
-                return
-            }
+        selectedStylesObservationScope.cancelAll()
+        guard let selectedNodeStyles = css.selectedNodeStyles else {
+            return
+        }
 
-            selectedNodeStyles.observe([\.state, \.sections]) { [weak self] in
-                self?.render()
-            }
-            .store(in: selectedStylesObservationScope)
+        selectedStylesObservationScope.observe(selectedNodeStyles) { [weak self] _, _ in
+            self?.render()
         }
     }
 
     private func render() {
+        render(session: session)
+    }
+
+    private func render(session: InspectorSession?) {
         guard isViewLoaded else {
+            return
+        }
+
+        _ = dom.treeRevision
+        _ = dom.selectionRevision
+
+        guard session?.isAttached != false else {
+            showPlaceholder(
+                text: webInspectorLocalized("dom.element.loading.title", default: "Loading DOM..."),
+                secondaryText: nil,
+                image: UIImage(systemName: "arrow.clockwise")
+            )
             return
         }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -36,6 +36,23 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         paragraphStyle.paragraphSpacingBefore = 0
         return paragraphStyle
     }()
+    private struct DOMObservationCursor {
+        var treeRevision: UInt64?
+        var selectionRevision: UInt64?
+
+        mutating func changes(
+            treeRevision nextTreeRevision: UInt64,
+            selectionRevision nextSelectionRevision: UInt64,
+            isInitial: Bool
+        ) -> (treeChanged: Bool, selectionChanged: Bool) {
+            let treeChanged = isInitial || treeRevision != nextTreeRevision
+            let selectionChanged = selectionRevision != nextSelectionRevision
+            treeRevision = nextTreeRevision
+            selectionRevision = nextSelectionRevision
+            return (treeChanged, selectionChanged)
+        }
+    }
+
     private let dom: DOMSession
     private let menuModel: DOMTreeMenuModel
     private let observationScope = ObservationScope()
@@ -73,6 +90,7 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     private var lastBoundsSize: CGSize = .zero
     private var rowIndexByNodeID: [DOMNode.ID: Int] = [:]
     private var lastRenderedDocumentRootID: DOMNode.ID?
+    private var domObservationCursor = DOMObservationCursor()
     private var lastObservedSelectedNodeID: DOMNode.ID?
     private var pendingRevealSelectedNodeID: DOMNode.ID?
     private var pendingTreeInvalidation: DOMTreeInvalidation?
@@ -138,7 +156,6 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
         configureTextSystem()
         configureInteractions()
         startObservingDocument()
-        reloadTree(resetFragments: true)
     }
 
     @available(*, unavailable)
@@ -551,15 +568,23 @@ final class DOMTreeTextView: UIScrollView, @preconcurrency NSTextViewportLayoutC
     }
 
     private func startObservingDocument() {
-        dom.observe(\.treeRevision) { [weak self] _ in
-            self?.scheduleTreeReload(for: .documentReset)
+        observationScope.observe(dom) { [weak self] event, dom in
+            self?.routeDOMInvalidation(from: dom, isInitial: event.kind == .initial)
         }
-        .store(in: observationScope)
+    }
 
-        dom.observe(\.selectionRevision) { [weak self] _ in
-            self?.handleSelectedNodeChange()
+    private func routeDOMInvalidation(from dom: DOMSession, isInitial: Bool) {
+        let changes = domObservationCursor.changes(
+            treeRevision: dom.treeRevision,
+            selectionRevision: dom.selectionRevision,
+            isInitial: isInitial
+        )
+
+        if changes.treeChanged {
+            scheduleTreeReload(for: .documentReset)
+        } else if changes.selectionChanged {
+            handleSelectedNodeChange()
         }
-        .store(in: observationScope)
     }
 
     private func handleSelectedNodeChange() {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -47,7 +47,6 @@ package final class DOMTreeViewController: UIViewController {
             }
         )
         super.init(nibName: nil, bundle: nil)
-        startObservingDOMRoot(session: session)
     }
 
     package init(dom: DOMSession) {
@@ -71,23 +70,34 @@ package final class DOMTreeViewController: UIViewController {
         view = treeView
     }
 
-    override package func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override package func viewDidLoad() {
+        super.viewDidLoad()
+        if let session {
+            startObservingDOMRoot(session: session)
+        }
+    }
+
+    override package func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         ensureDOMDocumentLoadedIfNeeded()
     }
 
     private func startObservingDOMRoot(session: InspectorSession) {
-        session.dom.observe(\.treeRevision) { [weak self] _ in
+        observationScope.cancelAll()
+        observationScope.observe(session.dom) { [weak self] _, _ in
             self?.ensureDOMDocumentLoadedIfNeeded()
         }
-        .store(in: observationScope)
     }
 
     private func ensureDOMDocumentLoadedIfNeeded() {
-        guard let session,
-              viewIfLoaded?.window != nil,
+        guard let session else {
+            return
+        }
+        _ = session.dom.treeRevision
+        let currentPageRootNode = session.dom.currentPageRootNode
+        guard viewIfLoaded?.window != nil,
               !isEnsuringDOMDocumentLoaded,
-              session.dom.currentPageRootNode == nil else {
+              currentPageRootNode == nil else {
             return
         }
 

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -66,11 +66,12 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func startObservingSelection() {
-        observationScope.update {
-            model.observe(\.selectedRequest) { [weak self] selectedRequest in
-                self?.syncStack(with: selectedRequest, animated: true)
-            }
-            .store(in: observationScope)
+        observationScope.cancelAll()
+        observationScope.observe(model) { [weak self] event, model in
+            self?.syncStack(
+                with: model.selectedRequest,
+                animated: event.kind != .initial
+            )
         }
     }
 

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -6,14 +6,17 @@ import WebInspectorCore
 
 @MainActor
 final class NetworkBodyViewController: UIViewController {
-    private let syntaxModel = SyntaxEditorModel(
-        text: "",
+    private let syntaxDocument = SyntaxEditorDocument(text: "")
+    private let syntaxConfiguration = SyntaxEditorConfiguration(
         language: .json,
         isEditable: false,
         lineWrappingEnabled: true,
         colorTheme: .v2WebInspectorPlainText
     )
-    private lazy var syntaxView = SyntaxEditorView(model: syntaxModel)
+    private lazy var syntaxView = SyntaxEditorView(
+        document: syntaxDocument,
+        configuration: syntaxConfiguration
+    )
     private let observationScope = ObservationScope()
     private weak var body: NetworkBody?
 
@@ -30,7 +33,7 @@ final class NetworkBodyViewController: UIViewController {
     func display(body: NetworkBody?) {
         self.body = body
         startObserving(body: body)
-        renderBody()
+        renderBody(body)
     }
 
     private func configureSyntaxView() {
@@ -54,26 +57,19 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func startObserving(body: NetworkBody?) {
-        observationScope.update {
-            if let body {
-                body.observe(
-                    [
-                        \.textRepresentation,
-                        \.textRepresentationSyntaxKind,
-                        \.fetchState,
-                    ]
-                ) { [weak self, weak body] in
-                    guard let self, body === self.body else {
-                        return
-                    }
-                    self.renderBody()
-                }
-                .store(in: observationScope)
+        observationScope.cancelAll()
+        guard let body else {
+            return
+        }
+        observationScope.observe(body) { [weak self] _, body in
+            guard let self, body === self.body else {
+                return
             }
+            self.renderBody(body)
         }
     }
 
-    private func renderBody() {
+    private func renderBody(_ body: NetworkBody?) {
         let displayText: String
         let syntaxKind: NetworkBodySyntaxKind
         guard let body else {
@@ -121,15 +117,15 @@ final class NetworkBodyViewController: UIViewController {
         syntaxKind: NetworkBodySyntaxKind
     ) {
         let syntax = syntaxKind.syntax
-        if syntaxModel.language != syntax.language {
-            syntaxModel.language = syntax.language
+        if syntaxConfiguration.language != syntax.language {
+            syntaxConfiguration.language = syntax.language
         }
-        let colorTheme: SyntaxEditorColorTheme = syntax.usesPlainTextTheme ? .v2WebInspectorPlainText : .xcode
-        if syntaxModel.colorTheme != colorTheme {
-            syntaxModel.colorTheme = colorTheme
+        let colorTheme: SyntaxEditorColorTheme = syntax.usesPlainTextTheme ? .v2WebInspectorPlainText : .default
+        if syntaxConfiguration.colorTheme != colorTheme {
+            syntaxConfiguration.colorTheme = colorTheme
         }
-        if syntaxModel.text != text {
-            syntaxModel.text = text
+        if syntaxDocument.textSnapshot() != text {
+            syntaxDocument.replaceText(text)
         }
     }
 }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -73,10 +73,9 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         self.model = model
         super.init(nibName: nil, bundle: nil)
 
-        model.observe(\.selectedRequest) { [weak self] selectedRequest in
-            self?.display(selectedRequest, reloadData: true)
+        observationScope.observe(model) { [weak self] _, model in
+            self?.display(model.selectedRequest, reloadData: true)
         }
-        .store(in: observationScope)
     }
 
     @available(*, unavailable)
@@ -219,7 +218,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
             return
         }
         guard let request else {
-            selectedRequestObservationScope.update {}
+            selectedRequestObservationScope.cancelAll()
             collectionView.isHidden = true
             bodyViewController.view.isHidden = true
             bodyViewController.display(body: nil)
@@ -241,16 +240,14 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     }
 
     private func startObserving(_ request: NetworkRequest) {
-        selectedRequestObservationScope.update {
-            request.observe([\.request, \.response, \.requestBody, \.responseBody]) { [weak self, weak request] in
-                guard let self, let request, self.selectedRequest?.id == request.id else {
-                    return
-                }
-                self.title = request.displayName
-                self.renderCurrentMode(reloadData: false)
-                self.modeMenu.render()
+        selectedRequestObservationScope.cancelAll()
+        selectedRequestObservationScope.observe(request) { [weak self] _, request in
+            guard let self, self.selectedRequest?.id == request.id else {
+                return
             }
-            .store(in: selectedRequestObservationScope)
+            self.title = request.displayName
+            self.renderCurrentMode(reloadData: false)
+            self.modeMenu.render()
         }
     }
 
@@ -351,8 +348,8 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         guard isViewLoaded else {
             return
         }
+        let snapshot = makeSnapshot()
         Task {
-            let snapshot = self.makeSnapshot()
             await self.dataSource.apply(snapshot, animatingDifferences: false)
         }
     }
@@ -361,8 +358,8 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         guard isViewLoaded else {
             return
         }
+        let snapshot = makeSnapshot()
         Task {
-            let snapshot = self.makeSnapshot()
             await self.dataSource.applySnapshotUsingReloadData(snapshot)
         }
     }
@@ -381,6 +378,12 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
 @MainActor
 private final class NetworkDetailModeMenu {
+    private struct ModeAvailability {
+        var hasSelectedRequest: Bool
+        var hasRequestBody: Bool
+        var hasResponseBody: Bool
+    }
+
     private weak var detailViewController: NetworkDetailViewController?
     private let model: NetworkPanelModel
     private let observationScope = ObservationScope()
@@ -392,11 +395,10 @@ private final class NetworkDetailModeMenu {
         self.detailViewController = detailViewController
         self.model = model
 
-        model.observe(\.selectedRequest) { [weak self] request in
-            self?.observeBodyAvailability(in: request)
+        observationScope.observe(model) { [weak self] _, model in
+            self?.observeBodyAvailability(in: model.selectedRequest)
             self?.render()
         }
-        .store(in: observationScope)
     }
 
     isolated deinit {
@@ -405,30 +407,28 @@ private final class NetworkDetailModeMenu {
     }
 
     private func observeBodyAvailability(in request: NetworkRequest?) {
-        selectedRequestObservationScope.update {
-            guard let request else {
+        selectedRequestObservationScope.cancelAll()
+        guard let request else {
+            return
+        }
+        selectedRequestObservationScope.observe(request) { [weak self] _, request in
+            guard let self, self.model.selectedRequest?.id == request.id else {
                 return
             }
-            request.observe([\.requestBody, \.responseBody]) { [weak self, weak request] in
-                guard let self, let request, self.model.selectedRequest?.id == request.id else {
-                    return
-                }
-                self.render()
-            }
-            .store(in: selectedRequestObservationScope)
+            self.render(selectedRequest: request)
         }
     }
 
-    fileprivate func render() {
+    fileprivate func render(selectedRequest: NetworkRequest? = nil) {
         let mode = detailViewController?.mode ?? .overview
-        let selectedRequest = model.selectedRequest
-        let isEnabled = selectedRequest != nil
+        let availability = modeAvailability(for: selectedRequest ?? model.selectedRequest)
+        let isEnabled = availability.hasSelectedRequest
 
         if let compactItem {
             compactItem.image = UIImage(systemName: mode.systemImageName)
             compactItem.title = nil
             compactItem.isEnabled = isEnabled
-            compactItem.menu = makeMenu(includesImages: true)
+            compactItem.menu = makeMenu(includesImages: true, availability: availability)
             compactItem.accessibilityLabel = mode.title
             compactItem.preferredMenuElementOrder = .fixed
         }
@@ -442,7 +442,7 @@ private final class NetworkDetailModeMenu {
                 var configuration = button.configuration ?? .bordered()
                 configuration.title = mode.title
                 button.configuration = configuration
-                button.menu = makeMenu(includesImages: false)
+                button.menu = makeMenu(includesImages: false, availability: availability)
                 button.isEnabled = isEnabled
                 button.accessibilityLabel = mode.title
                 button.preferredMenuElementOrder = .fixed
@@ -473,13 +473,17 @@ private final class NetworkDetailModeMenu {
     }
 
     func makeMenuForTesting() -> UIMenu {
-        makeMenu(includesImages: true)
+        makeMenu(
+            includesImages: true,
+            availability: modeAvailability(for: model.selectedRequest)
+        )
     }
 
     private func makeCompactBarButtonItem() -> UIBarButtonItem {
+        let availability = modeAvailability(for: model.selectedRequest)
         let item = UIBarButtonItem(
             image: UIImage(systemName: (detailViewController?.mode ?? .overview).systemImageName),
-            menu: makeMenu(includesImages: true)
+            menu: makeMenu(includesImages: true, availability: availability)
         )
         item.accessibilityIdentifier = "WebInspector.Network.DetailModeButton"
         item.preferredMenuElementOrder = .fixed
@@ -501,13 +505,19 @@ private final class NetworkDetailModeMenu {
         button.showsMenuAsPrimaryAction = true
         button.changesSelectionAsPrimaryAction = true
         button.preferredMenuElementOrder = .fixed
-        button.menu = makeMenu(includesImages: false)
+        button.menu = makeMenu(
+            includesImages: false,
+            availability: modeAvailability(for: model.selectedRequest)
+        )
         button.accessibilityIdentifier = "WebInspector.Network.DetailModeButton.Regular.Button"
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         return button
     }
 
-    private func makeMenu(includesImages: Bool) -> UIMenu {
+    private func makeMenu(
+        includesImages: Bool,
+        availability: ModeAvailability
+    ) -> UIMenu {
         UIMenu(
             title: "",
             options: .singleSelection,
@@ -515,7 +525,7 @@ private final class NetworkDetailModeMenu {
                 UIAction(
                     title: mode.title,
                     image: includesImages ? UIImage(systemName: mode.systemImageName) : nil,
-                    attributes: isModeEnabled(mode) ? [] : [.disabled],
+                    attributes: isModeEnabled(mode, availability: availability) ? [] : [.disabled],
                     state: detailViewController?.mode == mode ? .on : .off
                 ) { [weak detailViewController] _ in
                     detailViewController?.mode = mode
@@ -524,17 +534,28 @@ private final class NetworkDetailModeMenu {
         )
     }
 
-    private func isModeEnabled(_ mode: NetworkDetailMode) -> Bool {
-        guard let selectedRequest = model.selectedRequest else {
+    private func modeAvailability(for selectedRequest: NetworkRequest?) -> ModeAvailability {
+        ModeAvailability(
+            hasSelectedRequest: selectedRequest != nil,
+            hasRequestBody: selectedRequest?.requestBody != nil,
+            hasResponseBody: selectedRequest?.responseBody != nil
+        )
+    }
+
+    private func isModeEnabled(
+        _ mode: NetworkDetailMode,
+        availability: ModeAvailability
+    ) -> Bool {
+        guard availability.hasSelectedRequest else {
             return mode == .overview
         }
         switch mode {
         case .overview:
             return true
         case .requestBody:
-            return selectedRequest.requestBody != nil
+            return availability.hasRequestBody
         case .responseBody:
-            return selectedRequest.responseBody != nil
+            return availability.hasResponseBody
         }
     }
 }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkOverviewCell.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkOverviewCell.swift
@@ -27,31 +27,13 @@ final class NetworkOverviewCell: UICollectionViewListCell {
         content.attributedText = makeMetricsAttributedText(for: request)
         contentConfiguration = content
 
-        observationScope.update {
-            request.observe(\.request) { [weak self, weak request] _ in
-                guard let request else {
-                    return
-                }
-                self?.renderURL(request.request.url)
+        observationScope.cancelAll()
+        observationScope.observe(request) { [weak self] _, request in
+            guard let self else {
+                return
             }
-            .store(in: observationScope)
-
-            request.observe(
-                [
-                    \.response,
-                    \.state,
-                    \.responseReceivedTimestamp,
-                    \.lastDataReceivedTimestamp,
-                    \.finishedOrFailedTimestamp,
-                    \.encodedDataLength,
-                ]
-            ) { [weak self, weak request] in
-                guard let self, let request else {
-                    return
-                }
-                self.renderMetrics(self.makeMetricsAttributedText(for: request))
-            }
-            .store(in: observationScope)
+            self.renderURL(request.request.url)
+            self.renderMetrics(self.makeMetricsAttributedText(for: request))
         }
     }
 

--- a/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
@@ -32,15 +32,10 @@ package final class NetworkListCell: UICollectionViewListCell {
         render(displayName: request.displayName)
         renderAccessories(request: request)
 
-        observationScope.update {
-            request.observe([\.request, \.response, \.resourceType, \.state]) { [weak self, weak request] in
-                guard let request else {
-                    return
-                }
-                self?.render(displayName: request.displayName)
-                self?.renderAccessories(request: request)
-            }
-            .store(in: observationScope)
+        observationScope.cancelAll()
+        observationScope.observe(request) { [weak self] _, request in
+            self?.render(displayName: request.displayName)
+            self?.renderAccessories(request: request)
         }
     }
 

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -22,7 +22,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         var mode: SnapshotApplyMode
     }
 
-    private static let snapshotObservationOptions = ObservationOptions.rateLimit(
+    private static let snapshotStreamOptions = ObservationStreamOptions.rateLimit(
         .throttle(
             ObservationThrottle(
                 interval: .milliseconds(80),
@@ -34,6 +34,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private let model: NetworkPanelModel
     private var requestSelectionAction: RequestSelectionAction
     private let observationScope = ObservationScope()
+    private var displayRequestsObservationTask: Task<Void, Never>?
 
     private var needsSnapshotReloadOnNextAppearance = false
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
@@ -72,6 +73,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     isolated deinit {
+        displayRequestsObservationTask?.cancel()
         observationScope.cancelAll()
         detachSearchPresentation()
     }
@@ -128,20 +130,26 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func startObservingModel() {
-        model.observe(\.displayRequests, options: Self.snapshotObservationOptions) { [weak self] displayRequests in
-            self?.reloadDataFromModel(displayRequests: displayRequests)
+        displayRequestsObservationTask?.cancel()
+        let model = model
+        displayRequestsObservationTask = Task { @MainActor [weak self, model] in
+            let stream = makeObservationBridgeStream(options: Self.snapshotStreamOptions) {
+                model.displayRequests
+            }
+            for await displayRequests in stream {
+                guard let self else {
+                    return
+                }
+                self.reloadDataFromModel(displayRequests: displayRequests)
+            }
         }
-        .store(in: observationScope)
 
-        model.observe(\.searchText) { [weak self] searchText in
-            self?.renderSearchText(searchText)
+        observationScope.observe(model) { [weak self] _, model in
+            self?.renderModelControls(
+                searchText: model.searchText,
+                effectiveResourceFilters: model.effectiveResourceFilters
+            )
         }
-        .store(in: observationScope)
-
-        model.observe(\.effectiveResourceFilters) { [weak self] _ in
-            self?.resourceFilterSelectionDidChange()
-        }
-        .store(in: observationScope)
     }
 
     private func configureNavigationItem() {
@@ -159,8 +167,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         ]
         navigationItem.additionalOverflowItems = makeOverflowMenuElement()
 
-        renderSearchText(model.searchText)
-        renderFilterItem()
+        renderModelControls(
+            searchText: model.searchText,
+            effectiveResourceFilters: model.effectiveResourceFilters
+        )
     }
 
     package func updateSearchResults(for searchController: UISearchController) {
@@ -228,18 +238,26 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         activeSearchController.searchBar.text = text
     }
 
-    private func renderFilterItem() {
+    private func renderFilterItem(effectiveResourceFilters: Set<NetworkResourceFilter>) {
         guard isViewLoaded else {
             return
         }
-        filterItem.isSelected = model.effectiveResourceFilters.isEmpty == false
+        filterItem.isSelected = effectiveResourceFilters.isEmpty == false
     }
 
-    private func resourceFilterSelectionDidChange() {
+    private func renderModelControls(
+        searchText: String,
+        effectiveResourceFilters: Set<NetworkResourceFilter>
+    ) {
+        renderSearchText(searchText)
+        resourceFilterSelectionDidChange(effectiveResourceFilters: effectiveResourceFilters)
+    }
+
+    private func resourceFilterSelectionDidChange(effectiveResourceFilters: Set<NetworkResourceFilter>) {
         if isViewLoaded {
             filterHostingMenu.setNeedsUpdate()
         }
-        renderFilterItem()
+        renderFilterItem(effectiveResourceFilters: effectiveResourceFilters)
     }
 
     private func makeFilterMenu() -> UIMenu {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -22,6 +22,36 @@ struct DOMContainerTests {
     }
 
     @Test
+    func elementViewControllerLeavesLoadingWhenDocumentRootArrivesAfterViewLoad() async throws {
+        let targetID = ProtocolTargetIdentifier("page-main")
+        let dom = DOMSession()
+        dom.applyTargetCreated(
+            ProtocolTargetRecord(
+                id: targetID,
+                kind: .page,
+                frameID: DOMFrameIdentifier("main-frame"),
+                capabilities: .pageDefault
+            ),
+            makeCurrentMainPage: true
+        )
+        let viewController = DOMElementViewController(dom: dom)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let loadingConfiguration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
+        #expect(loadingConfiguration?.text == "Loading DOM...")
+
+        _ = dom.replaceDocumentRoot(documentNode(), targetID: targetID)
+
+        let didRenderCurrentRoot = await waitUntil {
+            let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
+            return configuration?.text == "Select an element"
+                && viewController.collectionViewForTesting.isHidden
+        }
+        #expect(didRenderCurrentRoot)
+    }
+
+    @Test
     func elementViewControllerRendersLoadedStyleSections() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let body = try #require(firstElement(named: "body", in: dom))

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -54,6 +54,62 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func detailUpdatesResponseHeadersAfterSelection() async throws {
+        let network = NetworkSession()
+        let targetID = ProtocolTargetIdentifier("page")
+        let requestID = NetworkRequestIdentifier("1")
+        let key = network.applyRequestWillBeSent(
+            targetID: targetID,
+            requestID: requestID,
+            frameID: DOMFrameIdentifier("main"),
+            loaderID: "loader",
+            documentURL: "https://example.com",
+            request: NetworkRequestPayload(
+                url: "https://example.com/api/data.json",
+                method: "GET"
+            ),
+            resourceType: .script,
+            timestamp: 1
+        )
+        let request = try #require(network.request(for: key))
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderEmptyResponseHeaders = await waitUntil {
+            let collectionView = viewController.collectionViewForTesting
+            return collectionView.numberOfSections == 3
+                && collectionView.numberOfItems(inSection: 2) == 1
+                && listCellText(in: collectionView, at: IndexPath(item: 0, section: 2)) == "No headers"
+        }
+        #expect(didRenderEmptyResponseHeaders)
+
+        network.applyResponseReceived(
+            targetID: targetID,
+            requestID: requestID,
+            resourceType: .script,
+            response: NetworkResponsePayload(
+                url: "https://example.com/api/data.json",
+                status: 200,
+                statusText: "OK",
+                headers: ["content-type": "application/json"],
+                mimeType: "application/json"
+            ),
+            timestamp: 2
+        )
+
+        let didRenderResponseHeaders = await waitUntil {
+            let collectionView = viewController.collectionViewForTesting
+            return collectionView.numberOfItems(inSection: 2) == 1
+                && listCellText(in: collectionView, at: IndexPath(item: 0, section: 2)) == "content-type"
+                && listCellSecondaryText(in: collectionView, at: IndexPath(item: 0, section: 2)) == "application/json"
+        }
+        #expect(didRenderResponseHeaders)
+    }
+
+    @Test
     func detailModeMenuUsesCoreBodyAvailabilityAndRendersRequestBody() async throws {
         let network = NetworkSession()
         let request = try #require(
@@ -146,6 +202,23 @@ struct NetworkDetailViewControllerTests {
             navigationController.viewControllers == [listViewController]
         }
         #expect(didPop)
+    }
+
+    @Test
+    func listControllerDeallocatesWhileDisplayRequestObservationIsActive() async throws {
+        let model = NetworkPanelModel(network: NetworkSession())
+        weak var weakViewController: NetworkListViewController?
+
+        do {
+            let viewController = NetworkListViewController(model: model)
+            viewController.loadViewIfNeeded()
+            weakViewController = viewController
+        }
+
+        let didDeallocate = await waitUntil {
+            weakViewController == nil
+        }
+        #expect(didDeallocate)
     }
 
     private func applyRequest(

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3568c3ac47756f8eab0e39e449a54e9f97bc87ccd4a65dad6ac96f2d27b72e4",
+  "originHash" : "3457f5332b246d8307179af4412a71ae0649050a0c87961746de5f237a094b4c",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "ba3b94adc34467dfa53836292c88f6d43095802e",
-        "version" : "0.8.0"
+        "revision" : "a5962525799eaf4b4202cabedac0947f89417b36",
+        "version" : "0.9.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "ea84443700d63141d15cc69d7a0cf26a392cdd01",
-        "version" : "0.5.1"
+        "revision" : "1c7c673844ed45d84e1d31929dac0493b145c2ba",
+        "version" : "0.8.1"
       }
     },
     {
@@ -166,10 +166,10 @@
     {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
+      "location" : "https://github.com/lynnswap/tree-sitter-swift",
       "state" : {
-        "revision" : "277b583bbb024f20ba88b95c48bf5a6a0b4f2287",
-        "version" : "0.7.1-with-generated-files"
+        "revision" : "60941d667d0bd58f7d5b83dcd59fe22a9865f200",
+        "version" : "0.1.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin ObservationBridge to 0.9.1 and SyntaxEditorUI to 0.8.1 across Package.swift and all SwiftPM resolution files.
- Migrate ObservationBridge usage to owner-bound observation, including throttled network list updates through ObservationBridge streams.
- Replace SyntaxEditorModel usage with SyntaxEditorDocument and SyntaxEditorConfiguration in the network body editor.
- Rework DOM rendering lifecycle for page navigation so initial/late document roots leave the loading state, and remove unintended DOM/Network tab switch animation.
- Add regression coverage for DOM loading after navigation, response header updates, and network list observation task lifetime.

## Testing
- `git diff --check`
- `rg "\\.store\\(in:|ObservationScope\\.update|ObservationOptions\\.rateLimit|SyntaxEditorModel|SyntaxEditorView\\(model:|\\.xcode" Sources Tests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` uncommitted changes: clean (`859FBECF-9077-4189-BE51-F6EC8321A618`)