### PR TITLE
Fix element styles header source display

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -172,7 +172,7 @@ package final class CSSStyle: Equatable {
 
 package struct CSSRuleSourceLocation: Equatable, Sendable {
     package var sourceURL: String
-    /// Zero-based source line, matching WebKit protocol/source location values.
+    /// Zero-based source line, matching WebKit source location values.
     package var line: Int
     /// Zero-based source column when the selector range provides one.
     package var column: Int?
@@ -186,20 +186,50 @@ package struct CSSRuleSourceLocation: Equatable, Sendable {
     package init?(
         sourceURL: String?,
         selectorRange: CSSSourceRange?,
-        fallbackLine: Int
+        fallbackLine: Int,
+        styleSheetSourceLocation: CSSStyleSheetSourceLocation? = nil
     ) {
-        guard let sourceURL else {
+        guard let resolvedSourceURL = Self.nonEmpty(sourceURL) ?? Self.nonEmpty(styleSheetSourceLocation?.sourceURL) else {
             return nil
         }
+        let line: Int
+        let column: Int?
         if let selectorRange {
+            line = selectorRange.startLine
+            column = selectorRange.startColumn
+        } else {
+            line = fallbackLine
+            column = nil
+        }
+
+        if let styleSheetSourceLocation {
             self.init(
-                sourceURL: sourceURL,
-                line: selectorRange.startLine,
-                column: selectorRange.startColumn
+                sourceURL: resolvedSourceURL,
+                line: styleSheetSourceLocation.startLine + line,
+                column: column.map { styleSheetSourceLocation.startColumn + $0 }
             )
         } else {
-            self.init(sourceURL: sourceURL, line: fallbackLine)
+            self.init(sourceURL: resolvedSourceURL, line: line, column: column)
         }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}
+
+package struct CSSStyleSheetSourceLocation: Equatable, Sendable {
+    package var sourceURL: String?
+    package var startLine: Int
+    package var startColumn: Int
+
+    package init(sourceURL: String?, startLine: Int, startColumn: Int) {
+        self.sourceURL = sourceURL
+        self.startLine = startLine
+        self.startColumn = startColumn
     }
 }
 
@@ -209,6 +239,7 @@ package final class CSSRule: Equatable {
     package var selectorList: CSSSelectorList
     package var sourceURL: String?
     package var sourceLine: Int
+    package var styleSheetSourceLocation: CSSStyleSheetSourceLocation?
     package var origin: CSSStyleOrigin
     package var style: CSSStyle
     package var groupings: [CSSGrouping]
@@ -219,6 +250,7 @@ package final class CSSRule: Equatable {
         selectorList: CSSSelectorList,
         sourceURL: String? = nil,
         sourceLine: Int,
+        styleSheetSourceLocation: CSSStyleSheetSourceLocation? = nil,
         origin: CSSStyleOrigin,
         style: CSSStyle,
         groupings: [CSSGrouping] = [],
@@ -228,6 +260,7 @@ package final class CSSRule: Equatable {
         self.selectorList = selectorList
         self.sourceURL = sourceURL
         self.sourceLine = sourceLine
+        self.styleSheetSourceLocation = styleSheetSourceLocation
         self.origin = origin
         self.style = style
         self.groupings = groupings
@@ -238,7 +271,8 @@ package final class CSSRule: Equatable {
         CSSRuleSourceLocation(
             sourceURL: sourceURL,
             selectorRange: selectorList.range,
-            fallbackLine: sourceLine
+            fallbackLine: sourceLine,
+            styleSheetSourceLocation: styleSheetSourceLocation
         )
     }
 
@@ -329,6 +363,11 @@ package final class CSSNodeStyles {
 @MainActor
 @Observable
 package final class CSSSession {
+    private struct StyleSheetRecord: Equatable {
+        var targetID: ProtocolTargetIdentifier
+        var header: CSSStyleSheetHeaderPayload
+    }
+
     private struct SectionMembership: Equatable {
         var id: CSSStyleSectionIdentifier
         var propertyIDs: [PropertyMembership]
@@ -343,6 +382,7 @@ package final class CSSSession {
     package private(set) var selectedState: CSSNodeStylesState
 
     @ObservationIgnored private var stylesByNodeID: [DOMNodeIdentifier: CSSNodeStyles]
+    @ObservationIgnored private var styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
     @ObservationIgnored private var activeRefreshSequenceByNodeID: [DOMNodeIdentifier: UInt64]
     @ObservationIgnored private var nextRefreshSequence: UInt64
 
@@ -350,6 +390,7 @@ package final class CSSSession {
         selectedNodeStyles = nil
         selectedState = .unavailable(.noSelection)
         stylesByNodeID = [:]
+        styleSheetRecordsByID = [:]
         activeRefreshSequenceByNodeID = [:]
         nextRefreshSequence = 0
     }
@@ -358,6 +399,7 @@ package final class CSSSession {
         selectedNodeStyles = nil
         selectedState = .unavailable(.noSelection)
         stylesByNodeID.removeAll()
+        styleSheetRecordsByID.removeAll()
         activeRefreshSequenceByNodeID.removeAll()
         nextRefreshSequence = 0
     }
@@ -400,7 +442,8 @@ package final class CSSSession {
             with: Self.makeSections(
                 identity: token.identity,
                 matched: matched,
-                inline: inline
+                inline: inline,
+                styleSheetRecordsByID: styleSheetRecordsByID
             )
         )
         Self.updateComputedProperties(
@@ -410,6 +453,17 @@ package final class CSSSession {
         nodeStyles.state = .loaded
         selectedState = .loaded
         activeRefreshSequenceByNodeID.removeValue(forKey: token.identity.nodeID)
+    }
+
+    package func registerStyleSheetHeader(_ header: CSSStyleSheetHeaderPayload, targetID: ProtocolTargetIdentifier) {
+        styleSheetRecordsByID[header.styleSheetID] = StyleSheetRecord(
+            targetID: targetID,
+            header: header
+        )
+    }
+
+    package func removeStyleSheetHeader(styleSheetID: CSSStyleSheetIdentifier) {
+        styleSheetRecordsByID.removeValue(forKey: styleSheetID)
     }
 
     package func markRefreshFailed(_ token: CSSStyleRefreshToken, message: String) {
@@ -490,6 +544,7 @@ package final class CSSSession {
             stylesByNodeID.removeValue(forKey: nodeID)
             activeRefreshSequenceByNodeID.removeValue(forKey: nodeID)
         }
+        styleSheetRecordsByID = styleSheetRecordsByID.filter { $0.value.targetID != targetID }
         if let removedSelectedNodeID = selectedNodeStyles?.identity.nodeID,
            selectedNodeStyles?.identity.targetID == targetID {
             selectedNodeStyles = nil
@@ -572,7 +627,8 @@ package final class CSSSession {
     private static func makeSections(
         identity: CSSNodeStyleIdentity,
         matched: CSSMatchedStylesPayload,
-        inline: CSSInlineStylesPayload
+        inline: CSSInlineStylesPayload,
+        styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
     ) -> [CSSStyleSection] {
         var sections: [CSSStyleSection] = []
         var ordinal = 0
@@ -590,7 +646,14 @@ package final class CSSSession {
         }
 
         for match in matched.matchedRules.reversed() {
-            appendRuleSection(&sections, identity: identity, ordinal: &ordinal, match: match, kind: .rule)
+            appendRuleSection(
+                &sections,
+                identity: identity,
+                ordinal: &ordinal,
+                match: match,
+                kind: .rule,
+                styleSheetRecordsByID: styleSheetRecordsByID
+            )
         }
 
         if let attributesStyle = inline.attributesStyle {
@@ -612,7 +675,8 @@ package final class CSSSession {
                     identity: identity,
                     ordinal: &ordinal,
                     match: match,
-                    kind: .pseudoElement(pseudo.pseudoID)
+                    kind: .pseudoElement(pseudo.pseudoID),
+                    styleSheetRecordsByID: styleSheetRecordsByID
                 )
             }
         }
@@ -635,7 +699,8 @@ package final class CSSSession {
                     identity: identity,
                     ordinal: &ordinal,
                     match: match,
-                    kind: .inheritedRule(ancestorIndex: ancestorIndex)
+                    kind: .inheritedRule(ancestorIndex: ancestorIndex),
+                    styleSheetRecordsByID: styleSheetRecordsByID
                 )
             }
         }
@@ -686,6 +751,7 @@ package final class CSSSession {
         rule.selectorList = refreshedRule.selectorList
         rule.sourceURL = refreshedRule.sourceURL
         rule.sourceLine = refreshedRule.sourceLine
+        rule.styleSheetSourceLocation = refreshedRule.styleSheetSourceLocation
         rule.origin = refreshedRule.origin
         rule.groupings = refreshedRule.groupings
         rule.isImplicitlyNested = refreshedRule.isImplicitlyNested
@@ -789,7 +855,8 @@ package final class CSSSession {
         identity: CSSNodeStyleIdentity,
         ordinal: inout Int,
         match: CSSRuleMatchPayload,
-        kind: CSSStyleSectionKind
+        kind: CSSStyleSectionKind,
+        styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
     ) {
         let isEditable = match.rule.origin != .userAgent && match.rule.style.id != nil
         let ruleStyle = normalizedStyle(match.rule.style, isEditable: isEditable, ruleOrigin: match.rule.origin)
@@ -798,6 +865,11 @@ package final class CSSSession {
             selectorList: match.rule.selectorList,
             sourceURL: match.rule.sourceURL,
             sourceLine: match.rule.sourceLine,
+            styleSheetSourceLocation: styleSheetSourceLocation(
+                for: match.rule,
+                targetID: identity.targetID,
+                recordsByID: styleSheetRecordsByID
+            ),
             origin: match.rule.origin,
             style: ruleStyle,
             groupings: match.rule.groupings,
@@ -814,6 +886,23 @@ package final class CSSSession {
             )
         )
         ordinal += 1
+    }
+
+    private static func styleSheetSourceLocation(
+        for rule: CSSRulePayload,
+        targetID: ProtocolTargetIdentifier,
+        recordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
+    ) -> CSSStyleSheetSourceLocation? {
+        guard let styleSheetID = rule.id?.styleSheetID ?? rule.style.id?.styleSheetID,
+              let record = recordsByID[styleSheetID],
+              record.targetID == targetID else {
+            return nil
+        }
+        return CSSStyleSheetSourceLocation(
+            sourceURL: record.header.sourceURL,
+            startLine: record.header.startLine,
+            startColumn: record.header.startColumn
+        )
     }
 
     private static func appendSection(

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -170,6 +170,39 @@ package final class CSSStyle: Equatable {
     }
 }
 
+package struct CSSRuleSourceLocation: Equatable, Sendable {
+    package var sourceURL: String
+    /// Zero-based source line, matching WebKit protocol/source location values.
+    package var line: Int
+    /// Zero-based source column when the selector range provides one.
+    package var column: Int?
+
+    package init(sourceURL: String, line: Int, column: Int? = nil) {
+        self.sourceURL = sourceURL
+        self.line = line
+        self.column = column
+    }
+
+    package init?(
+        sourceURL: String?,
+        selectorRange: CSSSourceRange?,
+        fallbackLine: Int
+    ) {
+        guard let sourceURL else {
+            return nil
+        }
+        if let selectorRange {
+            self.init(
+                sourceURL: sourceURL,
+                line: selectorRange.startLine,
+                column: selectorRange.startColumn
+            )
+        } else {
+            self.init(sourceURL: sourceURL, line: fallbackLine)
+        }
+    }
+}
+
 @Observable
 package final class CSSRule: Equatable {
     package var id: CSSRuleIdentifier?
@@ -199,6 +232,14 @@ package final class CSSRule: Equatable {
         self.style = style
         self.groupings = groupings
         self.isImplicitlyNested = isImplicitlyNested
+    }
+
+    package var sourceLocation: CSSRuleSourceLocation? {
+        CSSRuleSourceLocation(
+            sourceURL: sourceURL,
+            selectorRange: selectorList.range,
+            fallbackLine: sourceLine
+        )
     }
 
     package static func == (lhs: CSSRule, rhs: CSSRule) -> Bool {
@@ -239,7 +280,6 @@ package final class CSSStyleSection: Equatable {
     package var id: CSSStyleSectionIdentifier
     package var kind: CSSStyleSectionKind
     package var title: String
-    package var subtitle: String?
     package var rule: CSSRule?
     package var style: CSSStyle
     package var isEditable: Bool
@@ -248,7 +288,6 @@ package final class CSSStyleSection: Equatable {
         id: CSSStyleSectionIdentifier,
         kind: CSSStyleSectionKind,
         title: String,
-        subtitle: String? = nil,
         rule: CSSRule? = nil,
         style: CSSStyle,
         isEditable: Bool
@@ -256,7 +295,6 @@ package final class CSSStyleSection: Equatable {
         self.id = id
         self.kind = kind
         self.title = title
-        self.subtitle = subtitle
         self.rule = rule
         self.style = style
         self.isEditable = isEditable
@@ -627,7 +665,6 @@ package final class CSSSession {
     private static func updateSection(_ section: CSSStyleSection, from refreshedSection: CSSStyleSection) {
         section.kind = refreshedSection.kind
         section.title = refreshedSection.title
-        section.subtitle = refreshedSection.subtitle
         section.isEditable = refreshedSection.isEditable
 
         if let refreshedRule = refreshedSection.rule {
@@ -771,7 +808,6 @@ package final class CSSSession {
                 id: .init(nodeID: identity.nodeID, kind: kind, ordinal: ordinal),
                 kind: kind,
                 title: rule.selectorList.text,
-                subtitle: rule.sourceURL,
                 rule: rule,
                 style: rule.style,
                 isEditable: isEditable

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -543,6 +543,7 @@ package final class CSSSession {
         let removedIDs = stylesByNodeID
             .filter { $0.value.identity.targetID == targetID }
             .map(\.key)
+        styleSheetHeadersByKey = styleSheetHeadersByKey.filter { $0.key.targetID != targetID }
         guard !removedIDs.isEmpty else {
             return
         }
@@ -550,7 +551,6 @@ package final class CSSSession {
             stylesByNodeID.removeValue(forKey: nodeID)
             activeRefreshSequenceByNodeID.removeValue(forKey: nodeID)
         }
-        styleSheetHeadersByKey = styleSheetHeadersByKey.filter { $0.key.targetID != targetID }
         if let removedSelectedNodeID = selectedNodeStyles?.identity.nodeID,
            selectedNodeStyles?.identity.targetID == targetID {
             selectedNodeStyles = nil

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -203,10 +203,13 @@ package struct CSSRuleSourceLocation: Equatable, Sendable {
         }
 
         if let styleSheetSourceLocation {
+            let offsetColumn = column.map { column in
+                line == 0 ? styleSheetSourceLocation.startColumn + column : column
+            }
             self.init(
                 sourceURL: resolvedSourceURL,
                 line: styleSheetSourceLocation.startLine + line,
-                column: column.map { styleSheetSourceLocation.startColumn + $0 }
+                column: offsetColumn
             )
         } else {
             self.init(sourceURL: resolvedSourceURL, line: line, column: column)
@@ -363,9 +366,9 @@ package final class CSSNodeStyles {
 @MainActor
 @Observable
 package final class CSSSession {
-    private struct StyleSheetRecord: Equatable {
+    private struct StyleSheetKey: Equatable, Hashable {
         var targetID: ProtocolTargetIdentifier
-        var header: CSSStyleSheetHeaderPayload
+        var styleSheetID: CSSStyleSheetIdentifier
     }
 
     private struct SectionMembership: Equatable {
@@ -382,7 +385,7 @@ package final class CSSSession {
     package private(set) var selectedState: CSSNodeStylesState
 
     @ObservationIgnored private var stylesByNodeID: [DOMNodeIdentifier: CSSNodeStyles]
-    @ObservationIgnored private var styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
+    @ObservationIgnored private var styleSheetHeadersByKey: [StyleSheetKey: CSSStyleSheetHeaderPayload]
     @ObservationIgnored private var activeRefreshSequenceByNodeID: [DOMNodeIdentifier: UInt64]
     @ObservationIgnored private var nextRefreshSequence: UInt64
 
@@ -390,7 +393,7 @@ package final class CSSSession {
         selectedNodeStyles = nil
         selectedState = .unavailable(.noSelection)
         stylesByNodeID = [:]
-        styleSheetRecordsByID = [:]
+        styleSheetHeadersByKey = [:]
         activeRefreshSequenceByNodeID = [:]
         nextRefreshSequence = 0
     }
@@ -399,7 +402,7 @@ package final class CSSSession {
         selectedNodeStyles = nil
         selectedState = .unavailable(.noSelection)
         stylesByNodeID.removeAll()
-        styleSheetRecordsByID.removeAll()
+        styleSheetHeadersByKey.removeAll()
         activeRefreshSequenceByNodeID.removeAll()
         nextRefreshSequence = 0
     }
@@ -443,7 +446,7 @@ package final class CSSSession {
                 identity: token.identity,
                 matched: matched,
                 inline: inline,
-                styleSheetRecordsByID: styleSheetRecordsByID
+                styleSheetHeadersByKey: styleSheetHeadersByKey
             )
         )
         Self.updateComputedProperties(
@@ -456,14 +459,17 @@ package final class CSSSession {
     }
 
     package func registerStyleSheetHeader(_ header: CSSStyleSheetHeaderPayload, targetID: ProtocolTargetIdentifier) {
-        styleSheetRecordsByID[header.styleSheetID] = StyleSheetRecord(
+        styleSheetHeadersByKey[StyleSheetKey(
             targetID: targetID,
-            header: header
-        )
+            styleSheetID: header.styleSheetID
+        )] = header
     }
 
-    package func removeStyleSheetHeader(styleSheetID: CSSStyleSheetIdentifier) {
-        styleSheetRecordsByID.removeValue(forKey: styleSheetID)
+    package func removeStyleSheetHeader(styleSheetID: CSSStyleSheetIdentifier, targetID: ProtocolTargetIdentifier) {
+        styleSheetHeadersByKey.removeValue(forKey: StyleSheetKey(
+            targetID: targetID,
+            styleSheetID: styleSheetID
+        ))
     }
 
     package func markRefreshFailed(_ token: CSSStyleRefreshToken, message: String) {
@@ -544,7 +550,7 @@ package final class CSSSession {
             stylesByNodeID.removeValue(forKey: nodeID)
             activeRefreshSequenceByNodeID.removeValue(forKey: nodeID)
         }
-        styleSheetRecordsByID = styleSheetRecordsByID.filter { $0.value.targetID != targetID }
+        styleSheetHeadersByKey = styleSheetHeadersByKey.filter { $0.key.targetID != targetID }
         if let removedSelectedNodeID = selectedNodeStyles?.identity.nodeID,
            selectedNodeStyles?.identity.targetID == targetID {
             selectedNodeStyles = nil
@@ -628,7 +634,7 @@ package final class CSSSession {
         identity: CSSNodeStyleIdentity,
         matched: CSSMatchedStylesPayload,
         inline: CSSInlineStylesPayload,
-        styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
+        styleSheetHeadersByKey: [StyleSheetKey: CSSStyleSheetHeaderPayload]
     ) -> [CSSStyleSection] {
         var sections: [CSSStyleSection] = []
         var ordinal = 0
@@ -652,7 +658,7 @@ package final class CSSSession {
                 ordinal: &ordinal,
                 match: match,
                 kind: .rule,
-                styleSheetRecordsByID: styleSheetRecordsByID
+                styleSheetHeadersByKey: styleSheetHeadersByKey
             )
         }
 
@@ -676,7 +682,7 @@ package final class CSSSession {
                     ordinal: &ordinal,
                     match: match,
                     kind: .pseudoElement(pseudo.pseudoID),
-                    styleSheetRecordsByID: styleSheetRecordsByID
+                    styleSheetHeadersByKey: styleSheetHeadersByKey
                 )
             }
         }
@@ -700,7 +706,7 @@ package final class CSSSession {
                     ordinal: &ordinal,
                     match: match,
                     kind: .inheritedRule(ancestorIndex: ancestorIndex),
-                    styleSheetRecordsByID: styleSheetRecordsByID
+                    styleSheetHeadersByKey: styleSheetHeadersByKey
                 )
             }
         }
@@ -856,7 +862,7 @@ package final class CSSSession {
         ordinal: inout Int,
         match: CSSRuleMatchPayload,
         kind: CSSStyleSectionKind,
-        styleSheetRecordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
+        styleSheetHeadersByKey: [StyleSheetKey: CSSStyleSheetHeaderPayload]
     ) {
         let isEditable = match.rule.origin != .userAgent && match.rule.style.id != nil
         let ruleStyle = normalizedStyle(match.rule.style, isEditable: isEditable, ruleOrigin: match.rule.origin)
@@ -868,7 +874,7 @@ package final class CSSSession {
             styleSheetSourceLocation: styleSheetSourceLocation(
                 for: match.rule,
                 targetID: identity.targetID,
-                recordsByID: styleSheetRecordsByID
+                headersByKey: styleSheetHeadersByKey
             ),
             origin: match.rule.origin,
             style: ruleStyle,
@@ -891,17 +897,16 @@ package final class CSSSession {
     private static func styleSheetSourceLocation(
         for rule: CSSRulePayload,
         targetID: ProtocolTargetIdentifier,
-        recordsByID: [CSSStyleSheetIdentifier: StyleSheetRecord]
+        headersByKey: [StyleSheetKey: CSSStyleSheetHeaderPayload]
     ) -> CSSStyleSheetSourceLocation? {
         guard let styleSheetID = rule.id?.styleSheetID ?? rule.style.id?.styleSheetID,
-              let record = recordsByID[styleSheetID],
-              record.targetID == targetID else {
+              let header = headersByKey[StyleSheetKey(targetID: targetID, styleSheetID: styleSheetID)] else {
             return nil
         }
         return CSSStyleSheetSourceLocation(
-            sourceURL: record.header.sourceURL,
-            startLine: record.header.startLine,
-            startColumn: record.header.startColumn
+            sourceURL: header.sourceURL,
+            startLine: header.startLine,
+            startColumn: header.startColumn
         )
     }
 

--- a/Sources/WebInspectorCore/CSS/CSSProtocol.swift
+++ b/Sources/WebInspectorCore/CSS/CSSProtocol.swift
@@ -46,6 +46,78 @@ package struct CSSRuleIdentifier: Hashable, Codable, Sendable {
     }
 }
 
+package struct CSSStyleSheetHeaderPayload: Equatable, Codable, Sendable {
+    package var styleSheetID: CSSStyleSheetIdentifier
+    package var frameID: DOMFrameIdentifier?
+    package var sourceURL: String?
+    package var origin: CSSStyleOrigin?
+    package var title: String?
+    package var disabled: Bool
+    package var isInline: Bool
+    package var startLine: Int
+    package var startColumn: Int
+
+    package init(
+        styleSheetID: CSSStyleSheetIdentifier,
+        frameID: DOMFrameIdentifier? = nil,
+        sourceURL: String? = nil,
+        origin: CSSStyleOrigin? = nil,
+        title: String? = nil,
+        disabled: Bool = false,
+        isInline: Bool = false,
+        startLine: Int = 0,
+        startColumn: Int = 0
+    ) {
+        self.styleSheetID = styleSheetID
+        self.frameID = frameID
+        self.sourceURL = sourceURL
+        self.origin = origin
+        self.title = title
+        self.disabled = disabled
+        self.isInline = isInline
+        self.startLine = startLine
+        self.startColumn = startColumn
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case styleSheetID = "styleSheetId"
+        case frameID = "frameId"
+        case sourceURL
+        case origin
+        case title
+        case disabled
+        case isInline
+        case startLine
+        case startColumn
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        styleSheetID = try container.decode(CSSStyleSheetIdentifier.self, forKey: .styleSheetID)
+        frameID = try container.decodeIfPresent(DOMFrameIdentifier.self, forKey: .frameID)
+        sourceURL = try container.decodeIfPresent(String.self, forKey: .sourceURL)
+        origin = try container.decodeIfPresent(CSSStyleOrigin.self, forKey: .origin)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        disabled = try container.decodeIfPresent(Bool.self, forKey: .disabled) ?? false
+        isInline = try container.decodeIfPresent(Bool.self, forKey: .isInline) ?? false
+        startLine = try container.decodeIfPresent(Int.self, forKey: .startLine) ?? 0
+        startColumn = try container.decodeIfPresent(Int.self, forKey: .startColumn) ?? 0
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(styleSheetID, forKey: .styleSheetID)
+        try container.encodeIfPresent(frameID, forKey: .frameID)
+        try container.encodeIfPresent(sourceURL, forKey: .sourceURL)
+        try container.encodeIfPresent(origin, forKey: .origin)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encode(disabled, forKey: .disabled)
+        try container.encode(isInline, forKey: .isInline)
+        try container.encode(startLine, forKey: .startLine)
+        try container.encode(startColumn, forKey: .startColumn)
+    }
+}
+
 package struct CSSSourceRange: Equatable, Codable, Sendable {
     package var startLine: Int
     package var startColumn: Int

--- a/Sources/WebInspectorCore/Docs/CSSModelResearch.md
+++ b/Sources/WebInspectorCore/Docs/CSSModelResearch.md
@@ -56,6 +56,8 @@ DOM selection -> selected DOMNode.ID
 | `Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js` | Shared style-sidebar shell. It only supports element DOM nodes, installs the style panel, filter bar, new-rule control, class toggles, and forced pseudo-class checkboxes. |
 | `Source/WebInspectorUI/UserInterface/Views/StyleDetailsPanel.js` | Base panel that owns the current `WI.DOMNodeStyles`, refreshes it when the selected DOM node changes, and preserves scroll position across refreshes. |
 | `Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js` | Builds the rules list from `nodeStyles.uniqueOrderedStyles`, inserting pseudo-element and inherited headers, then creating one `SpreadsheetCSSStyleDeclarationSection` per style declaration. |
+| `Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js` | Renders each rule header from the selector plus `StyleOriginView`; the protocol `sourceURL` is not displayed directly as a raw subtitle. |
+| `Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js` | Renders rule origin/source information from `CSSRule.sourceCodeLocation`, falling back to origin labels such as "User Agent Style Sheet" when no source location is available. |
 | `Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.js` | Builds the computed surface from `nodeStyles.computedStyle`, plus box model, variable grouping, and property trace links into the rules panel. |
 | `Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js` | Node-scoped CSS source of truth for matched rules, pseudo rules, inherited rules, inline style, attribute style, computed style, ordered cascade styles, effective properties, and CSS variables. |
 | `Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js` | Style declaration model with style id, owner rule/sheet, editable state, enabled/visible properties, variables, source ranges, and text editing. |
@@ -114,6 +116,25 @@ valid for user-agent, attribute, inline, source-less, or non-editable styles.
 | `CSS.CSSComputedStyleProperty` | `name`, `value` | none | Drives the Computed tab/list and can later be traced back to effective authored properties. |
 | `CSS.InheritedStyleEntry` | `matchedCSSRules` | `inlineStyle` | Separates inherited sections by ancestor node and avoids showing non-inherited properties as normal active declarations. |
 | `CSS.PseudoIdMatches` | `pseudoId`, `matches` | none | Allows `::before`, `::after`, and other pseudo-element sections before inherited rules. |
+
+## WebKit Source Links and Header Display
+
+- `DOMNodeStyles._parseRulePayload` builds a `CSSRule.sourceCodeLocation` from
+  `selectorList.range.startLine/startColumn` when available. If the range is
+  absent, it falls back to `CSSRule.sourceLine`. Stylesheet metadata can then
+  offset the resulting location for inline or nested stylesheet sources.
+- `StyleOriginView` displays that source location through
+  `createSourceCodeLocationLink`, whose default display is the short source
+  name plus a 1-based line number. Columns are shown only for large columns
+  (`SourceCodeLocation.LargeColumnNumber` is 80).
+- `displayNameForURL` uses a decoded last path component when present, then a
+  host fallback, then the original URL. This is why a Google search URL appears
+  as a compact `search:<line>` style label rather than the full request URL.
+- Long source/origin text is constrained in WebKit UI rather than allowed to
+  grow section headers: `.spreadsheet-css-declaration .origin` uses one-line
+  overflow ellipsis, and generic details-section headers also use `nowrap` plus
+  ellipsis. Inherited/pseudo group headers are a separate list grouping surface;
+  inherited node links are pre-truncated with `maxLength: 100`.
 
 ## WebKit Cascade and Refresh Behavior
 
@@ -216,6 +237,9 @@ Toggle availability follows style editability, not just row display:
 - `Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js`
 - `Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.js`
 - `Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js`
+- `Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css`
+- `Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js`
+- `Source/WebInspectorUI/UserInterface/Views/DetailsSection.css`
 - `Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.js`
 - `Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js`
 - `Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js`
@@ -223,6 +247,8 @@ Toggle availability follows style editability, not just row display:
 - `Source/WebInspectorUI/UserInterface/Models/CSSRule.js`
 - `Source/WebInspectorUI/UserInterface/Models/CSSProperty.js`
 - `Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js`
+- `Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js`
+- `Source/WebInspectorUI/UserInterface/Base/URLUtilities.js`
 - `Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js`
 - `Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js`
 - `Source/JavaScriptCore/inspector/protocol/CSS.json`

--- a/Sources/WebInspectorTransport/CSSTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/CSSTransportAdapter.swift
@@ -78,7 +78,7 @@ package enum CSSTransportAdapter {
             session.markNeedsRefresh(targetID: targetID)
         case "CSS.styleSheetRemoved":
             let params = try TransportMessageParser.decode(StyleSheetIdentifierParams.self, from: event.paramsData)
-            session.removeStyleSheetHeader(styleSheetID: params.styleSheetId)
+            session.removeStyleSheetHeader(styleSheetID: params.styleSheetId, targetID: targetID)
             session.markNeedsRefresh(targetID: targetID, styleSheetID: params.styleSheetId)
         case "CSS.styleSheetAdded":
             let params = try TransportMessageParser.decode(StyleSheetAddedParams.self, from: event.paramsData)

--- a/Sources/WebInspectorTransport/CSSTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/CSSTransportAdapter.swift
@@ -78,9 +78,13 @@ package enum CSSTransportAdapter {
             session.markNeedsRefresh(targetID: targetID)
         case "CSS.styleSheetRemoved":
             let params = try TransportMessageParser.decode(StyleSheetIdentifierParams.self, from: event.paramsData)
+            session.removeStyleSheetHeader(styleSheetID: params.styleSheetId)
             session.markNeedsRefresh(targetID: targetID, styleSheetID: params.styleSheetId)
-        case "CSS.styleSheetAdded",
-             "CSS.mediaQueryResultChanged":
+        case "CSS.styleSheetAdded":
+            let params = try TransportMessageParser.decode(StyleSheetAddedParams.self, from: event.paramsData)
+            session.registerStyleSheetHeader(params.header, targetID: targetID)
+            session.markNeedsRefresh(targetID: targetID)
+        case "CSS.mediaQueryResultChanged":
             session.markNeedsRefresh(targetID: targetID)
         case "CSS.nodeLayoutFlagsChanged":
             let params = try TransportMessageParser.decode(NodeLayoutFlagsChangedParams.self, from: event.paramsData)
@@ -104,6 +108,10 @@ package enum CSSTransportAdapter {
 
 private struct StyleSheetIdentifierParams: Decodable {
     var styleSheetId: CSSStyleSheetIdentifier
+}
+
+private struct StyleSheetAddedParams: Decodable {
+    var header: CSSStyleSheetHeaderPayload
 }
 
 private struct ComputedStyleResult: Decodable {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -10,6 +10,11 @@ package actor TransportSession {
         var hasBufferedProvisionalResponse: Bool
     }
 
+    private struct ResolvedStyleSheetAddedEvent: Sendable {
+        var targetID: ProtocolTargetIdentifier
+        var paramsData: Data
+    }
+
     package typealias ResponseTimeoutSleep = @Sendable (Duration) async throws -> Void
 
     private let backend: any TransportBackend
@@ -29,6 +34,8 @@ package actor TransportSession {
     private var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
     private var styleSheetTargetIDsByStyleSheetID: [CSSStyleSheetIdentifier: ProtocolTargetIdentifier]
     private var unresolvedStyleSheetFrameIDsByStyleSheetID: [CSSStyleSheetIdentifier: DOMFrameIdentifier]
+    private var unresolvedStyleSheetAddedParamsDataByStyleSheetID: [CSSStyleSheetIdentifier: Data]
+    private var pendingResolvedStyleSheetAddedEvents: [ResolvedStyleSheetAddedEvent]
     private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
@@ -60,6 +67,8 @@ package actor TransportSession {
         frameTargetIDsByFrameID = [:]
         styleSheetTargetIDsByStyleSheetID = [:]
         unresolvedStyleSheetFrameIDsByStyleSheetID = [:]
+        unresolvedStyleSheetAddedParamsDataByStyleSheetID = [:]
+        pendingResolvedStyleSheetAddedEvents = []
         executionContextsByID = [:]
         currentMainPageTargetID = nil
         subscribers = [:]
@@ -428,6 +437,7 @@ package actor TransportSession {
         let targetID = targetIDForRootEvent(method: method, paramsData: parsed.paramsData)
         await updateRegistryFromRootEvent(method: method, targetID: targetID, paramsData: parsed.paramsData)
         await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetID, paramsData: parsed.paramsData)
+        await emitPendingResolvedStyleSheetAddedEvents()
         await dispatchCommittedProvisionalTargetMessagesIfNeeded(method: method, paramsData: parsed.paramsData)
     }
 
@@ -810,12 +820,14 @@ package actor TransportSession {
                 } else {
                     styleSheetTargetIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
                     unresolvedStyleSheetFrameIDsByStyleSheetID[params.header.styleSheetID] = frameID
+                    unresolvedStyleSheetAddedParamsDataByStyleSheetID[params.header.styleSheetID] = paramsData
                 }
                 return
             }
             if let resolvedTargetID = targetID {
                 styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] = resolvedTargetID
                 unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
+                unresolvedStyleSheetAddedParamsDataByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
             }
         case "CSS.styleSheetRemoved":
             guard let params = try? TransportMessageParser.decode(CSSStyleSheetIDParams.self, from: paramsData) else {
@@ -823,6 +835,7 @@ package actor TransportSession {
             }
             styleSheetTargetIDsByStyleSheetID.removeValue(forKey: params.styleSheetID)
             unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.styleSheetID)
+            unresolvedStyleSheetAddedParamsDataByStyleSheetID.removeValue(forKey: params.styleSheetID)
         default:
             return
         }
@@ -835,6 +848,28 @@ package actor TransportSession {
         for styleSheetID in styleSheetIDs {
             styleSheetTargetIDsByStyleSheetID[styleSheetID] = targetID
             unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: styleSheetID)
+            if let paramsData = unresolvedStyleSheetAddedParamsDataByStyleSheetID.removeValue(forKey: styleSheetID) {
+                pendingResolvedStyleSheetAddedEvents.append(ResolvedStyleSheetAddedEvent(
+                    targetID: targetID,
+                    paramsData: paramsData
+                ))
+            }
+        }
+    }
+
+    private func emitPendingResolvedStyleSheetAddedEvents() async {
+        guard !pendingResolvedStyleSheetAddedEvents.isEmpty else {
+            return
+        }
+        let events = pendingResolvedStyleSheetAddedEvents
+        pendingResolvedStyleSheetAddedEvents.removeAll(keepingCapacity: true)
+        for event in events {
+            await emit(
+                domain: .css,
+                method: "CSS.styleSheetAdded",
+                targetID: event.targetID,
+                paramsData: event.paramsData
+            )
         }
     }
 

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -561,7 +561,9 @@ package actor TransportSession {
         targetsByID[record.id] = record
         if let frameID = record.frameID {
             frameTargetIDsByFrameID[frameID] = record.id
-            resolvePendingStyleSheets(frameID: frameID, targetID: record.id)
+            if !record.isProvisional {
+                resolvePendingStyleSheets(frameID: frameID, targetID: record.id)
+            }
         }
         if currentMainPageTargetID == nil,
            record.kind == .page,
@@ -783,12 +785,12 @@ package actor TransportSession {
         guard let params = try? TransportMessageParser.decode(CSSStyleSheetAddedParams.self, from: paramsData) else {
             return nil
         }
-        if let frameID = params.header.frameID,
-           frameTargetIDsByFrameID[frameID] == nil {
-            return nil
-        }
         if let frameID = params.header.frameID {
-            return frameTargetIDsByFrameID[frameID]
+            guard let targetID = frameTargetIDsByFrameID[frameID],
+                  targetsByID[targetID]?.isProvisional != true else {
+                return nil
+            }
+            return targetID
         }
         return styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] ?? currentMainPageTargetID
     }
@@ -814,9 +816,11 @@ package actor TransportSession {
                 return
             }
             if let frameID = params.header.frameID {
-                if let resolvedTargetID = frameTargetIDsByFrameID[frameID] {
+                if let resolvedTargetID = frameTargetIDsByFrameID[frameID],
+                   targetsByID[resolvedTargetID]?.isProvisional != true {
                     styleSheetTargetIDsByStyleSheetID[params.header.styleSheetID] = resolvedTargetID
                     unresolvedStyleSheetFrameIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
+                    unresolvedStyleSheetAddedParamsDataByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
                 } else {
                     styleSheetTargetIDsByStyleSheetID.removeValue(forKey: params.header.styleSheetID)
                     unresolvedStyleSheetFrameIDsByStyleSheetID[params.header.styleSheetID] = frameID

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -1043,16 +1043,6 @@ private struct CSSStyleSheetAddedParams: Decodable {
     var header: CSSStyleSheetHeaderPayload
 }
 
-private struct CSSStyleSheetHeaderPayload: Decodable {
-    var styleSheetID: CSSStyleSheetIdentifier
-    var frameID: DOMFrameIdentifier?
-
-    private enum CodingKeys: String, CodingKey {
-        case styleSheetID = "styleSheetId"
-        case frameID = "frameId"
-    }
-}
-
 private struct CSSStyleSheetIDParams: Decodable {
     var styleSheetID: CSSStyleSheetIdentifier
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
@@ -27,7 +27,7 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
 
     override package func prepareForReuse() {
         super.prepareForReuse()
-        clear()
+        unbind()
     }
 
     override package func updateConfiguration(using state: UICellConfigurationState) {
@@ -47,7 +47,6 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
             property: property,
             onToggle: onToggle
         )
-        setNeedsUpdateConfiguration()
 
         observationScope.cancelAll()
         observationScope.observe(property) { [weak self] _, property in
@@ -65,7 +64,19 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
         observationScope.cancelAll()
         property = nil
         propertyView.clear()
-        setNeedsUpdateConfiguration()
+        renderBackground(
+            isModifiedByInspector: false,
+            state: configurationState
+        )
+    }
+
+    private func unbind() {
+        observationScope.cancelAll()
+        property = nil
+        renderBackground(
+            isModifiedByInspector: false,
+            state: configurationState
+        )
     }
 
     private func configureStaticViews() {

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
@@ -34,8 +34,6 @@ package final class DOMElementStylePropertyView: UIView {
         self.property = property
         toggleAction = onToggle
 
-        renderAll(from: property)
-
         observationScope.cancelAll()
         observationScope.observe(property) { [weak self] _, property in
             self?.renderAll(from: property)

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -142,6 +142,7 @@ private struct DOMElementStyleSectionHeaderContent: View {
         } label: {
             Text(configuration.title)
         }
+        .textScale(.secondary)
         .lineLimit(1)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(configuration.accessibilityLabel)

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -1,19 +1,30 @@
 #if canImport(UIKit)
-import ObservationBridge
+import Observation
+import SwiftUI
 import UIKit
 import WebInspectorCore
 
-package struct DOMElementStyleSectionHeaderPresentation: Equatable {
+@MainActor
+@Observable
+package final class DOMElementStyleSectionHeaderConfiguration {
     private static let largeColumnNumber = 80
 
-    package var title: String
-    package var originText: String?
-    package var accessibilityOriginText: String?
+    package var section: CSSStyleSection?
 
-    package init(section: CSSStyleSection) {
-        title = section.title
-        originText = section.rule.flatMap(Self.displayOriginText(for:))
-        accessibilityOriginText = section.rule.flatMap(Self.accessibilityOriginText(for:))
+    package init(section: CSSStyleSection? = nil) {
+        self.section = section
+    }
+
+    package var title: String {
+        section?.title ?? ""
+    }
+
+    package var originText: String? {
+        section?.rule.flatMap(Self.displayOriginText(for:))
+    }
+
+    package var accessibilityOriginText: String? {
+        section?.rule.flatMap(Self.accessibilityOriginText(for:))
     }
 
     package var accessibilityLabel: String {
@@ -98,14 +109,14 @@ package struct DOMElementStyleSectionHeaderPresentation: Equatable {
 }
 
 @MainActor
-final class DOMElementStyleSectionHeaderView: UICollectionReusableView {
-    private let observationScope = ObservationScope()
-    private let titleLabel = UILabel()
-    private let originLabel = UILabel()
+final class DOMElementStyleSectionHeaderView: UICollectionViewListCell {
+    private let headerConfiguration = DOMElementStyleSectionHeaderConfiguration()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configureStaticViews()
+        contentConfiguration = UIHostingConfiguration {
+            DOMElementStyleSectionHeaderContent(configuration: headerConfiguration)
+        }
     }
 
     @available(*, unavailable)
@@ -113,106 +124,27 @@ final class DOMElementStyleSectionHeaderView: UICollectionReusableView {
         nil
     }
 
-    isolated deinit {
-        observationScope.cancelAll()
+    func bind(_ section: CSSStyleSection?) {
+        headerConfiguration.section = section
     }
+}
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        clear()
-    }
+private struct DOMElementStyleSectionHeaderContent: View {
+    var configuration: DOMElementStyleSectionHeaderConfiguration
 
-    func bind(_ section: CSSStyleSection) {
-        render(section)
-
-        observationScope.cancelAll()
-        observationScope.observe(section) { [weak self] _, section in
-            self?.render(section)
+    var body: some View {
+        LabeledContent {
+            if let originText = configuration.originText {
+                Text(originText)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(.trailing)
+            }
+        } label: {
+            Text(configuration.title)
         }
-    }
-
-    func clear() {
-        observationScope.cancelAll()
-        titleLabel.text = nil
-        originLabel.text = nil
-        originLabel.isHidden = true
-        accessibilityLabel = nil
-    }
-
-    private func configureStaticViews() {
-        preservesSuperviewLayoutMargins = true
-        directionalLayoutMargins = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 4, trailing: 16)
-
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = .preferredFont(forTextStyle: .footnote)
-        titleLabel.textColor = .secondaryLabel
-        titleLabel.adjustsFontForContentSizeCategory = true
-        titleLabel.numberOfLines = 1
-        titleLabel.lineBreakMode = .byTruncatingTail
-        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-
-        originLabel.translatesAutoresizingMaskIntoConstraints = false
-        originLabel.font = .preferredFont(forTextStyle: .caption1)
-        originLabel.textColor = .tertiaryLabel
-        originLabel.textAlignment = .right
-        originLabel.adjustsFontForContentSizeCategory = true
-        originLabel.numberOfLines = 1
-        originLabel.lineBreakMode = .byTruncatingTail
-        originLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        originLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        originLabel.isHidden = true
-
-        addSubview(titleLabel)
-        addSubview(originLabel)
-
-        let layoutGuide = layoutMarginsGuide
-        NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
-            titleLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
-            titleLabel.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: originLabel.leadingAnchor, constant: -8),
-
-            originLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            originLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
-            originLabel.widthAnchor.constraint(lessThanOrEqualTo: layoutGuide.widthAnchor, multiplier: 0.55),
-        ])
-    }
-
-    private func render(_ section: CSSStyleSection) {
-        let presentation = DOMElementStyleSectionHeaderPresentation(section: section)
-        titleLabel.text = presentation.title
-        originLabel.text = presentation.originText
-        originLabel.isHidden = presentation.originText?.isEmpty != false
-        accessibilityLabel = presentation.accessibilityLabel
+        .lineLimit(1)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(configuration.accessibilityLabel)
     }
 }
-
-#if DEBUG
-extension DOMElementStyleSectionHeaderView {
-    package var titleTextForTesting: String? {
-        titleLabel.text
-    }
-
-    package var originTextForTesting: String? {
-        originLabel.text
-    }
-
-    package var titleNumberOfLinesForTesting: Int {
-        titleLabel.numberOfLines
-    }
-
-    package var originNumberOfLinesForTesting: Int {
-        originLabel.numberOfLines
-    }
-
-    package var titleLineBreakModeForTesting: NSLineBreakMode {
-        titleLabel.lineBreakMode
-    }
-
-    package var originLineBreakModeForTesting: NSLineBreakMode {
-        originLabel.lineBreakMode
-    }
-}
-#endif
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -3,12 +3,105 @@ import ObservationBridge
 import UIKit
 import WebInspectorCore
 
+package struct DOMElementStyleSectionHeaderPresentation: Equatable {
+    private static let largeColumnNumber = 80
+
+    package var title: String
+    package var originText: String?
+    package var accessibilityOriginText: String?
+
+    package init(section: CSSStyleSection) {
+        title = section.title
+        originText = section.rule.flatMap(Self.displayOriginText(for:))
+        accessibilityOriginText = section.rule.flatMap(Self.accessibilityOriginText(for:))
+    }
+
+    package var accessibilityLabel: String {
+        [title, accessibilityOriginText]
+            .compactMap { text in
+                guard let text, !text.isEmpty else {
+                    return nil
+                }
+                return text
+            }
+            .joined(separator: ", ")
+    }
+
+    package static func displayOriginText(for rule: CSSRule) -> String? {
+        if let sourceLocation = rule.sourceLocation {
+            return displayText(for: sourceLocation)
+        }
+        return displayText(for: rule.origin)
+    }
+
+    package static func accessibilityOriginText(for rule: CSSRule) -> String? {
+        if let sourceLocation = rule.sourceLocation {
+            return fullDisplayText(for: sourceLocation)
+        }
+        return displayText(for: rule.origin)
+    }
+
+    package static func displayText(for sourceLocation: CSSRuleSourceLocation) -> String {
+        var text = displayName(forSourceURL: sourceLocation.sourceURL)
+        text += ":\(sourceLocation.line + 1)"
+        if let column = sourceLocation.column, column > largeColumnNumber {
+            text += ":\(column + 1)"
+        }
+        return text
+    }
+
+    package static func fullDisplayText(for sourceLocation: CSSRuleSourceLocation) -> String {
+        var text = sourceLocation.sourceURL
+        text += ":\(sourceLocation.line + 1)"
+        if let column = sourceLocation.column {
+            text += ":\(column + 1)"
+        }
+        return text
+    }
+
+    package static func displayName(forSourceURL sourceURL: String) -> String {
+        guard !sourceURL.hasPrefix("data:") else {
+            return sourceURL
+        }
+
+        guard let components = URLComponents(string: sourceURL) else {
+            return sourceURL
+        }
+
+        let path = components.percentEncodedPath
+        if let encodedName = path.split(separator: "/", omittingEmptySubsequences: true).last {
+            let name = String(encodedName)
+            return name.removingPercentEncoding ?? name
+        }
+
+        if let host = components.host, !host.isEmpty {
+            return host
+        }
+
+        return sourceURL
+    }
+
+    package static func displayText(for origin: CSSStyleOrigin) -> String? {
+        switch origin {
+        case .user:
+            webInspectorLocalized("dom.element.styles.origin.user", default: "User Style Sheet")
+        case .userAgent:
+            webInspectorLocalized("dom.element.styles.origin.user_agent", default: "User Agent Style Sheet")
+        case .author:
+            webInspectorLocalized("dom.element.styles.origin.author", default: "Author Style Sheet")
+        case .inspector:
+            webInspectorLocalized("dom.element.styles.origin.inspector", default: "Web Inspector")
+        case let .other(value):
+            value.isEmpty ? nil : value
+        }
+    }
+}
+
 @MainActor
 final class DOMElementStyleSectionHeaderView: UICollectionReusableView {
     private let observationScope = ObservationScope()
-    private let contentView = UIListContentView(
-        configuration: UIListContentConfiguration.header()
-    )
+    private let titleLabel = UILabel()
+    private let originLabel = UILabel()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -40,28 +133,86 @@ final class DOMElementStyleSectionHeaderView: UICollectionReusableView {
 
     func clear() {
         observationScope.cancelAll()
-        contentView.configuration = UIListContentConfiguration.header()
+        titleLabel.text = nil
+        originLabel.text = nil
+        originLabel.isHidden = true
+        accessibilityLabel = nil
     }
 
     private func configureStaticViews() {
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(contentView)
+        preservesSuperviewLayoutMargins = true
+        directionalLayoutMargins = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 4, trailing: 16)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .preferredFont(forTextStyle: .footnote)
+        titleLabel.textColor = .secondaryLabel
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        originLabel.translatesAutoresizingMaskIntoConstraints = false
+        originLabel.font = .preferredFont(forTextStyle: .caption1)
+        originLabel.textColor = .tertiaryLabel
+        originLabel.textAlignment = .right
+        originLabel.adjustsFontForContentSizeCategory = true
+        originLabel.numberOfLines = 1
+        originLabel.lineBreakMode = .byTruncatingTail
+        originLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        originLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        originLabel.isHidden = true
+
+        addSubview(titleLabel)
+        addSubview(originLabel)
+
+        let layoutGuide = layoutMarginsGuide
         NSLayoutConstraint.activate([
-            contentView.topAnchor.constraint(equalTo: topAnchor),
-            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            titleLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: originLabel.leadingAnchor, constant: -8),
+
+            originLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            originLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
+            originLabel.widthAnchor.constraint(lessThanOrEqualTo: layoutGuide.widthAnchor, multiplier: 0.55),
         ])
     }
 
     private func render(_ section: CSSStyleSection) {
-        var configuration = UIListContentConfiguration.header()
-        configuration.text = section.title
-        configuration.secondaryText = section.subtitle
-        contentView.configuration = configuration
-        accessibilityLabel = [section.title, section.subtitle]
-            .compactMap { $0 }
-            .joined(separator: ", ")
+        let presentation = DOMElementStyleSectionHeaderPresentation(section: section)
+        titleLabel.text = presentation.title
+        originLabel.text = presentation.originText
+        originLabel.isHidden = presentation.originText?.isEmpty != false
+        accessibilityLabel = presentation.accessibilityLabel
     }
 }
+
+#if DEBUG
+extension DOMElementStyleSectionHeaderView {
+    package var titleTextForTesting: String? {
+        titleLabel.text
+    }
+
+    package var originTextForTesting: String? {
+        originLabel.text
+    }
+
+    package var titleNumberOfLinesForTesting: Int {
+        titleLabel.numberOfLines
+    }
+
+    package var originNumberOfLinesForTesting: Int {
+        originLabel.numberOfLines
+    }
+
+    package var titleLineBreakModeForTesting: NSLineBreakMode {
+        titleLabel.lineBreakMode
+    }
+
+    package var originLineBreakModeForTesting: NSLineBreakMode {
+        originLabel.lineBreakMode
+    }
+}
+#endif
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -178,12 +178,12 @@ package final class DOMElementViewController: UIViewController {
             guard let self,
                   let dataSource,
                   dataSource.snapshot().sectionIdentifiers.indices.contains(indexPath.section) else {
-                header.clear()
+                header.bind(nil)
                 return
             }
             let sectionID = dataSource.snapshot().sectionIdentifiers[indexPath.section]
             guard let section = section(for: sectionID) else {
-                header.clear()
+                header.bind(nil)
                 return
             }
             header.bind(section)

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -131,6 +131,74 @@ func cssSessionBuildsOrderedSectionsAndPropertyRowState() throws {
 
 @Test
 @MainActor
+func cssRuleSourceLocationPrefersSelectorRangeOverSourceLine() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(css.beginRefresh(identity: identity))
+
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: ".result-card",
+                    sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+                    sourceLine: 4,
+                    selectorRange: CSSSourceRange(startLine: 27, startColumn: 22164, endLine: 27, endColumn: 22176),
+                    properties: [
+                        CSSPropertyPayload(name: "display", value: "flex", text: "display: flex;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let section = try #require(css.selectedNodeStyles?.sections.first)
+    let rule = try #require(section.rule)
+    #expect(section.title == ".result-card")
+    #expect(rule.sourceURL == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87")
+    #expect(rule.sourceLocation == CSSRuleSourceLocation(
+        sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+        line: 27,
+        column: 22164
+    ))
+}
+
+@Test
+@MainActor
+func cssRuleSourceLocationFallsBackToSourceLineWhenSelectorRangeIsMissing() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(css.beginRefresh(identity: identity))
+
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: "body",
+                    sourceURL: "styles.css",
+                    sourceLine: 11,
+                    properties: [
+                        CSSPropertyPayload(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
+    #expect(rule.sourceLocation == CSSRuleSourceLocation(sourceURL: "styles.css", line: 11))
+}
+
+@Test
+@MainActor
 func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
     let css = CSSSession()
     let identity = cssIdentity()
@@ -802,13 +870,17 @@ private func rule(
     selector: String,
     styleID: CSSStyleIdentifier = CSSStyleIdentifier(styleSheetID: .init("sheet"), ordinal: 0),
     origin: CSSStyleOrigin = .author,
+    sourceURL: String? = nil,
+    sourceLine: Int = 1,
+    selectorRange: CSSSourceRange? = nil,
     properties: [CSSPropertyPayload],
     cssText: String? = nil
 ) -> CSSRulePayload {
     CSSRulePayload(
         id: CSSRuleIdentifier(styleSheetID: styleID.styleSheetID, ordinal: styleID.ordinal),
-        selectorList: CSSSelectorList(selectors: [CSSSelector(text: selector)], text: selector),
-        sourceLine: 1,
+        selectorList: CSSSelectorList(selectors: [CSSSelector(text: selector)], text: selector, range: selectorRange),
+        sourceURL: sourceURL,
+        sourceLine: sourceLine,
         origin: origin,
         style: style(id: styleID, properties: properties, cssText: cssText)
     )

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -199,6 +199,51 @@ func cssRuleSourceLocationFallsBackToSourceLineWhenSelectorRangeIsMissing() thro
 
 @Test
 @MainActor
+func cssRuleSourceLocationAppliesStyleSheetHeaderOffset() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    css.registerStyleSheetHeader(
+        CSSStyleSheetHeaderPayload(
+            styleSheetID: .init("sheet"),
+            sourceURL: "https://example.com/document.html",
+            origin: .author,
+            isInline: true,
+            startLine: 18,
+            startColumn: 6
+        ),
+        targetID: identity.targetID
+    )
+    let token = try #require(css.beginRefresh(identity: identity))
+
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: ".inline-rule",
+                    sourceLine: 2,
+                    selectorRange: CSSSourceRange(startLine: 3, startColumn: 4, endLine: 3, endColumn: 16),
+                    properties: [
+                        CSSPropertyPayload(name: "color", value: "red", text: "color: red;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
+    #expect(rule.sourceLocation == CSSRuleSourceLocation(
+        sourceURL: "https://example.com/document.html",
+        line: 21,
+        column: 10
+    ))
+}
+
+@Test
+@MainActor
 func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
     let css = CSSSession()
     let identity = cssIdentity()

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -222,7 +222,7 @@ func cssRuleSourceLocationAppliesStyleSheetHeaderOffset() throws {
                 rule: rule(
                     selector: ".inline-rule",
                     sourceLine: 2,
-                    selectorRange: CSSSourceRange(startLine: 3, startColumn: 4, endLine: 3, endColumn: 16),
+                    selectorRange: CSSSourceRange(startLine: 0, startColumn: 4, endLine: 0, endColumn: 16),
                     properties: [
                         CSSPropertyPayload(name: "color", value: "red", text: "color: red;"),
                     ]
@@ -237,8 +237,109 @@ func cssRuleSourceLocationAppliesStyleSheetHeaderOffset() throws {
     let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
     #expect(rule.sourceLocation == CSSRuleSourceLocation(
         sourceURL: "https://example.com/document.html",
-        line: 21,
+        line: 18,
         column: 10
+    ))
+}
+
+@Test
+@MainActor
+func cssRuleSourceLocationKeepsSubsequentLineColumnsRelativeToLineStart() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    css.registerStyleSheetHeader(
+        CSSStyleSheetHeaderPayload(
+            styleSheetID: .init("sheet"),
+            sourceURL: "https://example.com/document.html",
+            origin: .author,
+            isInline: true,
+            startLine: 18,
+            startColumn: 6
+        ),
+        targetID: identity.targetID
+    )
+    let token = try #require(css.beginRefresh(identity: identity))
+
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: ".later-rule",
+                    selectorRange: CSSSourceRange(startLine: 3, startColumn: 4, endLine: 3, endColumn: 15),
+                    properties: [
+                        CSSPropertyPayload(name: "color", value: "blue", text: "color: blue;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
+    #expect(rule.sourceLocation == CSSRuleSourceLocation(
+        sourceURL: "https://example.com/document.html",
+        line: 21,
+        column: 4
+    ))
+}
+
+@Test
+@MainActor
+func cssRuleSourceLocationScopesStyleSheetHeadersByTarget() throws {
+    let css = CSSSession()
+    let pageIdentity = cssIdentity(targetID: .init("page"), nodeRawID: 2)
+    let frameIdentity = cssIdentity(targetID: .init("frame"), nodeRawID: 3)
+    css.registerStyleSheetHeader(
+        CSSStyleSheetHeaderPayload(
+            styleSheetID: .init("sheet"),
+            sourceURL: "https://example.com/page.html",
+            origin: .author,
+            isInline: true,
+            startLine: 10,
+            startColumn: 1
+        ),
+        targetID: pageIdentity.targetID
+    )
+    css.registerStyleSheetHeader(
+        CSSStyleSheetHeaderPayload(
+            styleSheetID: .init("sheet"),
+            sourceURL: "https://example.com/frame.html",
+            origin: .author,
+            isInline: true,
+            startLine: 30,
+            startColumn: 2
+        ),
+        targetID: frameIdentity.targetID
+    )
+    css.removeStyleSheetHeader(styleSheetID: .init("sheet"), targetID: frameIdentity.targetID)
+
+    let token = try #require(css.beginRefresh(identity: pageIdentity))
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: ".target-rule",
+                    selectorRange: CSSSourceRange(startLine: 0, startColumn: 4, endLine: 0, endColumn: 16),
+                    properties: [
+                        CSSPropertyPayload(name: "display", value: "block", text: "display: block;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
+    #expect(rule.sourceLocation == CSSRuleSourceLocation(
+        sourceURL: "https://example.com/page.html",
+        line: 10,
+        column: 5
     ))
 }
 

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -345,6 +345,47 @@ func cssRuleSourceLocationScopesStyleSheetHeadersByTarget() throws {
 
 @Test
 @MainActor
+func cssSessionRemovesStyleSheetHeadersEvenWhenTargetHasNoCachedStyles() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    css.registerStyleSheetHeader(
+        CSSStyleSheetHeaderPayload(
+            styleSheetID: .init("sheet"),
+            sourceURL: "https://example.com/stale.html",
+            origin: .author,
+            isInline: true,
+            startLine: 10,
+            startColumn: 1
+        ),
+        targetID: identity.targetID
+    )
+    css.removeStyles(targetID: identity.targetID)
+
+    let token = try #require(css.beginRefresh(identity: identity))
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: ".fresh-rule",
+                    selectorRange: CSSSourceRange(startLine: 0, startColumn: 4, endLine: 0, endColumn: 15),
+                    properties: [
+                        CSSPropertyPayload(name: "display", value: "block", text: "display: block;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let rule = try #require(css.selectedNodeStyles?.sections.first?.rule)
+    #expect(rule.sourceLocation == nil)
+}
+
+@Test
+@MainActor
 func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
     let css = CSSSession()
     let identity = cssIdentity()

--- a/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
@@ -161,6 +161,62 @@ func cssTransportAdapterAppliesTargetScopedInvalidationEvents() async throws {
     #expect(await css.selectedState == .needsRefresh)
 }
 
+@Test
+@MainActor
+func cssTransportAdapterRegistersStyleSheetHeaderOffsets() async throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+
+    try CSSTransportAdapter.applyCSSEvent(
+        ProtocolEventEnvelope(
+            sequence: 1,
+            domain: .css,
+            method: "CSS.styleSheetAdded",
+            targetID: identity.targetID,
+            paramsData: Data("""
+            {
+              "header": {
+                "styleSheetId": "sheet",
+                "sourceURL": "https://example.com/document.html",
+                "origin": "author",
+                "isInline": true,
+                "startLine": 12,
+                "startColumn": 7
+              }
+            }
+            """.utf8)
+        ),
+        to: css
+    )
+
+    let token = try #require(css.beginRefresh(identity: identity))
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: cssRule(
+                    selector: ".card",
+                    styleID: .init(styleSheetID: .init("sheet"), ordinal: 0),
+                    selectorRange: CSSSourceRange(startLine: 2, startColumn: 3, endLine: 2, endColumn: 8),
+                    properties: [
+                        CSSPropertyPayload(name: "display", value: "grid", text: "display: grid;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    let sourceLocation = try #require(css.selectedNodeStyles?.sections.first?.rule?.sourceLocation)
+    #expect(sourceLocation == CSSRuleSourceLocation(
+        sourceURL: "https://example.com/document.html",
+        line: 14,
+        column: 10
+    ))
+}
+
 private func cssIdentity() -> CSSNodeStyleIdentity {
     let targetID = ProtocolTargetIdentifier("page")
     let documentID = DOMDocumentIdentifier(targetID: targetID, localDocumentLifetimeID: .init(1))
@@ -176,12 +232,16 @@ private func cssIdentity() -> CSSNodeStyleIdentity {
 private func cssRule(
     selector: String,
     styleID: CSSStyleIdentifier,
+    sourceURL: String? = nil,
+    sourceLine: Int = 1,
+    selectorRange: CSSSourceRange? = nil,
     properties: [CSSPropertyPayload]
 ) -> CSSRulePayload {
     CSSRulePayload(
         id: CSSRuleIdentifier(styleSheetID: styleID.styleSheetID, ordinal: styleID.ordinal),
-        selectorList: CSSSelectorList(selectors: [CSSSelector(text: selector)], text: selector),
-        sourceLine: 1,
+        selectorList: CSSSelectorList(selectors: [CSSSelector(text: selector)], text: selector, range: selectorRange),
+        sourceURL: sourceURL,
+        sourceLine: sourceLine,
         origin: .author,
         style: CSSStylePayload(id: styleID, cssProperties: properties)
     )

--- a/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/CSSTransportAdapterTests.swift
@@ -197,7 +197,7 @@ func cssTransportAdapterRegistersStyleSheetHeaderOffsets() async throws {
                 rule: cssRule(
                     selector: ".card",
                     styleID: .init(styleSheetID: .init("sheet"), ordinal: 0),
-                    selectorRange: CSSSourceRange(startLine: 2, startColumn: 3, endLine: 2, endColumn: 8),
+                    selectorRange: CSSSourceRange(startLine: 0, startColumn: 3, endLine: 0, endColumn: 8),
                     properties: [
                         CSSPropertyPayload(name: "display", value: "grid", text: "display: grid;"),
                     ]
@@ -212,7 +212,7 @@ func cssTransportAdapterRegistersStyleSheetHeaderOffsets() async throws {
     let sourceLocation = try #require(css.selectedNodeStyles?.sections.first?.rule?.sourceLocation)
     #expect(sourceLocation == CSSRuleSourceLocation(
         sourceURL: "https://example.com/document.html",
-        line: 14,
+        line: 12,
         column: 10
     ))
 }

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -732,7 +732,7 @@ func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let cssStream = await session.events(for: .css)
-    let eventsTask = firstEvents(2, from: cssStream)
+    let eventsTask = firstEvents(3, from: cssStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-late-frame","frameId":"late-frame"}}}"#)
@@ -740,9 +740,10 @@ func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-late-frame"}}"#)
 
     let events = await eventsTask.value
-    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged"])
+    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         nil,
+        ProtocolTargetIdentifier("frame-late"),
         ProtocolTargetIdentifier("frame-late"),
     ])
 }

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -749,6 +749,26 @@ func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws
 }
 
 @Test
+func rootCSSStyleSheetAddedBeforeProvisionalFrameTargetReplaysAfterCommit() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+    let cssStream = await session.events(for: .css)
+    let eventsTask = firstEvents(2, from: cssStream)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-provisional-frame","frameId":"ad-frame"}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
+
+    let events = await eventsTask.value
+    #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded"])
+    #expect(events.map(\.targetID) == [
+        nil,
+        ProtocolTargetIdentifier("frame-committed"),
+    ])
+}
+
+@Test
 func orderedStreamReceivesTargetEventsAcrossDomainsInTransportOrder() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -74,14 +74,16 @@ struct DOMContainerTests {
         #expect(viewController.contentUnavailableConfiguration == nil)
         #expect(viewController.collectionViewForTesting.isHidden == false)
 
-        let headers = viewController.collectionViewForTesting
-            .visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
-            .compactMap(\.accessibilityLabel)
+        let headers = styleSectionHeaders(in: viewController)
         let propertyViews = stylePropertyViews(in: viewController)
         let declarations = propertyViews.map(\.declarationTextForTesting)
 
-        #expect(headers.contains { $0.contains("body") })
-        #expect(headers.contains { $0.contains("styles.css") })
+        #expect(headers.contains { $0.titleTextForTesting == "body" })
+        #expect(headers.contains { $0.originTextForTesting == "styles.css:2" })
+        #expect(headers.allSatisfy { $0.titleNumberOfLinesForTesting == 1 })
+        #expect(headers.allSatisfy { $0.originNumberOfLinesForTesting == 1 })
+        #expect(headers.allSatisfy { $0.titleLineBreakModeForTesting == .byTruncatingTail })
+        #expect(headers.allSatisfy { $0.originLineBreakModeForTesting == .byTruncatingTail })
         #expect(declarations.contains("margin: 0;"))
         #expect(declarations.contains("/* box-sizing: border-box; */"))
         #expect(declarations.contains("font-size: 12px;"))
@@ -89,6 +91,28 @@ struct DOMContainerTests {
         #expect(propertyView(named: "box-sizing", in: propertyViews)?.isToggleOnForTesting == false)
         #expect(propertyView(named: "font-size", in: propertyViews)?.isToggleEnabledForTesting == false)
         #expect(propertyView(named: "margin", in: propertyViews)?.declarationFontForTesting?.pointSize == UIFont.preferredFont(forTextStyle: .body).pointSize)
+    }
+
+    @Test
+    func elementStyleHeaderPresentationFormatsRuleOriginText() {
+        let googleLocation = CSSRuleSourceLocation(
+            sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+            line: 27,
+            column: 22164
+        )
+        #expect(DOMElementStyleSectionHeaderPresentation.displayText(for: googleLocation) == "search:28:22165")
+        #expect(DOMElementStyleSectionHeaderPresentation.fullDisplayText(for: googleLocation) == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87:28:22165")
+
+        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+            for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 1)
+        ) == "styles.css:2")
+        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+            for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 80)
+        ) == "styles.css:1")
+        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+            for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 81)
+        ) == "styles.css:1:82")
+        #expect(DOMElementStyleSectionHeaderPresentation.displayText(for: .userAgent) == "User Agent Style Sheet")
     }
 
     @Test
@@ -908,6 +932,12 @@ struct DOMContainerTests {
     private func stylePropertyViews(in viewController: DOMElementViewController) -> [DOMElementStylePropertyView] {
         viewController.collectionViewForTesting.visibleCells
             .compactMap { ($0 as? DOMElementStylePropertyCollectionCell)?.propertyViewForTesting }
+    }
+
+    private func styleSectionHeaders(in viewController: DOMElementViewController) -> [DOMElementStyleSectionHeaderView] {
+        viewController.collectionViewForTesting
+            .visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
+            .compactMap { $0 as? DOMElementStyleSectionHeaderView }
     }
 
     private func hiddenVariableCells(in viewController: DOMElementViewController) -> [DOMElementStyleHiddenVariablesCollectionCell] {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -74,16 +74,9 @@ struct DOMContainerTests {
         #expect(viewController.contentUnavailableConfiguration == nil)
         #expect(viewController.collectionViewForTesting.isHidden == false)
 
-        let headers = styleSectionHeaders(in: viewController)
         let propertyViews = stylePropertyViews(in: viewController)
         let declarations = propertyViews.map(\.declarationTextForTesting)
 
-        #expect(headers.contains { $0.titleTextForTesting == "body" })
-        #expect(headers.contains { $0.originTextForTesting == "styles.css:2" })
-        #expect(headers.allSatisfy { $0.titleNumberOfLinesForTesting == 1 })
-        #expect(headers.allSatisfy { $0.originNumberOfLinesForTesting == 1 })
-        #expect(headers.allSatisfy { $0.titleLineBreakModeForTesting == .byTruncatingTail })
-        #expect(headers.allSatisfy { $0.originLineBreakModeForTesting == .byTruncatingTail })
         #expect(declarations.contains("margin: 0;"))
         #expect(declarations.contains("/* box-sizing: border-box; */"))
         #expect(declarations.contains("font-size: 12px;"))
@@ -94,25 +87,25 @@ struct DOMContainerTests {
     }
 
     @Test
-    func elementStyleHeaderPresentationFormatsRuleOriginText() {
+    func elementStyleHeaderConfigurationFormatsRuleOriginText() {
         let googleLocation = CSSRuleSourceLocation(
             sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
             line: 27,
             column: 22164
         )
-        #expect(DOMElementStyleSectionHeaderPresentation.displayText(for: googleLocation) == "search:28:22165")
-        #expect(DOMElementStyleSectionHeaderPresentation.fullDisplayText(for: googleLocation) == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87:28:22165")
+        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(for: googleLocation) == "search:28:22165")
+        #expect(DOMElementStyleSectionHeaderConfiguration.fullDisplayText(for: googleLocation) == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87:28:22165")
 
-        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 1)
         ) == "styles.css:2")
-        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 80)
         ) == "styles.css:1")
-        #expect(DOMElementStyleSectionHeaderPresentation.displayText(
+        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 81)
         ) == "styles.css:1:82")
-        #expect(DOMElementStyleSectionHeaderPresentation.displayText(for: .userAgent) == "User Agent Style Sheet")
+        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(for: .userAgent) == "User Agent Style Sheet")
     }
 
     @Test
@@ -932,12 +925,6 @@ struct DOMContainerTests {
     private func stylePropertyViews(in viewController: DOMElementViewController) -> [DOMElementStylePropertyView] {
         viewController.collectionViewForTesting.visibleCells
             .compactMap { ($0 as? DOMElementStylePropertyCollectionCell)?.propertyViewForTesting }
-    }
-
-    private func styleSectionHeaders(in viewController: DOMElementViewController) -> [DOMElementStyleSectionHeaderView] {
-        viewController.collectionViewForTesting
-            .visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
-            .compactMap { $0 as? DOMElementStyleSectionHeaderView }
     }
 
     private func hiddenVariableCells(in viewController: DOMElementViewController) -> [DOMElementStyleHiddenVariablesCollectionCell] {


### PR DESCRIPTION
## Purpose

Fix the Element styles section header so it matches WebKit's source/origin presentation more closely, avoids long raw URLs in the header, and keeps source locations correct for inline and target-scoped stylesheets.

## Changes

- Added CSS stylesheet header/source-location modeling so rule headers can use selector ranges plus stylesheet offsets instead of raw `sourceURL` subtitles.
- Reworked the Element styles section header to use SwiftUI `LabeledContent` backed by the observed `CSSStyleSection`, with one-line truncation and short source display names.
- Updated stylesheet event handling to scope stylesheet headers by target, preserve late frame stylesheet headers, and replay them after provisional frame commits.
- Reduced style property cell reuse/render work by avoiding unnecessary clears and duplicate initial renders during scrolling.
- Updated CSS model research notes and added Core/Transport/UI regression coverage for the new source display behavior.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` against `main`: clean

## Screenshots

- Not captured in this run.