### PR TITLE
Add Runtime and Console transport core

### DIFF
--- a/Docs/ArchitectureOverview.md
+++ b/Docs/ArchitectureOverview.md
@@ -53,11 +53,12 @@ Responsibilities stay intentionally narrow:
 
 - `WebInspectorNativeBridge`: attach, send raw JSON, receive raw JSON, detach.
 - `WebInspectorTransport`: parse protocol envelopes, unwrap target messages,
-  route commands, manage replies, track protocol targets and execution contexts.
+  route commands, manage replies, track protocol targets, and preserve
+  execution-context owner/source target identity.
 - `InspectorSession`: bootstrap domains, own event pumps, apply decoded domain
   events to semantic sessions, perform command intents.
 - `WebInspectorCore`: hold `@MainActor @Observable` semantic model state for
-  DOM and Network.
+  DOM, Runtime, Console, and Network.
 - `WebInspectorUI`: render and interact with native UIKit/TextKit2 views.
 
 ## Event And Command Flow

--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,8 @@ let package = Package(
             name: "WebInspectorRuntime",
             dependencies: [
                 "WebInspectorCore",
-                "WebInspectorTransport"
+                "WebInspectorTransport",
+                .product(name: "ObservationBridge", package: "ObservationBridge")
             ],
             swiftSettings: strictSwiftSettings
         ),

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -411,6 +411,10 @@ package final class CSSSession {
     }
 
     package func markSelectedNodeUnavailable(_ reason: CSSNodeStylesUnavailableReason) {
+        if reason == .noSelection,
+           case .unavailable(.staleNode) = selectedNodeStyles?.state {
+            return
+        }
         guard selectedNodeStyles != nil || selectedState != .unavailable(reason) else {
             return
         }

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -382,8 +382,11 @@ package final class CSSSession {
     }
 
     package private(set) var selectedNodeStyles: CSSNodeStyles?
-    package private(set) var selectedState: CSSNodeStylesState
+    package var selectedState: CSSNodeStylesState {
+        selectedNodeStyles?.state ?? .unavailable(selectedUnavailableReason)
+    }
 
+    private var selectedUnavailableReason: CSSNodeStylesUnavailableReason
     @ObservationIgnored private var stylesByNodeID: [DOMNodeIdentifier: CSSNodeStyles]
     @ObservationIgnored private var styleSheetHeadersByKey: [StyleSheetKey: CSSStyleSheetHeaderPayload]
     @ObservationIgnored private var activeRefreshSequenceByNodeID: [DOMNodeIdentifier: UInt64]
@@ -391,7 +394,7 @@ package final class CSSSession {
 
     package init() {
         selectedNodeStyles = nil
-        selectedState = .unavailable(.noSelection)
+        selectedUnavailableReason = .noSelection
         stylesByNodeID = [:]
         styleSheetHeadersByKey = [:]
         activeRefreshSequenceByNodeID = [:]
@@ -400,7 +403,7 @@ package final class CSSSession {
 
     package func reset() {
         selectedNodeStyles = nil
-        selectedState = .unavailable(.noSelection)
+        selectedUnavailableReason = .noSelection
         stylesByNodeID.removeAll()
         styleSheetHeadersByKey.removeAll()
         activeRefreshSequenceByNodeID.removeAll()
@@ -408,8 +411,32 @@ package final class CSSSession {
     }
 
     package func markSelectedNodeUnavailable(_ reason: CSSNodeStylesUnavailableReason) {
+        guard selectedNodeStyles != nil || selectedState != .unavailable(reason) else {
+            return
+        }
         selectedNodeStyles = nil
-        selectedState = .unavailable(reason)
+        selectedUnavailableReason = reason
+    }
+
+    package func markSelectedNodeStylesUnavailable(
+        identity: CSSNodeStyleIdentity,
+        reason: CSSNodeStylesUnavailableReason
+    ) {
+        let nodeStyles = stylesByNodeID[identity.nodeID] ?? CSSNodeStyles(identity: identity)
+        stylesByNodeID[identity.nodeID] = nodeStyles
+        guard selectedNodeStyles !== nodeStyles || nodeStyles.state != .unavailable(reason) else {
+            return
+        }
+        nodeStyles.state = .unavailable(reason)
+        selectedNodeStyles = nodeStyles
+        activeRefreshSequenceByNodeID.removeValue(forKey: identity.nodeID)
+    }
+
+    package func refreshState(forSelected identity: CSSNodeStyleIdentity) -> CSSNodeStylesState? {
+        guard selectedNodeStyles?.identity == identity else {
+            return nil
+        }
+        return selectedNodeStyles?.state
     }
 
     package func beginRefresh(identity: CSSNodeStyleIdentity) -> CSSStyleRefreshToken? {
@@ -423,7 +450,6 @@ package final class CSSSession {
         stylesByNodeID[identity.nodeID] = nodeStyles
         nodeStyles.state = .loading
         selectedNodeStyles = nodeStyles
-        selectedState = .loading
         activeRefreshSequenceByNodeID[identity.nodeID] = nextRefreshSequence
         return CSSStyleRefreshToken(identity: identity, sequence: nextRefreshSequence)
     }
@@ -454,7 +480,6 @@ package final class CSSSession {
             with: computed.map(CSSComputedStyleProperty.init(payload:))
         )
         nodeStyles.state = .loaded
-        selectedState = .loaded
         activeRefreshSequenceByNodeID.removeValue(forKey: token.identity.nodeID)
     }
 
@@ -479,7 +504,6 @@ package final class CSSSession {
             return
         }
         nodeStyles.state = .failed(message)
-        selectedState = .failed(message)
         activeRefreshSequenceByNodeID.removeValue(forKey: token.identity.nodeID)
     }
 
@@ -504,9 +528,6 @@ package final class CSSSession {
             }
             nodeStyles.state = .needsRefresh
             activeRefreshSequenceByNodeID.removeValue(forKey: nodeStyles.identity.nodeID)
-            if selectedNodeStyles === nodeStyles {
-                selectedState = .needsRefresh
-            }
         }
     }
 
@@ -534,9 +555,6 @@ package final class CSSSession {
         }
         current.state = .needsRefresh
         activeRefreshSequenceByNodeID.removeValue(forKey: current.identity.nodeID)
-        if selectedNodeStyles === current {
-            selectedState = .needsRefresh
-        }
     }
 
     package func removeStyles(targetID: ProtocolTargetIdentifier) {
@@ -551,10 +569,9 @@ package final class CSSSession {
             stylesByNodeID.removeValue(forKey: nodeID)
             activeRefreshSequenceByNodeID.removeValue(forKey: nodeID)
         }
-        if let removedSelectedNodeID = selectedNodeStyles?.identity.nodeID,
-           selectedNodeStyles?.identity.targetID == targetID {
-            selectedNodeStyles = nil
-            selectedState = .unavailable(.staleNode(removedSelectedNodeID))
+        if let selectedNodeStyles,
+           selectedNodeStyles.identity.targetID == targetID {
+            selectedNodeStyles.state = .unavailable(.staleNode(selectedNodeStyles.identity.nodeID))
         }
     }
 
@@ -608,9 +625,6 @@ package final class CSSSession {
                     rule.style = section.style
                 }
                 nodeStyles.state = .needsRefresh
-                if selectedNodeStyles === nodeStyles {
-                    selectedState = .needsRefresh
-                }
             }
         }
     }

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -511,6 +511,15 @@ package final class CSSSession {
         activeRefreshSequenceByNodeID.removeValue(forKey: token.identity.nodeID)
     }
 
+    package func cancelRefresh(identity: CSSNodeStyleIdentity) {
+        guard activeRefreshSequenceByNodeID.removeValue(forKey: identity.nodeID) != nil,
+              let nodeStyles = stylesByNodeID[identity.nodeID],
+              nodeStyles.state == .loading else {
+            return
+        }
+        nodeStyles.state = .needsRefresh
+    }
+
     package func markNeedsRefresh(targetID: ProtocolTargetIdentifier) {
         markNeedsRefresh(targetID: targetID, including: { _ in true })
     }

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -88,43 +88,25 @@ package struct ConsoleSessionSnapshot: Equatable, Sendable {
 
 @MainActor
 @Observable
-package final class ConsoleSession {
+package final class ConsoleTargetState {
+    package let targetID: ProtocolTargetIdentifier
+    package private(set) var orderedMessageIDs: [ConsoleMessageIdentifier]
+    private var messagesByID: [ConsoleMessageIdentifier: ConsoleMessage]
+    private var lastRepeatableMessageID: ConsoleMessageIdentifier?
     package private(set) var warningCount: Int
     package private(set) var errorCount: Int
+    package private(set) var lastClearReason: ConsoleClearReason?
+    private var unsupportedCommands: Set<String>
 
-    @ObservationIgnored private var nextMessageOrdinal: UInt64
-    private var orderedMessageIDs: [ConsoleMessageIdentifier]
-    private var messagesByID: [ConsoleMessageIdentifier: ConsoleMessage]
-    @ObservationIgnored private var lastRepeatableMessageIDByTargetID: [ProtocolTargetIdentifier: ConsoleMessageIdentifier]
-    @ObservationIgnored private var warningCountByTargetID: [ProtocolTargetIdentifier: Int]
-    @ObservationIgnored private var errorCountByTargetID: [ProtocolTargetIdentifier: Int]
-    @ObservationIgnored private var lastClearReasonByTargetID: [ProtocolTargetIdentifier: ConsoleClearReason]
-    @ObservationIgnored private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
-
-    package init() {
-        warningCount = 0
-        errorCount = 0
-        nextMessageOrdinal = 0
+    init(targetID: ProtocolTargetIdentifier) {
+        self.targetID = targetID
         orderedMessageIDs = []
         messagesByID = [:]
-        lastRepeatableMessageIDByTargetID = [:]
-        warningCountByTargetID = [:]
-        errorCountByTargetID = [:]
-        lastClearReasonByTargetID = [:]
-        unsupportedCommandsByTargetID = [:]
-    }
-
-    package func reset() {
+        lastRepeatableMessageID = nil
         warningCount = 0
         errorCount = 0
-        nextMessageOrdinal = 0
-        orderedMessageIDs.removeAll()
-        messagesByID.removeAll()
-        lastRepeatableMessageIDByTargetID.removeAll()
-        warningCountByTargetID.removeAll()
-        errorCountByTargetID.removeAll()
-        lastClearReasonByTargetID.removeAll()
-        unsupportedCommandsByTargetID.removeAll()
+        lastClearReason = nil
+        unsupportedCommands = []
     }
 
     package var messages: [ConsoleMessage] {
@@ -135,10 +117,107 @@ package final class ConsoleSession {
         messagesByID[id]
     }
 
-    package func snapshot() -> ConsoleSessionSnapshot {
-        ConsoleSessionSnapshot(
-            orderedMessageIDs: orderedMessageIDs,
-            messagesByID: messagesByID.mapValues { message in
+    func append(_ payload: ConsoleMessagePayload, ordinal: UInt64) -> ConsoleMessageIdentifier {
+        let id = ConsoleMessageIdentifier(targetID: targetID, ordinal: ordinal)
+        let message = ConsoleMessage(id: id, targetID: targetID, payload: payload)
+        orderedMessageIDs.append(id)
+        messagesByID[id] = message
+        if payload.type != .clear {
+            lastRepeatableMessageID = id
+        }
+        incrementSeverity(level: message.level, repeatCount: message.repeatCount)
+        return id
+    }
+
+    func updateRepeatCount(count: Int, timestamp: Double?) {
+        guard let messageID = lastRepeatableMessageID,
+              let message = messagesByID[messageID] else {
+            return
+        }
+        incrementSeverity(level: message.level, repeatCount: -message.repeatCount)
+        message.repeatCount = max(1, count)
+        if let timestamp {
+            message.timestamp = timestamp
+        }
+        incrementSeverity(level: message.level, repeatCount: message.repeatCount)
+    }
+
+    func clearMessages(reason: ConsoleClearReason) {
+        lastClearReason = reason
+        orderedMessageIDs.removeAll()
+        messagesByID.removeAll()
+        lastRepeatableMessageID = nil
+        warningCount = 0
+        errorCount = 0
+    }
+
+    func retargeted(to newTargetID: ProtocolTargetIdentifier) -> ConsoleTargetState {
+        let nextState = ConsoleTargetState(targetID: newTargetID)
+        nextState.lastClearReason = lastClearReason
+        nextState.unsupportedCommands = unsupportedCommands
+        for oldID in orderedMessageIDs {
+            guard let message = messagesByID[oldID] else {
+                continue
+            }
+            let newID = ConsoleMessageIdentifier(targetID: newTargetID, ordinal: oldID.ordinal)
+            nextState.orderedMessageIDs.append(newID)
+            nextState.messagesByID[newID] = ConsoleMessage(
+                id: newID,
+                targetID: newTargetID,
+                payload: ConsoleMessagePayload(
+                    source: message.source,
+                    level: message.level,
+                    text: message.text,
+                    type: message.type,
+                    url: message.url,
+                    line: message.line,
+                    column: message.column,
+                    repeatCount: message.repeatCount,
+                    parameters: message.parameters,
+                    stackTrace: message.stackTrace,
+                    networkRequestID: message.networkRequestKey?.requestID,
+                    timestamp: message.timestamp
+                )
+            )
+        }
+        if let lastRepeatableMessageID {
+            nextState.lastRepeatableMessageID = ConsoleMessageIdentifier(
+                targetID: newTargetID,
+                ordinal: lastRepeatableMessageID.ordinal
+            )
+        }
+        nextState.recalculateSeverityCounts()
+        return nextState
+    }
+
+    func mergeCommittedState(_ committedState: ConsoleTargetState) {
+        orderedMessageIDs.append(contentsOf: committedState.orderedMessageIDs)
+        orderedMessageIDs.sort()
+        for (id, message) in committedState.messagesByID {
+            messagesByID[id] = message
+        }
+        if let lastRepeatableMessageID = committedState.lastRepeatableMessageID {
+            self.lastRepeatableMessageID = lastRepeatableMessageID
+        }
+        if let lastClearReason = committedState.lastClearReason {
+            self.lastClearReason = lastClearReason
+        }
+        unsupportedCommands.formUnion(committedState.unsupportedCommands)
+        recalculateSeverityCounts()
+    }
+
+    func markCommandUnsupported(_ method: String) {
+        unsupportedCommands.insert(method)
+    }
+
+    func supportsCommand(_ method: String) -> Bool {
+        unsupportedCommands.contains(method) == false
+    }
+
+    fileprivate var messageSnapshotEntries: [(ConsoleMessageIdentifier, ConsoleMessageSnapshot)] {
+        messagesByID.map { id, message in
+            (
+                id,
                 ConsoleMessageSnapshot(
                     id: message.id,
                     source: message.source,
@@ -154,153 +233,177 @@ package final class ConsoleSession {
                     networkRequestKey: message.networkRequestKey,
                     timestamp: message.timestamp
                 )
-            },
+            )
+        }
+    }
+
+    fileprivate var unsupportedCommandSnapshot: Set<String> {
+        unsupportedCommands
+    }
+
+    private func incrementSeverity(level: ConsoleMessageLevel, repeatCount: Int) {
+        switch level {
+        case .warning:
+            warningCount += repeatCount
+        case .error:
+            errorCount += repeatCount
+        default:
+            break
+        }
+    }
+
+    private func recalculateSeverityCounts() {
+        warningCount = 0
+        errorCount = 0
+        for message in messagesByID.values {
+            incrementSeverity(level: message.level, repeatCount: message.repeatCount)
+        }
+    }
+}
+
+@MainActor
+@Observable
+package final class ConsoleSession {
+    package private(set) var warningCount: Int
+    package private(set) var errorCount: Int
+
+    @ObservationIgnored private var nextMessageOrdinal: UInt64
+    private var targetStatesByID: [ProtocolTargetIdentifier: ConsoleTargetState]
+
+    package init() {
+        warningCount = 0
+        errorCount = 0
+        nextMessageOrdinal = 0
+        targetStatesByID = [:]
+    }
+
+    package func reset() {
+        warningCount = 0
+        errorCount = 0
+        nextMessageOrdinal = 0
+        targetStatesByID.removeAll()
+    }
+
+    package var messages: [ConsoleMessage] {
+        orderedMessageIDs.compactMap { targetStatesByID[$0.targetID]?.message(for: $0) }
+    }
+
+    package var targetStates: [ConsoleTargetState] {
+        targetStatesByID.values.sorted { $0.targetID.rawValue < $1.targetID.rawValue }
+    }
+
+    package func targetState(for targetID: ProtocolTargetIdentifier) -> ConsoleTargetState? {
+        targetStatesByID[targetID]
+    }
+
+    package func message(for id: ConsoleMessageIdentifier) -> ConsoleMessage? {
+        targetStatesByID[id.targetID]?.message(for: id)
+    }
+
+    package func snapshot() -> ConsoleSessionSnapshot {
+        let orderedMessageIDs = orderedMessageIDs
+        return ConsoleSessionSnapshot(
+            orderedMessageIDs: orderedMessageIDs,
+            messagesByID: Dictionary(
+                uniqueKeysWithValues: targetStatesByID.values.flatMap { state in
+                    state.messageSnapshotEntries
+                }
+            ),
             warningCount: warningCount,
             errorCount: errorCount,
-            warningCountByTargetID: warningCountByTargetID,
-            errorCountByTargetID: errorCountByTargetID,
-            lastClearReasonByTargetID: lastClearReasonByTargetID,
-            unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
+            warningCountByTargetID: Dictionary(
+                uniqueKeysWithValues: targetStatesByID.values
+                    .filter { $0.warningCount > 0 }
+                    .map { ($0.targetID, $0.warningCount) }
+            ),
+            errorCountByTargetID: Dictionary(
+                uniqueKeysWithValues: targetStatesByID.values
+                    .filter { $0.errorCount > 0 }
+                    .map { ($0.targetID, $0.errorCount) }
+            ),
+            lastClearReasonByTargetID: Dictionary(
+                uniqueKeysWithValues: targetStatesByID.values.compactMap { state in
+                    state.lastClearReason.map { (state.targetID, $0) }
+                }
+            ),
+            unsupportedCommandsByTargetID: Dictionary(
+                uniqueKeysWithValues: targetStatesByID.values
+                    .filter { $0.unsupportedCommandSnapshot.isEmpty == false }
+                    .map { ($0.targetID, $0.unsupportedCommandSnapshot) }
+            )
         )
     }
 
     @discardableResult
     package func applyMessageAdded(_ payload: ConsoleMessagePayload, targetID: ProtocolTargetIdentifier) -> ConsoleMessageIdentifier {
         nextMessageOrdinal &+= 1
-        let id = ConsoleMessageIdentifier(targetID: targetID, ordinal: nextMessageOrdinal)
-        let message = ConsoleMessage(id: id, targetID: targetID, payload: payload)
-        orderedMessageIDs.append(id)
-        messagesByID[id] = message
-        if payload.type != .clear {
-            lastRepeatableMessageIDByTargetID[targetID] = id
-        }
-        recalculateSeverityCounts()
+        let state = ensureTargetState(for: targetID)
+        let id = state.append(payload, ordinal: nextMessageOrdinal)
+        updateAggregateSeverityCounts()
         return id
     }
 
     package func applyRepeatCountUpdated(count: Int, timestamp: Double?, targetID: ProtocolTargetIdentifier) {
-        guard let messageID = lastRepeatableMessageIDByTargetID[targetID],
-              let message = messagesByID[messageID] else {
+        guard let state = targetStatesByID[targetID] else {
             return
         }
-        message.repeatCount = max(1, count)
-        if let timestamp {
-            message.timestamp = timestamp
-        }
-        recalculateSeverityCounts()
+        state.updateRepeatCount(count: count, timestamp: timestamp)
+        updateAggregateSeverityCounts()
     }
 
     package func applyMessagesCleared(reason: ConsoleClearReason, targetID: ProtocolTargetIdentifier) {
-        lastClearReasonByTargetID[targetID] = reason
-        let removedIDs = Set(orderedMessageIDs.filter { $0.targetID == targetID })
-        orderedMessageIDs.removeAll { removedIDs.contains($0) }
-        for id in removedIDs {
-            messagesByID.removeValue(forKey: id)
-        }
-        lastRepeatableMessageIDByTargetID.removeValue(forKey: targetID)
-        recalculateSeverityCounts()
+        let state = ensureTargetState(for: targetID)
+        state.clearMessages(reason: reason)
+        updateAggregateSeverityCounts()
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
-        let removedIDs = Set(orderedMessageIDs.filter { $0.targetID == targetID })
-        orderedMessageIDs.removeAll { removedIDs.contains($0) }
-        for id in removedIDs {
-            messagesByID.removeValue(forKey: id)
-        }
-        lastRepeatableMessageIDByTargetID.removeValue(forKey: targetID)
-        warningCountByTargetID.removeValue(forKey: targetID)
-        errorCountByTargetID.removeValue(forKey: targetID)
-        lastClearReasonByTargetID.removeValue(forKey: targetID)
-        unsupportedCommandsByTargetID.removeValue(forKey: targetID)
-        recalculateSeverityCounts()
+        targetStatesByID.removeValue(forKey: targetID)
+        updateAggregateSeverityCounts()
     }
 
     package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
-        guard let oldTargetID else {
+        guard let oldTargetID,
+              let oldState = targetStatesByID.removeValue(forKey: oldTargetID) else {
             return
         }
-        var movedIDs: [ConsoleMessageIdentifier: ConsoleMessageIdentifier] = [:]
-        for id in orderedMessageIDs where id.targetID == oldTargetID {
-            movedIDs[id] = ConsoleMessageIdentifier(targetID: newTargetID, ordinal: id.ordinal)
+        let committedState = oldState.retargeted(to: newTargetID)
+        if let newState = targetStatesByID[newTargetID] {
+            newState.mergeCommittedState(committedState)
+        } else {
+            targetStatesByID[newTargetID] = committedState
         }
-        guard movedIDs.isEmpty == false else {
-            if let reason = lastClearReasonByTargetID.removeValue(forKey: oldTargetID) {
-                lastClearReasonByTargetID[newTargetID] = reason
-            }
-            if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
-                unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
-            }
-            return
-        }
-        orderedMessageIDs = orderedMessageIDs.map { movedIDs[$0] ?? $0 }
-        for (oldID, newID) in movedIDs {
-            if let oldMessage = messagesByID.removeValue(forKey: oldID) {
-                messagesByID[newID] = ConsoleMessage(
-                    id: newID,
-                    targetID: newTargetID,
-                    payload: ConsoleMessagePayload(
-                        source: oldMessage.source,
-                        level: oldMessage.level,
-                        text: oldMessage.text,
-                        type: oldMessage.type,
-                        url: oldMessage.url,
-                        line: oldMessage.line,
-                        column: oldMessage.column,
-                        repeatCount: oldMessage.repeatCount,
-                        parameters: oldMessage.parameters,
-                        stackTrace: oldMessage.stackTrace,
-                        networkRequestID: oldMessage.networkRequestKey?.requestID,
-                        timestamp: oldMessage.timestamp
-                    )
-                )
-            }
-        }
-        if let oldLastID = lastRepeatableMessageIDByTargetID.removeValue(forKey: oldTargetID) {
-            lastRepeatableMessageIDByTargetID[newTargetID] = movedIDs[oldLastID] ?? oldLastID
-        }
-        if let reason = lastClearReasonByTargetID.removeValue(forKey: oldTargetID) {
-            lastClearReasonByTargetID[newTargetID] = reason
-        }
-        if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
-            unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
-        }
-        recalculateSeverityCounts()
+        updateAggregateSeverityCounts()
     }
 
     package func markCommandUnsupported(_ method: String, targetID: ProtocolTargetIdentifier) {
-        unsupportedCommandsByTargetID[targetID, default: []].insert(method)
+        let state = ensureTargetState(for: targetID)
+        state.markCommandUnsupported(method)
     }
 
     package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
-        unsupportedCommandsByTargetID[targetID]?.contains(method) != true
+        targetStatesByID[targetID]?.supportsCommand(method) ?? true
     }
 
     package func enableIntent(targetID: ProtocolTargetIdentifier) -> ConsoleCommandIntent {
         .enable(targetID: targetID)
     }
 
-    private func recalculateSeverityCounts() {
-        var nextWarningCount = 0
-        var nextErrorCount = 0
-        var nextWarningCountByTargetID: [ProtocolTargetIdentifier: Int] = [:]
-        var nextErrorCountByTargetID: [ProtocolTargetIdentifier: Int] = [:]
+    private var orderedMessageIDs: [ConsoleMessageIdentifier] {
+        targetStatesByID.values.flatMap(\.orderedMessageIDs).sorted()
+    }
 
-        for message in messagesByID.values {
-            switch message.level {
-            case .warning:
-                nextWarningCount += message.repeatCount
-                nextWarningCountByTargetID[message.targetID, default: 0] += message.repeatCount
-            case .error:
-                nextErrorCount += message.repeatCount
-                nextErrorCountByTargetID[message.targetID, default: 0] += message.repeatCount
-            default:
-                break
-            }
+    private func ensureTargetState(for targetID: ProtocolTargetIdentifier) -> ConsoleTargetState {
+        if let state = targetStatesByID[targetID] {
+            return state
         }
+        let state = ConsoleTargetState(targetID: targetID)
+        targetStatesByID[targetID] = state
+        return state
+    }
 
-        warningCount = nextWarningCount
-        errorCount = nextErrorCount
-        warningCountByTargetID = nextWarningCountByTargetID
-        errorCountByTargetID = nextErrorCountByTargetID
+    private func updateAggregateSeverityCounts() {
+        warningCount = targetStatesByID.values.reduce(0) { $0 + $1.warningCount }
+        errorCount = targetStatesByID.values.reduce(0) { $0 + $1.errorCount }
     }
 }

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -1,0 +1,306 @@
+import Observation
+
+package struct ConsoleMessageIdentifier: Hashable, Sendable, Comparable {
+    package var targetID: ProtocolTargetIdentifier
+    package var ordinal: UInt64
+
+    package init(targetID: ProtocolTargetIdentifier, ordinal: UInt64) {
+        self.targetID = targetID
+        self.ordinal = ordinal
+    }
+
+    package static func < (lhs: ConsoleMessageIdentifier, rhs: ConsoleMessageIdentifier) -> Bool {
+        if lhs.ordinal == rhs.ordinal {
+            return lhs.targetID.rawValue < rhs.targetID.rawValue
+        }
+        return lhs.ordinal < rhs.ordinal
+    }
+}
+
+@MainActor
+@Observable
+package final class ConsoleMessage {
+    package typealias ID = ConsoleMessageIdentifier
+
+    package let id: ID
+    package var source: ConsoleMessageSource
+    package var level: ConsoleMessageLevel
+    package var text: String
+    package var type: ConsoleMessageType?
+    package var url: String?
+    package var line: Int?
+    package var column: Int?
+    package var repeatCount: Int
+    package var parameters: [RuntimeRemoteObjectPayload]
+    package var stackTrace: ConsoleStackTracePayload?
+    package var networkRequestKey: NetworkRequestIdentifierKey?
+    package var timestamp: Double?
+
+    package init(id: ID, targetID: ProtocolTargetIdentifier, payload: ConsoleMessagePayload) {
+        self.id = id
+        self.source = payload.source
+        self.level = payload.level
+        self.text = payload.text
+        self.type = payload.type
+        self.url = payload.url
+        self.line = payload.line
+        self.column = payload.column
+        self.repeatCount = max(1, payload.repeatCount ?? 1)
+        self.parameters = payload.parameters
+        self.stackTrace = payload.stackTrace
+        self.networkRequestKey = payload.networkRequestID.map {
+            NetworkRequestIdentifierKey(targetID: targetID, requestID: $0)
+        }
+        self.timestamp = payload.timestamp
+    }
+
+    package var targetID: ProtocolTargetIdentifier {
+        id.targetID
+    }
+}
+
+package struct ConsoleMessageSnapshot: Equatable, Sendable {
+    package var id: ConsoleMessageIdentifier
+    package var source: ConsoleMessageSource
+    package var level: ConsoleMessageLevel
+    package var text: String
+    package var type: ConsoleMessageType?
+    package var url: String?
+    package var line: Int?
+    package var column: Int?
+    package var repeatCount: Int
+    package var parameters: [RuntimeRemoteObjectPayload]
+    package var stackTrace: ConsoleStackTracePayload?
+    package var networkRequestKey: NetworkRequestIdentifierKey?
+    package var timestamp: Double?
+}
+
+package struct ConsoleSessionSnapshot: Equatable, Sendable {
+    package var orderedMessageIDs: [ConsoleMessageIdentifier]
+    package var messagesByID: [ConsoleMessageIdentifier: ConsoleMessageSnapshot]
+    package var warningCount: Int
+    package var errorCount: Int
+    package var warningCountByTargetID: [ProtocolTargetIdentifier: Int]
+    package var errorCountByTargetID: [ProtocolTargetIdentifier: Int]
+    package var lastClearReasonByTargetID: [ProtocolTargetIdentifier: ConsoleClearReason]
+    package var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+}
+
+@MainActor
+@Observable
+package final class ConsoleSession {
+    package private(set) var warningCount: Int
+    package private(set) var errorCount: Int
+
+    @ObservationIgnored private var nextMessageOrdinal: UInt64
+    @ObservationIgnored private var orderedMessageIDs: [ConsoleMessageIdentifier]
+    @ObservationIgnored private var messagesByID: [ConsoleMessageIdentifier: ConsoleMessage]
+    @ObservationIgnored private var lastRepeatableMessageIDByTargetID: [ProtocolTargetIdentifier: ConsoleMessageIdentifier]
+    @ObservationIgnored private var warningCountByTargetID: [ProtocolTargetIdentifier: Int]
+    @ObservationIgnored private var errorCountByTargetID: [ProtocolTargetIdentifier: Int]
+    @ObservationIgnored private var lastClearReasonByTargetID: [ProtocolTargetIdentifier: ConsoleClearReason]
+    @ObservationIgnored private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+
+    package init() {
+        warningCount = 0
+        errorCount = 0
+        nextMessageOrdinal = 0
+        orderedMessageIDs = []
+        messagesByID = [:]
+        lastRepeatableMessageIDByTargetID = [:]
+        warningCountByTargetID = [:]
+        errorCountByTargetID = [:]
+        lastClearReasonByTargetID = [:]
+        unsupportedCommandsByTargetID = [:]
+    }
+
+    package func reset() {
+        warningCount = 0
+        errorCount = 0
+        nextMessageOrdinal = 0
+        orderedMessageIDs.removeAll()
+        messagesByID.removeAll()
+        lastRepeatableMessageIDByTargetID.removeAll()
+        warningCountByTargetID.removeAll()
+        errorCountByTargetID.removeAll()
+        lastClearReasonByTargetID.removeAll()
+        unsupportedCommandsByTargetID.removeAll()
+    }
+
+    package var messages: [ConsoleMessage] {
+        orderedMessageIDs.compactMap { messagesByID[$0] }
+    }
+
+    package func message(for id: ConsoleMessageIdentifier) -> ConsoleMessage? {
+        messagesByID[id]
+    }
+
+    package func snapshot() -> ConsoleSessionSnapshot {
+        ConsoleSessionSnapshot(
+            orderedMessageIDs: orderedMessageIDs,
+            messagesByID: messagesByID.mapValues { message in
+                ConsoleMessageSnapshot(
+                    id: message.id,
+                    source: message.source,
+                    level: message.level,
+                    text: message.text,
+                    type: message.type,
+                    url: message.url,
+                    line: message.line,
+                    column: message.column,
+                    repeatCount: message.repeatCount,
+                    parameters: message.parameters,
+                    stackTrace: message.stackTrace,
+                    networkRequestKey: message.networkRequestKey,
+                    timestamp: message.timestamp
+                )
+            },
+            warningCount: warningCount,
+            errorCount: errorCount,
+            warningCountByTargetID: warningCountByTargetID,
+            errorCountByTargetID: errorCountByTargetID,
+            lastClearReasonByTargetID: lastClearReasonByTargetID,
+            unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
+        )
+    }
+
+    @discardableResult
+    package func applyMessageAdded(_ payload: ConsoleMessagePayload, targetID: ProtocolTargetIdentifier) -> ConsoleMessageIdentifier {
+        nextMessageOrdinal &+= 1
+        let id = ConsoleMessageIdentifier(targetID: targetID, ordinal: nextMessageOrdinal)
+        let message = ConsoleMessage(id: id, targetID: targetID, payload: payload)
+        orderedMessageIDs.append(id)
+        messagesByID[id] = message
+        if payload.type != .clear {
+            lastRepeatableMessageIDByTargetID[targetID] = id
+        }
+        recalculateSeverityCounts()
+        return id
+    }
+
+    package func applyRepeatCountUpdated(count: Int, timestamp: Double?, targetID: ProtocolTargetIdentifier) {
+        guard let messageID = lastRepeatableMessageIDByTargetID[targetID],
+              let message = messagesByID[messageID] else {
+            return
+        }
+        message.repeatCount = max(1, count)
+        if let timestamp {
+            message.timestamp = timestamp
+        }
+        recalculateSeverityCounts()
+    }
+
+    package func applyMessagesCleared(reason: ConsoleClearReason, targetID: ProtocolTargetIdentifier) {
+        lastClearReasonByTargetID[targetID] = reason
+        let removedIDs = Set(orderedMessageIDs.filter { $0.targetID == targetID })
+        orderedMessageIDs.removeAll { removedIDs.contains($0) }
+        for id in removedIDs {
+            messagesByID.removeValue(forKey: id)
+        }
+        lastRepeatableMessageIDByTargetID.removeValue(forKey: targetID)
+        recalculateSeverityCounts()
+    }
+
+    package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
+        let removedIDs = Set(orderedMessageIDs.filter { $0.targetID == targetID })
+        orderedMessageIDs.removeAll { removedIDs.contains($0) }
+        for id in removedIDs {
+            messagesByID.removeValue(forKey: id)
+        }
+        lastRepeatableMessageIDByTargetID.removeValue(forKey: targetID)
+        warningCountByTargetID.removeValue(forKey: targetID)
+        errorCountByTargetID.removeValue(forKey: targetID)
+        lastClearReasonByTargetID.removeValue(forKey: targetID)
+        unsupportedCommandsByTargetID.removeValue(forKey: targetID)
+        recalculateSeverityCounts()
+    }
+
+    package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
+        guard let oldTargetID else {
+            return
+        }
+        var movedIDs: [ConsoleMessageIdentifier: ConsoleMessageIdentifier] = [:]
+        for id in orderedMessageIDs where id.targetID == oldTargetID {
+            movedIDs[id] = ConsoleMessageIdentifier(targetID: newTargetID, ordinal: id.ordinal)
+        }
+        guard movedIDs.isEmpty == false else {
+            if let reason = lastClearReasonByTargetID.removeValue(forKey: oldTargetID) {
+                lastClearReasonByTargetID[newTargetID] = reason
+            }
+            if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
+                unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
+            }
+            return
+        }
+        orderedMessageIDs = orderedMessageIDs.map { movedIDs[$0] ?? $0 }
+        for (oldID, newID) in movedIDs {
+            if let oldMessage = messagesByID.removeValue(forKey: oldID) {
+                messagesByID[newID] = ConsoleMessage(
+                    id: newID,
+                    targetID: newTargetID,
+                    payload: ConsoleMessagePayload(
+                        source: oldMessage.source,
+                        level: oldMessage.level,
+                        text: oldMessage.text,
+                        type: oldMessage.type,
+                        url: oldMessage.url,
+                        line: oldMessage.line,
+                        column: oldMessage.column,
+                        repeatCount: oldMessage.repeatCount,
+                        parameters: oldMessage.parameters,
+                        stackTrace: oldMessage.stackTrace,
+                        networkRequestID: oldMessage.networkRequestKey?.requestID,
+                        timestamp: oldMessage.timestamp
+                    )
+                )
+            }
+        }
+        if let oldLastID = lastRepeatableMessageIDByTargetID.removeValue(forKey: oldTargetID) {
+            lastRepeatableMessageIDByTargetID[newTargetID] = movedIDs[oldLastID] ?? oldLastID
+        }
+        if let reason = lastClearReasonByTargetID.removeValue(forKey: oldTargetID) {
+            lastClearReasonByTargetID[newTargetID] = reason
+        }
+        if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
+            unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
+        }
+        recalculateSeverityCounts()
+    }
+
+    package func markCommandUnsupported(_ method: String, targetID: ProtocolTargetIdentifier) {
+        unsupportedCommandsByTargetID[targetID, default: []].insert(method)
+    }
+
+    package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
+        unsupportedCommandsByTargetID[targetID]?.contains(method) != true
+    }
+
+    package func enableIntent(targetID: ProtocolTargetIdentifier) -> ConsoleCommandIntent {
+        .enable(targetID: targetID)
+    }
+
+    private func recalculateSeverityCounts() {
+        var nextWarningCount = 0
+        var nextErrorCount = 0
+        var nextWarningCountByTargetID: [ProtocolTargetIdentifier: Int] = [:]
+        var nextErrorCountByTargetID: [ProtocolTargetIdentifier: Int] = [:]
+
+        for message in messagesByID.values {
+            switch message.level {
+            case .warning:
+                nextWarningCount += message.repeatCount
+                nextWarningCountByTargetID[message.targetID, default: 0] += message.repeatCount
+            case .error:
+                nextErrorCount += message.repeatCount
+                nextErrorCountByTargetID[message.targetID, default: 0] += message.repeatCount
+            default:
+                break
+            }
+        }
+
+        warningCount = nextWarningCount
+        errorCount = nextErrorCount
+        warningCountByTargetID = nextWarningCountByTargetID
+        errorCountByTargetID = nextErrorCountByTargetID
+    }
+}

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -31,12 +31,17 @@ package final class ConsoleMessage {
     package var line: Int?
     package var column: Int?
     package var repeatCount: Int
-    package var parameters: [RuntimeRemoteObjectPayload]
+    package var parameters: [RuntimeRemoteObject]
     package var stackTrace: ConsoleStackTracePayload?
     package var networkRequestKey: NetworkRequestIdentifierKey?
     package var timestamp: Double?
 
-    package init(id: ID, targetID: ProtocolTargetIdentifier, payload: ConsoleMessagePayload) {
+    package init(
+        id: ID,
+        targetID: ProtocolTargetIdentifier,
+        payload: ConsoleMessagePayload,
+        parameters: [RuntimeRemoteObject]? = nil
+    ) {
         self.id = id
         self.source = payload.source
         self.level = payload.level
@@ -46,7 +51,7 @@ package final class ConsoleMessage {
         self.line = payload.line
         self.column = payload.column
         self.repeatCount = max(1, payload.repeatCount ?? 1)
-        self.parameters = payload.parameters
+        self.parameters = parameters ?? Self.parameterObjects(from: payload.parameters, targetID: targetID)
         self.stackTrace = payload.stackTrace
         self.networkRequestKey = payload.networkRequestID.map {
             NetworkRequestIdentifierKey(targetID: targetID, requestID: $0)
@@ -56,6 +61,19 @@ package final class ConsoleMessage {
 
     package var targetID: ProtocolTargetIdentifier {
         id.targetID
+    }
+
+    private static func parameterObjects(
+        from payloads: [RuntimeRemoteObjectPayload],
+        targetID: ProtocolTargetIdentifier
+    ) -> [RuntimeRemoteObject] {
+        payloads.map { payload in
+            RuntimeRemoteObject(
+                remoteObjectKey: payload.identifierKey(runtimeAgentTargetID: targetID),
+                payload: payload,
+                objectGroup: .console
+            )
+        }
     }
 }
 
@@ -117,9 +135,13 @@ package final class ConsoleTargetState {
         messagesByID[id]
     }
 
-    func append(_ payload: ConsoleMessagePayload, ordinal: UInt64) -> ConsoleMessageIdentifier {
+    func append(
+        _ payload: ConsoleMessagePayload,
+        ordinal: UInt64,
+        parameters: [RuntimeRemoteObject]? = nil
+    ) -> ConsoleMessageIdentifier {
         let id = ConsoleMessageIdentifier(targetID: targetID, ordinal: ordinal)
-        let message = ConsoleMessage(id: id, targetID: targetID, payload: payload)
+        let message = ConsoleMessage(id: id, targetID: targetID, payload: payload, parameters: parameters)
         orderedMessageIDs.append(id)
         messagesByID[id] = message
         if payload.type != .clear {
@@ -173,7 +195,7 @@ package final class ConsoleTargetState {
                     line: message.line,
                     column: message.column,
                     repeatCount: message.repeatCount,
-                    parameters: message.parameters,
+                    parameters: message.parameters.map(\.payload),
                     stackTrace: message.stackTrace,
                     networkRequestID: message.networkRequestKey?.requestID,
                     timestamp: message.timestamp
@@ -196,8 +218,12 @@ package final class ConsoleTargetState {
         for (id, message) in committedState.messagesByID {
             messagesByID[id] = message
         }
-        if let lastRepeatableMessageID = committedState.lastRepeatableMessageID {
-            self.lastRepeatableMessageID = lastRepeatableMessageID
+        if let committedLastRepeatableMessageID = committedState.lastRepeatableMessageID {
+            if let currentLastRepeatableMessageID = lastRepeatableMessageID {
+                lastRepeatableMessageID = max(currentLastRepeatableMessageID, committedLastRepeatableMessageID)
+            } else {
+                lastRepeatableMessageID = committedLastRepeatableMessageID
+            }
         }
         if let lastClearReason = committedState.lastClearReason {
             self.lastClearReason = lastClearReason
@@ -228,7 +254,7 @@ package final class ConsoleTargetState {
                     line: message.line,
                     column: message.column,
                     repeatCount: message.repeatCount,
-                    parameters: message.parameters,
+                    parameters: message.parameters.map(\.payload),
                     stackTrace: message.stackTrace,
                     networkRequestKey: message.networkRequestKey,
                     timestamp: message.timestamp
@@ -335,10 +361,14 @@ package final class ConsoleSession {
     }
 
     @discardableResult
-    package func applyMessageAdded(_ payload: ConsoleMessagePayload, targetID: ProtocolTargetIdentifier) -> ConsoleMessageIdentifier {
+    package func applyMessageAdded(
+        _ payload: ConsoleMessagePayload,
+        targetID: ProtocolTargetIdentifier,
+        parameters: [RuntimeRemoteObject]? = nil
+    ) -> ConsoleMessageIdentifier {
         nextMessageOrdinal &+= 1
         let state = ensureTargetState(for: targetID)
-        let id = state.append(payload, ordinal: nextMessageOrdinal)
+        let id = state.append(payload, ordinal: nextMessageOrdinal, parameters: parameters)
         updateAggregateSeverityCounts()
         return id
     }

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -93,8 +93,8 @@ package final class ConsoleSession {
     package private(set) var errorCount: Int
 
     @ObservationIgnored private var nextMessageOrdinal: UInt64
-    @ObservationIgnored private var orderedMessageIDs: [ConsoleMessageIdentifier]
-    @ObservationIgnored private var messagesByID: [ConsoleMessageIdentifier: ConsoleMessage]
+    private var orderedMessageIDs: [ConsoleMessageIdentifier]
+    private var messagesByID: [ConsoleMessageIdentifier: ConsoleMessage]
     @ObservationIgnored private var lastRepeatableMessageIDByTargetID: [ProtocolTargetIdentifier: ConsoleMessageIdentifier]
     @ObservationIgnored private var warningCountByTargetID: [ProtocolTargetIdentifier: Int]
     @ObservationIgnored private var errorCountByTargetID: [ProtocolTargetIdentifier: Int]

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -199,7 +199,8 @@ package final class ConsoleTargetState {
                     stackTrace: message.stackTrace,
                     networkRequestID: message.networkRequestKey?.requestID,
                     timestamp: message.timestamp
-                )
+                ),
+                parameters: message.parameters.map(Self.displayOnlyParameter)
             )
         }
         if let lastRepeatableMessageID {
@@ -210,6 +211,14 @@ package final class ConsoleTargetState {
         }
         nextState.recalculateSeverityCounts()
         return nextState
+    }
+
+    private static func displayOnlyParameter(_ parameter: RuntimeRemoteObject) -> RuntimeRemoteObject {
+        RuntimeRemoteObject(
+            payload: parameter.payload,
+            objectGroup: parameter.objectGroup,
+            executionContextKey: parameter.executionContextKey
+        )
     }
 
     func mergeCommittedState(_ committedState: ConsoleTargetState) {

--- a/Sources/WebInspectorCore/Console/ConsoleProtocol.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleProtocol.swift
@@ -1,0 +1,220 @@
+package struct ConsoleMessageSource: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let xml = Self("xml")
+    package static let javascript = Self("javascript")
+    package static let network = Self("network")
+    package static let consoleAPI = Self("console-api")
+    package static let storage = Self("storage")
+    package static let rendering = Self("rendering")
+    package static let css = Self("css")
+    package static let accessibility = Self("accessibility")
+    package static let security = Self("security")
+    package static let contentBlocker = Self("content-blocker")
+    package static let media = Self("media")
+    package static let mediaSource = Self("mediasource")
+    package static let webRTC = Self("webrtc")
+    package static let itpDebug = Self("itp-debug")
+    package static let privateClickMeasurement = Self("private-click-measurement")
+    package static let paymentRequest = Self("payment-request")
+    package static let other = Self("other")
+}
+
+package struct ConsoleMessageLevel: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let log = Self("log")
+    package static let info = Self("info")
+    package static let warning = Self("warning")
+    package static let error = Self("error")
+    package static let debug = Self("debug")
+}
+
+package struct ConsoleMessageType: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let log = Self("log")
+    package static let dir = Self("dir")
+    package static let dirXML = Self("dirxml")
+    package static let table = Self("table")
+    package static let trace = Self("trace")
+    package static let clear = Self("clear")
+    package static let startGroup = Self("startGroup")
+    package static let startGroupCollapsed = Self("startGroupCollapsed")
+    package static let endGroup = Self("endGroup")
+    package static let assert = Self("assert")
+    package static let timing = Self("timing")
+    package static let profile = Self("profile")
+    package static let profileEnd = Self("profileEnd")
+    package static let image = Self("image")
+}
+
+package struct ConsoleClearReason: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let consoleAPI = Self("console-api")
+    package static let frontend = Self("frontend")
+    package static let mainFrameNavigation = Self("main-frame-navigation")
+}
+
+package struct ConsoleLoggingChannelLevel: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let off = Self("off")
+    package static let basic = Self("basic")
+    package static let verbose = Self("verbose")
+}
+
+package struct ConsoleLoggingChannelPayload: Equatable, Sendable, Codable {
+    package var source: ConsoleMessageSource
+    package var level: ConsoleLoggingChannelLevel
+
+    package init(source: ConsoleMessageSource, level: ConsoleLoggingChannelLevel) {
+        self.source = source
+        self.level = level
+    }
+}
+
+package struct ConsoleMessagePayload: Equatable, Sendable, Codable {
+    package var source: ConsoleMessageSource
+    package var level: ConsoleMessageLevel
+    package var text: String
+    package var type: ConsoleMessageType?
+    package var url: String?
+    package var line: Int?
+    package var column: Int?
+    package var repeatCount: Int?
+    package var parameters: [RuntimeRemoteObjectPayload]
+    package var stackTrace: ConsoleStackTracePayload?
+    package var networkRequestID: NetworkRequestIdentifier?
+    package var timestamp: Double?
+
+    package init(
+        source: ConsoleMessageSource,
+        level: ConsoleMessageLevel,
+        text: String,
+        type: ConsoleMessageType? = nil,
+        url: String? = nil,
+        line: Int? = nil,
+        column: Int? = nil,
+        repeatCount: Int? = nil,
+        parameters: [RuntimeRemoteObjectPayload] = [],
+        stackTrace: ConsoleStackTracePayload? = nil,
+        networkRequestID: NetworkRequestIdentifier? = nil,
+        timestamp: Double? = nil
+    ) {
+        self.source = source
+        self.level = level
+        self.text = text
+        self.type = type
+        self.url = url
+        self.line = line
+        self.column = column
+        self.repeatCount = repeatCount
+        self.parameters = parameters
+        self.stackTrace = stackTrace
+        self.networkRequestID = networkRequestID
+        self.timestamp = timestamp
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case source
+        case level
+        case text
+        case type
+        case url
+        case line
+        case column
+        case repeatCount
+        case parameters
+        case stackTrace
+        case networkRequestID = "networkRequestId"
+        case timestamp
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        source = try container.decode(ConsoleMessageSource.self, forKey: .source)
+        level = try container.decode(ConsoleMessageLevel.self, forKey: .level)
+        text = try container.decode(String.self, forKey: .text)
+        type = try container.decodeIfPresent(ConsoleMessageType.self, forKey: .type)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        line = try container.decodeIfPresent(Int.self, forKey: .line)
+        column = try container.decodeIfPresent(Int.self, forKey: .column)
+        repeatCount = try container.decodeIfPresent(Int.self, forKey: .repeatCount)
+        parameters = try container.decodeIfPresent([RuntimeRemoteObjectPayload].self, forKey: .parameters) ?? []
+        stackTrace = try container.decodeIfPresent(ConsoleStackTracePayload.self, forKey: .stackTrace)
+        networkRequestID = try container.decodeIfPresent(NetworkRequestIdentifier.self, forKey: .networkRequestID)
+        timestamp = try container.decodeIfPresent(Double.self, forKey: .timestamp)
+    }
+}
+
+package enum ConsoleCommandIntent: Equatable, Sendable {
+    case enable(targetID: ProtocolTargetIdentifier)
+    case disable(targetID: ProtocolTargetIdentifier)
+    case clearMessages(targetID: ProtocolTargetIdentifier)
+    case setConsoleClearAPIEnabled(targetID: ProtocolTargetIdentifier, enabled: Bool)
+    case getLoggingChannels(targetID: ProtocolTargetIdentifier)
+    case setLoggingChannelLevel(
+        targetID: ProtocolTargetIdentifier,
+        source: ConsoleMessageSource,
+        level: ConsoleLoggingChannelLevel
+    )
+
+    package var targetID: ProtocolTargetIdentifier {
+        switch self {
+        case let .enable(targetID):
+            targetID
+        case let .disable(targetID):
+            targetID
+        case let .clearMessages(targetID):
+            targetID
+        case let .setConsoleClearAPIEnabled(targetID, _):
+            targetID
+        case let .getLoggingChannels(targetID):
+            targetID
+        case let .setLoggingChannelLevel(targetID, _, _):
+            targetID
+        }
+    }
+}

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -542,8 +542,8 @@ package final class DOMSession {
         targetGraph.removeExecutionContext(contextID)
     }
 
-    package func applyExecutionContextsCleared(targetID: ProtocolTarget.ID) {
-        targetGraph.removeExecutionContexts(targetID: targetID)
+    package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTarget.ID) {
+        targetGraph.removeExecutionContexts(runtimeAgentTargetID: runtimeAgentTargetID)
     }
 
     package func applyExecutionContextCreated(

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -539,8 +539,8 @@ package final class DOMSession {
         targetGraph.recordExecutionContext(context)
     }
 
-    package func applyExecutionContextDestroyed(_ contextID: ExecutionContextID) {
-        targetGraph.removeExecutionContext(contextID)
+    package func applyExecutionContextDestroyed(_ contextKey: RuntimeExecutionContextKey) {
+        targetGraph.removeExecutionContext(contextKey)
     }
 
     package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTarget.ID) {
@@ -1301,7 +1301,7 @@ package final class DOMSession {
                 )
             },
             currentNodeIDByKey: currentNodeIDByKey,
-            executionContextsByID: targetGraph.executionContextSnapshots(),
+            executionContextsByKey: targetGraph.executionContextSnapshots(),
             selection: DOMSelectionSnapshot(
                 selectedNodeID: selection.selectedNodeID,
                 pendingRequest: selection.pendingRequest.map {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -512,6 +512,7 @@ package final class DOMSession {
             return
         }
         targetGraph.removeExecutionContexts(targetID: targetID)
+        targetGraph.removeExecutionContexts(runtimeAgentTargetID: targetID)
         if let documentID = documentStore.currentDocument(forTargetID: targetID)?.id {
             removeDocument(documentID)
         }

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -532,7 +532,7 @@ package final class DOMSession {
         treeRevision &+= 1
     }
 
-    package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
+    package func applyExecutionContextCreated(_ context: RuntimeExecutionContextRecord) {
         guard targetGraph.containsTarget(context.targetID) else {
             return
         }
@@ -552,7 +552,7 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         frameID: DOMFrame.ID? = nil
     ) {
-        applyExecutionContextCreated(RuntimeExecutionContext(id: id, targetID: targetID, frameID: frameID))
+        applyExecutionContextCreated(RuntimeExecutionContextRecord(id: id, targetID: targetID, frameID: frameID))
     }
 
     @discardableResult

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -531,11 +531,19 @@ package final class DOMSession {
         treeRevision &+= 1
     }
 
-    package func applyExecutionContextCreated(_ record: ExecutionContextRecord) {
-        guard targetGraph.containsTarget(record.targetID) else {
+    package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
+        guard targetGraph.containsTarget(context.targetID) else {
             return
         }
-        targetGraph.recordExecutionContext(record)
+        targetGraph.recordExecutionContext(context)
+    }
+
+    package func applyExecutionContextDestroyed(_ contextID: ExecutionContextID) {
+        targetGraph.removeExecutionContext(contextID)
+    }
+
+    package func applyExecutionContextsCleared(targetID: ProtocolTarget.ID) {
+        targetGraph.removeExecutionContexts(targetID: targetID)
     }
 
     package func applyExecutionContextCreated(
@@ -543,7 +551,7 @@ package final class DOMSession {
         targetID: ProtocolTarget.ID,
         frameID: DOMFrame.ID? = nil
     ) {
-        applyExecutionContextCreated(.init(id: id, targetID: targetID, frameID: frameID))
+        applyExecutionContextCreated(RuntimeExecutionContext(id: id, targetID: targetID, frameID: frameID))
     }
 
     @discardableResult

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -197,7 +197,7 @@ package struct DOMSessionSnapshot: Equatable, Sendable {
     package var frameDocumentProjections: [ProtocolTargetIdentifier: FrameDocumentProjectionSnapshot]
     package var transactions: [DOMTransactionSnapshot]
     package var currentNodeIDByKey: [DOMNodeCurrentKey: DOMNodeIdentifier]
-    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord]
     package var selection: DOMSelectionSnapshot
 }
 
@@ -213,13 +213,13 @@ package extension DOMSessionSnapshot {
     func executionContext(
         runtimeAgentTargetID: ProtocolTargetIdentifier,
         contextID: ExecutionContextID
-    ) -> RuntimeExecutionContext? {
+    ) -> RuntimeExecutionContextRecord? {
         executionContextsByKey[
             RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: contextID)
         ]
     }
 
-    func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+    func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContextRecord? {
         let matches = executionContextsByKey.values.filter { $0.id == contextID }
         return matches.count == 1 ? matches[0] : nil
     }

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -197,7 +197,7 @@ package struct DOMSessionSnapshot: Equatable, Sendable {
     package var frameDocumentProjections: [ProtocolTargetIdentifier: FrameDocumentProjectionSnapshot]
     package var transactions: [DOMTransactionSnapshot]
     package var currentNodeIDByKey: [DOMNodeCurrentKey: DOMNodeIdentifier]
-    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
     package var selection: DOMSelectionSnapshot
 }
 
@@ -208,5 +208,19 @@ package extension DOMSessionSnapshot {
         }
         return targetStatesByID[currentPageTargetID]?.currentDocumentID
             ?? targetsByID[currentPageTargetID]?.currentDocumentID
+    }
+
+    func executionContext(
+        runtimeAgentTargetID: ProtocolTargetIdentifier,
+        contextID: ExecutionContextID
+    ) -> RuntimeExecutionContext? {
+        executionContextsByKey[
+            RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: contextID)
+        ]
+    }
+
+    func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+        let matches = executionContextsByKey.values.filter { $0.id == contextID }
+        return matches.count == 1 ? matches[0] : nil
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -197,7 +197,7 @@ package struct DOMSessionSnapshot: Equatable, Sendable {
     package var frameDocumentProjections: [ProtocolTargetIdentifier: FrameDocumentProjectionSnapshot]
     package var transactions: [DOMTransactionSnapshot]
     package var currentNodeIDByKey: [DOMNodeCurrentKey: DOMNodeIdentifier]
-    package var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     package var selection: DOMSelectionSnapshot
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -70,6 +70,20 @@ package struct ProtocolTargetSnapshot: Equatable, Sendable {
     package var currentDocumentID: DOMDocumentIdentifier?
 }
 
+package extension ProtocolTargetSnapshot {
+    var record: ProtocolTargetRecord {
+        ProtocolTargetRecord(
+            id: id,
+            kind: kind,
+            frameID: frameID,
+            parentFrameID: parentFrameID,
+            capabilities: capabilities,
+            isProvisional: isProvisional,
+            isPaused: isPaused
+        )
+    }
+}
+
 package struct DOMFrameSnapshot: Equatable, Sendable {
     package var id: DOMFrameIdentifier
     package var parentFrameID: DOMFrameIdentifier?

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -255,6 +255,10 @@ package final class DOMTargetGraph {
         executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
     }
 
+    package func removeExecutionContexts(runtimeAgentTargetID: ProtocolTarget.ID) {
+        executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
+    }
+
     package func removeExecutionContext(_ contextID: ExecutionContextID) {
         executionContextsByID.removeValue(forKey: contextID)
     }
@@ -264,6 +268,9 @@ package final class DOMTargetGraph {
             var movedRecord = record
             movedRecord.targetID = newTargetID
             executionContextsByID[contextID] = movedRecord
+        }
+        for (contextID, record) in executionContextsByID where record.runtimeAgentTargetID == oldTargetID {
+            executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
         }
     }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -12,7 +12,7 @@ package struct DOMTargetRemoval: Equatable, Sendable {
 package final class DOMTargetGraph {
     private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
     private var framesByID: [DOMFrame.ID: DOMFrame]
-    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord]
 
     package init() {
         targetsByID = [:]
@@ -276,11 +276,13 @@ package final class DOMTargetGraph {
                 continue
             }
             executionContextsByKey.removeValue(forKey: contextKey)
-            executionContextsByKey[movedRecord.key] = movedRecord
+            if executionContextsByKey[movedRecord.key] == nil {
+                executionContextsByKey[movedRecord.key] = movedRecord
+            }
         }
     }
 
-    package func recordExecutionContext(_ context: RuntimeExecutionContext) {
+    package func recordExecutionContext(_ context: RuntimeExecutionContextRecord) {
         executionContextsByKey[context.key] = context
     }
 
@@ -313,7 +315,7 @@ package final class DOMTargetGraph {
         }
     }
 
-    package func executionContextSnapshots() -> [RuntimeExecutionContextKey: RuntimeExecutionContext] {
+    package func executionContextSnapshots() -> [RuntimeExecutionContextKey: RuntimeExecutionContextRecord] {
         executionContextsByKey
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -12,7 +12,7 @@ package struct DOMTargetRemoval: Equatable, Sendable {
 package final class DOMTargetGraph {
     private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
     private var framesByID: [DOMFrame.ID: DOMFrame]
-    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
 
     package init() {
         targetsByID = [:]
@@ -255,6 +255,10 @@ package final class DOMTargetGraph {
         executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
     }
 
+    package func removeExecutionContext(_ contextID: ExecutionContextID) {
+        executionContextsByID.removeValue(forKey: contextID)
+    }
+
     package func retargetExecutionContexts(from oldTargetID: ProtocolTarget.ID, to newTargetID: ProtocolTarget.ID) {
         for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
             var movedRecord = record
@@ -263,8 +267,8 @@ package final class DOMTargetGraph {
         }
     }
 
-    package func recordExecutionContext(_ record: ExecutionContextRecord) {
-        executionContextsByID[record.id] = record
+    package func recordExecutionContext(_ context: RuntimeExecutionContext) {
+        executionContextsByID[context.id] = context
     }
 
     package func targetSnapshots(
@@ -296,7 +300,7 @@ package final class DOMTargetGraph {
         }
     }
 
-    package func executionContextSnapshots() -> [ExecutionContextID: ExecutionContextRecord] {
+    package func executionContextSnapshots() -> [ExecutionContextID: RuntimeExecutionContext] {
         executionContextsByID
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -12,18 +12,18 @@ package struct DOMTargetRemoval: Equatable, Sendable {
 package final class DOMTargetGraph {
     private var targetsByID: [ProtocolTarget.ID: ProtocolTarget]
     private var framesByID: [DOMFrame.ID: DOMFrame]
-    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
 
     package init() {
         targetsByID = [:]
         framesByID = [:]
-        executionContextsByID = [:]
+        executionContextsByKey = [:]
     }
 
     package func reset() {
         targetsByID.removeAll()
         framesByID.removeAll()
-        executionContextsByID.removeAll()
+        executionContextsByKey.removeAll()
     }
 
     package func containsTarget(_ targetID: ProtocolTarget.ID) -> Bool {
@@ -252,30 +252,36 @@ package final class DOMTargetGraph {
     }
 
     package func removeExecutionContexts(targetID: ProtocolTarget.ID) {
-        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+        executionContextsByKey = executionContextsByKey.filter { $0.value.targetID != targetID }
     }
 
     package func removeExecutionContexts(runtimeAgentTargetID: ProtocolTarget.ID) {
-        executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
+        executionContextsByKey = executionContextsByKey.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
     }
 
-    package func removeExecutionContext(_ contextID: ExecutionContextID) {
-        executionContextsByID.removeValue(forKey: contextID)
+    package func removeExecutionContext(_ contextKey: RuntimeExecutionContextKey) {
+        executionContextsByKey.removeValue(forKey: contextKey)
     }
 
     package func retargetExecutionContexts(from oldTargetID: ProtocolTarget.ID, to newTargetID: ProtocolTarget.ID) {
-        for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
+        for (contextKey, record) in Array(executionContextsByKey) {
             var movedRecord = record
-            movedRecord.targetID = newTargetID
-            executionContextsByID[contextID] = movedRecord
-        }
-        for (contextID, record) in executionContextsByID where record.runtimeAgentTargetID == oldTargetID {
-            executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
+            if movedRecord.targetID == oldTargetID {
+                movedRecord.targetID = newTargetID
+            }
+            if movedRecord.runtimeAgentTargetID == oldTargetID {
+                movedRecord.runtimeAgentTargetID = newTargetID
+            }
+            guard movedRecord != record else {
+                continue
+            }
+            executionContextsByKey.removeValue(forKey: contextKey)
+            executionContextsByKey[movedRecord.key] = movedRecord
         }
     }
 
     package func recordExecutionContext(_ context: RuntimeExecutionContext) {
-        executionContextsByID[context.id] = context
+        executionContextsByKey[context.key] = context
     }
 
     package func targetSnapshots(
@@ -307,8 +313,8 @@ package final class DOMTargetGraph {
         }
     }
 
-    package func executionContextSnapshots() -> [ExecutionContextID: RuntimeExecutionContext] {
-        executionContextsByID
+    package func executionContextSnapshots() -> [RuntimeExecutionContextKey: RuntimeExecutionContext] {
+        executionContextsByKey
     }
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -257,11 +257,9 @@ package final class DOMTargetGraph {
 
     package func retargetExecutionContexts(from oldTargetID: ProtocolTarget.ID, to newTargetID: ProtocolTarget.ID) {
         for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
-            executionContextsByID[contextID] = ExecutionContextRecord(
-                id: record.id,
-                targetID: newTargetID,
-                frameID: record.frameID
-            )
+            var movedRecord = record
+            movedRecord.targetID = newTargetID
+            executionContextsByID[contextID] = movedRecord
         }
     }
 

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -378,6 +378,12 @@ when probing is acceptable, and conservative defaults otherwise.
   group `"console"`, and `Console.messagesCleared` /
   `Runtime.executionContextsCleared` release the matching Runtime agent's cached
   handles.
+- `ConsoleMessage.parameters` should hold `RuntimeRemoteObject` live model
+  instances, matching WebKit's `RemoteObject.fromPayload` conversion in
+  `ConsoleManager`, not a Console-local remote object type or raw payload list.
+  Object-ID-backed parameters should be the same observable objects registered
+  in `RuntimeSession`; by-value parameters can be message-owned
+  `RuntimeRemoteObject` instances with no protocol object handle.
 - `Target.didCommitProvisionalTarget` may move semantic context ownership to
   the committed target, but it must not re-key existing remote object handles to
   the new Runtime agent target. Handles created by the old agent are stale and

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -55,6 +55,46 @@ This note records the WebKit Console and Runtime transport behavior that
 
 ## WebKit Protocol Surface
 
+## 2026-05-26 WebKit UI Ownership Recheck
+
+The latest checked WebKit UI does not keep Console/Runtime enablement as loose
+per-target dictionaries on the session object. The relevant ownership is
+target-centric:
+
+- `Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js` owns the
+  target map and target lifecycle. `targetCreated` constructs a target-specific
+  connection plus a typed target object, then initializes and registers it.
+- `Source/WebInspectorUI/UserInterface/Protocol/Target.js` owns target
+  metadata, provisional/paused state, and the per-target agent table. `hasDomain`
+  / `hasCommand` / `hasEvent` are target methods, so domain availability is a
+  target fact, not inferred from target kind alone.
+- `Target.initialize()` calls each manager's `initializeTarget(target)` and then
+  enables `ConsoleAgent` at the end when the target has the Console domain. This
+  keeps Console replay events behind the rest of target initialization.
+- `Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js` enables
+  `RuntimeAgent` per target from `initializeTarget(target)` and uses the active
+  execution context's target for evaluation.
+- `Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js` does not
+  send `Console.enable` itself from `initializeTarget`; it only configures
+  Console behavior such as clear-API support. The actual enable is deferred to
+  `Target.initialize()`.
+- `Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js` routes
+  `Runtime.executionContextCreated` to `WI.FrameTarget` directly when the event
+  is delivered by a frame target. Otherwise it delegates to `NetworkManager`,
+  which resolves page-delivered contexts through frame ownership.
+- `Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js` owns a
+  frame-target execution-context list. A new normal context replaces prior frame
+  contexts, matching navigation semantics.
+- `Source/WebInspectorUI/UserInterface/Protocol/Connection.js` buffers messages
+  delivered to provisional targets and dispatches them after commit.
+
+Model implication for `WebInspectorKit`: connection-level bootstrap state should
+be owned by target objects or target-scoped state objects. Avoid parallel
+session dictionaries such as `runtimeEnabledByTargetID`,
+`consoleEnabledByTargetID`, and `enableTaskByTargetID` with pass-through
+accessors. Optional command fallback remains domain/model state because it is a
+capability probe result for the target's agent surface.
+
 ### Console Domain
 
 `Source/JavaScriptCore/inspector/protocol/Console.json` defines the useful
@@ -352,7 +392,9 @@ when probing is acceptable, and conservative defaults otherwise.
   from the page agent. Execution context IDs are only unique inside one Runtime
   agent, so Core, DOM compatibility storage, and Transport registries use
   `RuntimeExecutionContextKey(runtimeAgentTargetID, contextID)` for context
-  identity.
+  identity. Core exposes `RuntimeExecutionContext` as the observable live model
+  for UI/event integration, while `RuntimeExecutionContextRecord` is the
+  Sendable value used by snapshots, DOM compatibility storage, and Transport.
 - Site Isolation frame Console means `ConsoleSession` must merge page, frame,
   worker, and service-worker message streams without dropping the target
   identity. A flat display can still be built later, but the Core model should
@@ -371,6 +413,16 @@ Add first-class Runtime and Console domains beside DOM/CSS/Network:
   - command intents
 - `Sources/WebInspectorCore/Runtime/RuntimeModel.swift`
   - `@MainActor @Observable RuntimeSession`
+  - `@MainActor @Observable RuntimeTargetState` for target-owned default
+    execution context selection
+  - `@MainActor @Observable RuntimeAgentState` for agent-scoped execution
+    contexts, remote objects, and unsupported optional commands
+  - `@MainActor @Observable RuntimeExecutionContext` for context selector and
+    event-routing identity without replacing UI row identity
+  - `@MainActor @Observable RuntimeRemoteObject` for future Console object
+    previews/properties without replacing UI row identity
+  - `RuntimeExecutionContextRecord` for snapshots and actor/transport
+    handoff
   - execution contexts keyed by `RuntimeExecutionContextKey`
   - `RuntimeExecutionContext.targetID` for semantic ownership
   - `RuntimeExecutionContext.runtimeAgentTargetID` for agent-scoped clears
@@ -383,6 +435,10 @@ Add first-class Runtime and Console domains beside DOM/CSS/Network:
   - command intents
 - `Sources/WebInspectorCore/Console/ConsoleModel.swift`
   - `@MainActor @Observable ConsoleSession`
+  - `@MainActor @Observable ConsoleTargetState` for target-owned message list,
+    repeat state, clear reason, warning count, error count, and unsupported
+    optional commands
+  - `@MainActor @Observable ConsoleMessage`
   - append message
   - update previous repeat count
   - clear with reason

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -349,7 +349,10 @@ when probing is acceptable, and conservative defaults otherwise.
   page Runtime agent reports a subframe context that should be owned by a frame
   target. Normal-context replacement is scoped by both semantic target and
   Runtime agent so a later frame agent does not discard still-valid contexts
-  from the page agent.
+  from the page agent. Execution context IDs are only unique inside one Runtime
+  agent, so Core, DOM compatibility storage, and Transport registries use
+  `RuntimeExecutionContextKey(runtimeAgentTargetID, contextID)` for context
+  identity.
 - Site Isolation frame Console means `ConsoleSession` must merge page, frame,
   worker, and service-worker message streams without dropping the target
   identity. A flat display can still be built later, but the Core model should
@@ -368,7 +371,7 @@ Add first-class Runtime and Console domains beside DOM/CSS/Network:
   - command intents
 - `Sources/WebInspectorCore/Runtime/RuntimeModel.swift`
   - `@MainActor @Observable RuntimeSession`
-  - execution contexts keyed by id
+  - execution contexts keyed by `RuntimeExecutionContextKey`
   - `RuntimeExecutionContext.targetID` for semantic ownership
   - `RuntimeExecutionContext.runtimeAgentTargetID` for agent-scoped clears
   - Runtime-agent-scoped remote object records, object group index, and

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -411,6 +411,8 @@ Add `console` to `InspectorSession` construction and event handling:
   is no longer provisional.
 - handle `.console` in `handleProtocolEvent` by applying decoded events to
   `ConsoleSession`.
+- when handling `Console.messagesCleared`, also release Runtime object group
+  `"console"` for the console event target to match backend lifetime.
 - handle `.runtime` by applying decoded events to `RuntimeSession` and the DOM
   compatibility execution-context store. Runtime agent source target controls
   `executionContextsCleared`, while semantic target ownership remains available

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -329,10 +329,17 @@ when probing is acceptable, and conservative defaults otherwise.
   command to that context's `runtimeAgentTargetID`. Without UI context
   selection, the current page target/main-world context is the simplest first
   behavior.
-- Remote object lifetime belongs to `RuntimeSession`. `Console.messageAdded`
-  registers parameter objects in Runtime under object group `"console"`, and
-  `Console.messagesCleared` / `Runtime.executionContextsCleared` release the
-  matching Runtime agent's cached handles.
+- Remote object lifetime belongs to `RuntimeSession`. It keeps the remote object
+  payload plus object group/context metadata as the single release owner; any
+  snapshot-level object group target index is derived from those records.
+  `Console.messageAdded` registers parameter objects in Runtime under object
+  group `"console"`, and `Console.messagesCleared` /
+  `Runtime.executionContextsCleared` release the matching Runtime agent's cached
+  handles.
+- `Target.didCommitProvisionalTarget` may move semantic context ownership to
+  the committed target, but it must not re-key existing remote object handles to
+  the new Runtime agent target. Handles created by the old agent are stale and
+  should be dropped.
 - Runtime execution contexts need two target identities. `targetID` is the
   semantic owner used by DOM selection and future UI grouping.
   `runtimeAgentTargetID` is the protocol agent that delivered the context and

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -311,9 +311,10 @@ when probing is acceptable, and conservative defaults otherwise.
 - Console message identity is local to `ConsoleSession`; WebKit does not send a
   stable message id.
 - Console messages must retain the protocol event target that delivered them.
-- Remote objects must retain their owning target. `Runtime.releaseObject`,
-  `getPreview`, `getProperties`, and `releaseObjectGroup` must be sent back to
-  that same target.
+- Remote objects must retain their owning Runtime agent target.
+  `Runtime.releaseObject`, `getPreview`, `getProperties`, and
+  `releaseObjectGroup` must be sent back to that same agent target. This can
+  differ from the semantic frame target used to group DOM/Console UI state.
 - `networkRequestId` is not globally unique. Resolve it with the console event
   target.
 - `messageRepeatCountUpdated` updates the previous repeatable message for the
@@ -328,6 +329,10 @@ when probing is acceptable, and conservative defaults otherwise.
   command to that context's `runtimeAgentTargetID`. Without UI context
   selection, the current page target/main-world context is the simplest first
   behavior.
+- Remote object lifetime belongs to `RuntimeSession`. `Console.messageAdded`
+  registers parameter objects in Runtime under object group `"console"`, and
+  `Console.messagesCleared` / `Runtime.executionContextsCleared` release the
+  matching Runtime agent's cached handles.
 - Runtime execution contexts need two target identities. `targetID` is the
   semantic owner used by DOM selection and future UI grouping.
   `runtimeAgentTargetID` is the protocol agent that delivered the context and
@@ -355,7 +360,8 @@ Add first-class Runtime and Console domains beside DOM/CSS/Network:
   - execution contexts keyed by id
   - `RuntimeExecutionContext.targetID` for semantic ownership
   - `RuntimeExecutionContext.runtimeAgentTargetID` for agent-scoped clears
-  - target-scoped remote object groups and unsupported command state
+  - Runtime-agent-scoped remote object records, object group index, and
+    unsupported command state
 - `Sources/WebInspectorCore/Console/ConsoleProtocol.swift`
   - identifiers
   - message/source/level/type/clear reason enums or raw wrappers
@@ -411,6 +417,8 @@ Add `console` to `InspectorSession` construction and event handling:
   is no longer provisional.
 - handle `.console` in `handleProtocolEvent` by applying decoded events to
   `ConsoleSession`.
+- when handling `Console.messageAdded`, register parameter `RemoteObject`
+  handles with `RuntimeSession` using object group `"console"`.
 - when handling `Console.messagesCleared`, also release Runtime object group
   `"console"` for the console event target to match backend lifetime.
 - handle `.runtime` by applying decoded events to `RuntimeSession` and the DOM
@@ -447,7 +455,8 @@ Useful tests before UI work:
 - `ConsoleTransportAdapter` builds `Runtime.evaluate` with WebInspectorUI-like
   console defaults.
 - `Console.messageAdded` appends a target-scoped message with parameters,
-  stack trace, source location, timestamp, and network request key.
+  stack trace, source location, timestamp, and network request key, and
+  registers parameter remote objects in `RuntimeSession`.
 - `Console.messageRepeatCountUpdated` updates the previous message instead of
   appending.
 - `Console.messagesCleared` clears or starts a new model session with the raw
@@ -460,7 +469,8 @@ Useful tests before UI work:
   commit is associated with the committed target only through the transport's
   target-commit rewrite/buffering path, not through URL or frame id guesses.
 - `Runtime.evaluate` result decodes `RemoteObject`, `wasThrown`, and
-  `savedResultIndex`, preserving the command target on the returned object.
+  `savedResultIndex`, preserving the Runtime agent target on the returned
+  object record.
 
 ## Source References
 

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -328,7 +328,9 @@ when probing is acceptable, and conservative defaults otherwise.
 - `Runtime.evaluate` should resolve the selected execution context and send the
   command to that context's `runtimeAgentTargetID`. Without UI context
   selection, the current page target/main-world context is the simplest first
-  behavior.
+  behavior. Later same-agent subframe contexts must not overwrite the target's
+  default context; they are addressable through explicit/selected contexts or
+  frame-target ownership when Site Isolation metadata is available.
 - Remote object lifetime belongs to `RuntimeSession`. It keeps the remote object
   payload plus object group/context metadata as the single release owner; any
   snapshot-level object group target index is derived from those records.

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -347,7 +347,9 @@ when probing is acceptable, and conservative defaults otherwise.
   `runtimeAgentTargetID` is the protocol agent that delivered the context and
   is the scope for `Runtime.executionContextsCleared`. They differ when the
   page Runtime agent reports a subframe context that should be owned by a frame
-  target.
+  target. Normal-context replacement is scoped by both semantic target and
+  Runtime agent so a later frame agent does not discard still-valid contexts
+  from the page agent.
 - Site Isolation frame Console means `ConsoleSession` must merge page, frame,
   worker, and service-worker message streams without dropping the target
   identity. A flat display can still be built later, but the Core model should

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -327,6 +327,12 @@ when probing is acceptable, and conservative defaults otherwise.
 - `Runtime.evaluate` should target the active execution context target when UI
   later exposes context selection. Without UI context selection, the current
   page target/main-world context is the simplest first behavior.
+- Runtime execution contexts need two target identities. `targetID` is the
+  semantic owner used by DOM selection and future UI grouping.
+  `runtimeAgentTargetID` is the protocol agent that delivered the context and
+  is the scope for `Runtime.executionContextsCleared`. They differ when the
+  page Runtime agent reports a subframe context that should be owned by a frame
+  target.
 - Site Isolation frame Console means `ConsoleSession` must merge page, frame,
   worker, and service-worker message streams without dropping the target
   identity. A flat display can still be built later, but the Core model should
@@ -336,16 +342,23 @@ when probing is acceptable, and conservative defaults otherwise.
 
 ### Core
 
-Add a first-class Console domain beside DOM/CSS/Network:
+Add first-class Runtime and Console domains beside DOM/CSS/Network:
 
+- `Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift`
+  - JSON values
+  - execution context payloads
+  - remote object, preview, property, collection, and evaluation payloads
+  - command intents
+- `Sources/WebInspectorCore/Runtime/RuntimeModel.swift`
+  - `@MainActor @Observable RuntimeSession`
+  - execution contexts keyed by id
+  - `RuntimeExecutionContext.targetID` for semantic ownership
+  - `RuntimeExecutionContext.runtimeAgentTargetID` for agent-scoped clears
+  - target-scoped remote object groups and unsupported command state
 - `Sources/WebInspectorCore/Console/ConsoleProtocol.swift`
   - identifiers
   - message/source/level/type/clear reason enums or raw wrappers
   - `ConsoleMessagePayload`
-  - `RuntimeRemoteObjectPayload`
-  - `RuntimeObjectPreviewPayload`
-  - `RuntimePropertyPreviewPayload`
-  - `RuntimeEvaluationResultPayload`
   - command intents
 - `Sources/WebInspectorCore/Console/ConsoleModel.swift`
   - `@MainActor @Observable ConsoleSession`
@@ -364,31 +377,43 @@ latest (`appcache` removed, `accessibility` added).
 Add `ConsoleTransportAdapter`:
 
 - build `Console.enable`, `Console.disable`, `Console.clearMessages`,
-  `Console.setConsoleClearAPIEnabled`, `Runtime.evaluate`,
-  `Runtime.getPreview`, `Runtime.getProperties`, `Runtime.releaseObject`, and
-  `Runtime.releaseObjectGroup` commands.
+  `Console.setConsoleClearAPIEnabled`, `Console.getLoggingChannels`, and
+  `Console.setLoggingChannelLevel` commands.
 - decode `Console.messageAdded`
 - decode `Console.messageRepeatCountUpdated`
 - decode `Console.messagesCleared`
-- decode `Runtime.evaluate` result
 - preserve target id from `ProtocolEventEnvelope.targetID`
 
-`Runtime.evaluate` belongs in this adapter because it is required by the
-Console feature, but its command domain must remain `.runtime`.
+Add `RuntimeTransportAdapter`:
+
+- build `Runtime.enable`, `Runtime.evaluate`, `Runtime.getPreview`,
+  `Runtime.getProperties`, `Runtime.getDisplayableProperties`,
+  `Runtime.getCollectionEntries`, `Runtime.saveResult`,
+  `Runtime.setSavedResultAlias`, `Runtime.releaseObject`, and
+  `Runtime.releaseObjectGroup` commands.
+- decode Runtime command results.
+- decode `Runtime.executionContextCreated`,
+  `Runtime.executionContextDestroyed`, and `Runtime.executionContextsCleared`.
+- preserve `ProtocolEventEnvelope.sourceTargetID` as the Runtime agent source
+  when recording contexts and applying clear events.
 
 ### Runtime Session
 
 Add `console` to `InspectorSession` construction and event handling:
 
+- `package let runtime: RuntimeSession`
 - `package let console: ConsoleSession`
 - bootstrap `Console.enable` for the main page target after existing DOM,
   Runtime, and Network setup when the target has Console capability.
-- when target lifecycle events create/commit a target with Console capability,
-  enable Console for that target after it is no longer provisional.
+- when target lifecycle events create/commit a target with Runtime and/or
+  Console capability, enable each supported agent independently after the target
+  is no longer provisional.
 - handle `.console` in `handleProtocolEvent` by applying decoded events to
   `ConsoleSession`.
-- keep `.runtime` execution context handling for DOM/transport registry as it
-  exists today; add Console-specific evaluation methods separately.
+- handle `.runtime` by applying decoded events to `RuntimeSession` and the DOM
+  compatibility execution-context store. Runtime agent source target controls
+  `executionContextsCleared`, while semantic target ownership remains available
+  for DOM selection and future Console UI grouping.
 
 Do not create a UI-only view model for Console transport state. The native UI
 can observe `ConsoleSession` directly later, matching the existing

--- a/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/ConsoleTransportResearch.md
@@ -324,9 +324,10 @@ when probing is acceptable, and conservative defaults otherwise.
 - `Console.enable` can synchronously cause a backlog of `messageAdded` events
   after its command response path begins. Bootstrap should enable Console after
   other required initial domain setup.
-- `Runtime.evaluate` should target the active execution context target when UI
-  later exposes context selection. Without UI context selection, the current
-  page target/main-world context is the simplest first behavior.
+- `Runtime.evaluate` should resolve the selected execution context and send the
+  command to that context's `runtimeAgentTargetID`. Without UI context
+  selection, the current page target/main-world context is the simplest first
+  behavior.
 - Runtime execution contexts need two target identities. `targetID` is the
   semantic owner used by DOM selection and future UI grouping.
   `runtimeAgentTargetID` is the protocol agent that delivered the context and

--- a/Sources/WebInspectorCore/Docs/TransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/TransportResearch.md
@@ -194,8 +194,12 @@ WebInspectorUI.
 - Network owns request/resource identity. Transport preserves the event target
   and optional payload `targetId` separately so Network can distinguish routing
   from origin/placement metadata.
-- Runtime owns execution contexts. Transport preserves the target connection
-  that delivered each context and the frame id carried by the context payload.
+- Runtime owns execution contexts. Transport preserves both the semantic owner
+  target (`targetID`) and the Runtime agent that delivered the context
+  (`runtimeAgentTargetID`). These can differ when a page Runtime agent reports a
+  subframe context that is displayed under a frame target. Root-scoped
+  `Runtime.executionContextsCleared` must clear by Runtime agent source, not by
+  the retargeted owner.
 
 ## Contradicted Interpretations
 

--- a/Sources/WebInspectorCore/Docs/TransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/TransportResearch.md
@@ -226,8 +226,10 @@ lifecycle code should not grow pass-through accessors over parallel
 dictionaries. UI-facing domain state should stay as observable live models
 with stable identity (`RuntimeTargetState`, `RuntimeAgentState`,
 `RuntimeExecutionContext`, `RuntimeRemoteObject`, `ConsoleTargetState`, and
-`ConsoleMessage`). Sendable records should be reserved for transport handoff
-and snapshots, such as `RuntimeExecutionContextRecord`.
+`ConsoleMessage`). Console message parameters should also reference
+`RuntimeRemoteObject` live objects; payload records should be reserved for
+protocol decode, transport handoff, and snapshots, such as
+`RuntimeExecutionContextRecord`.
 
 ## Contradicted Interpretations
 

--- a/Sources/WebInspectorCore/Docs/TransportResearch.md
+++ b/Sources/WebInspectorCore/Docs/TransportResearch.md
@@ -201,6 +201,34 @@ WebInspectorUI.
   `Runtime.executionContextsCleared` must clear by Runtime agent source, not by
   the retargeted owner.
 
+## Target-Owned Frontend State
+
+The latest checked WebKit UI keeps target lifecycle and agent availability on
+typed target objects rather than on a collection of session-level flags:
+
+- `WI.TargetManager` owns the target registry and applies create, destroy, and
+  provisional commit events.
+- `WI.Target` owns the per-target agent table and exposes `hasDomain`,
+  `hasCommand`, and `hasEvent`.
+- `WI.PageTarget`, `WI.FrameTarget`, and `WI.WorkerTarget` specialize target
+  behavior where the domain semantics differ. In particular, `WI.FrameTarget`
+  owns frame-target execution contexts and replaces normal contexts on
+  navigation.
+- Target initialization is manager-driven, but `ConsoleAgent.enable()` is
+  intentionally sent last from the target initialization path so replayed
+  console messages do not overtake earlier setup.
+
+For `WebInspectorKit`, transport/runtime integration should follow the same
+shape: keep target capability, provisional status, agent enablement, and
+in-flight target initialization work behind a target-owned model. Domain models
+such as Runtime and Console can still own their semantic data, but target
+lifecycle code should not grow pass-through accessors over parallel
+dictionaries. UI-facing domain state should stay as observable live models
+with stable identity (`RuntimeTargetState`, `RuntimeAgentState`,
+`RuntimeExecutionContext`, `RuntimeRemoteObject`, `ConsoleTargetState`, and
+`ConsoleMessage`). Sendable records should be reserved for transport handoff
+and snapshots, such as `RuntimeExecutionContextRecord`.
+
 ## Contradicted Interpretations
 
 ```text

--- a/Sources/WebInspectorCore/Network/NetworkProtocol.swift
+++ b/Sources/WebInspectorCore/Network/NetworkProtocol.swift
@@ -55,41 +55,6 @@ package enum NetworkCommandIntent: Equatable, Sendable {
     )
 }
 
-package struct ConsoleCallFramePayload: Equatable, Sendable {
-    package var functionName: String
-    package var url: String
-    package var scriptID: String
-    package var lineNumber: Int
-    package var columnNumber: Int
-
-    package init(functionName: String, url: String, scriptID: String, lineNumber: Int, columnNumber: Int) {
-        self.functionName = functionName
-        self.url = url
-        self.scriptID = scriptID
-        self.lineNumber = lineNumber
-        self.columnNumber = columnNumber
-    }
-}
-
-package struct ConsoleStackTracePayload: Equatable, Sendable {
-    package var callFrames: [ConsoleCallFramePayload]
-    package var topCallFrameIsBoundary: Bool?
-    package var truncated: Bool?
-    package var parentStackTraces: [ConsoleStackTracePayload]
-
-    package init(
-        callFrames: [ConsoleCallFramePayload],
-        topCallFrameIsBoundary: Bool? = nil,
-        truncated: Bool? = nil,
-        parentStackTraces: [ConsoleStackTracePayload] = []
-    ) {
-        self.callFrames = callFrames
-        self.topCallFrameIsBoundary = topCallFrameIsBoundary
-        self.truncated = truncated
-        self.parentStackTraces = parentStackTraces
-    }
-}
-
 package struct NetworkReferrerPolicy: RawRepresentable, Hashable, Sendable {
     package let rawValue: String
 

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -165,25 +165,3 @@ package struct ProtocolTargetRecord: Equatable, Sendable {
         self.isPaused = isPaused
     }
 }
-
-package struct ExecutionContextRecord: Equatable, Sendable {
-    package var id: ExecutionContextID
-    package var targetID: ProtocolTargetIdentifier
-    package var type: RuntimeExecutionContextType
-    package var name: String
-    package var frameID: DOMFrameIdentifier?
-
-    package init(
-        id: ExecutionContextID,
-        targetID: ProtocolTargetIdentifier,
-        type: RuntimeExecutionContextType = .normal,
-        name: String = "",
-        frameID: DOMFrameIdentifier? = nil
-    ) {
-        self.id = id
-        self.targetID = targetID
-        self.type = type
-        self.name = name
-        self.frameID = frameID
-    }
-}

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -82,7 +82,7 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Hashable, Senda
 
     package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network, .css, .console]
     package static let frameDefault: Self = []
-    package static let workerDefault: Self = [.runtime]
+    package static let workerDefault: Self = [.runtime, .console]
     package static let serviceWorkerDefault: Self = [.runtime, .network, .console]
 
     package static func protocolDefault(for kind: ProtocolTargetKind) -> Self {
@@ -169,15 +169,21 @@ package struct ProtocolTargetRecord: Equatable, Sendable {
 package struct ExecutionContextRecord: Equatable, Sendable {
     package var id: ExecutionContextID
     package var targetID: ProtocolTargetIdentifier
+    package var type: RuntimeExecutionContextType
+    package var name: String
     package var frameID: DOMFrameIdentifier?
 
     package init(
         id: ExecutionContextID,
         targetID: ProtocolTargetIdentifier,
+        type: RuntimeExecutionContextType = .normal,
+        name: String = "",
         frameID: DOMFrameIdentifier? = nil
     ) {
         self.id = id
         self.targetID = targetID
+        self.type = type
+        self.name = name
         self.frameID = frameID
     }
 }

--- a/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
+++ b/Sources/WebInspectorCore/Protocol/ProtocolTypes.swift
@@ -78,11 +78,12 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Hashable, Senda
     package static let inspector = Self(rawValue: 1 << 3)
     package static let network = Self(rawValue: 1 << 4)
     package static let css = Self(rawValue: 1 << 5)
+    package static let console = Self(rawValue: 1 << 6)
 
-    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network, .css]
+    package static let pageDefault: Self = [.dom, .runtime, .target, .inspector, .network, .css, .console]
     package static let frameDefault: Self = []
     package static let workerDefault: Self = [.runtime]
-    package static let serviceWorkerDefault: Self = [.runtime, .network]
+    package static let serviceWorkerDefault: Self = [.runtime, .network, .console]
 
     package static func protocolDefault(for kind: ProtocolTargetKind) -> Self {
         switch kind {
@@ -127,6 +128,8 @@ package struct ProtocolTargetCapabilities: OptionSet, Equatable, Hashable, Senda
                 capabilities.insert(.network)
             case "css":
                 capabilities.insert(.css)
+            case "console":
+                capabilities.insert(.console)
             default:
                 break
             }

--- a/Sources/WebInspectorCore/Protocol/StackTracePayload.swift
+++ b/Sources/WebInspectorCore/Protocol/StackTracePayload.swift
@@ -1,0 +1,74 @@
+package struct ConsoleCallFramePayload: Equatable, Sendable, Codable {
+    package var functionName: String
+    package var url: String
+    package var scriptID: String
+    package var lineNumber: Int
+    package var columnNumber: Int
+
+    package init(functionName: String, url: String, scriptID: String, lineNumber: Int, columnNumber: Int) {
+        self.functionName = functionName
+        self.url = url
+        self.scriptID = scriptID
+        self.lineNumber = lineNumber
+        self.columnNumber = columnNumber
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case functionName
+        case url
+        case scriptID = "scriptId"
+        case lineNumber
+        case columnNumber
+    }
+}
+
+package struct ConsoleStackTracePayload: Equatable, Sendable, Codable {
+    package var callFrames: [ConsoleCallFramePayload]
+    package var topCallFrameIsBoundary: Bool?
+    package var truncated: Bool?
+    package var parentStackTraces: [ConsoleStackTracePayload]
+
+    package init(
+        callFrames: [ConsoleCallFramePayload],
+        topCallFrameIsBoundary: Bool? = nil,
+        truncated: Bool? = nil,
+        parentStackTraces: [ConsoleStackTracePayload] = []
+    ) {
+        self.callFrames = callFrames
+        self.topCallFrameIsBoundary = topCallFrameIsBoundary
+        self.truncated = truncated
+        self.parentStackTraces = parentStackTraces
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case callFrames
+        case topCallFrameIsBoundary
+        case truncated
+        case parentStackTrace
+        case parentStackTraces
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        callFrames = try container.decode([ConsoleCallFramePayload].self, forKey: .callFrames)
+        topCallFrameIsBoundary = try container.decodeIfPresent(Bool.self, forKey: .topCallFrameIsBoundary)
+        truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated)
+        if let parentStackTrace = try container.decodeIfPresent(ConsoleStackTracePayload.self, forKey: .parentStackTrace) {
+            parentStackTraces = [parentStackTrace]
+        } else {
+            parentStackTraces = try container.decodeIfPresent([ConsoleStackTracePayload].self, forKey: .parentStackTraces) ?? []
+        }
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(callFrames, forKey: .callFrames)
+        try container.encodeIfPresent(topCallFrameIsBoundary, forKey: .topCallFrameIsBoundary)
+        try container.encodeIfPresent(truncated, forKey: .truncated)
+        if parentStackTraces.count == 1 {
+            try container.encode(parentStackTraces[0], forKey: .parentStackTrace)
+        } else if parentStackTraces.isEmpty == false {
+            try container.encode(parentStackTraces, forKey: .parentStackTraces)
+        }
+    }
+}

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -325,6 +325,7 @@ package final class RuntimeSession {
                 .filter {
                     $0.type == .normal
                         && $0.targetID == context.targetID
+                        && $0.runtimeAgentTargetID == context.runtimeAgentTargetID
                         && $0.frameID == context.frameID
                         && $0.name == context.name
                         && $0.id != context.id

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -1,6 +1,6 @@
 import Observation
 
-package struct RuntimeExecutionContext: Equatable, Sendable {
+package struct RuntimeExecutionContextRecord: Equatable, Sendable {
     package var id: ExecutionContextID
     package var targetID: ProtocolTargetIdentifier
     package var runtimeAgentTargetID: ProtocolTargetIdentifier
@@ -29,6 +29,67 @@ package struct RuntimeExecutionContext: Equatable, Sendable {
     }
 }
 
+@MainActor
+@Observable
+package final class RuntimeExecutionContext {
+    package let id: ExecutionContextID
+    package var targetID: ProtocolTargetIdentifier
+    package var runtimeAgentTargetID: ProtocolTargetIdentifier
+    package var type: RuntimeExecutionContextType
+    package var name: String
+    package var frameID: DOMFrameIdentifier?
+
+    package init(
+        id: ExecutionContextID,
+        targetID: ProtocolTargetIdentifier,
+        runtimeAgentTargetID: ProtocolTargetIdentifier? = nil,
+        type: RuntimeExecutionContextType = .normal,
+        name: String = "",
+        frameID: DOMFrameIdentifier? = nil
+    ) {
+        self.id = id
+        self.targetID = targetID
+        self.runtimeAgentTargetID = runtimeAgentTargetID ?? targetID
+        self.type = type
+        self.name = name
+        self.frameID = frameID
+    }
+
+    package convenience init(record: RuntimeExecutionContextRecord) {
+        self.init(
+            id: record.id,
+            targetID: record.targetID,
+            runtimeAgentTargetID: record.runtimeAgentTargetID,
+            type: record.type,
+            name: record.name,
+            frameID: record.frameID
+        )
+    }
+
+    package var key: RuntimeExecutionContextKey {
+        RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: id)
+    }
+
+    package var snapshotRecord: RuntimeExecutionContextRecord {
+        RuntimeExecutionContextRecord(
+            id: id,
+            targetID: targetID,
+            runtimeAgentTargetID: runtimeAgentTargetID,
+            type: type,
+            name: name,
+            frameID: frameID
+        )
+    }
+
+    func update(from record: RuntimeExecutionContextRecord) {
+        targetID = record.targetID
+        runtimeAgentTargetID = record.runtimeAgentTargetID
+        type = record.type
+        name = record.name
+        frameID = record.frameID
+    }
+}
+
 package struct RuntimeRemoteObjectRecord: Equatable, Sendable {
     package var payload: RuntimeRemoteObjectPayload
     package var objectGroup: RuntimeObjectGroup?
@@ -45,8 +106,37 @@ package struct RuntimeRemoteObjectRecord: Equatable, Sendable {
     }
 }
 
+@MainActor
+@Observable
+package final class RuntimeRemoteObject {
+    package let id: RuntimeRemoteObjectIdentifierKey
+    package var payload: RuntimeRemoteObjectPayload
+    package var objectGroup: RuntimeObjectGroup?
+    package var executionContextKey: RuntimeExecutionContextKey?
+
+    package init(
+        id: RuntimeRemoteObjectIdentifierKey,
+        payload: RuntimeRemoteObjectPayload,
+        objectGroup: RuntimeObjectGroup? = nil,
+        executionContextKey: RuntimeExecutionContextKey? = nil
+    ) {
+        self.id = id
+        self.payload = payload
+        self.objectGroup = objectGroup
+        self.executionContextKey = executionContextKey
+    }
+
+    package var snapshotRecord: RuntimeRemoteObjectRecord {
+        RuntimeRemoteObjectRecord(
+            payload: payload,
+            objectGroup: objectGroup,
+            executionContextKey: executionContextKey
+        )
+    }
+}
+
 package struct RuntimeSessionSnapshot: Equatable, Sendable {
-    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord]
     package var selectedContextKey: RuntimeExecutionContextKey?
     package var normalContextKeyByTargetID: [ProtocolTargetIdentifier: RuntimeExecutionContextKey]
     package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
@@ -56,15 +146,175 @@ package struct RuntimeSessionSnapshot: Equatable, Sendable {
     package func executionContext(
         runtimeAgentTargetID: ProtocolTargetIdentifier,
         contextID: ExecutionContextID
-    ) -> RuntimeExecutionContext? {
+    ) -> RuntimeExecutionContextRecord? {
         executionContextsByKey[
             RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: contextID)
         ]
     }
 
-    package func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+    package func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContextRecord? {
         let matches = executionContextsByKey.values.filter { $0.id == contextID }
         return matches.count == 1 ? matches[0] : nil
+    }
+}
+
+@MainActor
+@Observable
+package final class RuntimeTargetState {
+    package let targetID: ProtocolTargetIdentifier
+    package var normalContextKey: RuntimeExecutionContextKey?
+
+    package init(targetID: ProtocolTargetIdentifier, normalContextKey: RuntimeExecutionContextKey? = nil) {
+        self.targetID = targetID
+        self.normalContextKey = normalContextKey
+    }
+}
+
+@MainActor
+@Observable
+package final class RuntimeAgentState {
+    package let targetID: ProtocolTargetIdentifier
+    package private(set) var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifier: RuntimeRemoteObject]
+    private var unsupportedCommands: Set<String>
+
+    init(targetID: ProtocolTargetIdentifier) {
+        self.targetID = targetID
+        executionContextsByID = [:]
+        remoteObjectsByID = [:]
+        unsupportedCommands = []
+    }
+
+    package var executionContexts: [RuntimeExecutionContext] {
+        executionContextsByID.values.sorted {
+            if $0.id == $1.id {
+                return $0.targetID.rawValue < $1.targetID.rawValue
+            }
+            return $0.id.rawValue < $1.id.rawValue
+        }
+    }
+
+    package var remoteObjects: [RuntimeRemoteObject] {
+        remoteObjectsByID.values.sorted {
+            $0.id.objectID.rawValue < $1.id.objectID.rawValue
+        }
+    }
+
+    package var remoteObjectRecords: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] {
+        remoteObjectsByKey
+    }
+
+    var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext] {
+        Dictionary(uniqueKeysWithValues: executionContextsByID.values.map { ($0.key, $0) })
+    }
+
+    var executionContextRecordsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord] {
+        Dictionary(uniqueKeysWithValues: executionContextsByID.values.map { ($0.key, $0.snapshotRecord) })
+    }
+
+    var remoteObjectsByKey: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] {
+        Dictionary(
+            uniqueKeysWithValues: remoteObjectsByID.map { _, remoteObject in
+                (remoteObject.id, remoteObject.snapshotRecord)
+            }
+        )
+    }
+
+    func executionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+        executionContextsByID[contextID]
+    }
+
+    func recordExecutionContext(_ record: RuntimeExecutionContextRecord) {
+        if let context = executionContextsByID[record.id] {
+            context.update(from: record)
+        } else {
+            executionContextsByID[record.id] = RuntimeExecutionContext(record: record)
+        }
+    }
+
+    func insertExecutionContext(_ context: RuntimeExecutionContext) {
+        executionContextsByID[context.id] = context
+    }
+
+    func removeExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+        executionContextsByID.removeValue(forKey: contextID)
+    }
+
+    func registerRemoteObject(
+        _ object: RuntimeRemoteObjectPayload,
+        objectGroup: RuntimeObjectGroup?,
+        executionContextID: ExecutionContextID?
+    ) {
+        guard let objectID = object.objectID else {
+            return
+        }
+        let objectKey = RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: targetID, objectID: objectID)
+        let executionContextKey = executionContextID.map {
+            RuntimeExecutionContextKey(runtimeAgentTargetID: targetID, contextID: $0)
+        }
+        if let remoteObject = remoteObjectsByID[objectID] {
+            remoteObject.payload = object
+            remoteObject.objectGroup = objectGroup
+            remoteObject.executionContextKey = executionContextKey
+        } else {
+            remoteObjectsByID[objectID] = RuntimeRemoteObject(
+                id: objectKey,
+                payload: object,
+                objectGroup: objectGroup,
+                executionContextKey: executionContextKey
+            )
+        }
+    }
+
+    func releaseRemoteObjects(executionContextKey: RuntimeExecutionContextKey) {
+        releaseRemoteObjects { _, record in
+            record.executionContextKey == executionContextKey
+        }
+    }
+
+    func releaseRemoteObjects(objectGroup: RuntimeObjectGroup) {
+        releaseRemoteObjects { _, record in
+            record.objectGroup == objectGroup
+        }
+    }
+
+    func releaseRemoteObject(_ objectID: RuntimeRemoteObjectIdentifier) {
+        remoteObjectsByID.removeValue(forKey: objectID)
+    }
+
+    func clearExecutionContexts() {
+        executionContextsByID.removeAll()
+    }
+
+    func clearRemoteObjects() {
+        remoteObjectsByID.removeAll()
+    }
+
+    func markCommandUnsupported(_ method: String) {
+        unsupportedCommands.insert(method)
+    }
+
+    func mergeUnsupportedCommands(_ methods: Set<String>) {
+        unsupportedCommands.formUnion(methods)
+    }
+
+    func supportsCommand(_ method: String) -> Bool {
+        unsupportedCommands.contains(method) == false
+    }
+
+    fileprivate var unsupportedCommandSnapshot: Set<String> {
+        unsupportedCommands
+    }
+
+    private func releaseRemoteObjects(
+        matching shouldRelease: (RuntimeRemoteObjectIdentifier, RuntimeRemoteObjectRecord) -> Bool
+    ) {
+        let releasedObjectIDs = remoteObjectsByID
+            .filter { shouldRelease($0.key, $0.value.snapshotRecord) }
+            .map(\.key)
+        for objectID in releasedObjectIDs {
+            remoteObjectsByID.removeValue(forKey: objectID)
+        }
     }
 }
 
@@ -73,30 +323,25 @@ package struct RuntimeSessionSnapshot: Equatable, Sendable {
 package final class RuntimeSession {
     package private(set) var selectedContextKey: RuntimeExecutionContextKey?
 
-    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
-    private var normalContextKeyByTargetID: [ProtocolTargetIdentifier: RuntimeExecutionContextKey]
-    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
-    private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+    private var targetStatesByID: [ProtocolTargetIdentifier: RuntimeTargetState]
+    private var runtimeAgentStatesByID: [ProtocolTargetIdentifier: RuntimeAgentState]
 
     package init() {
         selectedContextKey = nil
-        executionContextsByKey = [:]
-        normalContextKeyByTargetID = [:]
-        remoteObjectsByID = [:]
-        unsupportedCommandsByTargetID = [:]
+        targetStatesByID = [:]
+        runtimeAgentStatesByID = [:]
     }
 
     package func reset() {
         selectedContextKey = nil
-        executionContextsByKey.removeAll()
-        normalContextKeyByTargetID.removeAll()
-        remoteObjectsByID.removeAll()
-        unsupportedCommandsByTargetID.removeAll()
+        targetStatesByID.removeAll()
+        runtimeAgentStatesByID.removeAll()
     }
 
     package func snapshot() -> RuntimeSessionSnapshot {
-        RuntimeSessionSnapshot(
-            executionContextsByKey: executionContextsByKey,
+        let remoteObjectsByID = remoteObjectsByID
+        return RuntimeSessionSnapshot(
+            executionContextsByKey: executionContextRecordsByKey,
             selectedContextKey: selectedContextKey,
             normalContextKeyByTargetID: normalContextKeyByTargetID,
             remoteObjectsByID: remoteObjectsByID,
@@ -106,12 +351,28 @@ package final class RuntimeSession {
     }
 
     package func executionContext(for key: RuntimeExecutionContextKey) -> RuntimeExecutionContext? {
-        executionContextsByKey[key]
+        runtimeAgentStatesByID[key.runtimeAgentTargetID]?.executionContext(contextID: key.contextID)
+    }
+
+    package var targetStates: [RuntimeTargetState] {
+        targetStatesByID.values.sorted { $0.targetID.rawValue < $1.targetID.rawValue }
+    }
+
+    package var runtimeAgentStates: [RuntimeAgentState] {
+        runtimeAgentStatesByID.values.sorted { $0.targetID.rawValue < $1.targetID.rawValue }
+    }
+
+    package func targetState(for targetID: ProtocolTargetIdentifier) -> RuntimeTargetState? {
+        targetStatesByID[targetID]
+    }
+
+    package func runtimeAgentState(for targetID: ProtocolTargetIdentifier) -> RuntimeAgentState? {
+        runtimeAgentStatesByID[targetID]
     }
 
     package func selectedContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
         guard let selectedContextKey,
-              let context = executionContextsByKey[selectedContextKey] else {
+              let context = executionContext(for: selectedContextKey) else {
             return nil
         }
         if let targetID {
@@ -121,84 +382,86 @@ package final class RuntimeSession {
     }
 
     package func defaultContext(targetID: ProtocolTargetIdentifier) -> RuntimeExecutionContext? {
-        guard let contextKey = normalContextKeyByTargetID[targetID] else {
+        guard let contextKey = targetStatesByID[targetID]?.normalContextKey else {
             return nil
         }
-        return executionContextsByKey[contextKey]
+        return executionContext(for: contextKey)
     }
 
     package func applyExecutionContextCreated(_ payload: RuntimeExecutionContextPayload, targetID: ProtocolTargetIdentifier) {
         let type = payload.type ?? .normal
-        let context = RuntimeExecutionContext(
+        let record = RuntimeExecutionContextRecord(
             id: payload.id,
             targetID: targetID,
             type: type,
             name: payload.name ?? "",
             frameID: payload.frameID
         )
-        applyExecutionContextCreated(context)
+        applyExecutionContextCreated(record)
     }
 
-    package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
-        let oldContextKeys = context.type == .normal ? normalContextKeysToReplace(with: context) : []
+    package func applyExecutionContextCreated(_ record: RuntimeExecutionContextRecord) {
+        let oldContextKeys = record.type == .normal ? normalContextKeysToReplace(with: record) : []
         if oldContextKeys.isEmpty == false {
             for oldContextKey in oldContextKeys {
-                releaseRemoteObjects(executionContextKey: oldContextKey)
-                executionContextsByKey.removeValue(forKey: oldContextKey)
+                removeExecutionContext(oldContextKey, releaseRemoteObjects: true)
             }
             if let selectedContextKey,
                oldContextKeys.contains(selectedContextKey) {
                 self.selectedContextKey = nil
             }
         }
-        executionContextsByKey[context.key] = context
-        if context.type == .normal {
-            if let defaultContextKey = normalContextKeyByTargetID[context.targetID] {
+        let agentState = ensureRuntimeAgentState(for: record.runtimeAgentTargetID)
+        agentState.recordExecutionContext(record)
+        storeRuntimeAgentState(agentState)
+        if record.type == .normal {
+            let targetState = ensureTargetState(for: record.targetID)
+            if let defaultContextKey = targetState.normalContextKey {
                 if oldContextKeys.contains(defaultContextKey) {
-                    normalContextKeyByTargetID[context.targetID] = context.key
+                    targetState.normalContextKey = record.key
                 }
             } else {
-                normalContextKeyByTargetID[context.targetID] = context.key
+                targetState.normalContextKey = record.key
             }
         }
-        if context.type == .normal,
+        if record.type == .normal,
            selectedContextKey == nil {
-            selectedContextKey = context.key
+            selectedContextKey = record.key
         }
     }
 
     package func applyExecutionContextDestroyed(_ contextKey: RuntimeExecutionContextKey) {
-        guard let context = executionContextsByKey.removeValue(forKey: contextKey) else {
+        guard let context = removeExecutionContext(contextKey, releaseRemoteObjects: true) else {
             return
         }
-        if normalContextKeyByTargetID[context.targetID] == contextKey {
-            normalContextKeyByTargetID.removeValue(forKey: context.targetID)
+        if targetStatesByID[context.targetID]?.normalContextKey == contextKey {
+            targetStatesByID[context.targetID]?.normalContextKey = nil
         }
         if selectedContextKey == contextKey {
             selectedContextKey = nil
         }
-        releaseRemoteObjects(executionContextKey: contextKey)
     }
 
     package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTargetIdentifier) {
-        let removedContextKeys = Set(
-            executionContextsByKey
-                .filter { $0.key.runtimeAgentTargetID == runtimeAgentTargetID }
-                .map(\.key)
-        )
-        let removedTargetIDs = Set(removedContextKeys.compactMap { executionContextsByKey[$0]?.targetID })
-        executionContextsByKey = executionContextsByKey.filter { $0.key.runtimeAgentTargetID != runtimeAgentTargetID }
+        guard let agentState = runtimeAgentStatesByID[runtimeAgentTargetID] else {
+            return
+        }
+        let removedContexts = Array(agentState.executionContextsByID.values)
+        let removedContextKeys = Set(removedContexts.map(\.key))
+        let removedTargetIDs = Set(removedContexts.map(\.targetID))
+        agentState.clearExecutionContexts()
+        agentState.clearRemoteObjects()
+        storeRuntimeAgentState(agentState)
         for targetID in removedTargetIDs {
-            if let normalContextKey = normalContextKeyByTargetID[targetID],
+            if let normalContextKey = targetStatesByID[targetID]?.normalContextKey,
                removedContextKeys.contains(normalContextKey) {
-                normalContextKeyByTargetID.removeValue(forKey: targetID)
+                targetStatesByID[targetID]?.normalContextKey = nil
             }
         }
         if let selectedContextKey,
            removedContextKeys.contains(selectedContextKey) {
             self.selectedContextKey = nil
         }
-        releaseRemoteObjects(runtimeAgentTargetID: runtimeAgentTargetID)
     }
 
     package func selectExecutionContext(_ contextKey: RuntimeExecutionContextKey?) {
@@ -206,33 +469,44 @@ package final class RuntimeSession {
             selectedContextKey = nil
             return
         }
-        guard executionContextsByKey[contextKey] != nil else {
+        guard executionContext(for: contextKey) != nil else {
             return
         }
         selectedContextKey = contextKey
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
-        let removedContextKeys = Set(
-            executionContextsByKey
-                .filter { $0.value.targetID == targetID || $0.value.runtimeAgentTargetID == targetID }
-                .map(\.key)
-        )
-        let removedTargetIDs = Set(removedContextKeys.compactMap { executionContextsByKey[$0]?.targetID })
-        executionContextsByKey = executionContextsByKey.filter {
-            $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
+        var removedContexts: [RuntimeExecutionContext] = []
+        if let removedAgent = runtimeAgentStatesByID.removeValue(forKey: targetID) {
+            removedContexts.append(contentsOf: removedAgent.executionContextsByID.values)
         }
+        for agentID in Array(runtimeAgentStatesByID.keys) {
+            guard let agentState = runtimeAgentStatesByID[agentID] else {
+                continue
+            }
+            let contextIDs = agentState.executionContextsByID.values
+                .filter { $0.targetID == targetID }
+                .map(\.id)
+            guard contextIDs.isEmpty == false else {
+                continue
+            }
+            for contextID in contextIDs {
+                if let context = agentState.removeExecutionContext(contextID: contextID) {
+                    removedContexts.append(context)
+                    agentState.releaseRemoteObjects(executionContextKey: context.key)
+                }
+            }
+            storeRuntimeAgentState(agentState)
+        }
+        let removedContextKeys = Set(removedContexts.map(\.key))
+        let removedTargetIDs = Set(removedContexts.map(\.targetID))
         for removedTargetID in removedTargetIDs {
-            if let normalContextKey = normalContextKeyByTargetID[removedTargetID],
+            if let normalContextKey = targetStatesByID[removedTargetID]?.normalContextKey,
                removedContextKeys.contains(normalContextKey) {
-                normalContextKeyByTargetID.removeValue(forKey: removedTargetID)
+                targetStatesByID[removedTargetID]?.normalContextKey = nil
             }
         }
-        releaseRemoteObjects(runtimeAgentTargetID: targetID)
-        for contextKey in removedContextKeys {
-            releaseRemoteObjects(executionContextKey: contextKey)
-        }
-        unsupportedCommandsByTargetID.removeValue(forKey: targetID)
+        targetStatesByID.removeValue(forKey: targetID)
         if let selectedContextKey,
            removedContextKeys.contains(selectedContextKey) {
             self.selectedContextKey = nil
@@ -241,37 +515,30 @@ package final class RuntimeSession {
 
     package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
         if let oldTargetID {
-            var movedKeys: [RuntimeExecutionContextKey: RuntimeExecutionContextKey] = [:]
-            for (contextKey, context) in Array(executionContextsByKey) {
-                var movedContext = context
-                if movedContext.targetID == oldTargetID {
-                    movedContext.targetID = newTargetID
-                }
-                if movedContext.runtimeAgentTargetID == oldTargetID {
-                    movedContext.runtimeAgentTargetID = newTargetID
-                }
-                guard movedContext != context else {
+            let movedContextKeys = retargetExecutionContexts(from: oldTargetID, to: newTargetID)
+            for targetState in targetStatesByID.values {
+                guard let normalContextKey = targetState.normalContextKey,
+                      let movedKey = movedContextKeys[normalContextKey] else {
                     continue
                 }
-                executionContextsByKey.removeValue(forKey: contextKey)
-                executionContextsByKey[movedContext.key] = movedContext
-                movedKeys[contextKey] = movedContext.key
+                targetState.normalContextKey = movedKey
             }
-            for (targetID, contextKey) in Array(normalContextKeyByTargetID) {
-                if let movedKey = movedKeys[contextKey] {
-                    normalContextKeyByTargetID[targetID] = movedKey
+            if let oldTargetState = targetStatesByID.removeValue(forKey: oldTargetID) {
+                let newTargetState = ensureTargetState(for: newTargetID)
+                if newTargetState.normalContextKey == nil,
+                   let normalContextKey = oldTargetState.normalContextKey {
+                    newTargetState.normalContextKey = movedContextKeys[normalContextKey] ?? normalContextKey
                 }
             }
-            if let normalContextKey = normalContextKeyByTargetID.removeValue(forKey: oldTargetID) {
-                normalContextKeyByTargetID[newTargetID] = movedKeys[normalContextKey] ?? normalContextKey
-            }
             if let selectedContextKey,
-               let movedKey = movedKeys[selectedContextKey] {
+               let movedKey = movedContextKeys[selectedContextKey] {
                 self.selectedContextKey = movedKey
             }
-            releaseRemoteObjects(runtimeAgentTargetID: oldTargetID)
-            if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
-                unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
+            if let oldAgentState = runtimeAgentStatesByID.removeValue(forKey: oldTargetID),
+               oldAgentState.unsupportedCommandSnapshot.isEmpty == false {
+                let newAgentState = ensureRuntimeAgentState(for: newTargetID)
+                newAgentState.mergeUnsupportedCommands(oldAgentState.unsupportedCommandSnapshot)
+                storeRuntimeAgentState(newAgentState)
             }
         }
     }
@@ -282,15 +549,13 @@ package final class RuntimeSession {
         objectGroup: RuntimeObjectGroup? = nil,
         executionContextID: ExecutionContextID? = nil
     ) {
-        if let key = object.identifierKey(runtimeAgentTargetID: runtimeAgentTargetID) {
-            remoteObjectsByID[key] = RuntimeRemoteObjectRecord(
-                payload: object,
-                objectGroup: objectGroup,
-                executionContextKey: executionContextID.map {
-                    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: $0)
-                }
-            )
-        }
+        let agentState = ensureRuntimeAgentState(for: runtimeAgentTargetID)
+        agentState.registerRemoteObject(
+            object,
+            objectGroup: objectGroup,
+            executionContextID: executionContextID
+        )
+        storeRuntimeAgentState(agentState)
     }
 
     package func applyEvaluationResult(_ result: RuntimeEvaluationResultPayload, request: RuntimeEvaluationRequest) {
@@ -303,47 +568,161 @@ package final class RuntimeSession {
     }
 
     package func releaseObject(_ key: RuntimeRemoteObjectIdentifierKey) {
-        releaseRemoteObjects { candidateKey, _ in
-            candidateKey == key
+        guard let agentState = runtimeAgentStatesByID[key.runtimeAgentTargetID] else {
+            return
         }
+        agentState.releaseRemoteObject(key.objectID)
+        storeRuntimeAgentState(agentState)
     }
 
     package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, runtimeAgentTargetID: ProtocolTargetIdentifier) {
-        releaseRemoteObjects { key, record in
-            key.runtimeAgentTargetID == runtimeAgentTargetID && record.objectGroup == objectGroup
+        guard let agentState = runtimeAgentStatesByID[runtimeAgentTargetID] else {
+            return
         }
+        agentState.releaseRemoteObjects(objectGroup: objectGroup)
+        storeRuntimeAgentState(agentState)
     }
 
     package func markCommandUnsupported(_ method: String, targetID: ProtocolTargetIdentifier) {
-        unsupportedCommandsByTargetID[targetID, default: []].insert(method)
+        let agentState = ensureRuntimeAgentState(for: targetID)
+        agentState.markCommandUnsupported(method)
+        storeRuntimeAgentState(agentState)
     }
 
     package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
-        unsupportedCommandsByTargetID[targetID]?.contains(method) != true
+        runtimeAgentStatesByID[targetID]?.supportsCommand(method) ?? true
     }
 
-    private func releaseRemoteObjects(runtimeAgentTargetID: ProtocolTargetIdentifier) {
-        releaseRemoteObjects { key, _ in
-            key.runtimeAgentTargetID == runtimeAgentTargetID
-        }
+    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext] {
+        Dictionary(
+            uniqueKeysWithValues: runtimeAgentStatesByID.values.flatMap { state in
+                state.executionContextsByKey.map { ($0.key, $0.value) }
+            }
+        )
     }
 
-    private func releaseRemoteObjects(executionContextKey: RuntimeExecutionContextKey) {
-        releaseRemoteObjects { _, record in
-            record.executionContextKey == executionContextKey
-        }
+    private var executionContextRecordsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord] {
+        Dictionary(
+            uniqueKeysWithValues: runtimeAgentStatesByID.values.flatMap { state in
+                state.executionContextRecordsByKey.map { ($0.key, $0.value) }
+            }
+        )
     }
 
-    private func releaseRemoteObjects(
-        matching shouldRelease: (RuntimeRemoteObjectIdentifierKey, RuntimeRemoteObjectRecord) -> Bool
-    ) {
-        var releasedKeys: [RuntimeRemoteObjectIdentifierKey] = []
-        for (key, record) in remoteObjectsByID where shouldRelease(key, record) {
-            releasedKeys.append(key)
+    private var normalContextKeyByTargetID: [ProtocolTargetIdentifier: RuntimeExecutionContextKey] {
+        Dictionary(
+            uniqueKeysWithValues: targetStatesByID.values.compactMap { state in
+                state.normalContextKey.map { (state.targetID, $0) }
+            }
+        )
+    }
+
+    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] {
+        Dictionary(
+            uniqueKeysWithValues: runtimeAgentStatesByID.values.flatMap { state in
+                state.remoteObjectsByKey.map { ($0.key, $0.value) }
+            }
+        )
+    }
+
+    private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>] {
+        Dictionary(
+            uniqueKeysWithValues: runtimeAgentStatesByID.values
+                .filter { $0.unsupportedCommandSnapshot.isEmpty == false }
+                .map { ($0.targetID, $0.unsupportedCommandSnapshot) }
+        )
+    }
+
+    private func ensureTargetState(for targetID: ProtocolTargetIdentifier) -> RuntimeTargetState {
+        if let state = targetStatesByID[targetID] {
+            return state
         }
-        for key in releasedKeys {
-            remoteObjectsByID.removeValue(forKey: key)
+        let state = RuntimeTargetState(targetID: targetID)
+        targetStatesByID[targetID] = state
+        return state
+    }
+
+    private func ensureRuntimeAgentState(for targetID: ProtocolTargetIdentifier) -> RuntimeAgentState {
+        if let state = runtimeAgentStatesByID[targetID] {
+            return state
         }
+        let state = RuntimeAgentState(targetID: targetID)
+        runtimeAgentStatesByID[targetID] = state
+        return state
+    }
+
+    private func storeRuntimeAgentState(_ state: RuntimeAgentState) {
+        runtimeAgentStatesByID[state.targetID] = state
+    }
+
+    @discardableResult
+    private func removeExecutionContext(
+        _ contextKey: RuntimeExecutionContextKey,
+        releaseRemoteObjects: Bool
+    ) -> RuntimeExecutionContext? {
+        guard let agentState = runtimeAgentStatesByID[contextKey.runtimeAgentTargetID],
+              let context = agentState.removeExecutionContext(contextID: contextKey.contextID) else {
+            return nil
+        }
+        if releaseRemoteObjects {
+            agentState.releaseRemoteObjects(executionContextKey: contextKey)
+        }
+        storeRuntimeAgentState(agentState)
+        return context
+    }
+
+    private func retargetExecutionContexts(
+        from oldTargetID: ProtocolTargetIdentifier,
+        to newTargetID: ProtocolTargetIdentifier
+    ) -> [RuntimeExecutionContextKey: RuntimeExecutionContextKey] {
+        var movedContextKeys: [RuntimeExecutionContextKey: RuntimeExecutionContextKey] = [:]
+        let currentContexts = runtimeAgentStatesByID.values.flatMap { state in
+            state.executionContexts.map { (runtimeAgentTargetID: state.targetID, context: $0) }
+        }
+
+        for entry in currentContexts {
+            guard let sourceAgentState = runtimeAgentStatesByID[entry.runtimeAgentTargetID],
+                  sourceAgentState.executionContext(contextID: entry.context.id) === entry.context else {
+                continue
+            }
+
+            let oldKey = entry.context.key
+            var nextTargetID = entry.context.targetID
+            var nextRuntimeAgentTargetID = entry.context.runtimeAgentTargetID
+            if nextTargetID == oldTargetID {
+                nextTargetID = newTargetID
+            }
+            if nextRuntimeAgentTargetID == oldTargetID {
+                nextRuntimeAgentTargetID = newTargetID
+            }
+            guard nextTargetID != entry.context.targetID
+                    || nextRuntimeAgentTargetID != entry.context.runtimeAgentTargetID else {
+                continue
+            }
+
+            let nextKey = RuntimeExecutionContextKey(
+                runtimeAgentTargetID: nextRuntimeAgentTargetID,
+                contextID: entry.context.id
+            )
+            guard sourceAgentState.removeExecutionContext(contextID: entry.context.id) != nil else {
+                continue
+            }
+            storeRuntimeAgentState(sourceAgentState)
+            movedContextKeys[oldKey] = nextKey
+
+            if let destinationAgentState = runtimeAgentStatesByID[nextRuntimeAgentTargetID],
+               destinationAgentState.executionContext(contextID: entry.context.id) != nil {
+                continue
+            }
+
+            entry.context.targetID = nextTargetID
+            entry.context.runtimeAgentTargetID = nextRuntimeAgentTargetID
+            let destinationAgentState = ensureRuntimeAgentState(for: nextRuntimeAgentTargetID)
+            destinationAgentState.insertExecutionContext(entry.context)
+            storeRuntimeAgentState(destinationAgentState)
+        }
+
+        return movedContextKeys
     }
 
     private static func objectGroupRuntimeAgentTargets(
@@ -358,19 +737,21 @@ package final class RuntimeSession {
         return targetsByGroup
     }
 
-    private func normalContextKeysToReplace(with context: RuntimeExecutionContext) -> Set<RuntimeExecutionContextKey> {
-        Set(
-            executionContextsByKey.values
-                .filter {
-                    $0.type == .normal
-                        && $0.targetID == context.targetID
-                        && $0.runtimeAgentTargetID == context.runtimeAgentTargetID
-                        && $0.frameID == context.frameID
-                        && $0.name == context.name
-                        && $0.key != context.key
-                }
-                .map(\.key)
-        )
+    private func normalContextKeysToReplace(with record: RuntimeExecutionContextRecord) -> Set<RuntimeExecutionContextKey> {
+        guard let agentState = runtimeAgentStatesByID[record.runtimeAgentTargetID] else {
+            return []
+        }
+        let replacementKeys = agentState.executionContextsByID.values
+            .filter {
+                $0.type == .normal
+                    && $0.targetID == record.targetID
+                    && $0.runtimeAgentTargetID == record.runtimeAgentTargetID
+                    && $0.frameID == record.frameID
+                    && $0.name == record.name
+                    && $0.key != record.key
+            }
+            .map(\.key)
+        return Set(replacementKeys)
     }
 
     package func enableIntent(targetID: ProtocolTargetIdentifier) -> RuntimeCommandIntent {

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -110,18 +110,6 @@ package final class RuntimeSession {
         applyExecutionContextCreated(context)
     }
 
-    package func applyExecutionContextCreated(_ record: ExecutionContextRecord) {
-        applyExecutionContextCreated(
-            RuntimeExecutionContext(
-                id: record.id,
-                targetID: record.targetID,
-                type: record.type,
-                name: record.name,
-                frameID: record.frameID
-            )
-        )
-    }
-
     package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
         if context.type == .normal,
            let oldContextID = normalContextIDToReplace(with: context),
@@ -137,6 +125,35 @@ package final class RuntimeSession {
         }
         if context.type == .normal {
             activeContextID = context.id
+        }
+    }
+
+    package func applyExecutionContextDestroyed(_ contextID: ExecutionContextID) {
+        guard let context = executionContextsByID.removeValue(forKey: contextID) else {
+            return
+        }
+        if normalContextIDByTargetID[context.targetID] == contextID {
+            normalContextIDByTargetID.removeValue(forKey: context.targetID)
+        }
+        if activeContextID == contextID {
+            activeContextID = nil
+        }
+    }
+
+    package func applyExecutionContextsCleared(targetID: ProtocolTargetIdentifier) {
+        let removedContextIDs = Set(
+            executionContextsByID.values
+                .filter { $0.targetID == targetID }
+                .map(\.id)
+        )
+        guard removedContextIDs.isEmpty == false else {
+            return
+        }
+        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+        normalContextIDByTargetID.removeValue(forKey: targetID)
+        if let activeContextID,
+           removedContextIDs.contains(activeContextID) {
+            self.activeContextID = nil
         }
     }
 

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -27,7 +27,7 @@ package struct RuntimeExecutionContext: Equatable, Sendable {
 
 package struct RuntimeSessionSnapshot: Equatable, Sendable {
     package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
-    package var activeContextID: ExecutionContextID?
+    package var selectedContextID: ExecutionContextID?
     package var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
     package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
     package var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
@@ -38,7 +38,7 @@ package struct RuntimeSessionSnapshot: Equatable, Sendable {
 @MainActor
 @Observable
 package final class RuntimeSession {
-    package private(set) var activeContextID: ExecutionContextID?
+    package private(set) var selectedContextID: ExecutionContextID?
 
     private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
@@ -48,7 +48,7 @@ package final class RuntimeSession {
     private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 
     package init() {
-        activeContextID = nil
+        selectedContextID = nil
         executionContextsByID = [:]
         normalContextIDByTargetID = [:]
         remoteObjectsByID = [:]
@@ -58,7 +58,7 @@ package final class RuntimeSession {
     }
 
     package func reset() {
-        activeContextID = nil
+        selectedContextID = nil
         executionContextsByID.removeAll()
         normalContextIDByTargetID.removeAll()
         remoteObjectsByID.removeAll()
@@ -70,7 +70,7 @@ package final class RuntimeSession {
     package func snapshot() -> RuntimeSessionSnapshot {
         RuntimeSessionSnapshot(
             executionContextsByID: executionContextsByID,
-            activeContextID: activeContextID,
+            selectedContextID: selectedContextID,
             normalContextIDByTargetID: normalContextIDByTargetID,
             remoteObjectsByID: remoteObjectsByID,
             objectGroupByRemoteObjectID: objectGroupByRemoteObjectID,
@@ -83,22 +83,22 @@ package final class RuntimeSession {
         executionContextsByID[contextID]
     }
 
-    package func activeContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
-        if let targetID {
-            if let contextID = normalContextIDByTargetID[targetID] {
-                return executionContextsByID[contextID]
-            }
-            guard let activeContextID,
-                  let context = executionContextsByID[activeContextID],
-                  context.targetID == targetID else {
-                return nil
-            }
-            return context
-        }
-        guard let activeContextID else {
+    package func selectedContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
+        guard let selectedContextID,
+              let context = executionContextsByID[selectedContextID] else {
             return nil
         }
-        return executionContextsByID[activeContextID]
+        if let targetID {
+            return context.targetID == targetID ? context : nil
+        }
+        return context
+    }
+
+    package func defaultContext(targetID: ProtocolTargetIdentifier) -> RuntimeExecutionContext? {
+        guard let contextID = normalContextIDByTargetID[targetID] else {
+            return nil
+        }
+        return executionContextsByID[contextID]
     }
 
     package func applyExecutionContextCreated(_ payload: RuntimeExecutionContextPayload, targetID: ProtocolTargetIdentifier) {
@@ -118,16 +118,17 @@ package final class RuntimeSession {
            let oldContextID = normalContextIDToReplace(with: context),
            oldContextID != context.id {
             executionContextsByID.removeValue(forKey: oldContextID)
-            if activeContextID == oldContextID {
-                activeContextID = nil
+            if selectedContextID == oldContextID {
+                selectedContextID = nil
             }
         }
         executionContextsByID[context.id] = context
         if context.type == .normal {
             normalContextIDByTargetID[context.targetID] = context.id
         }
-        if context.type == .normal {
-            activeContextID = context.id
+        if context.type == .normal,
+           selectedContextID == nil {
+            selectedContextID = context.id
         }
     }
 
@@ -138,8 +139,8 @@ package final class RuntimeSession {
         if normalContextIDByTargetID[context.targetID] == contextID {
             normalContextIDByTargetID.removeValue(forKey: context.targetID)
         }
-        if activeContextID == contextID {
-            activeContextID = nil
+        if selectedContextID == contextID {
+            selectedContextID = nil
         }
     }
 
@@ -160,21 +161,21 @@ package final class RuntimeSession {
                 normalContextIDByTargetID.removeValue(forKey: targetID)
             }
         }
-        if let activeContextID,
-           removedContextIDs.contains(activeContextID) {
-            self.activeContextID = nil
+        if let selectedContextID,
+           removedContextIDs.contains(selectedContextID) {
+            self.selectedContextID = nil
         }
     }
 
     package func selectExecutionContext(_ contextID: ExecutionContextID?) {
         guard let contextID else {
-            activeContextID = nil
+            selectedContextID = nil
             return
         }
         guard executionContextsByID[contextID] != nil else {
             return
         }
-        activeContextID = contextID
+        selectedContextID = contextID
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
@@ -202,9 +203,9 @@ package final class RuntimeSession {
             }
         }
         unsupportedCommandsByTargetID.removeValue(forKey: targetID)
-        if let activeContextID,
-           removedContextIDs.contains(activeContextID) {
-            self.activeContextID = normalContextIDByTargetID.values.sorted(by: { $0.rawValue < $1.rawValue }).first
+        if let selectedContextID,
+           removedContextIDs.contains(selectedContextID) {
+            self.selectedContextID = nil
         }
     }
 
@@ -332,7 +333,7 @@ package final class RuntimeSession {
         contextID: ExecutionContextID? = nil,
         objectGroup: RuntimeObjectGroup? = .console
     ) -> RuntimeCommandIntent {
-        let context = contextID.flatMap { executionContextsByID[$0] } ?? activeContext(targetID: targetID)
+        let context = evaluationContext(targetID: targetID, contextID: contextID)
         return .evaluate(
             RuntimeEvaluationRequest(
                 targetID: context?.runtimeAgentTargetID ?? targetID,
@@ -347,5 +348,15 @@ package final class RuntimeSession {
                 emulateUserGesture: true
             )
         )
+    }
+
+    private func evaluationContext(
+        targetID: ProtocolTargetIdentifier,
+        contextID: ExecutionContextID?
+    ) -> RuntimeExecutionContext? {
+        if let contextID {
+            return executionContextsByID[contextID]
+        }
+        return selectedContext(targetID: targetID) ?? defaultContext(targetID: targetID)
     }
 }

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -58,7 +58,6 @@ package final class RuntimeSession {
     private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
     private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
-    private var objectGroupRuntimeAgentTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
     private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 
     package init() {
@@ -66,7 +65,6 @@ package final class RuntimeSession {
         executionContextsByID = [:]
         normalContextIDByTargetID = [:]
         remoteObjectsByID = [:]
-        objectGroupRuntimeAgentTargetsByGroup = [:]
         unsupportedCommandsByTargetID = [:]
     }
 
@@ -75,7 +73,6 @@ package final class RuntimeSession {
         executionContextsByID.removeAll()
         normalContextIDByTargetID.removeAll()
         remoteObjectsByID.removeAll()
-        objectGroupRuntimeAgentTargetsByGroup.removeAll()
         unsupportedCommandsByTargetID.removeAll()
     }
 
@@ -85,7 +82,7 @@ package final class RuntimeSession {
             selectedContextID: selectedContextID,
             normalContextIDByTargetID: normalContextIDByTargetID,
             remoteObjectsByID: remoteObjectsByID,
-            objectGroupRuntimeAgentTargetsByGroup: objectGroupRuntimeAgentTargetsByGroup,
+            objectGroupRuntimeAgentTargetsByGroup: Self.objectGroupRuntimeAgentTargets(from: remoteObjectsByID),
             unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
         )
     }
@@ -125,12 +122,15 @@ package final class RuntimeSession {
     }
 
     package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
-        if context.type == .normal,
-           let oldContextID = normalContextIDToReplace(with: context),
-           oldContextID != context.id {
-            executionContextsByID.removeValue(forKey: oldContextID)
-            if selectedContextID == oldContextID {
-                selectedContextID = nil
+        let oldContextIDs = context.type == .normal ? normalContextIDsToReplace(with: context) : []
+        if oldContextIDs.isEmpty == false {
+            for oldContextID in oldContextIDs {
+                releaseRemoteObjects(executionContextID: oldContextID)
+                executionContextsByID.removeValue(forKey: oldContextID)
+            }
+            if let selectedContextID,
+               oldContextIDs.contains(selectedContextID) {
+                self.selectedContextID = nil
             }
         }
         executionContextsByID[context.id] = context
@@ -226,21 +226,7 @@ package final class RuntimeSession {
             if let normalContextID = normalContextIDByTargetID.removeValue(forKey: oldTargetID) {
                 normalContextIDByTargetID[newTargetID] = normalContextID
             }
-            var movedObjects: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] = [:]
-            for (key, record) in remoteObjectsByID where key.runtimeAgentTargetID == oldTargetID {
-                let newKey = RuntimeRemoteObjectIdentifierKey(
-                    runtimeAgentTargetID: newTargetID,
-                    objectID: key.objectID
-                )
-                movedObjects[newKey] = record
-                remoteObjectsByID.removeValue(forKey: key)
-            }
-            remoteObjectsByID.merge(movedObjects) { _, new in new }
-            for group in objectGroupRuntimeAgentTargetsByGroup.keys {
-                if objectGroupRuntimeAgentTargetsByGroup[group]?.remove(oldTargetID) != nil {
-                    objectGroupRuntimeAgentTargetsByGroup[group]?.insert(newTargetID)
-                }
-            }
+            releaseRemoteObjects(runtimeAgentTargetID: oldTargetID)
             if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
                 unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
             }
@@ -254,19 +240,11 @@ package final class RuntimeSession {
         executionContextID: ExecutionContextID? = nil
     ) {
         if let key = object.identifierKey(runtimeAgentTargetID: runtimeAgentTargetID) {
-            let previousGroup = remoteObjectsByID[key]?.objectGroup
             remoteObjectsByID[key] = RuntimeRemoteObjectRecord(
                 payload: object,
                 objectGroup: objectGroup,
                 executionContextID: executionContextID
             )
-            if let objectGroup {
-                objectGroupRuntimeAgentTargetsByGroup[objectGroup, default: []].insert(runtimeAgentTargetID)
-            }
-            if let previousGroup,
-               previousGroup != objectGroup {
-                removeObjectGroupTargetIfEmpty(previousGroup, runtimeAgentTargetID: runtimeAgentTargetID)
-            }
         }
     }
 
@@ -315,50 +293,38 @@ package final class RuntimeSession {
         matching shouldRelease: (RuntimeRemoteObjectIdentifierKey, RuntimeRemoteObjectRecord) -> Bool
     ) {
         var releasedKeys: [RuntimeRemoteObjectIdentifierKey] = []
-        var affectedTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>] = [:]
         for (key, record) in remoteObjectsByID where shouldRelease(key, record) {
             releasedKeys.append(key)
-            if let objectGroup = record.objectGroup {
-                affectedTargetsByGroup[objectGroup, default: []].insert(key.runtimeAgentTargetID)
-            }
         }
         for key in releasedKeys {
             remoteObjectsByID.removeValue(forKey: key)
         }
-        for (objectGroup, runtimeAgentTargetIDs) in affectedTargetsByGroup {
-            for runtimeAgentTargetID in runtimeAgentTargetIDs {
-                removeObjectGroupTargetIfEmpty(objectGroup, runtimeAgentTargetID: runtimeAgentTargetID)
-            }
-        }
     }
 
-    private func removeObjectGroupTargetIfEmpty(
-        _ objectGroup: RuntimeObjectGroup,
-        runtimeAgentTargetID: ProtocolTargetIdentifier
-    ) {
-        let hasRemainingObject = remoteObjectsByID.contains { key, record in
-            key.runtimeAgentTargetID == runtimeAgentTargetID && record.objectGroup == objectGroup
+    private static func objectGroupRuntimeAgentTargets(
+        from remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
+    ) -> [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>] {
+        var targetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>] = [:]
+        for (key, record) in remoteObjectsByID {
+            if let objectGroup = record.objectGroup {
+                targetsByGroup[objectGroup, default: []].insert(key.runtimeAgentTargetID)
+            }
         }
-        guard hasRemainingObject == false else {
-            return
-        }
-        objectGroupRuntimeAgentTargetsByGroup[objectGroup]?.remove(runtimeAgentTargetID)
-        if objectGroupRuntimeAgentTargetsByGroup[objectGroup]?.isEmpty == true {
-            objectGroupRuntimeAgentTargetsByGroup.removeValue(forKey: objectGroup)
-        }
+        return targetsByGroup
     }
 
-    private func normalContextIDToReplace(with context: RuntimeExecutionContext) -> ExecutionContextID? {
-        executionContextsByID.values
-            .filter {
-                $0.type == .normal
-                    && $0.targetID == context.targetID
-                    && $0.frameID == context.frameID
-                    && $0.name == context.name
-                    && $0.id != context.id
-            }
-            .map(\.id)
-            .min { $0.rawValue < $1.rawValue }
+    private func normalContextIDsToReplace(with context: RuntimeExecutionContext) -> Set<ExecutionContextID> {
+        Set(
+            executionContextsByID.values
+                .filter {
+                    $0.type == .normal
+                        && $0.targetID == context.targetID
+                        && $0.frameID == context.frameID
+                        && $0.name == context.name
+                        && $0.id != context.id
+                }
+                .map(\.id)
+        )
     }
 
     package func enableIntent(targetID: ProtocolTargetIdentifier) -> RuntimeCommandIntent {

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -178,8 +178,21 @@ package final class RuntimeSession {
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
-        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
-        normalContextIDByTargetID.removeValue(forKey: targetID)
+        let removedContextIDs = Set(
+            executionContextsByID.values
+                .filter { $0.targetID == targetID || $0.runtimeAgentTargetID == targetID }
+                .map(\.id)
+        )
+        let removedTargetIDs = Set(removedContextIDs.compactMap { executionContextsByID[$0]?.targetID })
+        executionContextsByID = executionContextsByID.filter {
+            $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
+        }
+        for removedTargetID in removedTargetIDs {
+            if let normalContextID = normalContextIDByTargetID[removedTargetID],
+               removedContextIDs.contains(normalContextID) {
+                normalContextIDByTargetID.removeValue(forKey: removedTargetID)
+            }
+        }
         remoteObjectsByID = remoteObjectsByID.filter { $0.key.targetID != targetID }
         objectGroupByRemoteObjectID = objectGroupByRemoteObjectID.filter { $0.key.targetID != targetID }
         for group in Array(objectGroupTargetsByGroup.keys) {
@@ -190,7 +203,7 @@ package final class RuntimeSession {
         }
         unsupportedCommandsByTargetID.removeValue(forKey: targetID)
         if let activeContextID,
-           executionContextsByID[activeContextID] == nil {
+           removedContextIDs.contains(activeContextID) {
             self.activeContextID = normalContextIDByTargetID.values.sorted(by: { $0.rawValue < $1.rawValue }).first
         }
     }
@@ -319,14 +332,15 @@ package final class RuntimeSession {
         contextID: ExecutionContextID? = nil,
         objectGroup: RuntimeObjectGroup? = RuntimeObjectGroup("console")
     ) -> RuntimeCommandIntent {
-        .evaluate(
+        let context = contextID.flatMap { executionContextsByID[$0] } ?? activeContext(targetID: targetID)
+        return .evaluate(
             RuntimeEvaluationRequest(
-                targetID: targetID,
+                targetID: context?.runtimeAgentTargetID ?? targetID,
                 expression: expression,
                 objectGroup: objectGroup,
                 includeCommandLineAPI: true,
                 doNotPauseOnExceptionsAndMuteConsole: false,
-                contextID: contextID ?? activeContext(targetID: targetID)?.id,
+                contextID: contextID ?? context?.id,
                 returnByValue: false,
                 generatePreview: true,
                 saveResult: true,

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -330,7 +330,7 @@ package final class RuntimeSession {
         expression: String,
         targetID: ProtocolTargetIdentifier,
         contextID: ExecutionContextID? = nil,
-        objectGroup: RuntimeObjectGroup? = RuntimeObjectGroup("console")
+        objectGroup: RuntimeObjectGroup? = .console
     ) -> RuntimeCommandIntent {
         let context = contextID.flatMap { executionContextsByID[$0] } ?? activeContext(targetID: targetID)
         return .evaluate(

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -558,10 +558,14 @@ package final class RuntimeSession {
         storeRuntimeAgentState(agentState)
     }
 
-    package func applyEvaluationResult(_ result: RuntimeEvaluationResultPayload, request: RuntimeEvaluationRequest) {
+    package func applyEvaluationResult(
+        _ result: RuntimeEvaluationResultPayload,
+        request: RuntimeEvaluationRequest,
+        runtimeAgentTargetID: ProtocolTargetIdentifier? = nil
+    ) {
         registerRemoteObject(
             result.result,
-            runtimeAgentTargetID: request.runtimeAgentTargetID,
+            runtimeAgentTargetID: runtimeAgentTargetID ?? request.runtimeAgentTargetID,
             objectGroup: request.objectGroup,
             executionContextID: request.contextID
         )

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -109,18 +109,18 @@ package struct RuntimeRemoteObjectRecord: Equatable, Sendable {
 @MainActor
 @Observable
 package final class RuntimeRemoteObject {
-    package let id: RuntimeRemoteObjectIdentifierKey
+    package let remoteObjectKey: RuntimeRemoteObjectIdentifierKey?
     package var payload: RuntimeRemoteObjectPayload
     package var objectGroup: RuntimeObjectGroup?
     package var executionContextKey: RuntimeExecutionContextKey?
 
     package init(
-        id: RuntimeRemoteObjectIdentifierKey,
+        remoteObjectKey: RuntimeRemoteObjectIdentifierKey? = nil,
         payload: RuntimeRemoteObjectPayload,
         objectGroup: RuntimeObjectGroup? = nil,
         executionContextKey: RuntimeExecutionContextKey? = nil
     ) {
-        self.id = id
+        self.remoteObjectKey = remoteObjectKey
         self.payload = payload
         self.objectGroup = objectGroup
         self.executionContextKey = executionContextKey
@@ -196,7 +196,7 @@ package final class RuntimeAgentState {
 
     package var remoteObjects: [RuntimeRemoteObject] {
         remoteObjectsByID.values.sorted {
-            $0.id.objectID.rawValue < $1.id.objectID.rawValue
+            ($0.remoteObjectKey?.objectID.rawValue ?? "") < ($1.remoteObjectKey?.objectID.rawValue ?? "")
         }
     }
 
@@ -214,8 +214,11 @@ package final class RuntimeAgentState {
 
     var remoteObjectsByKey: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] {
         Dictionary(
-            uniqueKeysWithValues: remoteObjectsByID.map { _, remoteObject in
-                (remoteObject.id, remoteObject.snapshotRecord)
+            uniqueKeysWithValues: remoteObjectsByID.map { objectID, remoteObject in
+                (
+                    RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: targetID, objectID: objectID),
+                    remoteObject.snapshotRecord
+                )
             }
         )
     }
@@ -240,29 +243,37 @@ package final class RuntimeAgentState {
         executionContextsByID.removeValue(forKey: contextID)
     }
 
+    @discardableResult
     func registerRemoteObject(
         _ object: RuntimeRemoteObjectPayload,
         objectGroup: RuntimeObjectGroup?,
         executionContextID: ExecutionContextID?
-    ) {
-        guard let objectID = object.objectID else {
-            return
-        }
-        let objectKey = RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: targetID, objectID: objectID)
+    ) -> RuntimeRemoteObject {
         let executionContextKey = executionContextID.map {
             RuntimeExecutionContextKey(runtimeAgentTargetID: targetID, contextID: $0)
         }
-        if let remoteObject = remoteObjectsByID[objectID] {
-            remoteObject.payload = object
-            remoteObject.objectGroup = objectGroup
-            remoteObject.executionContextKey = executionContextKey
-        } else {
-            remoteObjectsByID[objectID] = RuntimeRemoteObject(
-                id: objectKey,
+        guard let objectID = object.objectID else {
+            return RuntimeRemoteObject(
                 payload: object,
                 objectGroup: objectGroup,
                 executionContextKey: executionContextKey
             )
+        }
+        let objectKey = RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: targetID, objectID: objectID)
+        if let remoteObject = remoteObjectsByID[objectID] {
+            remoteObject.payload = object
+            remoteObject.objectGroup = objectGroup
+            remoteObject.executionContextKey = executionContextKey
+            return remoteObject
+        } else {
+            let remoteObject = RuntimeRemoteObject(
+                remoteObjectKey: objectKey,
+                payload: object,
+                objectGroup: objectGroup,
+                executionContextKey: executionContextKey
+            )
+            remoteObjectsByID[objectID] = remoteObject
+            return remoteObject
         }
     }
 
@@ -543,19 +554,21 @@ package final class RuntimeSession {
         }
     }
 
+    @discardableResult
     package func registerRemoteObject(
         _ object: RuntimeRemoteObjectPayload,
         runtimeAgentTargetID: ProtocolTargetIdentifier,
         objectGroup: RuntimeObjectGroup? = nil,
         executionContextID: ExecutionContextID? = nil
-    ) {
+    ) -> RuntimeRemoteObject {
         let agentState = ensureRuntimeAgentState(for: runtimeAgentTargetID)
-        agentState.registerRemoteObject(
+        let remoteObject = agentState.registerRemoteObject(
             object,
             objectGroup: objectGroup,
             executionContextID: executionContextID
         )
         storeRuntimeAgentState(agentState)
+        return remoteObject
     }
 
     package func applyEvaluationResult(

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -115,7 +115,8 @@ package final class RuntimeSession {
             RuntimeExecutionContext(
                 id: record.id,
                 targetID: record.targetID,
-                type: .normal,
+                type: record.type,
+                name: record.name,
                 frameID: record.frameID
             )
         )
@@ -134,7 +135,7 @@ package final class RuntimeSession {
         if context.type == .normal {
             normalContextIDByTargetID[context.targetID] = context.id
         }
-        if activeContextID == nil || context.type == .normal {
+        if context.type == .normal {
             activeContextID = context.id
         }
     }

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -1,0 +1,269 @@
+import Observation
+
+package struct RuntimeExecutionContext: Equatable, Sendable {
+    package var id: ExecutionContextID
+    package var targetID: ProtocolTargetIdentifier
+    package var type: RuntimeExecutionContextType
+    package var name: String
+    package var frameID: DOMFrameIdentifier?
+
+    package init(
+        id: ExecutionContextID,
+        targetID: ProtocolTargetIdentifier,
+        type: RuntimeExecutionContextType = .normal,
+        name: String = "",
+        frameID: DOMFrameIdentifier? = nil
+    ) {
+        self.id = id
+        self.targetID = targetID
+        self.type = type
+        self.name = name
+        self.frameID = frameID
+    }
+}
+
+package struct RuntimeSessionSnapshot: Equatable, Sendable {
+    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    package var activeContextID: ExecutionContextID?
+    package var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
+    package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
+    package var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
+    package var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
+    package var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+}
+
+@MainActor
+@Observable
+package final class RuntimeSession {
+    package private(set) var activeContextID: ExecutionContextID?
+
+    @ObservationIgnored private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    @ObservationIgnored private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
+    @ObservationIgnored private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
+    @ObservationIgnored private var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
+    @ObservationIgnored private var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
+    @ObservationIgnored private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+
+    package init() {
+        activeContextID = nil
+        executionContextsByID = [:]
+        normalContextIDByTargetID = [:]
+        remoteObjectsByID = [:]
+        objectGroupByRemoteObjectID = [:]
+        objectGroupTargetsByGroup = [:]
+        unsupportedCommandsByTargetID = [:]
+    }
+
+    package func reset() {
+        activeContextID = nil
+        executionContextsByID.removeAll()
+        normalContextIDByTargetID.removeAll()
+        remoteObjectsByID.removeAll()
+        objectGroupByRemoteObjectID.removeAll()
+        objectGroupTargetsByGroup.removeAll()
+        unsupportedCommandsByTargetID.removeAll()
+    }
+
+    package func snapshot() -> RuntimeSessionSnapshot {
+        RuntimeSessionSnapshot(
+            executionContextsByID: executionContextsByID,
+            activeContextID: activeContextID,
+            normalContextIDByTargetID: normalContextIDByTargetID,
+            remoteObjectsByID: remoteObjectsByID,
+            objectGroupByRemoteObjectID: objectGroupByRemoteObjectID,
+            objectGroupTargetsByGroup: objectGroupTargetsByGroup,
+            unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
+        )
+    }
+
+    package func executionContext(for contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+        executionContextsByID[contextID]
+    }
+
+    package func activeContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
+        if let targetID,
+           let contextID = normalContextIDByTargetID[targetID] {
+            return executionContextsByID[contextID]
+        }
+        guard let activeContextID else {
+            return nil
+        }
+        return executionContextsByID[activeContextID]
+    }
+
+    package func applyExecutionContextCreated(_ payload: RuntimeExecutionContextPayload, targetID: ProtocolTargetIdentifier) {
+        let type = payload.type ?? .normal
+        let context = RuntimeExecutionContext(
+            id: payload.id,
+            targetID: targetID,
+            type: type,
+            name: payload.name ?? "",
+            frameID: payload.frameID
+        )
+        applyExecutionContextCreated(context)
+    }
+
+    package func applyExecutionContextCreated(_ record: ExecutionContextRecord) {
+        applyExecutionContextCreated(
+            RuntimeExecutionContext(
+                id: record.id,
+                targetID: record.targetID,
+                type: .normal,
+                frameID: record.frameID
+            )
+        )
+    }
+
+    package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
+        if context.type == .normal,
+           let oldContextID = normalContextIDByTargetID[context.targetID],
+           oldContextID != context.id {
+            executionContextsByID.removeValue(forKey: oldContextID)
+            if activeContextID == oldContextID {
+                activeContextID = nil
+            }
+        }
+        executionContextsByID[context.id] = context
+        if context.type == .normal {
+            normalContextIDByTargetID[context.targetID] = context.id
+        }
+        if activeContextID == nil || context.type == .normal {
+            activeContextID = context.id
+        }
+    }
+
+    package func selectExecutionContext(_ contextID: ExecutionContextID?) {
+        guard let contextID else {
+            activeContextID = nil
+            return
+        }
+        guard executionContextsByID[contextID] != nil else {
+            return
+        }
+        activeContextID = contextID
+    }
+
+    package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
+        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+        normalContextIDByTargetID.removeValue(forKey: targetID)
+        remoteObjectsByID = remoteObjectsByID.filter { $0.key.targetID != targetID }
+        objectGroupByRemoteObjectID = objectGroupByRemoteObjectID.filter { $0.key.targetID != targetID }
+        for group in Array(objectGroupTargetsByGroup.keys) {
+            objectGroupTargetsByGroup[group]?.remove(targetID)
+            if objectGroupTargetsByGroup[group]?.isEmpty == true {
+                objectGroupTargetsByGroup.removeValue(forKey: group)
+            }
+        }
+        unsupportedCommandsByTargetID.removeValue(forKey: targetID)
+        if let activeContextID,
+           executionContextsByID[activeContextID] == nil {
+            self.activeContextID = normalContextIDByTargetID.values.sorted(by: { $0.rawValue < $1.rawValue }).first
+        }
+    }
+
+    package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
+        if let oldTargetID {
+            for (contextID, context) in executionContextsByID where context.targetID == oldTargetID {
+                executionContextsByID[contextID]?.targetID = newTargetID
+            }
+            if let normalContextID = normalContextIDByTargetID.removeValue(forKey: oldTargetID) {
+                normalContextIDByTargetID[newTargetID] = normalContextID
+            }
+            var movedObjects: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload] = [:]
+            var movedObjectGroups: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup] = [:]
+            for (key, object) in remoteObjectsByID where key.targetID == oldTargetID {
+                let newKey = RuntimeRemoteObjectIdentifierKey(targetID: newTargetID, objectID: key.objectID)
+                movedObjects[newKey] = object
+                remoteObjectsByID.removeValue(forKey: key)
+                if let group = objectGroupByRemoteObjectID.removeValue(forKey: key) {
+                    movedObjectGroups[newKey] = group
+                }
+            }
+            remoteObjectsByID.merge(movedObjects) { _, new in new }
+            objectGroupByRemoteObjectID.merge(movedObjectGroups) { _, new in new }
+            for group in objectGroupTargetsByGroup.keys {
+                if objectGroupTargetsByGroup[group]?.remove(oldTargetID) != nil {
+                    objectGroupTargetsByGroup[group]?.insert(newTargetID)
+                }
+            }
+            if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
+                unsupportedCommandsByTargetID[newTargetID, default: []].formUnion(unsupported)
+            }
+        }
+    }
+
+    package func registerRemoteObject(
+        _ object: RuntimeRemoteObjectPayload,
+        targetID: ProtocolTargetIdentifier,
+        objectGroup: RuntimeObjectGroup? = nil
+    ) {
+        if let key = object.identifierKey(targetID: targetID) {
+            remoteObjectsByID[key] = object
+            if let objectGroup {
+                objectGroupByRemoteObjectID[key] = objectGroup
+            } else {
+                objectGroupByRemoteObjectID.removeValue(forKey: key)
+            }
+        }
+        if let objectGroup {
+            objectGroupTargetsByGroup[objectGroup, default: []].insert(targetID)
+        }
+    }
+
+    package func applyEvaluationResult(_ result: RuntimeEvaluationResultPayload, request: RuntimeEvaluationRequest) {
+        registerRemoteObject(result.result, targetID: request.targetID, objectGroup: request.objectGroup)
+    }
+
+    package func releaseObject(_ key: RuntimeRemoteObjectIdentifierKey) {
+        remoteObjectsByID.removeValue(forKey: key)
+        objectGroupByRemoteObjectID.removeValue(forKey: key)
+    }
+
+    package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, targetID: ProtocolTargetIdentifier) {
+        let releasedKeys = objectGroupByRemoteObjectID.compactMap { key, group in
+            key.targetID == targetID && group == objectGroup ? key : nil
+        }
+        for key in releasedKeys {
+            remoteObjectsByID.removeValue(forKey: key)
+            objectGroupByRemoteObjectID.removeValue(forKey: key)
+        }
+        objectGroupTargetsByGroup[objectGroup]?.remove(targetID)
+        if objectGroupTargetsByGroup[objectGroup]?.isEmpty == true {
+            objectGroupTargetsByGroup.removeValue(forKey: objectGroup)
+        }
+    }
+
+    package func markCommandUnsupported(_ method: String, targetID: ProtocolTargetIdentifier) {
+        unsupportedCommandsByTargetID[targetID, default: []].insert(method)
+    }
+
+    package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
+        unsupportedCommandsByTargetID[targetID]?.contains(method) != true
+    }
+
+    package func enableIntent(targetID: ProtocolTargetIdentifier) -> RuntimeCommandIntent {
+        .enable(targetID: targetID)
+    }
+
+    package func evaluateIntent(
+        expression: String,
+        targetID: ProtocolTargetIdentifier,
+        contextID: ExecutionContextID? = nil,
+        objectGroup: RuntimeObjectGroup? = RuntimeObjectGroup("console")
+    ) -> RuntimeCommandIntent {
+        .evaluate(
+            RuntimeEvaluationRequest(
+                targetID: targetID,
+                expression: expression,
+                objectGroup: objectGroup,
+                includeCommandLineAPI: true,
+                doNotPauseOnExceptionsAndMuteConsole: false,
+                contextID: contextID ?? normalContextIDByTargetID[targetID] ?? activeContextID,
+                returnByValue: false,
+                generatePreview: true,
+                saveResult: true,
+                emulateUserGesture: true
+            )
+        )
+    }
+}

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -3,6 +3,7 @@ import Observation
 package struct RuntimeExecutionContext: Equatable, Sendable {
     package var id: ExecutionContextID
     package var targetID: ProtocolTargetIdentifier
+    package var runtimeAgentTargetID: ProtocolTargetIdentifier
     package var type: RuntimeExecutionContextType
     package var name: String
     package var frameID: DOMFrameIdentifier?
@@ -10,12 +11,14 @@ package struct RuntimeExecutionContext: Equatable, Sendable {
     package init(
         id: ExecutionContextID,
         targetID: ProtocolTargetIdentifier,
+        runtimeAgentTargetID: ProtocolTargetIdentifier? = nil,
         type: RuntimeExecutionContextType = .normal,
         name: String = "",
         frameID: DOMFrameIdentifier? = nil
     ) {
         self.id = id
         self.targetID = targetID
+        self.runtimeAgentTargetID = runtimeAgentTargetID ?? targetID
         self.type = type
         self.name = name
         self.frameID = frameID
@@ -140,17 +143,23 @@ package final class RuntimeSession {
         }
     }
 
-    package func applyExecutionContextsCleared(targetID: ProtocolTargetIdentifier) {
+    package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTargetIdentifier) {
         let removedContextIDs = Set(
             executionContextsByID.values
-                .filter { $0.targetID == targetID }
+                .filter { $0.runtimeAgentTargetID == runtimeAgentTargetID }
                 .map(\.id)
         )
         guard removedContextIDs.isEmpty == false else {
             return
         }
-        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
-        normalContextIDByTargetID.removeValue(forKey: targetID)
+        let removedTargetIDs = Set(removedContextIDs.compactMap { executionContextsByID[$0]?.targetID })
+        executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
+        for targetID in removedTargetIDs {
+            if let normalContextID = normalContextIDByTargetID[targetID],
+               removedContextIDs.contains(normalContextID) {
+                normalContextIDByTargetID.removeValue(forKey: targetID)
+            }
+        }
         if let activeContextID,
            removedContextIDs.contains(activeContextID) {
             self.activeContextID = nil
@@ -190,6 +199,9 @@ package final class RuntimeSession {
         if let oldTargetID {
             for (contextID, context) in executionContextsByID where context.targetID == oldTargetID {
                 executionContextsByID[contextID]?.targetID = newTargetID
+            }
+            for (contextID, context) in executionContextsByID where context.runtimeAgentTargetID == oldTargetID {
+                executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
             }
             if let normalContextID = normalContextIDByTargetID.removeValue(forKey: oldTargetID) {
                 normalContextIDByTargetID[newTargetID] = normalContextID

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -23,77 +23,95 @@ package struct RuntimeExecutionContext: Equatable, Sendable {
         self.name = name
         self.frameID = frameID
     }
+
+    package var key: RuntimeExecutionContextKey {
+        RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: id)
+    }
 }
 
 package struct RuntimeRemoteObjectRecord: Equatable, Sendable {
     package var payload: RuntimeRemoteObjectPayload
     package var objectGroup: RuntimeObjectGroup?
-    package var executionContextID: ExecutionContextID?
+    package var executionContextKey: RuntimeExecutionContextKey?
 
     package init(
         payload: RuntimeRemoteObjectPayload,
         objectGroup: RuntimeObjectGroup? = nil,
-        executionContextID: ExecutionContextID? = nil
+        executionContextKey: RuntimeExecutionContextKey? = nil
     ) {
         self.payload = payload
         self.objectGroup = objectGroup
-        self.executionContextID = executionContextID
+        self.executionContextKey = executionContextKey
     }
 }
 
 package struct RuntimeSessionSnapshot: Equatable, Sendable {
-    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
-    package var selectedContextID: ExecutionContextID?
-    package var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    package var selectedContextKey: RuntimeExecutionContextKey?
+    package var normalContextKeyByTargetID: [ProtocolTargetIdentifier: RuntimeExecutionContextKey]
     package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
     package var objectGroupRuntimeAgentTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
     package var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+
+    package func executionContext(
+        runtimeAgentTargetID: ProtocolTargetIdentifier,
+        contextID: ExecutionContextID
+    ) -> RuntimeExecutionContext? {
+        executionContextsByKey[
+            RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: contextID)
+        ]
+    }
+
+    package func uniqueExecutionContext(contextID: ExecutionContextID) -> RuntimeExecutionContext? {
+        let matches = executionContextsByKey.values.filter { $0.id == contextID }
+        return matches.count == 1 ? matches[0] : nil
+    }
 }
 
 @MainActor
 @Observable
 package final class RuntimeSession {
-    package private(set) var selectedContextID: ExecutionContextID?
+    package private(set) var selectedContextKey: RuntimeExecutionContextKey?
 
-    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
-    private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
+    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    private var normalContextKeyByTargetID: [ProtocolTargetIdentifier: RuntimeExecutionContextKey]
     private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
     private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 
     package init() {
-        selectedContextID = nil
-        executionContextsByID = [:]
-        normalContextIDByTargetID = [:]
+        selectedContextKey = nil
+        executionContextsByKey = [:]
+        normalContextKeyByTargetID = [:]
         remoteObjectsByID = [:]
         unsupportedCommandsByTargetID = [:]
     }
 
     package func reset() {
-        selectedContextID = nil
-        executionContextsByID.removeAll()
-        normalContextIDByTargetID.removeAll()
+        selectedContextKey = nil
+        executionContextsByKey.removeAll()
+        normalContextKeyByTargetID.removeAll()
         remoteObjectsByID.removeAll()
         unsupportedCommandsByTargetID.removeAll()
     }
 
     package func snapshot() -> RuntimeSessionSnapshot {
         RuntimeSessionSnapshot(
-            executionContextsByID: executionContextsByID,
-            selectedContextID: selectedContextID,
-            normalContextIDByTargetID: normalContextIDByTargetID,
+            executionContextsByKey: executionContextsByKey,
+            selectedContextKey: selectedContextKey,
+            normalContextKeyByTargetID: normalContextKeyByTargetID,
             remoteObjectsByID: remoteObjectsByID,
             objectGroupRuntimeAgentTargetsByGroup: Self.objectGroupRuntimeAgentTargets(from: remoteObjectsByID),
             unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
         )
     }
 
-    package func executionContext(for contextID: ExecutionContextID) -> RuntimeExecutionContext? {
-        executionContextsByID[contextID]
+    package func executionContext(for key: RuntimeExecutionContextKey) -> RuntimeExecutionContext? {
+        executionContextsByKey[key]
     }
 
     package func selectedContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
-        guard let selectedContextID,
-              let context = executionContextsByID[selectedContextID] else {
+        guard let selectedContextKey,
+              let context = executionContextsByKey[selectedContextKey] else {
             return nil
         }
         if let targetID {
@@ -103,10 +121,10 @@ package final class RuntimeSession {
     }
 
     package func defaultContext(targetID: ProtocolTargetIdentifier) -> RuntimeExecutionContext? {
-        guard let contextID = normalContextIDByTargetID[targetID] else {
+        guard let contextKey = normalContextKeyByTargetID[targetID] else {
             return nil
         }
-        return executionContextsByID[contextID]
+        return executionContextsByKey[contextKey]
     }
 
     package func applyExecutionContextCreated(_ payload: RuntimeExecutionContextPayload, targetID: ProtocolTargetIdentifier) {
@@ -122,115 +140,134 @@ package final class RuntimeSession {
     }
 
     package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
-        let oldContextIDs = context.type == .normal ? normalContextIDsToReplace(with: context) : []
-        if oldContextIDs.isEmpty == false {
-            for oldContextID in oldContextIDs {
-                releaseRemoteObjects(executionContextID: oldContextID)
-                executionContextsByID.removeValue(forKey: oldContextID)
+        let oldContextKeys = context.type == .normal ? normalContextKeysToReplace(with: context) : []
+        if oldContextKeys.isEmpty == false {
+            for oldContextKey in oldContextKeys {
+                releaseRemoteObjects(executionContextKey: oldContextKey)
+                executionContextsByKey.removeValue(forKey: oldContextKey)
             }
-            if let selectedContextID,
-               oldContextIDs.contains(selectedContextID) {
-                self.selectedContextID = nil
+            if let selectedContextKey,
+               oldContextKeys.contains(selectedContextKey) {
+                self.selectedContextKey = nil
             }
         }
-        executionContextsByID[context.id] = context
+        executionContextsByKey[context.key] = context
         if context.type == .normal {
-            if let defaultContextID = normalContextIDByTargetID[context.targetID] {
-                if oldContextIDs.contains(defaultContextID) {
-                    normalContextIDByTargetID[context.targetID] = context.id
+            if let defaultContextKey = normalContextKeyByTargetID[context.targetID] {
+                if oldContextKeys.contains(defaultContextKey) {
+                    normalContextKeyByTargetID[context.targetID] = context.key
                 }
             } else {
-                normalContextIDByTargetID[context.targetID] = context.id
+                normalContextKeyByTargetID[context.targetID] = context.key
             }
         }
         if context.type == .normal,
-           selectedContextID == nil {
-            selectedContextID = context.id
+           selectedContextKey == nil {
+            selectedContextKey = context.key
         }
     }
 
-    package func applyExecutionContextDestroyed(_ contextID: ExecutionContextID) {
-        guard let context = executionContextsByID.removeValue(forKey: contextID) else {
+    package func applyExecutionContextDestroyed(_ contextKey: RuntimeExecutionContextKey) {
+        guard let context = executionContextsByKey.removeValue(forKey: contextKey) else {
             return
         }
-        if normalContextIDByTargetID[context.targetID] == contextID {
-            normalContextIDByTargetID.removeValue(forKey: context.targetID)
+        if normalContextKeyByTargetID[context.targetID] == contextKey {
+            normalContextKeyByTargetID.removeValue(forKey: context.targetID)
         }
-        if selectedContextID == contextID {
-            selectedContextID = nil
+        if selectedContextKey == contextKey {
+            selectedContextKey = nil
         }
-        releaseRemoteObjects(executionContextID: context.id)
+        releaseRemoteObjects(executionContextKey: contextKey)
     }
 
     package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTargetIdentifier) {
-        let removedContextIDs = Set(
-            executionContextsByID.values
-                .filter { $0.runtimeAgentTargetID == runtimeAgentTargetID }
-                .map(\.id)
+        let removedContextKeys = Set(
+            executionContextsByKey
+                .filter { $0.key.runtimeAgentTargetID == runtimeAgentTargetID }
+                .map(\.key)
         )
-        let removedTargetIDs = Set(removedContextIDs.compactMap { executionContextsByID[$0]?.targetID })
-        executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
+        let removedTargetIDs = Set(removedContextKeys.compactMap { executionContextsByKey[$0]?.targetID })
+        executionContextsByKey = executionContextsByKey.filter { $0.key.runtimeAgentTargetID != runtimeAgentTargetID }
         for targetID in removedTargetIDs {
-            if let normalContextID = normalContextIDByTargetID[targetID],
-               removedContextIDs.contains(normalContextID) {
-                normalContextIDByTargetID.removeValue(forKey: targetID)
+            if let normalContextKey = normalContextKeyByTargetID[targetID],
+               removedContextKeys.contains(normalContextKey) {
+                normalContextKeyByTargetID.removeValue(forKey: targetID)
             }
         }
-        if let selectedContextID,
-           removedContextIDs.contains(selectedContextID) {
-            self.selectedContextID = nil
+        if let selectedContextKey,
+           removedContextKeys.contains(selectedContextKey) {
+            self.selectedContextKey = nil
         }
         releaseRemoteObjects(runtimeAgentTargetID: runtimeAgentTargetID)
     }
 
-    package func selectExecutionContext(_ contextID: ExecutionContextID?) {
-        guard let contextID else {
-            selectedContextID = nil
+    package func selectExecutionContext(_ contextKey: RuntimeExecutionContextKey?) {
+        guard let contextKey else {
+            selectedContextKey = nil
             return
         }
-        guard executionContextsByID[contextID] != nil else {
+        guard executionContextsByKey[contextKey] != nil else {
             return
         }
-        selectedContextID = contextID
+        selectedContextKey = contextKey
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
-        let removedContextIDs = Set(
-            executionContextsByID.values
-                .filter { $0.targetID == targetID || $0.runtimeAgentTargetID == targetID }
-                .map(\.id)
+        let removedContextKeys = Set(
+            executionContextsByKey
+                .filter { $0.value.targetID == targetID || $0.value.runtimeAgentTargetID == targetID }
+                .map(\.key)
         )
-        let removedTargetIDs = Set(removedContextIDs.compactMap { executionContextsByID[$0]?.targetID })
-        executionContextsByID = executionContextsByID.filter {
+        let removedTargetIDs = Set(removedContextKeys.compactMap { executionContextsByKey[$0]?.targetID })
+        executionContextsByKey = executionContextsByKey.filter {
             $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
         }
         for removedTargetID in removedTargetIDs {
-            if let normalContextID = normalContextIDByTargetID[removedTargetID],
-               removedContextIDs.contains(normalContextID) {
-                normalContextIDByTargetID.removeValue(forKey: removedTargetID)
+            if let normalContextKey = normalContextKeyByTargetID[removedTargetID],
+               removedContextKeys.contains(normalContextKey) {
+                normalContextKeyByTargetID.removeValue(forKey: removedTargetID)
             }
         }
         releaseRemoteObjects(runtimeAgentTargetID: targetID)
-        for contextID in removedContextIDs {
-            releaseRemoteObjects(executionContextID: contextID)
+        for contextKey in removedContextKeys {
+            releaseRemoteObjects(executionContextKey: contextKey)
         }
         unsupportedCommandsByTargetID.removeValue(forKey: targetID)
-        if let selectedContextID,
-           removedContextIDs.contains(selectedContextID) {
-            self.selectedContextID = nil
+        if let selectedContextKey,
+           removedContextKeys.contains(selectedContextKey) {
+            self.selectedContextKey = nil
         }
     }
 
     package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
         if let oldTargetID {
-            for (contextID, context) in executionContextsByID where context.targetID == oldTargetID {
-                executionContextsByID[contextID]?.targetID = newTargetID
+            var movedKeys: [RuntimeExecutionContextKey: RuntimeExecutionContextKey] = [:]
+            for (contextKey, context) in Array(executionContextsByKey) {
+                var movedContext = context
+                if movedContext.targetID == oldTargetID {
+                    movedContext.targetID = newTargetID
+                }
+                if movedContext.runtimeAgentTargetID == oldTargetID {
+                    movedContext.runtimeAgentTargetID = newTargetID
+                }
+                guard movedContext != context else {
+                    continue
+                }
+                executionContextsByKey.removeValue(forKey: contextKey)
+                executionContextsByKey[movedContext.key] = movedContext
+                movedKeys[contextKey] = movedContext.key
             }
-            for (contextID, context) in executionContextsByID where context.runtimeAgentTargetID == oldTargetID {
-                executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
+            for (targetID, contextKey) in Array(normalContextKeyByTargetID) {
+                if let movedKey = movedKeys[contextKey] {
+                    normalContextKeyByTargetID[targetID] = movedKey
+                }
             }
-            if let normalContextID = normalContextIDByTargetID.removeValue(forKey: oldTargetID) {
-                normalContextIDByTargetID[newTargetID] = normalContextID
+            if let normalContextKey = normalContextKeyByTargetID.removeValue(forKey: oldTargetID) {
+                normalContextKeyByTargetID[newTargetID] = movedKeys[normalContextKey] ?? normalContextKey
+            }
+            if let selectedContextKey,
+               let movedKey = movedKeys[selectedContextKey] {
+                self.selectedContextKey = movedKey
             }
             releaseRemoteObjects(runtimeAgentTargetID: oldTargetID)
             if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
@@ -249,7 +286,9 @@ package final class RuntimeSession {
             remoteObjectsByID[key] = RuntimeRemoteObjectRecord(
                 payload: object,
                 objectGroup: objectGroup,
-                executionContextID: executionContextID
+                executionContextKey: executionContextID.map {
+                    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: $0)
+                }
             )
         }
     }
@@ -289,9 +328,9 @@ package final class RuntimeSession {
         }
     }
 
-    private func releaseRemoteObjects(executionContextID: ExecutionContextID) {
+    private func releaseRemoteObjects(executionContextKey: RuntimeExecutionContextKey) {
         releaseRemoteObjects { _, record in
-            record.executionContextID == executionContextID
+            record.executionContextKey == executionContextKey
         }
     }
 
@@ -319,18 +358,18 @@ package final class RuntimeSession {
         return targetsByGroup
     }
 
-    private func normalContextIDsToReplace(with context: RuntimeExecutionContext) -> Set<ExecutionContextID> {
+    private func normalContextKeysToReplace(with context: RuntimeExecutionContext) -> Set<RuntimeExecutionContextKey> {
         Set(
-            executionContextsByID.values
+            executionContextsByKey.values
                 .filter {
                     $0.type == .normal
                         && $0.targetID == context.targetID
                         && $0.runtimeAgentTargetID == context.runtimeAgentTargetID
                         && $0.frameID == context.frameID
                         && $0.name == context.name
-                        && $0.id != context.id
+                        && $0.key != context.key
                 }
-                .map(\.id)
+                .map(\.key)
         )
     }
 
@@ -341,10 +380,10 @@ package final class RuntimeSession {
     package func evaluateIntent(
         expression: String,
         targetID: ProtocolTargetIdentifier,
-        contextID: ExecutionContextID? = nil,
+        contextKey: RuntimeExecutionContextKey? = nil,
         objectGroup: RuntimeObjectGroup? = .console
     ) -> RuntimeCommandIntent {
-        let context = evaluationContext(targetID: targetID, contextID: contextID)
+        let context = evaluationContext(targetID: targetID, contextKey: contextKey)
         return .evaluate(
             RuntimeEvaluationRequest(
                 runtimeAgentTargetID: context?.runtimeAgentTargetID ?? targetID,
@@ -352,7 +391,7 @@ package final class RuntimeSession {
                 objectGroup: objectGroup,
                 includeCommandLineAPI: true,
                 doNotPauseOnExceptionsAndMuteConsole: false,
-                contextID: contextID ?? context?.id,
+                contextID: context?.id,
                 returnByValue: false,
                 generatePreview: true,
                 saveResult: true,
@@ -363,10 +402,10 @@ package final class RuntimeSession {
 
     private func evaluationContext(
         targetID: ProtocolTargetIdentifier,
-        contextID: ExecutionContextID?
+        contextKey: RuntimeExecutionContextKey?
     ) -> RuntimeExecutionContext? {
-        if let contextID {
-            return executionContextsByID[contextID]
+        if let contextKey {
+            return executionContextsByKey[contextKey]
         }
         return selectedContext(targetID: targetID) ?? defaultContext(targetID: targetID)
     }

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -135,7 +135,13 @@ package final class RuntimeSession {
         }
         executionContextsByID[context.id] = context
         if context.type == .normal {
-            normalContextIDByTargetID[context.targetID] = context.id
+            if let defaultContextID = normalContextIDByTargetID[context.targetID] {
+                if oldContextIDs.contains(defaultContextID) {
+                    normalContextIDByTargetID[context.targetID] = context.id
+                }
+            } else {
+                normalContextIDByTargetID[context.targetID] = context.id
+            }
         }
         if context.type == .normal,
            selectedContextID == nil {

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -27,6 +27,25 @@ package struct RuntimeExecutionContextRecord: Equatable, Sendable {
     package var key: RuntimeExecutionContextKey {
         RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: id)
     }
+
+    package static func stableOrder(_ lhs: Self, _ rhs: Self) -> Bool {
+        if lhs.runtimeAgentTargetID != rhs.runtimeAgentTargetID {
+            return lhs.runtimeAgentTargetID.rawValue < rhs.runtimeAgentTargetID.rawValue
+        }
+        if lhs.id != rhs.id {
+            return lhs.id.rawValue < rhs.id.rawValue
+        }
+        if lhs.targetID != rhs.targetID {
+            return lhs.targetID.rawValue < rhs.targetID.rawValue
+        }
+        if lhs.frameID != rhs.frameID {
+            return (lhs.frameID?.rawValue ?? "") < (rhs.frameID?.rawValue ?? "")
+        }
+        if lhs.type != rhs.type {
+            return lhs.type.rawValue < rhs.type.rawValue
+        }
+        return lhs.name < rhs.name
+    }
 }
 
 @MainActor
@@ -162,10 +181,16 @@ package struct RuntimeSessionSnapshot: Equatable, Sendable {
 @Observable
 package final class RuntimeTargetState {
     package let targetID: ProtocolTargetIdentifier
+    package var frameID: DOMFrameIdentifier?
     package var normalContextKey: RuntimeExecutionContextKey?
 
-    package init(targetID: ProtocolTargetIdentifier, normalContextKey: RuntimeExecutionContextKey? = nil) {
+    package init(
+        targetID: ProtocolTargetIdentifier,
+        frameID: DOMFrameIdentifier? = nil,
+        normalContextKey: RuntimeExecutionContextKey? = nil
+    ) {
         self.targetID = targetID
+        self.frameID = frameID
         self.normalContextKey = normalContextKey
     }
 }
@@ -336,17 +361,20 @@ package final class RuntimeSession {
 
     private var targetStatesByID: [ProtocolTargetIdentifier: RuntimeTargetState]
     private var runtimeAgentStatesByID: [ProtocolTargetIdentifier: RuntimeAgentState]
+    @ObservationIgnored private var selectedContextIsExplicit: Bool
 
     package init() {
         selectedContextKey = nil
         targetStatesByID = [:]
         runtimeAgentStatesByID = [:]
+        selectedContextIsExplicit = false
     }
 
     package func reset() {
         selectedContextKey = nil
         targetStatesByID.removeAll()
         runtimeAgentStatesByID.removeAll()
+        selectedContextIsExplicit = false
     }
 
     package func snapshot() -> RuntimeSessionSnapshot {
@@ -420,6 +448,7 @@ package final class RuntimeSession {
             if let selectedContextKey,
                oldContextKeys.contains(selectedContextKey) {
                 self.selectedContextKey = nil
+                selectedContextIsExplicit = false
             }
         }
         let agentState = ensureRuntimeAgentState(for: record.runtimeAgentTargetID)
@@ -427,17 +456,21 @@ package final class RuntimeSession {
         storeRuntimeAgentState(agentState)
         if record.type == .normal {
             let targetState = ensureTargetState(for: record.targetID)
-            if let defaultContextKey = targetState.normalContextKey {
-                if oldContextKeys.contains(defaultContextKey) {
-                    targetState.normalContextKey = record.key
-                }
-            } else {
+            let previousDefaultContextKey = targetState.normalContextKey
+            if shouldUseAsDefaultNormalContext(record, replacing: previousDefaultContextKey)
+                || previousDefaultContextKey.map(oldContextKeys.contains) == true {
                 targetState.normalContextKey = record.key
+                if selectedContextKey == nil
+                    || (selectedContextIsExplicit == false && selectedContextKey == previousDefaultContextKey) {
+                    selectedContextKey = record.key
+                    selectedContextIsExplicit = false
+                }
             }
         }
         if record.type == .normal,
            selectedContextKey == nil {
             selectedContextKey = record.key
+            selectedContextIsExplicit = false
         }
     }
 
@@ -450,6 +483,7 @@ package final class RuntimeSession {
         }
         if selectedContextKey == contextKey {
             selectedContextKey = nil
+            selectedContextIsExplicit = false
         }
     }
 
@@ -472,18 +506,21 @@ package final class RuntimeSession {
         if let selectedContextKey,
            removedContextKeys.contains(selectedContextKey) {
             self.selectedContextKey = nil
+            selectedContextIsExplicit = false
         }
     }
 
     package func selectExecutionContext(_ contextKey: RuntimeExecutionContextKey?) {
         guard let contextKey else {
             selectedContextKey = nil
+            selectedContextIsExplicit = false
             return
         }
         guard executionContext(for: contextKey) != nil else {
             return
         }
         selectedContextKey = contextKey
+        selectedContextIsExplicit = true
     }
 
     package func applyTargetDestroyed(_ targetID: ProtocolTargetIdentifier) {
@@ -521,7 +558,14 @@ package final class RuntimeSession {
         if let selectedContextKey,
            removedContextKeys.contains(selectedContextKey) {
             self.selectedContextKey = nil
+            selectedContextIsExplicit = false
         }
+    }
+
+    package func applyTargetCreated(_ record: ProtocolTargetRecord) {
+        let targetState = ensureTargetState(for: record.id)
+        targetState.frameID = record.frameID
+        promotePreferredNormalContextIfNeeded(for: targetState)
     }
 
     package func applyTargetCommitted(oldTargetID: ProtocolTargetIdentifier?, newTargetID: ProtocolTargetIdentifier) {
@@ -536,6 +580,9 @@ package final class RuntimeSession {
             }
             if let oldTargetState = targetStatesByID.removeValue(forKey: oldTargetID) {
                 let newTargetState = ensureTargetState(for: newTargetID)
+                if newTargetState.frameID == nil {
+                    newTargetState.frameID = oldTargetState.frameID
+                }
                 if newTargetState.normalContextKey == nil,
                    let normalContextKey = oldTargetState.normalContextKey {
                     newTargetState.normalContextKey = movedContextKeys[normalContextKey] ?? normalContextKey
@@ -666,6 +713,56 @@ package final class RuntimeSession {
         let state = RuntimeAgentState(targetID: targetID)
         runtimeAgentStatesByID[targetID] = state
         return state
+    }
+
+    private func shouldUseAsDefaultNormalContext(
+        _ record: RuntimeExecutionContextRecord,
+        replacing currentKey: RuntimeExecutionContextKey?
+    ) -> Bool {
+        guard let currentKey else {
+            return true
+        }
+        guard let currentContext = executionContext(for: currentKey) else {
+            return true
+        }
+        guard let targetFrameID = targetStatesByID[record.targetID]?.frameID else {
+            return false
+        }
+        guard currentContext.frameID != targetFrameID else {
+            return false
+        }
+        return record.frameID == targetFrameID
+    }
+
+    private func promotePreferredNormalContextIfNeeded(for targetState: RuntimeTargetState) {
+        guard let targetFrameID = targetState.frameID else {
+            return
+        }
+        let currentDefaultContextKey = targetState.normalContextKey
+        if let currentDefaultContextKey,
+           executionContext(for: currentDefaultContextKey)?.frameID == targetFrameID {
+            return
+        }
+
+        guard let preferredContext = executionContextsByKey.values
+            .filter({
+                $0.type == .normal
+                    && $0.targetID == targetState.targetID
+                    && $0.frameID == targetFrameID
+            })
+            .sorted(by: {
+                RuntimeExecutionContextRecord.stableOrder($0.snapshotRecord, $1.snapshotRecord)
+            })
+            .first else {
+            return
+        }
+
+        targetState.normalContextKey = preferredContext.key
+        if selectedContextKey == nil
+            || (selectedContextIsExplicit == false && selectedContextKey == currentDefaultContextKey) {
+            selectedContextKey = preferredContext.key
+            selectedContextIsExplicit = false
+        }
     }
 
     private func storeRuntimeAgentState(_ state: RuntimeAgentState) {

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -81,9 +81,16 @@ package final class RuntimeSession {
     }
 
     package func activeContext(targetID: ProtocolTargetIdentifier? = nil) -> RuntimeExecutionContext? {
-        if let targetID,
-           let contextID = normalContextIDByTargetID[targetID] {
-            return executionContextsByID[contextID]
+        if let targetID {
+            if let contextID = normalContextIDByTargetID[targetID] {
+                return executionContextsByID[contextID]
+            }
+            guard let activeContextID,
+                  let context = executionContextsByID[activeContextID],
+                  context.targetID == targetID else {
+                return nil
+            }
+            return context
         }
         guard let activeContextID else {
             return nil
@@ -116,7 +123,7 @@ package final class RuntimeSession {
 
     package func applyExecutionContextCreated(_ context: RuntimeExecutionContext) {
         if context.type == .normal,
-           let oldContextID = normalContextIDByTargetID[context.targetID],
+           let oldContextID = normalContextIDToReplace(with: context),
            oldContextID != context.id {
             executionContextsByID.removeValue(forKey: oldContextID)
             if activeContextID == oldContextID {
@@ -241,6 +248,19 @@ package final class RuntimeSession {
         unsupportedCommandsByTargetID[targetID]?.contains(method) != true
     }
 
+    private func normalContextIDToReplace(with context: RuntimeExecutionContext) -> ExecutionContextID? {
+        executionContextsByID.values
+            .filter {
+                $0.type == .normal
+                    && $0.targetID == context.targetID
+                    && $0.frameID == context.frameID
+                    && $0.name == context.name
+                    && $0.id != context.id
+            }
+            .map(\.id)
+            .min { $0.rawValue < $1.rawValue }
+    }
+
     package func enableIntent(targetID: ProtocolTargetIdentifier) -> RuntimeCommandIntent {
         .enable(targetID: targetID)
     }
@@ -258,7 +278,7 @@ package final class RuntimeSession {
                 objectGroup: objectGroup,
                 includeCommandLineAPI: true,
                 doNotPauseOnExceptionsAndMuteConsole: false,
-                contextID: contextID ?? normalContextIDByTargetID[targetID] ?? activeContextID,
+                contextID: contextID ?? activeContext(targetID: targetID)?.id,
                 returnByValue: false,
                 generatePreview: true,
                 saveResult: true,

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -25,13 +25,28 @@ package struct RuntimeExecutionContext: Equatable, Sendable {
     }
 }
 
+package struct RuntimeRemoteObjectRecord: Equatable, Sendable {
+    package var payload: RuntimeRemoteObjectPayload
+    package var objectGroup: RuntimeObjectGroup?
+    package var executionContextID: ExecutionContextID?
+
+    package init(
+        payload: RuntimeRemoteObjectPayload,
+        objectGroup: RuntimeObjectGroup? = nil,
+        executionContextID: ExecutionContextID? = nil
+    ) {
+        self.payload = payload
+        self.objectGroup = objectGroup
+        self.executionContextID = executionContextID
+    }
+}
+
 package struct RuntimeSessionSnapshot: Equatable, Sendable {
     package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     package var selectedContextID: ExecutionContextID?
     package var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
-    package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
-    package var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
-    package var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
+    package var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
+    package var objectGroupRuntimeAgentTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
     package var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 }
 
@@ -42,9 +57,8 @@ package final class RuntimeSession {
 
     private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
-    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
-    private var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
-    private var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
+    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord]
+    private var objectGroupRuntimeAgentTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
     private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 
     package init() {
@@ -52,8 +66,7 @@ package final class RuntimeSession {
         executionContextsByID = [:]
         normalContextIDByTargetID = [:]
         remoteObjectsByID = [:]
-        objectGroupByRemoteObjectID = [:]
-        objectGroupTargetsByGroup = [:]
+        objectGroupRuntimeAgentTargetsByGroup = [:]
         unsupportedCommandsByTargetID = [:]
     }
 
@@ -62,8 +75,7 @@ package final class RuntimeSession {
         executionContextsByID.removeAll()
         normalContextIDByTargetID.removeAll()
         remoteObjectsByID.removeAll()
-        objectGroupByRemoteObjectID.removeAll()
-        objectGroupTargetsByGroup.removeAll()
+        objectGroupRuntimeAgentTargetsByGroup.removeAll()
         unsupportedCommandsByTargetID.removeAll()
     }
 
@@ -73,8 +85,7 @@ package final class RuntimeSession {
             selectedContextID: selectedContextID,
             normalContextIDByTargetID: normalContextIDByTargetID,
             remoteObjectsByID: remoteObjectsByID,
-            objectGroupByRemoteObjectID: objectGroupByRemoteObjectID,
-            objectGroupTargetsByGroup: objectGroupTargetsByGroup,
+            objectGroupRuntimeAgentTargetsByGroup: objectGroupRuntimeAgentTargetsByGroup,
             unsupportedCommandsByTargetID: unsupportedCommandsByTargetID
         )
     }
@@ -142,6 +153,7 @@ package final class RuntimeSession {
         if selectedContextID == contextID {
             selectedContextID = nil
         }
+        releaseRemoteObjects(executionContextID: context.id)
     }
 
     package func applyExecutionContextsCleared(runtimeAgentTargetID: ProtocolTargetIdentifier) {
@@ -150,9 +162,6 @@ package final class RuntimeSession {
                 .filter { $0.runtimeAgentTargetID == runtimeAgentTargetID }
                 .map(\.id)
         )
-        guard removedContextIDs.isEmpty == false else {
-            return
-        }
         let removedTargetIDs = Set(removedContextIDs.compactMap { executionContextsByID[$0]?.targetID })
         executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
         for targetID in removedTargetIDs {
@@ -165,6 +174,7 @@ package final class RuntimeSession {
            removedContextIDs.contains(selectedContextID) {
             self.selectedContextID = nil
         }
+        releaseRemoteObjects(runtimeAgentTargetID: runtimeAgentTargetID)
     }
 
     package func selectExecutionContext(_ contextID: ExecutionContextID?) {
@@ -194,13 +204,9 @@ package final class RuntimeSession {
                 normalContextIDByTargetID.removeValue(forKey: removedTargetID)
             }
         }
-        remoteObjectsByID = remoteObjectsByID.filter { $0.key.targetID != targetID }
-        objectGroupByRemoteObjectID = objectGroupByRemoteObjectID.filter { $0.key.targetID != targetID }
-        for group in Array(objectGroupTargetsByGroup.keys) {
-            objectGroupTargetsByGroup[group]?.remove(targetID)
-            if objectGroupTargetsByGroup[group]?.isEmpty == true {
-                objectGroupTargetsByGroup.removeValue(forKey: group)
-            }
+        releaseRemoteObjects(runtimeAgentTargetID: targetID)
+        for contextID in removedContextIDs {
+            releaseRemoteObjects(executionContextID: contextID)
         }
         unsupportedCommandsByTargetID.removeValue(forKey: targetID)
         if let selectedContextID,
@@ -220,21 +226,19 @@ package final class RuntimeSession {
             if let normalContextID = normalContextIDByTargetID.removeValue(forKey: oldTargetID) {
                 normalContextIDByTargetID[newTargetID] = normalContextID
             }
-            var movedObjects: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload] = [:]
-            var movedObjectGroups: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup] = [:]
-            for (key, object) in remoteObjectsByID where key.targetID == oldTargetID {
-                let newKey = RuntimeRemoteObjectIdentifierKey(targetID: newTargetID, objectID: key.objectID)
-                movedObjects[newKey] = object
+            var movedObjects: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectRecord] = [:]
+            for (key, record) in remoteObjectsByID where key.runtimeAgentTargetID == oldTargetID {
+                let newKey = RuntimeRemoteObjectIdentifierKey(
+                    runtimeAgentTargetID: newTargetID,
+                    objectID: key.objectID
+                )
+                movedObjects[newKey] = record
                 remoteObjectsByID.removeValue(forKey: key)
-                if let group = objectGroupByRemoteObjectID.removeValue(forKey: key) {
-                    movedObjectGroups[newKey] = group
-                }
             }
             remoteObjectsByID.merge(movedObjects) { _, new in new }
-            objectGroupByRemoteObjectID.merge(movedObjectGroups) { _, new in new }
-            for group in objectGroupTargetsByGroup.keys {
-                if objectGroupTargetsByGroup[group]?.remove(oldTargetID) != nil {
-                    objectGroupTargetsByGroup[group]?.insert(newTargetID)
+            for group in objectGroupRuntimeAgentTargetsByGroup.keys {
+                if objectGroupRuntimeAgentTargetsByGroup[group]?.remove(oldTargetID) != nil {
+                    objectGroupRuntimeAgentTargetsByGroup[group]?.insert(newTargetID)
                 }
             }
             if let unsupported = unsupportedCommandsByTargetID.removeValue(forKey: oldTargetID) {
@@ -245,47 +249,45 @@ package final class RuntimeSession {
 
     package func registerRemoteObject(
         _ object: RuntimeRemoteObjectPayload,
-        targetID: ProtocolTargetIdentifier,
-        objectGroup: RuntimeObjectGroup? = nil
+        runtimeAgentTargetID: ProtocolTargetIdentifier,
+        objectGroup: RuntimeObjectGroup? = nil,
+        executionContextID: ExecutionContextID? = nil
     ) {
-        if let key = object.identifierKey(targetID: targetID) {
-            let previousGroup = objectGroupByRemoteObjectID[key]
-            remoteObjectsByID[key] = object
+        if let key = object.identifierKey(runtimeAgentTargetID: runtimeAgentTargetID) {
+            let previousGroup = remoteObjectsByID[key]?.objectGroup
+            remoteObjectsByID[key] = RuntimeRemoteObjectRecord(
+                payload: object,
+                objectGroup: objectGroup,
+                executionContextID: executionContextID
+            )
             if let objectGroup {
-                objectGroupByRemoteObjectID[key] = objectGroup
-                objectGroupTargetsByGroup[objectGroup, default: []].insert(targetID)
-            } else {
-                objectGroupByRemoteObjectID.removeValue(forKey: key)
+                objectGroupRuntimeAgentTargetsByGroup[objectGroup, default: []].insert(runtimeAgentTargetID)
             }
             if let previousGroup,
                previousGroup != objectGroup {
-                removeObjectGroupTargetIfEmpty(previousGroup, targetID: targetID)
+                removeObjectGroupTargetIfEmpty(previousGroup, runtimeAgentTargetID: runtimeAgentTargetID)
             }
         }
     }
 
     package func applyEvaluationResult(_ result: RuntimeEvaluationResultPayload, request: RuntimeEvaluationRequest) {
-        registerRemoteObject(result.result, targetID: request.targetID, objectGroup: request.objectGroup)
+        registerRemoteObject(
+            result.result,
+            runtimeAgentTargetID: request.runtimeAgentTargetID,
+            objectGroup: request.objectGroup,
+            executionContextID: request.contextID
+        )
     }
 
     package func releaseObject(_ key: RuntimeRemoteObjectIdentifierKey) {
-        remoteObjectsByID.removeValue(forKey: key)
-        if let objectGroup = objectGroupByRemoteObjectID.removeValue(forKey: key) {
-            removeObjectGroupTargetIfEmpty(objectGroup, targetID: key.targetID)
+        releaseRemoteObjects { candidateKey, _ in
+            candidateKey == key
         }
     }
 
-    package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, targetID: ProtocolTargetIdentifier) {
-        let releasedKeys = objectGroupByRemoteObjectID.compactMap { key, group in
-            key.targetID == targetID && group == objectGroup ? key : nil
-        }
-        for key in releasedKeys {
-            remoteObjectsByID.removeValue(forKey: key)
-            objectGroupByRemoteObjectID.removeValue(forKey: key)
-        }
-        objectGroupTargetsByGroup[objectGroup]?.remove(targetID)
-        if objectGroupTargetsByGroup[objectGroup]?.isEmpty == true {
-            objectGroupTargetsByGroup.removeValue(forKey: objectGroup)
+    package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, runtimeAgentTargetID: ProtocolTargetIdentifier) {
+        releaseRemoteObjects { key, record in
+            key.runtimeAgentTargetID == runtimeAgentTargetID && record.objectGroup == objectGroup
         }
     }
 
@@ -297,16 +299,52 @@ package final class RuntimeSession {
         unsupportedCommandsByTargetID[targetID]?.contains(method) != true
     }
 
-    private func removeObjectGroupTargetIfEmpty(_ objectGroup: RuntimeObjectGroup, targetID: ProtocolTargetIdentifier) {
-        let hasRemainingObject = objectGroupByRemoteObjectID.contains { key, group in
-            key.targetID == targetID && group == objectGroup
+    private func releaseRemoteObjects(runtimeAgentTargetID: ProtocolTargetIdentifier) {
+        releaseRemoteObjects { key, _ in
+            key.runtimeAgentTargetID == runtimeAgentTargetID
+        }
+    }
+
+    private func releaseRemoteObjects(executionContextID: ExecutionContextID) {
+        releaseRemoteObjects { _, record in
+            record.executionContextID == executionContextID
+        }
+    }
+
+    private func releaseRemoteObjects(
+        matching shouldRelease: (RuntimeRemoteObjectIdentifierKey, RuntimeRemoteObjectRecord) -> Bool
+    ) {
+        var releasedKeys: [RuntimeRemoteObjectIdentifierKey] = []
+        var affectedTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>] = [:]
+        for (key, record) in remoteObjectsByID where shouldRelease(key, record) {
+            releasedKeys.append(key)
+            if let objectGroup = record.objectGroup {
+                affectedTargetsByGroup[objectGroup, default: []].insert(key.runtimeAgentTargetID)
+            }
+        }
+        for key in releasedKeys {
+            remoteObjectsByID.removeValue(forKey: key)
+        }
+        for (objectGroup, runtimeAgentTargetIDs) in affectedTargetsByGroup {
+            for runtimeAgentTargetID in runtimeAgentTargetIDs {
+                removeObjectGroupTargetIfEmpty(objectGroup, runtimeAgentTargetID: runtimeAgentTargetID)
+            }
+        }
+    }
+
+    private func removeObjectGroupTargetIfEmpty(
+        _ objectGroup: RuntimeObjectGroup,
+        runtimeAgentTargetID: ProtocolTargetIdentifier
+    ) {
+        let hasRemainingObject = remoteObjectsByID.contains { key, record in
+            key.runtimeAgentTargetID == runtimeAgentTargetID && record.objectGroup == objectGroup
         }
         guard hasRemainingObject == false else {
             return
         }
-        objectGroupTargetsByGroup[objectGroup]?.remove(targetID)
-        if objectGroupTargetsByGroup[objectGroup]?.isEmpty == true {
-            objectGroupTargetsByGroup.removeValue(forKey: objectGroup)
+        objectGroupRuntimeAgentTargetsByGroup[objectGroup]?.remove(runtimeAgentTargetID)
+        if objectGroupRuntimeAgentTargetsByGroup[objectGroup]?.isEmpty == true {
+            objectGroupRuntimeAgentTargetsByGroup.removeValue(forKey: objectGroup)
         }
     }
 
@@ -336,7 +374,7 @@ package final class RuntimeSession {
         let context = evaluationContext(targetID: targetID, contextID: contextID)
         return .evaluate(
             RuntimeEvaluationRequest(
-                targetID: context?.runtimeAgentTargetID ?? targetID,
+                runtimeAgentTargetID: context?.runtimeAgentTargetID ?? targetID,
                 expression: expression,
                 objectGroup: objectGroup,
                 includeCommandLineAPI: true,

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -37,12 +37,12 @@ package struct RuntimeSessionSnapshot: Equatable, Sendable {
 package final class RuntimeSession {
     package private(set) var activeContextID: ExecutionContextID?
 
-    @ObservationIgnored private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
-    @ObservationIgnored private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
-    @ObservationIgnored private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
-    @ObservationIgnored private var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
-    @ObservationIgnored private var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
-    @ObservationIgnored private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
+    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    private var normalContextIDByTargetID: [ProtocolTargetIdentifier: ExecutionContextID]
+    private var remoteObjectsByID: [RuntimeRemoteObjectIdentifierKey: RuntimeRemoteObjectPayload]
+    private var objectGroupByRemoteObjectID: [RuntimeRemoteObjectIdentifierKey: RuntimeObjectGroup]
+    private var objectGroupTargetsByGroup: [RuntimeObjectGroup: Set<ProtocolTargetIdentifier>]
+    private var unsupportedCommandsByTargetID: [ProtocolTargetIdentifier: Set<String>]
 
     package init() {
         activeContextID = nil
@@ -223,15 +223,18 @@ package final class RuntimeSession {
         objectGroup: RuntimeObjectGroup? = nil
     ) {
         if let key = object.identifierKey(targetID: targetID) {
+            let previousGroup = objectGroupByRemoteObjectID[key]
             remoteObjectsByID[key] = object
             if let objectGroup {
                 objectGroupByRemoteObjectID[key] = objectGroup
+                objectGroupTargetsByGroup[objectGroup, default: []].insert(targetID)
             } else {
                 objectGroupByRemoteObjectID.removeValue(forKey: key)
             }
-        }
-        if let objectGroup {
-            objectGroupTargetsByGroup[objectGroup, default: []].insert(targetID)
+            if let previousGroup,
+               previousGroup != objectGroup {
+                removeObjectGroupTargetIfEmpty(previousGroup, targetID: targetID)
+            }
         }
     }
 
@@ -241,7 +244,9 @@ package final class RuntimeSession {
 
     package func releaseObject(_ key: RuntimeRemoteObjectIdentifierKey) {
         remoteObjectsByID.removeValue(forKey: key)
-        objectGroupByRemoteObjectID.removeValue(forKey: key)
+        if let objectGroup = objectGroupByRemoteObjectID.removeValue(forKey: key) {
+            removeObjectGroupTargetIfEmpty(objectGroup, targetID: key.targetID)
+        }
     }
 
     package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, targetID: ProtocolTargetIdentifier) {
@@ -264,6 +269,19 @@ package final class RuntimeSession {
 
     package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
         unsupportedCommandsByTargetID[targetID]?.contains(method) != true
+    }
+
+    private func removeObjectGroupTargetIfEmpty(_ objectGroup: RuntimeObjectGroup, targetID: ProtocolTargetIdentifier) {
+        let hasRemainingObject = objectGroupByRemoteObjectID.contains { key, group in
+            key.targetID == targetID && group == objectGroup
+        }
+        guard hasRemainingObject == false else {
+            return
+        }
+        objectGroupTargetsByGroup[objectGroup]?.remove(targetID)
+        if objectGroupTargetsByGroup[objectGroup]?.isEmpty == true {
+            objectGroupTargetsByGroup.removeValue(forKey: objectGroup)
+        }
     }
 
     private func normalContextIDToReplace(with context: RuntimeExecutionContext) -> ExecutionContextID? {

--- a/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
@@ -92,6 +92,8 @@ package struct RuntimeRemoteObjectIdentifierKey: Hashable, Sendable {
 }
 
 package struct RuntimeObjectGroup: RawRepresentable, Hashable, Codable, Sendable {
+    package static let console = Self("console")
+
     package let rawValue: String
 
     package init(_ rawValue: String) {

--- a/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
@@ -91,6 +91,16 @@ package struct RuntimeRemoteObjectIdentifierKey: Hashable, Sendable {
     }
 }
 
+package struct RuntimeExecutionContextKey: Hashable, Sendable {
+    package var runtimeAgentTargetID: ProtocolTargetIdentifier
+    package var contextID: ExecutionContextID
+
+    package init(runtimeAgentTargetID: ProtocolTargetIdentifier, contextID: ExecutionContextID) {
+        self.runtimeAgentTargetID = runtimeAgentTargetID
+        self.contextID = contextID
+    }
+}
+
 package struct RuntimeObjectGroup: RawRepresentable, Hashable, Codable, Sendable {
     package static let console = Self("console")
 

--- a/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
@@ -1,0 +1,637 @@
+import Foundation
+
+package enum JSONValue: Equatable, Sendable, Codable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .number(Double(value))
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value.")
+        }
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case let .bool(value):
+            try container.encode(value)
+        case let .number(value):
+            try container.encode(value)
+        case let .string(value):
+            try container.encode(value)
+        case let .array(value):
+            try container.encode(value)
+        case let .object(value):
+            try container.encode(value)
+        }
+    }
+
+    package var foundationObject: Any {
+        switch self {
+        case .null:
+            NSNull()
+        case let .bool(value):
+            value
+        case let .number(value):
+            value
+        case let .string(value):
+            value
+        case let .array(value):
+            value.map(\.foundationObject)
+        case let .object(value):
+            value.mapValues(\.foundationObject)
+        }
+    }
+}
+
+package struct RuntimeRemoteObjectIdentifier: RawRepresentable, Hashable, Codable, Sendable, CustomStringConvertible {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package var description: String {
+        rawValue
+    }
+}
+
+package struct RuntimeRemoteObjectIdentifierKey: Hashable, Sendable {
+    package var targetID: ProtocolTargetIdentifier
+    package var objectID: RuntimeRemoteObjectIdentifier
+
+    package init(targetID: ProtocolTargetIdentifier, objectID: RuntimeRemoteObjectIdentifier) {
+        self.targetID = targetID
+        self.objectID = objectID
+    }
+}
+
+package struct RuntimeObjectGroup: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+package struct RuntimeRemoteObjectType: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let object = Self("object")
+    package static let function = Self("function")
+    package static let undefined = Self("undefined")
+    package static let string = Self("string")
+    package static let number = Self("number")
+    package static let boolean = Self("boolean")
+    package static let symbol = Self("symbol")
+    package static let bigint = Self("bigint")
+}
+
+package struct RuntimeRemoteObjectSubtype: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let array = Self("array")
+    package static let null = Self("null")
+    package static let node = Self("node")
+    package static let regexp = Self("regexp")
+    package static let date = Self("date")
+    package static let error = Self("error")
+    package static let map = Self("map")
+    package static let set = Self("set")
+    package static let weakMap = Self("weakmap")
+    package static let weakSet = Self("weakset")
+    package static let iterator = Self("iterator")
+    package static let `class` = Self("class")
+    package static let proxy = Self("proxy")
+    package static let weakRef = Self("weakref")
+}
+
+package struct RuntimeExecutionContextType: RawRepresentable, Hashable, Codable, Sendable {
+    package let rawValue: String
+
+    package init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    package static let normal = Self("normal")
+    package static let user = Self("user")
+    package static let `internal` = Self("internal")
+}
+
+package struct RuntimeExecutionContextPayload: Equatable, Sendable, Decodable {
+    package var id: ExecutionContextID
+    package var type: RuntimeExecutionContextType?
+    package var name: String?
+    package var frameID: DOMFrameIdentifier?
+
+    package init(
+        id: ExecutionContextID,
+        type: RuntimeExecutionContextType? = nil,
+        name: String? = nil,
+        frameID: DOMFrameIdentifier? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.name = name
+        self.frameID = frameID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case name
+        case frameID = "frameId"
+    }
+}
+
+package final class RuntimeRemoteObjectPayloadBox: Codable, Equatable, @unchecked Sendable {
+    package let value: RuntimeRemoteObjectPayload
+
+    package init(_ value: RuntimeRemoteObjectPayload) {
+        self.value = value
+    }
+
+    package init(from decoder: any Decoder) throws {
+        value = try RuntimeRemoteObjectPayload(from: decoder)
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        try value.encode(to: encoder)
+    }
+
+    package static func == (lhs: RuntimeRemoteObjectPayloadBox, rhs: RuntimeRemoteObjectPayloadBox) -> Bool {
+        lhs.value == rhs.value
+    }
+}
+
+package final class RuntimeObjectPreviewPayloadBox: Codable, Equatable, @unchecked Sendable {
+    package let value: RuntimeObjectPreviewPayload
+
+    package init(_ value: RuntimeObjectPreviewPayload) {
+        self.value = value
+    }
+
+    package init(from decoder: any Decoder) throws {
+        value = try RuntimeObjectPreviewPayload(from: decoder)
+    }
+
+    package func encode(to encoder: any Encoder) throws {
+        try value.encode(to: encoder)
+    }
+
+    package static func == (lhs: RuntimeObjectPreviewPayloadBox, rhs: RuntimeObjectPreviewPayloadBox) -> Bool {
+        lhs.value == rhs.value
+    }
+}
+
+package struct RuntimeRemoteObjectPayload: Equatable, Sendable, Codable {
+    package var type: RuntimeRemoteObjectType
+    package var subtype: RuntimeRemoteObjectSubtype?
+    package var className: String?
+    package var value: JSONValue?
+    package var description: String?
+    package var objectID: RuntimeRemoteObjectIdentifier?
+    package var size: Int?
+    package var classPrototype: RuntimeRemoteObjectPayloadBox?
+    package var preview: RuntimeObjectPreviewPayload?
+
+    package init(
+        type: RuntimeRemoteObjectType,
+        subtype: RuntimeRemoteObjectSubtype? = nil,
+        className: String? = nil,
+        value: JSONValue? = nil,
+        description: String? = nil,
+        objectID: RuntimeRemoteObjectIdentifier? = nil,
+        size: Int? = nil,
+        classPrototype: RuntimeRemoteObjectPayloadBox? = nil,
+        preview: RuntimeObjectPreviewPayload? = nil
+    ) {
+        self.type = type
+        self.subtype = subtype
+        self.className = className
+        self.value = value
+        self.description = description
+        self.objectID = objectID
+        self.size = size
+        self.classPrototype = classPrototype
+        self.preview = preview
+    }
+
+    package func identifierKey(targetID: ProtocolTargetIdentifier) -> RuntimeRemoteObjectIdentifierKey? {
+        objectID.map { RuntimeRemoteObjectIdentifierKey(targetID: targetID, objectID: $0) }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case subtype
+        case className
+        case value
+        case description
+        case objectID = "objectId"
+        case size
+        case classPrototype
+        case preview
+    }
+}
+
+package struct RuntimeObjectPreviewPayload: Equatable, Sendable, Codable {
+    package var type: RuntimeRemoteObjectType
+    package var subtype: RuntimeRemoteObjectSubtype?
+    package var description: String?
+    package var lossless: Bool
+    package var overflow: Bool?
+    package var properties: [RuntimePropertyPreviewPayload]
+    package var entries: [RuntimeEntryPreviewPayload]
+    package var size: Int?
+
+    package init(
+        type: RuntimeRemoteObjectType,
+        subtype: RuntimeRemoteObjectSubtype? = nil,
+        description: String? = nil,
+        lossless: Bool,
+        overflow: Bool? = nil,
+        properties: [RuntimePropertyPreviewPayload] = [],
+        entries: [RuntimeEntryPreviewPayload] = [],
+        size: Int? = nil
+    ) {
+        self.type = type
+        self.subtype = subtype
+        self.description = description
+        self.lossless = lossless
+        self.overflow = overflow
+        self.properties = properties
+        self.entries = entries
+        self.size = size
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case subtype
+        case description
+        case lossless
+        case overflow
+        case properties
+        case entries
+        case size
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(RuntimeRemoteObjectType.self, forKey: .type)
+        subtype = try container.decodeIfPresent(RuntimeRemoteObjectSubtype.self, forKey: .subtype)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        lossless = try container.decodeIfPresent(Bool.self, forKey: .lossless) ?? false
+        overflow = try container.decodeIfPresent(Bool.self, forKey: .overflow)
+        properties = try container.decodeIfPresent([RuntimePropertyPreviewPayload].self, forKey: .properties) ?? []
+        entries = try container.decodeIfPresent([RuntimeEntryPreviewPayload].self, forKey: .entries) ?? []
+        size = try container.decodeIfPresent(Int.self, forKey: .size)
+    }
+}
+
+package struct RuntimePropertyPreviewPayload: Equatable, Sendable, Codable {
+    package var name: String
+    package var type: RuntimeRemoteObjectType
+    package var subtype: RuntimeRemoteObjectSubtype?
+    package var value: String?
+    package var valuePreview: RuntimeObjectPreviewPayloadBox?
+    package var isPrivate: Bool?
+    package var isInternal: Bool?
+
+    package init(
+        name: String,
+        type: RuntimeRemoteObjectType,
+        subtype: RuntimeRemoteObjectSubtype? = nil,
+        value: String? = nil,
+        valuePreview: RuntimeObjectPreviewPayloadBox? = nil,
+        isPrivate: Bool? = nil,
+        isInternal: Bool? = nil
+    ) {
+        self.name = name
+        self.type = type
+        self.subtype = subtype
+        self.value = value
+        self.valuePreview = valuePreview
+        self.isPrivate = isPrivate
+        self.isInternal = isInternal
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case subtype
+        case value
+        case valuePreview
+        case isPrivate
+        case isInternal = "internal"
+    }
+}
+
+package struct RuntimeEntryPreviewPayload: Equatable, Sendable, Codable {
+    package var key: RuntimeObjectPreviewPayloadBox?
+    package var value: RuntimeObjectPreviewPayloadBox
+
+    package init(key: RuntimeObjectPreviewPayloadBox? = nil, value: RuntimeObjectPreviewPayloadBox) {
+        self.key = key
+        self.value = value
+    }
+}
+
+package struct RuntimePropertyDescriptorPayload: Equatable, Sendable, Codable {
+    package var name: String
+    package var value: RuntimeRemoteObjectPayload?
+    package var writable: Bool?
+    package var get: RuntimeRemoteObjectPayload?
+    package var set: RuntimeRemoteObjectPayload?
+    package var wasThrown: Bool?
+    package var configurable: Bool?
+    package var enumerable: Bool?
+    package var isOwn: Bool?
+    package var symbol: RuntimeRemoteObjectPayload?
+    package var isPrivate: Bool?
+    package var nativeGetter: Bool?
+
+    package init(
+        name: String,
+        value: RuntimeRemoteObjectPayload? = nil,
+        writable: Bool? = nil,
+        get: RuntimeRemoteObjectPayload? = nil,
+        set: RuntimeRemoteObjectPayload? = nil,
+        wasThrown: Bool? = nil,
+        configurable: Bool? = nil,
+        enumerable: Bool? = nil,
+        isOwn: Bool? = nil,
+        symbol: RuntimeRemoteObjectPayload? = nil,
+        isPrivate: Bool? = nil,
+        nativeGetter: Bool? = nil
+    ) {
+        self.name = name
+        self.value = value
+        self.writable = writable
+        self.get = get
+        self.set = set
+        self.wasThrown = wasThrown
+        self.configurable = configurable
+        self.enumerable = enumerable
+        self.isOwn = isOwn
+        self.symbol = symbol
+        self.isPrivate = isPrivate
+        self.nativeGetter = nativeGetter
+    }
+}
+
+package struct RuntimeInternalPropertyDescriptorPayload: Equatable, Sendable, Codable {
+    package var name: String
+    package var value: RuntimeRemoteObjectPayload?
+
+    package init(name: String, value: RuntimeRemoteObjectPayload? = nil) {
+        self.name = name
+        self.value = value
+    }
+}
+
+package struct RuntimeCollectionEntryPayload: Equatable, Sendable, Codable {
+    package var key: RuntimeRemoteObjectPayload?
+    package var value: RuntimeRemoteObjectPayload
+
+    package init(key: RuntimeRemoteObjectPayload? = nil, value: RuntimeRemoteObjectPayload) {
+        self.key = key
+        self.value = value
+    }
+}
+
+package struct RuntimeEvaluationResultPayload: Equatable, Sendable, Codable {
+    package var result: RuntimeRemoteObjectPayload
+    package var wasThrown: Bool
+    package var savedResultIndex: Int?
+
+    package init(result: RuntimeRemoteObjectPayload, wasThrown: Bool = false, savedResultIndex: Int? = nil) {
+        self.result = result
+        self.wasThrown = wasThrown
+        self.savedResultIndex = savedResultIndex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case result
+        case wasThrown
+        case savedResultIndex
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        result = try container.decode(RuntimeRemoteObjectPayload.self, forKey: .result)
+        wasThrown = try container.decodeIfPresent(Bool.self, forKey: .wasThrown) ?? false
+        savedResultIndex = try container.decodeIfPresent(Int.self, forKey: .savedResultIndex)
+    }
+}
+
+package struct RuntimePropertiesResultPayload: Equatable, Sendable, Codable {
+    package var properties: [RuntimePropertyDescriptorPayload]
+    package var internalProperties: [RuntimeInternalPropertyDescriptorPayload]
+
+    package init(
+        properties: [RuntimePropertyDescriptorPayload] = [],
+        internalProperties: [RuntimeInternalPropertyDescriptorPayload] = []
+    ) {
+        self.properties = properties
+        self.internalProperties = internalProperties
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case properties
+        case internalProperties
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        properties = try container.decodeIfPresent([RuntimePropertyDescriptorPayload].self, forKey: .properties) ?? []
+        internalProperties = try container.decodeIfPresent(
+            [RuntimeInternalPropertyDescriptorPayload].self,
+            forKey: .internalProperties
+        ) ?? []
+    }
+}
+
+package struct RuntimeCollectionEntriesResultPayload: Equatable, Sendable, Codable {
+    package var entries: [RuntimeCollectionEntryPayload]
+
+    package init(entries: [RuntimeCollectionEntryPayload] = []) {
+        self.entries = entries
+    }
+}
+
+package struct RuntimePreviewResultPayload: Equatable, Sendable, Codable {
+    package var preview: RuntimeObjectPreviewPayload
+
+    package init(preview: RuntimeObjectPreviewPayload) {
+        self.preview = preview
+    }
+}
+
+package struct RuntimeSaveResultPayload: Equatable, Sendable, Codable {
+    package var savedResultIndex: Int?
+
+    package init(savedResultIndex: Int? = nil) {
+        self.savedResultIndex = savedResultIndex
+    }
+}
+
+package struct RuntimeCallArgumentPayload: Equatable, Sendable {
+    package var value: JSONValue?
+    package var objectID: RuntimeRemoteObjectIdentifier?
+
+    package init(value: JSONValue? = nil, objectID: RuntimeRemoteObjectIdentifier? = nil) {
+        self.value = value
+        self.objectID = objectID
+    }
+
+    package var parametersObject: [String: Any] {
+        var object: [String: Any] = [:]
+        if let value {
+            object["value"] = value.foundationObject
+        }
+        if let objectID {
+            object["objectId"] = objectID.rawValue
+        }
+        return object
+    }
+}
+
+package struct RuntimeEvaluationRequest: Equatable, Sendable {
+    package var targetID: ProtocolTargetIdentifier
+    package var expression: String
+    package var objectGroup: RuntimeObjectGroup?
+    package var includeCommandLineAPI: Bool?
+    package var doNotPauseOnExceptionsAndMuteConsole: Bool?
+    package var contextID: ExecutionContextID?
+    package var returnByValue: Bool?
+    package var generatePreview: Bool?
+    package var saveResult: Bool?
+    package var emulateUserGesture: Bool?
+
+    package init(
+        targetID: ProtocolTargetIdentifier,
+        expression: String,
+        objectGroup: RuntimeObjectGroup? = nil,
+        includeCommandLineAPI: Bool? = nil,
+        doNotPauseOnExceptionsAndMuteConsole: Bool? = nil,
+        contextID: ExecutionContextID? = nil,
+        returnByValue: Bool? = nil,
+        generatePreview: Bool? = nil,
+        saveResult: Bool? = nil,
+        emulateUserGesture: Bool? = nil
+    ) {
+        self.targetID = targetID
+        self.expression = expression
+        self.objectGroup = objectGroup
+        self.includeCommandLineAPI = includeCommandLineAPI
+        self.doNotPauseOnExceptionsAndMuteConsole = doNotPauseOnExceptionsAndMuteConsole
+        self.contextID = contextID
+        self.returnByValue = returnByValue
+        self.generatePreview = generatePreview
+        self.saveResult = saveResult
+        self.emulateUserGesture = emulateUserGesture
+    }
+}
+
+package enum RuntimeCommandIntent: Equatable, Sendable {
+    case enable(targetID: ProtocolTargetIdentifier)
+    case evaluate(RuntimeEvaluationRequest)
+    case getPreview(object: RuntimeRemoteObjectIdentifierKey)
+    case getProperties(
+        object: RuntimeRemoteObjectIdentifierKey,
+        ownProperties: Bool?,
+        fetchStart: Int?,
+        fetchCount: Int?,
+        generatePreview: Bool?
+    )
+    case getDisplayableProperties(
+        object: RuntimeRemoteObjectIdentifierKey,
+        fetchStart: Int?,
+        fetchCount: Int?,
+        generatePreview: Bool?
+    )
+    case getCollectionEntries(
+        object: RuntimeRemoteObjectIdentifierKey,
+        objectGroup: RuntimeObjectGroup?,
+        fetchStart: Int?,
+        fetchCount: Int?
+    )
+    case saveResult(targetID: ProtocolTargetIdentifier, argument: RuntimeCallArgumentPayload, contextID: ExecutionContextID?)
+    case setSavedResultAlias(targetID: ProtocolTargetIdentifier, alias: String?)
+    case releaseObject(RuntimeRemoteObjectIdentifierKey)
+    case releaseObjectGroup(targetID: ProtocolTargetIdentifier, objectGroup: RuntimeObjectGroup)
+
+    package var targetID: ProtocolTargetIdentifier {
+        switch self {
+        case let .enable(targetID):
+            targetID
+        case let .evaluate(request):
+            request.targetID
+        case let .getPreview(object):
+            object.targetID
+        case let .getProperties(object, _, _, _, _):
+            object.targetID
+        case let .getDisplayableProperties(object, _, _, _):
+            object.targetID
+        case let .getCollectionEntries(object, _, _, _):
+            object.targetID
+        case let .saveResult(targetID, _, _):
+            targetID
+        case let .setSavedResultAlias(targetID, _):
+            targetID
+        case let .releaseObject(object):
+            object.targetID
+        case let .releaseObjectGroup(targetID, _):
+            targetID
+        }
+    }
+}

--- a/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeProtocol.swift
@@ -82,11 +82,11 @@ package struct RuntimeRemoteObjectIdentifier: RawRepresentable, Hashable, Codabl
 }
 
 package struct RuntimeRemoteObjectIdentifierKey: Hashable, Sendable {
-    package var targetID: ProtocolTargetIdentifier
+    package var runtimeAgentTargetID: ProtocolTargetIdentifier
     package var objectID: RuntimeRemoteObjectIdentifier
 
-    package init(targetID: ProtocolTargetIdentifier, objectID: RuntimeRemoteObjectIdentifier) {
-        self.targetID = targetID
+    package init(runtimeAgentTargetID: ProtocolTargetIdentifier, objectID: RuntimeRemoteObjectIdentifier) {
+        self.runtimeAgentTargetID = runtimeAgentTargetID
         self.objectID = objectID
     }
 }
@@ -268,8 +268,8 @@ package struct RuntimeRemoteObjectPayload: Equatable, Sendable, Codable {
         self.preview = preview
     }
 
-    package func identifierKey(targetID: ProtocolTargetIdentifier) -> RuntimeRemoteObjectIdentifierKey? {
-        objectID.map { RuntimeRemoteObjectIdentifierKey(targetID: targetID, objectID: $0) }
+    package func identifierKey(runtimeAgentTargetID: ProtocolTargetIdentifier) -> RuntimeRemoteObjectIdentifierKey? {
+        objectID.map { RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: runtimeAgentTargetID, objectID: $0) }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -548,7 +548,7 @@ package struct RuntimeCallArgumentPayload: Equatable, Sendable {
 }
 
 package struct RuntimeEvaluationRequest: Equatable, Sendable {
-    package var targetID: ProtocolTargetIdentifier
+    package var runtimeAgentTargetID: ProtocolTargetIdentifier
     package var expression: String
     package var objectGroup: RuntimeObjectGroup?
     package var includeCommandLineAPI: Bool?
@@ -560,7 +560,7 @@ package struct RuntimeEvaluationRequest: Equatable, Sendable {
     package var emulateUserGesture: Bool?
 
     package init(
-        targetID: ProtocolTargetIdentifier,
+        runtimeAgentTargetID: ProtocolTargetIdentifier,
         expression: String,
         objectGroup: RuntimeObjectGroup? = nil,
         includeCommandLineAPI: Bool? = nil,
@@ -571,7 +571,7 @@ package struct RuntimeEvaluationRequest: Equatable, Sendable {
         saveResult: Bool? = nil,
         emulateUserGesture: Bool? = nil
     ) {
-        self.targetID = targetID
+        self.runtimeAgentTargetID = runtimeAgentTargetID
         self.expression = expression
         self.objectGroup = objectGroup
         self.includeCommandLineAPI = includeCommandLineAPI
@@ -610,30 +610,30 @@ package enum RuntimeCommandIntent: Equatable, Sendable {
     case saveResult(targetID: ProtocolTargetIdentifier, argument: RuntimeCallArgumentPayload, contextID: ExecutionContextID?)
     case setSavedResultAlias(targetID: ProtocolTargetIdentifier, alias: String?)
     case releaseObject(RuntimeRemoteObjectIdentifierKey)
-    case releaseObjectGroup(targetID: ProtocolTargetIdentifier, objectGroup: RuntimeObjectGroup)
+    case releaseObjectGroup(runtimeAgentTargetID: ProtocolTargetIdentifier, objectGroup: RuntimeObjectGroup)
 
-    package var targetID: ProtocolTargetIdentifier {
+    package var routingTargetID: ProtocolTargetIdentifier {
         switch self {
         case let .enable(targetID):
             targetID
         case let .evaluate(request):
-            request.targetID
+            request.runtimeAgentTargetID
         case let .getPreview(object):
-            object.targetID
+            object.runtimeAgentTargetID
         case let .getProperties(object, _, _, _, _):
-            object.targetID
+            object.runtimeAgentTargetID
         case let .getDisplayableProperties(object, _, _, _):
-            object.targetID
+            object.runtimeAgentTargetID
         case let .getCollectionEntries(object, _, _, _):
-            object.targetID
+            object.runtimeAgentTargetID
         case let .saveResult(targetID, _, _):
             targetID
         case let .setSavedResultAlias(targetID, _):
             targetID
         case let .releaseObject(object):
-            object.targetID
-        case let .releaseObjectGroup(targetID, _):
-            targetID
+            object.runtimeAgentTargetID
+        case let .releaseObjectGroup(runtimeAgentTargetID, _):
+            runtimeAgentTargetID
         }
     }
 }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import ObservationBridge
 import OSLog
 import Synchronization
 import WebKit
@@ -19,6 +20,15 @@ private enum InspectorRuntimeLog {
     static func warning(_ message: String) {
         logger.warning("\(message, privacy: .public)")
     }
+}
+
+private enum SelectedNodeStyleHydrationState {
+    case detached
+    case waitingForDocument
+    case unavailable(CSSNodeStylesUnavailableReason)
+    case needsRefresh(CSSNodeStyleIdentity)
+    case refreshing(CSSNodeStyleIdentity)
+    case current(CSSNodeStyleIdentity)
 }
 
 package struct InspectorSessionError: Error, Equatable, Sendable, CustomStringConvertible {
@@ -302,8 +312,10 @@ package final class InspectorSession {
     @ObservationIgnored private var deleteUndoStates: [DOMDeleteUndoState]
     @ObservationIgnored private let deleteUndoOperationQueue: DOMDeleteUndoOperationQueue
     @ObservationIgnored private var domDocumentRequestHandlesByTargetID: [ProtocolTargetIdentifier: DOMDocumentRequestHandle]
-    @ObservationIgnored private var cssSelectedNodeRefreshTask: Task<Void, Never>?
-    @ObservationIgnored private var cssSelectedNodeRefreshIdentity: CSSNodeStyleIdentity?
+    @ObservationIgnored private var selectedNodeStyleHydrationObservationTask: Task<Void, Never>?
+    @ObservationIgnored private var selectedNodeStyleHydrationTask: Task<Void, Never>?
+    @ObservationIgnored private var selectedNodeStyleHydrationIdentity: CSSNodeStyleIdentity?
+    @ObservationIgnored private var isSelectedNodeStyleHydrationActive: Bool
     @ObservationIgnored private var cssPropertyUpdateTasks: [CSSPropertyIdentifier: Task<Void, Never>]
 
     package init(
@@ -333,8 +345,10 @@ package final class InspectorSession {
         deleteUndoStates = []
         deleteUndoOperationQueue = DOMDeleteUndoOperationQueue()
         domDocumentRequestHandlesByTargetID = [:]
-        cssSelectedNodeRefreshTask = nil
-        cssSelectedNodeRefreshIdentity = nil
+        selectedNodeStyleHydrationObservationTask = nil
+        selectedNodeStyleHydrationTask = nil
+        selectedNodeStyleHydrationIdentity = nil
+        isSelectedNodeStyleHydrationActive = false
         cssPropertyUpdateTasks = [:]
     }
 
@@ -410,6 +424,9 @@ package final class InspectorSession {
             pendingConnection = nil
             connection = nextConnection
             isAttached = true
+            if isSelectedNodeStyleHydrationActive {
+                startSelectedNodeStyleHydration()
+            }
             startDOMDocumentRequestsForAttachedFrameTargets()
             startRuntimeConsoleEnableForAttachedTargets()
             lastError = nil
@@ -428,6 +445,7 @@ package final class InspectorSession {
             await transport.detach()
             restoreInspectabilityIfNeeded(for: nextConnection)
             cancelCSSActionRequests()
+            stopSelectedNodeStyleHydration()
             dom.reset()
             css.reset()
             network.reset()
@@ -449,6 +467,7 @@ package final class InspectorSession {
         connection = nil
         pendingConnection = nil
         isAttached = false
+        stopSelectedNodeStyleHydration()
 
         if let previousConnection {
             cancelRuntimeConsoleEnableTasks(previousConnection)
@@ -906,16 +925,15 @@ package final class InspectorSession {
         }
     }
 
-    package func requestRefreshStylesForSelectedNode() {
-        guard isAttached else {
+    package func setSelectedNodeStyleHydrationActive(_ isActive: Bool) {
+        guard isSelectedNodeStyleHydrationActive != isActive else {
             return
         }
-
-        switch dom.selectedCSSNodeStyleIdentity() {
-        case let .success(identity):
-            requestStyleRefresh(for: identity)
-        case let .failure(reason):
-            css.markSelectedNodeUnavailable(reason)
+        isSelectedNodeStyleHydrationActive = isActive
+        if isActive, isAttached {
+            startSelectedNodeStyleHydration()
+        } else {
+            stopSelectedNodeStyleHydration()
         }
     }
 
@@ -963,25 +981,94 @@ package final class InspectorSession {
         lastError = nil
     }
 
-    private func requestStyleRefresh(for identity: CSSNodeStyleIdentity) {
-        guard cssSelectedNodeRefreshIdentity != identity else {
+    private func startSelectedNodeStyleHydration() {
+        selectedNodeStyleHydrationObservationTask?.cancel()
+        selectedNodeStyleHydrationObservationTask = Task { @MainActor [weak self] in
+            let stream = makeObservationBridgeStream {
+                self?.selectedNodeStyleHydrationState() ?? .detached
+            }
+            for await state in stream {
+                guard let self else {
+                    return
+                }
+                self.applySelectedNodeStyleHydrationState(state)
+            }
+        }
+    }
+
+    private func stopSelectedNodeStyleHydration() {
+        selectedNodeStyleHydrationObservationTask?.cancel()
+        selectedNodeStyleHydrationObservationTask = nil
+        selectedNodeStyleHydrationTask?.cancel()
+        selectedNodeStyleHydrationTask = nil
+        selectedNodeStyleHydrationIdentity = nil
+    }
+
+    private func selectedNodeStyleHydrationState() -> SelectedNodeStyleHydrationState {
+        guard isAttached else {
+            return .detached
+        }
+        guard dom.currentPageRootNode != nil else {
+            return .waitingForDocument
+        }
+
+        switch dom.selectedCSSNodeStyleIdentity() {
+        case let .success(identity):
+            switch css.refreshState(forSelected: identity) {
+            case nil, .needsRefresh:
+                return .needsRefresh(identity)
+            case .loading:
+                return .refreshing(identity)
+            case .loaded, .failed(_), .unavailable(_):
+                return .current(identity)
+            }
+        case let .failure(reason):
+            return .unavailable(reason)
+        }
+    }
+
+    private func applySelectedNodeStyleHydrationState(_ state: SelectedNodeStyleHydrationState) {
+        switch state {
+        case .detached, .waitingForDocument, .refreshing, .current:
+            return
+        case .unavailable(let reason):
+            selectedNodeStyleHydrationTask?.cancel()
+            selectedNodeStyleHydrationTask = nil
+            selectedNodeStyleHydrationIdentity = nil
+            css.markSelectedNodeUnavailable(reason)
+        case .needsRefresh(let identity):
+            hydrateSelectedNodeStyles(identity)
+        }
+    }
+
+    private func hydrateSelectedNodeStyles(_ identity: CSSNodeStyleIdentity) {
+        guard selectedNodeStyleHydrationIdentity != identity else {
             return
         }
 
-        cssSelectedNodeRefreshTask?.cancel()
-        cssSelectedNodeRefreshIdentity = identity
-        let task = Task { @MainActor [weak self] in
+        selectedNodeStyleHydrationTask?.cancel()
+        selectedNodeStyleHydrationIdentity = identity
+        selectedNodeStyleHydrationTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                if self.selectedNodeStyleHydrationIdentity == identity {
+                    self.selectedNodeStyleHydrationIdentity = nil
+                    self.selectedNodeStyleHydrationTask = nil
+                }
+            }
             guard Task.isCancelled == false else {
                 return
             }
-            await self?.refreshStylesForSelectedNode()
-            guard let self, cssSelectedNodeRefreshIdentity == identity else {
-                return
+
+            do {
+                try await self.refreshStyles(for: identity)
+                self.lastError = nil
+            } catch {
+                self.lastError = InspectorSessionError(String(describing: error))
             }
-            cssSelectedNodeRefreshIdentity = nil
-            cssSelectedNodeRefreshTask = nil
         }
-        cssSelectedNodeRefreshTask = task
     }
 
     private func refreshSelectedNodeStyles() async throws {
@@ -995,6 +1082,11 @@ package final class InspectorSession {
 
     private func refreshStyles(for identity: CSSNodeStyleIdentity) async throws {
         let connection = try activeConnection()
+        let targetExists = await connection.transport.snapshot().targetsByID[identity.targetID] != nil
+        guard targetExists else {
+            css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+            return
+        }
         guard let token = css.beginRefresh(identity: identity) else {
             return
         }
@@ -1794,9 +1886,9 @@ package final class InspectorSession {
     }
 
     private func cancelCSSActionRequests() {
-        cssSelectedNodeRefreshTask?.cancel()
-        cssSelectedNodeRefreshTask = nil
-        cssSelectedNodeRefreshIdentity = nil
+        selectedNodeStyleHydrationTask?.cancel()
+        selectedNodeStyleHydrationTask = nil
+        selectedNodeStyleHydrationIdentity = nil
 
         for task in cssPropertyUpdateTasks.values {
             task.cancel()

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -867,7 +867,11 @@ package final class InspectorSession {
         switch intent {
         case let .evaluate(request):
             let payload = try RuntimeTransportAdapter.evaluationResult(from: result)
-            runtime.applyEvaluationResult(payload, request: request)
+            runtime.applyEvaluationResult(
+                payload,
+                request: request,
+                runtimeAgentTargetID: result.targetID
+            )
         case let .releaseObject(key):
             runtime.releaseObject(key)
         case let .releaseObjectGroup(runtimeAgentTargetID, objectGroup):

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1171,7 +1171,8 @@ package final class InspectorSession {
         guard isAttached,
               let connection,
               connection.runtimeConsoleEnableTasksByTargetID[targetID] == nil,
-              shouldEnableConsoleAgents(targetID: targetID, connection: connection) else {
+              shouldEnableRuntimeAgent(targetID: targetID, connection: connection)
+                  || shouldEnableConsoleAgent(targetID: targetID, connection: connection) else {
             return
         }
 
@@ -1193,7 +1194,21 @@ package final class InspectorSession {
         connection.runtimeConsoleEnableTasksByTargetID[targetID] = task
     }
 
-    private func shouldEnableConsoleAgents(
+    private func shouldEnableRuntimeAgent(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection
+    ) -> Bool {
+        guard let target = dom.snapshot().targetsByID[targetID],
+              target.isProvisional == false,
+              target.capabilities.contains(.runtime),
+              connection.runtimeEnabledTargetIDs.contains(targetID) == false,
+              runtime.supportsCommand("Runtime.enable", targetID: targetID) else {
+            return false
+        }
+        return true
+    }
+
+    private func shouldEnableConsoleAgent(
         targetID: ProtocolTargetIdentifier,
         connection: InspectorConnection
     ) -> Bool {
@@ -1212,8 +1227,7 @@ package final class InspectorSession {
         connection: InspectorConnection
     ) async throws {
         guard let target = dom.snapshot().targetsByID[targetID],
-              target.isProvisional == false,
-              target.capabilities.contains(.console) else {
+              target.isProvisional == false else {
             return
         }
 
@@ -1230,7 +1244,8 @@ package final class InspectorSession {
             }
         }
 
-        guard connection.consoleEnabledTargetIDs.contains(targetID) == false,
+        guard target.capabilities.contains(.console),
+              connection.consoleEnabledTargetIDs.contains(targetID) == false,
               console.supportsCommand("Console.enable", targetID: targetID) else {
             return
         }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -999,9 +999,7 @@ package final class InspectorSession {
     private func stopSelectedNodeStyleHydration() {
         selectedNodeStyleHydrationObservationTask?.cancel()
         selectedNodeStyleHydrationObservationTask = nil
-        selectedNodeStyleHydrationTask?.cancel()
-        selectedNodeStyleHydrationTask = nil
-        selectedNodeStyleHydrationIdentity = nil
+        cancelSelectedNodeStyleHydrationRefresh()
     }
 
     private func selectedNodeStyleHydrationState() -> SelectedNodeStyleHydrationState {
@@ -1032,9 +1030,7 @@ package final class InspectorSession {
         case .detached, .waitingForDocument, .refreshing, .current:
             return
         case .unavailable(let reason):
-            selectedNodeStyleHydrationTask?.cancel()
-            selectedNodeStyleHydrationTask = nil
-            selectedNodeStyleHydrationIdentity = nil
+            cancelSelectedNodeStyleHydrationRefresh()
             css.markSelectedNodeUnavailable(reason)
         case .needsRefresh(let identity):
             hydrateSelectedNodeStyles(identity)
@@ -1046,7 +1042,7 @@ package final class InspectorSession {
             return
         }
 
-        selectedNodeStyleHydrationTask?.cancel()
+        cancelSelectedNodeStyleHydrationRefresh()
         selectedNodeStyleHydrationIdentity = identity
         selectedNodeStyleHydrationTask = Task { @MainActor [weak self] in
             guard let self else {
@@ -1066,10 +1062,20 @@ package final class InspectorSession {
                 try await self.refreshStyles(for: identity)
                 self.lastError = nil
             } catch is CancellationError {
+                self.css.cancelRefresh(identity: identity)
             } catch {
                 self.lastError = InspectorSessionError(String(describing: error))
             }
         }
+    }
+
+    private func cancelSelectedNodeStyleHydrationRefresh() {
+        selectedNodeStyleHydrationTask?.cancel()
+        selectedNodeStyleHydrationTask = nil
+        if let selectedNodeStyleHydrationIdentity {
+            css.cancelRefresh(identity: selectedNodeStyleHydrationIdentity)
+        }
+        selectedNodeStyleHydrationIdentity = nil
     }
 
     private func refreshSelectedNodeStyles() async throws {
@@ -1364,6 +1370,9 @@ package final class InspectorSession {
             let destroyedTargetID = targetDestroyedID(from: event)
             let targetCommit = try DOMTransportAdapter.targetCommitResolution(from: event, snapshot: dom.snapshot())
             let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
+            if let createdTarget {
+                runtime.applyTargetCreated(createdTarget)
+            }
             if let connection {
                 syncTargets(for: connection)
             }
@@ -1392,6 +1401,9 @@ package final class InspectorSession {
             }
             if event.method == "Target.didCommitProvisionalTarget",
                let targetCommit {
+                if let committedTarget = dom.snapshot().targetsByID[targetCommit.newTargetID] {
+                    runtime.applyTargetCreated(committedTarget.record)
+                }
                 if let oldTargetID = targetCommit.consumedOldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
                     cancelRuntimeConsoleEnableTask(targetID: oldTargetID)
@@ -1905,9 +1917,7 @@ package final class InspectorSession {
     }
 
     private func cancelCSSActionRequests() {
-        selectedNodeStyleHydrationTask?.cancel()
-        selectedNodeStyleHydrationTask = nil
-        selectedNodeStyleHydrationIdentity = nil
+        cancelSelectedNodeStyleHydrationRefresh()
 
         for task in cssPropertyUpdateTasks.values {
             task.cancel()
@@ -2185,13 +2195,16 @@ package final class InspectorSession {
                     && record.parentFrameID == nil
             )
         }
-        for record in snapshot.executionContextsByKey.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+        for record in snapshot.executionContextsByKey.values.sorted(by: RuntimeExecutionContextRecord.stableOrder) {
             dom.applyExecutionContextCreated(record)
         }
     }
 
     private func seedRuntimeSession(from snapshot: TransportSnapshot) {
-        for record in snapshot.executionContextsByKey.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+        for record in snapshot.targetsByID.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+            runtime.applyTargetCreated(record)
+        }
+        for record in snapshot.executionContextsByKey.values.sorted(by: RuntimeExecutionContextRecord.stableOrder) {
             runtime.applyExecutionContextCreated(record)
         }
     }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -110,16 +110,140 @@ private final class DOMDeleteUndoOperationQueue {
 }
 
 @MainActor
+private final class InspectorTarget {
+    let id: ProtocolTargetIdentifier
+    var kind: ProtocolTargetKind
+    var frameID: DOMFrameIdentifier?
+    var parentFrameID: DOMFrameIdentifier?
+    var capabilities: ProtocolTargetCapabilities
+    var isProvisional: Bool
+    var isPaused: Bool
+    var isBootstrapped: Bool
+    private var enabledDomains: ProtocolTargetCapabilities
+    private var runtimeConsoleEnableTask: Task<Void, Never>?
+
+    init(snapshot: ProtocolTargetSnapshot) {
+        id = snapshot.id
+        kind = snapshot.kind
+        frameID = snapshot.frameID
+        parentFrameID = snapshot.parentFrameID
+        capabilities = snapshot.capabilities
+        isProvisional = snapshot.isProvisional
+        isPaused = snapshot.isPaused
+        isBootstrapped = false
+        enabledDomains = []
+        runtimeConsoleEnableTask = nil
+    }
+
+    func update(from snapshot: ProtocolTargetSnapshot) {
+        kind = snapshot.kind
+        frameID = snapshot.frameID
+        parentFrameID = snapshot.parentFrameID
+        capabilities = snapshot.capabilities
+        isProvisional = snapshot.isProvisional
+        isPaused = snapshot.isPaused
+    }
+
+    func hasDomain(_ domain: ProtocolTargetCapabilities) -> Bool {
+        capabilities.contains(domain)
+    }
+
+    func markEnabled(_ domain: ProtocolTargetCapabilities) {
+        enabledDomains.insert(domain)
+    }
+
+    func shouldEnableCompatibilityCSS() -> Bool {
+        hasDomain(.css) && enabledDomains.contains(.css) == false
+    }
+
+    func shouldEnableRuntime(using runtime: RuntimeSession) -> Bool {
+        isProvisional == false
+            && hasDomain(.runtime)
+            && enabledDomains.contains(.runtime) == false
+            && runtime.supportsCommand("Runtime.enable", targetID: id)
+    }
+
+    func shouldEnableConsole(using console: ConsoleSession, force: Bool = false) -> Bool {
+        isProvisional == false
+            && hasDomain(.console)
+            && (force || enabledDomains.contains(.console) == false)
+            && console.supportsCommand("Console.enable", targetID: id)
+    }
+
+    func canStartRuntimeConsoleEnable(using runtime: RuntimeSession, console: ConsoleSession) -> Bool {
+        runtimeConsoleEnableTask == nil
+            && (shouldEnableRuntime(using: runtime) || shouldEnableConsole(using: console))
+    }
+
+    func startRuntimeConsoleEnableTask(_ task: Task<Void, Never>) {
+        runtimeConsoleEnableTask = task
+    }
+
+    func finishRuntimeConsoleEnableTask() {
+        runtimeConsoleEnableTask = nil
+    }
+
+    func cancelRuntimeConsoleEnableTask() {
+        runtimeConsoleEnableTask?.cancel()
+        runtimeConsoleEnableTask = nil
+    }
+}
+
+@MainActor
+private final class InspectorTargetRegistry {
+    private var targetsByID: [ProtocolTargetIdentifier: InspectorTarget]
+
+    init() {
+        targetsByID = [:]
+    }
+
+    var targets: [InspectorTarget] {
+        Array(targetsByID.values)
+    }
+
+    func sync(from snapshot: DOMSessionSnapshot) {
+        let currentTargetIDs = Set(snapshot.targetsByID.keys)
+        for removedTargetID in Array(targetsByID.keys) where currentTargetIDs.contains(removedTargetID) == false {
+            removeTarget(removedTargetID)
+        }
+        for targetSnapshot in snapshot.targetsByID.values {
+            upsertTarget(from: targetSnapshot)
+        }
+    }
+
+    func target(for targetID: ProtocolTargetIdentifier) -> InspectorTarget? {
+        targetsByID[targetID]
+    }
+
+    @discardableResult
+    func upsertTarget(from snapshot: ProtocolTargetSnapshot) -> InspectorTarget {
+        if let target = targetsByID[snapshot.id] {
+            target.update(from: snapshot)
+            return target
+        }
+        let target = InspectorTarget(snapshot: snapshot)
+        targetsByID[snapshot.id] = target
+        return target
+    }
+
+    func removeTarget(_ targetID: ProtocolTargetIdentifier) {
+        targetsByID.removeValue(forKey: targetID)?.cancelRuntimeConsoleEnableTask()
+    }
+
+    func cancelRuntimeConsoleEnableTasks() {
+        for target in targetsByID.values {
+            target.cancelRuntimeConsoleEnableTask()
+        }
+    }
+}
+
+@MainActor
 private final class InspectorConnection {
     let transport: TransportSession
     weak var webView: WKWebView?
     let originalInspectability: Bool?
     var eventPump: DomainEventPump?
-    var bootstrappedTargetIDs: Set<ProtocolTargetIdentifier>
-    var compatibilityCSSEnabledTargetIDs: Set<ProtocolTargetIdentifier>
-    var runtimeEnabledTargetIDs: Set<ProtocolTargetIdentifier>
-    var consoleEnabledTargetIDs: Set<ProtocolTargetIdentifier>
-    var runtimeConsoleEnableTasksByTargetID: [ProtocolTargetIdentifier: Task<Void, Never>]
+    let targets: InspectorTargetRegistry
 
     init(
         transport: TransportSession,
@@ -130,11 +254,7 @@ private final class InspectorConnection {
         self.webView = webView
         self.originalInspectability = originalInspectability
         eventPump = nil
-        bootstrappedTargetIDs = []
-        compatibilityCSSEnabledTargetIDs = []
-        runtimeEnabledTargetIDs = []
-        consoleEnabledTargetIDs = []
-        runtimeConsoleEnableTasksByTargetID = [:]
+        targets = InspectorTargetRegistry()
     }
 }
 
@@ -276,6 +396,7 @@ package final class InspectorSession {
         await startPumps(connection: nextConnection)
         seedDOMSession(from: await transport.snapshot())
         seedRuntimeSession(from: await transport.snapshot())
+        syncTargets(for: nextConnection)
 
         do {
             let mainTarget = try await transport.waitForCurrentMainPageTarget(
@@ -283,6 +404,7 @@ package final class InspectorSession {
             )
             seedDOMSession(from: await transport.snapshot())
             seedRuntimeSession(from: await transport.snapshot())
+            syncTargets(for: nextConnection)
             try await bootstrap(mainTargetID: mainTarget.targetID, connection: nextConnection)
             try ensureCurrentConnection(nextConnection)
             pendingConnection = nil
@@ -610,6 +732,7 @@ package final class InspectorSession {
         if let connection {
             seedDOMSession(from: await connection.transport.snapshot())
             seedRuntimeSession(from: await connection.transport.snapshot())
+            syncTargets(for: connection)
         }
         webView.reload()
     }
@@ -973,8 +1096,9 @@ package final class InspectorSession {
         targetID: ProtocolTargetIdentifier,
         connection: InspectorConnection
     ) async throws {
-        guard dom.targetCapabilities(for: targetID).contains(.css),
-              !connection.compatibilityCSSEnabledTargetIDs.contains(targetID) else {
+        syncTargets(for: connection)
+        guard let target = connection.targets.target(for: targetID),
+              target.shouldEnableCompatibilityCSS() else {
             return
         }
 
@@ -983,7 +1107,7 @@ package final class InspectorSession {
         // headers during page load, while the read commands work without it.
         _ = try await connection.transport.send(try CSSTransportAdapter.command(for: .enable(targetID: targetID)))
         try ensureCurrentConnection(connection)
-        connection.compatibilityCSSEnabledTargetIDs.insert(targetID)
+        target.markEnabled(.css)
     }
 
     package func fetchResponseBody(for id: NetworkRequest.ID) async {
@@ -1019,7 +1143,8 @@ package final class InspectorSession {
             try RuntimeTransportAdapter.command(for: .enable(targetID: mainTargetID))
         )
         try ensureCurrentConnection(connection)
-        connection.runtimeEnabledTargetIDs.insert(mainTargetID)
+        syncTargets(for: connection)
+        connection.targets.target(for: mainTargetID)?.markEnabled(.runtime)
 
         let documentResult = try await sendTargetCommand(domain: .dom, method: "DOM.getDocument", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
@@ -1034,7 +1159,7 @@ package final class InspectorSession {
         )
         try ensureCurrentConnection(connection)
         try await enableConsoleAgentIfSupported(targetID: mainTargetID, connection: connection, force: true)
-        connection.bootstrappedTargetIDs.insert(mainTargetID)
+        connection.targets.target(for: mainTargetID)?.isBootstrapped = true
     }
 
     private func sendTargetCommand(
@@ -1122,12 +1247,16 @@ package final class InspectorSession {
             let destroyedTargetID = targetDestroyedID(from: event)
             let targetCommit = try DOMTransportAdapter.targetCommitResolution(from: event, snapshot: dom.snapshot())
             let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
+            if let connection {
+                syncTargets(for: connection)
+            }
             if let destroyedTargetID {
                 cancelDOMDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
                 cancelRuntimeConsoleEnableTask(targetID: destroyedTargetID)
                 css.removeStyles(targetID: destroyedTargetID)
                 runtime.applyTargetDestroyed(destroyedTargetID)
                 console.applyTargetDestroyed(destroyedTargetID)
+                discardConnectionTargetState(targetID: destroyedTargetID)
             }
             applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
             if isAttached,
@@ -1146,17 +1275,13 @@ package final class InspectorSession {
             }
             if event.method == "Target.didCommitProvisionalTarget",
                let targetCommit {
-                if targetCommit.consumesOldTarget,
-                   let oldTargetID = targetCommit.oldTargetID {
+                if let oldTargetID = targetCommit.consumedOldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
                     cancelRuntimeConsoleEnableTask(targetID: oldTargetID)
                     css.removeStyles(targetID: oldTargetID)
                     runtime.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: targetCommit.newTargetID)
                     console.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: targetCommit.newTargetID)
-                    retargetRuntimeConsoleAgentState(
-                        oldTargetID: oldTargetID,
-                        newTargetID: targetCommit.newTargetID
-                    )
+                    discardConnectionTargetState(targetID: oldTargetID)
                 }
                 startFrameTargetDocumentRequestAfterCommit(targetID: targetCommit.newTargetID)
                 startRuntimeConsoleEnableIfNeeded(targetID: targetCommit.newTargetID, reason: "frameTargetCommit")
@@ -1184,10 +1309,12 @@ package final class InspectorSession {
 
     private func startRuntimeConsoleEnableIfNeeded(targetID: ProtocolTargetIdentifier, reason: String) {
         guard isAttached,
-              let connection,
-              connection.runtimeConsoleEnableTasksByTargetID[targetID] == nil,
-              shouldEnableRuntimeAgent(targetID: targetID, connection: connection)
-                  || shouldEnableConsoleAgent(targetID: targetID, connection: connection) else {
+              let connection else {
+            return
+        }
+        syncTargets(for: connection)
+        guard let target = connection.targets.target(for: targetID),
+              target.canStartRuntimeConsoleEnable(using: runtime, console: console) else {
             return
         }
 
@@ -1196,7 +1323,7 @@ package final class InspectorSession {
                 return
             }
             defer {
-                connection.runtimeConsoleEnableTasksByTargetID.removeValue(forKey: targetID)
+                connection.targets.target(for: targetID)?.finishRuntimeConsoleEnableTask()
             }
             do {
                 try await enableRuntimeConsoleIfNeeded(targetID: targetID, connection: connection)
@@ -1206,53 +1333,25 @@ package final class InspectorSession {
                 lastError = InspectorSessionError(String(describing: error))
             }
         }
-        connection.runtimeConsoleEnableTasksByTargetID[targetID] = task
-    }
-
-    private func shouldEnableRuntimeAgent(
-        targetID: ProtocolTargetIdentifier,
-        connection: InspectorConnection
-    ) -> Bool {
-        guard let target = dom.snapshot().targetsByID[targetID],
-              target.isProvisional == false,
-              target.capabilities.contains(.runtime),
-              connection.runtimeEnabledTargetIDs.contains(targetID) == false,
-              runtime.supportsCommand("Runtime.enable", targetID: targetID) else {
-            return false
-        }
-        return true
-    }
-
-    private func shouldEnableConsoleAgent(
-        targetID: ProtocolTargetIdentifier,
-        connection: InspectorConnection
-    ) -> Bool {
-        guard let target = dom.snapshot().targetsByID[targetID],
-              target.isProvisional == false,
-              target.capabilities.contains(.console),
-              connection.consoleEnabledTargetIDs.contains(targetID) == false,
-              console.supportsCommand("Console.enable", targetID: targetID) else {
-            return false
-        }
-        return true
+        target.startRuntimeConsoleEnableTask(task)
     }
 
     private func enableRuntimeConsoleIfNeeded(
         targetID: ProtocolTargetIdentifier,
         connection: InspectorConnection
     ) async throws {
-        guard let target = dom.snapshot().targetsByID[targetID],
+        try Task.checkCancellation()
+        syncTargets(for: connection)
+        guard let target = connection.targets.target(for: targetID),
               target.isProvisional == false else {
             return
         }
 
-        if target.capabilities.contains(.runtime),
-           connection.runtimeEnabledTargetIDs.contains(targetID) == false,
-           runtime.supportsCommand("Runtime.enable", targetID: targetID) {
+        if target.shouldEnableRuntime(using: runtime) {
             do {
                 _ = try await connection.transport.send(try RuntimeTransportAdapter.command(for: .enable(targetID: targetID)))
                 try ensureCurrentConnection(connection)
-                connection.runtimeEnabledTargetIDs.insert(targetID)
+                target.markEnabled(.runtime)
             } catch {
                 markRuntimeCommandUnsupportedIfNeeded("Runtime.enable", targetID: targetID, error: error)
                 if isUnsupportedProtocolCommandError(error) == false {
@@ -1261,9 +1360,8 @@ package final class InspectorSession {
             }
         }
 
-        guard target.capabilities.contains(.console),
-              connection.consoleEnabledTargetIDs.contains(targetID) == false,
-              console.supportsCommand("Console.enable", targetID: targetID) else {
+        try Task.checkCancellation()
+        guard target.shouldEnableConsole(using: console) else {
             return
         }
         try await enableConsoleAgentIfSupported(targetID: targetID, connection: connection)
@@ -1274,17 +1372,15 @@ package final class InspectorSession {
         connection: InspectorConnection,
         force: Bool = false
     ) async throws {
-        guard dom.targetCapabilities(for: targetID).contains(.console),
-              console.supportsCommand("Console.enable", targetID: targetID) else {
-            return
-        }
-        guard force || connection.consoleEnabledTargetIDs.contains(targetID) == false else {
+        syncTargets(for: connection)
+        guard let target = connection.targets.target(for: targetID),
+              target.shouldEnableConsole(using: console, force: force) else {
             return
         }
         do {
             _ = try await connection.transport.send(try ConsoleTransportAdapter.command(for: .enable(targetID: targetID)))
             try ensureCurrentConnection(connection)
-            connection.consoleEnabledTargetIDs.insert(targetID)
+            target.markEnabled(.console)
         } catch {
             markConsoleCommandUnsupportedIfNeeded("Console.enable", targetID: targetID, error: error)
             if isUnsupportedProtocolCommandError(error) {
@@ -1298,27 +1394,18 @@ package final class InspectorSession {
         guard let connection else {
             return
         }
-        connection.runtimeConsoleEnableTasksByTargetID.removeValue(forKey: targetID)?.cancel()
+        connection.targets.target(for: targetID)?.cancelRuntimeConsoleEnableTask()
     }
 
     private func cancelRuntimeConsoleEnableTasks(_ connection: InspectorConnection) {
-        for task in connection.runtimeConsoleEnableTasksByTargetID.values {
-            task.cancel()
-        }
-        connection.runtimeConsoleEnableTasksByTargetID.removeAll()
+        connection.targets.cancelRuntimeConsoleEnableTasks()
     }
 
-    private func retargetRuntimeConsoleAgentState(
-        oldTargetID: ProtocolTargetIdentifier?,
-        newTargetID: ProtocolTargetIdentifier
-    ) {
-        guard let oldTargetID,
-              oldTargetID != newTargetID,
-              let connection else {
+    private func discardConnectionTargetState(targetID: ProtocolTargetIdentifier) {
+        guard let connection else {
             return
         }
-        connection.runtimeEnabledTargetIDs.remove(oldTargetID)
-        connection.consoleEnabledTargetIDs.remove(oldTargetID)
+        connection.targets.removeTarget(targetID)
     }
 
     private func startFrameTargetDocumentRequestAfterCommit(targetID: ProtocolTargetIdentifier) {
@@ -1646,7 +1733,8 @@ package final class InspectorSession {
         targetID: ProtocolTargetIdentifier,
         connection: InspectorConnection
     ) {
-        if connection.bootstrappedTargetIDs.contains(targetID) {
+        syncTargets(for: connection)
+        if connection.targets.target(for: targetID)?.isBootstrapped == true {
             startDOMDocumentRequest(targetID: targetID, reason: "pageTargetCommit")
             return
         }
@@ -1782,8 +1870,7 @@ package final class InspectorSession {
             clearElementPickerState(invalidatePendingSelection: true)
         case "Target.didCommitProvisionalTarget":
             guard let targetCommit,
-                  targetCommit.consumesOldTarget,
-                  targetCommit.oldTargetID == activeTargetID else {
+                  targetCommit.consumedOldTargetID == activeTargetID else {
                 return
             }
             recordElementPickerFailure(
@@ -1990,6 +2077,10 @@ package final class InspectorSession {
         for record in snapshot.executionContextsByKey.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
             runtime.applyExecutionContextCreated(record)
         }
+    }
+
+    private func syncTargets(for connection: InspectorConnection) {
+        connection.targets.sync(from: dom.snapshot())
     }
 
     private func activeConnection() throws -> InspectorConnection {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -736,7 +736,7 @@ package final class InspectorSession {
         do {
             result = try await transport.send(command)
         } catch {
-            markRuntimeCommandUnsupportedIfNeeded(command.method, targetID: intent.targetID, error: error)
+            markRuntimeCommandUnsupportedIfNeeded(command.method, targetID: intent.routingTargetID, error: error)
             throw error
         }
         try ensureCurrentConnection(connection)
@@ -747,8 +747,8 @@ package final class InspectorSession {
             runtime.applyEvaluationResult(payload, request: request)
         case let .releaseObject(key):
             runtime.releaseObject(key)
-        case let .releaseObjectGroup(targetID, objectGroup):
-            runtime.releaseObjectGroup(objectGroup, targetID: targetID)
+        case let .releaseObjectGroup(runtimeAgentTargetID, objectGroup):
+            runtime.releaseObjectGroup(objectGroup, runtimeAgentTargetID: runtimeAgentTargetID)
         default:
             break
         }
@@ -1073,10 +1073,20 @@ package final class InspectorSession {
             }
         case .console:
             applyEvent(event) {
+                if let targetID = event.targetID,
+                   let message = try ConsoleTransportAdapter.messagePayload(from: event) {
+                    for parameter in message.parameters {
+                        $0.runtime.registerRemoteObject(
+                            parameter,
+                            runtimeAgentTargetID: targetID,
+                            objectGroup: .console
+                        )
+                    }
+                }
                 try ConsoleTransportAdapter.applyConsoleEvent(event, to: $0.console)
                 if event.method == "Console.messagesCleared",
                    let targetID = event.targetID {
-                    $0.runtime.releaseObjectGroup(.console, targetID: targetID)
+                    $0.runtime.releaseObjectGroup(.console, runtimeAgentTargetID: targetID)
                 }
             }
         case .inspector:

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1065,6 +1065,7 @@ package final class InspectorSession {
             do {
                 try await self.refreshStyles(for: identity)
                 self.lastError = nil
+            } catch is CancellationError {
             } catch {
                 self.lastError = InspectorSessionError(String(describing: error))
             }
@@ -1115,6 +1116,8 @@ package final class InspectorSession {
                 inline: try CSSTransportAdapter.inlineStyles(from: results.inline),
                 computed: try CSSTransportAdapter.computedStyles(from: results.computed)
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             css.markRefreshFailed(token, message: String(describing: error))
             throw error
@@ -1159,7 +1162,7 @@ package final class InspectorSession {
         targetID: ProtocolTargetIdentifier,
         error: any Error
     ) {
-        guard isUnsupportedProtocolCommandError(error) else {
+        guard isUnsupportedProtocolCommandError(method, error: error) else {
             return
         }
         runtime.markCommandUnsupported(method, targetID: targetID)
@@ -1170,22 +1173,38 @@ package final class InspectorSession {
         targetID: ProtocolTargetIdentifier,
         error: any Error
     ) {
-        guard isUnsupportedProtocolCommandError(error) else {
+        guard isUnsupportedProtocolCommandError(method, error: error) else {
             return
         }
         console.markCommandUnsupported(method, targetID: targetID)
     }
 
-    private func isUnsupportedProtocolCommandError(_ error: any Error) -> Bool {
-        guard case let TransportError.remoteError(_, _, message) = error else {
+    private func isUnsupportedProtocolCommandError(
+        _ method: String,
+        error: any Error
+    ) -> Bool {
+        guard case let TransportError.remoteError(errorMethod, _, message) = error,
+              errorMethod == method else {
             return false
         }
         let normalizedMessage = message.lowercased()
-        return normalizedMessage.contains("unrecognized")
-            || normalizedMessage.contains("unsupported")
-            || normalizedMessage.contains("unknown")
-            || normalizedMessage.contains("not found")
-            || normalizedMessage.contains("not implemented")
+        if normalizedMessage.contains("unknown command")
+            || normalizedMessage.contains("unknown method")
+            || normalizedMessage.contains("unrecognized command")
+            || normalizedMessage.contains("unrecognized method")
+            || normalizedMessage.contains("unsupported command")
+            || normalizedMessage.contains("unsupported method")
+            || normalizedMessage.contains("command not found")
+            || normalizedMessage.contains("method not found") {
+            return true
+        }
+
+        guard normalizedMessage.contains("not implemented") else {
+            return false
+        }
+        return normalizedMessage.contains(method.lowercased())
+            || normalizedMessage.contains("command")
+            || normalizedMessage.contains("method")
     }
 
     private func enableCSSAgentForCompatibility(
@@ -1452,7 +1471,7 @@ package final class InspectorSession {
                 target.markEnabled(.runtime)
             } catch {
                 markRuntimeCommandUnsupportedIfNeeded("Runtime.enable", targetID: targetID, error: error)
-                if isUnsupportedProtocolCommandError(error) == false {
+                if isUnsupportedProtocolCommandError("Runtime.enable", error: error) == false {
                     throw error
                 }
             }
@@ -1481,7 +1500,7 @@ package final class InspectorSession {
             target.markEnabled(.console)
         } catch {
             markConsoleCommandUnsupportedIfNeeded("Console.enable", targetID: targetID, error: error)
-            if isUnsupportedProtocolCommandError(error) {
+            if isUnsupportedProtocolCommandError("Console.enable", error: error) {
                 return
             }
             throw error

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -117,6 +117,9 @@ private final class InspectorConnection {
     var eventPump: DomainEventPump?
     var bootstrappedTargetIDs: Set<ProtocolTargetIdentifier>
     var compatibilityCSSEnabledTargetIDs: Set<ProtocolTargetIdentifier>
+    var runtimeEnabledTargetIDs: Set<ProtocolTargetIdentifier>
+    var consoleEnabledTargetIDs: Set<ProtocolTargetIdentifier>
+    var runtimeConsoleEnableTasksByTargetID: [ProtocolTargetIdentifier: Task<Void, Never>]
 
     init(
         transport: TransportSession,
@@ -129,6 +132,9 @@ private final class InspectorConnection {
         eventPump = nil
         bootstrappedTargetIDs = []
         compatibilityCSSEnabledTargetIDs = []
+        runtimeEnabledTargetIDs = []
+        consoleEnabledTargetIDs = []
+        runtimeConsoleEnableTasksByTargetID = [:]
     }
 }
 
@@ -159,6 +165,8 @@ package final class InspectorSession {
     package let dom: DOMSession
     package let css: CSSSession
     package let network: NetworkSession
+    package let runtime: RuntimeSession
+    package let console: ConsoleSession
     package private(set) var isAttached: Bool
     package private(set) var lastError: InspectorSessionError?
     package private(set) var isSelectingElement: Bool
@@ -182,12 +190,16 @@ package final class InspectorSession {
         configuration: InspectorSessionConfiguration = .init(),
         dom: DOMSession = DOMSession(),
         css: CSSSession = CSSSession(),
-        network: NetworkSession = NetworkSession()
+        network: NetworkSession = NetworkSession(),
+        runtime: RuntimeSession = RuntimeSession(),
+        console: ConsoleSession = ConsoleSession()
     ) {
         self.configuration = configuration
         self.dom = dom
         self.css = css
         self.network = network
+        self.runtime = runtime
+        self.console = console
         isAttached = false
         lastError = nil
         isSelectingElement = false
@@ -263,18 +275,21 @@ package final class InspectorSession {
         lastError = nil
         await startPumps(connection: nextConnection)
         seedDOMSession(from: await transport.snapshot())
+        seedRuntimeSession(from: await transport.snapshot())
 
         do {
             let mainTarget = try await transport.waitForCurrentMainPageTarget(
                 timeout: configuration.bootstrapTimeout
             )
             seedDOMSession(from: await transport.snapshot())
+            seedRuntimeSession(from: await transport.snapshot())
             try await bootstrap(mainTargetID: mainTarget.targetID, connection: nextConnection)
             try ensureCurrentConnection(nextConnection)
             pendingConnection = nil
             connection = nextConnection
             isAttached = true
             startDOMDocumentRequestsForAttachedFrameTargets()
+            startRuntimeConsoleEnableForAttachedTargets()
             lastError = nil
         } catch {
             guard connection === nextConnection || pendingConnection === nextConnection else {
@@ -294,6 +309,8 @@ package final class InspectorSession {
             dom.reset()
             css.reset()
             network.reset()
+            runtime.reset()
+            console.reset()
             let sessionError = InspectorSessionError(String(describing: error))
             lastError = sessionError
             throw error
@@ -312,11 +329,13 @@ package final class InspectorSession {
         isAttached = false
 
         if let previousConnection {
+            cancelRuntimeConsoleEnableTasks(previousConnection)
             stopPumps(previousConnection)
             await previousConnection.transport.detach()
             restoreInspectabilityIfNeeded(for: previousConnection)
         }
         if let previousPendingConnection {
+            cancelRuntimeConsoleEnableTasks(previousPendingConnection)
             stopPumps(previousPendingConnection)
             await previousPendingConnection.transport.detach()
             restoreInspectabilityIfNeeded(for: previousPendingConnection)
@@ -326,6 +345,8 @@ package final class InspectorSession {
         dom.reset()
         css.reset()
         network.reset()
+        runtime.reset()
+        console.reset()
         highlightedDOMTargetID = nil
         clearElementPickerState(invalidatePendingSelection: true)
         clearDeleteUndoHistory()
@@ -584,8 +605,11 @@ package final class InspectorSession {
         dom.reset()
         css.reset()
         network.reset()
+        runtime.reset()
+        console.reset()
         if let connection {
             seedDOMSession(from: await connection.transport.snapshot())
+            seedRuntimeSession(from: await connection.transport.snapshot())
         }
         webView.reload()
     }
@@ -701,6 +725,49 @@ package final class InspectorSession {
         let result = try await transport.send(CSSTransportAdapter.command(for: intent))
         try ensureCurrentConnection(connection)
         return result
+    }
+
+    @discardableResult
+    package func perform(_ intent: RuntimeCommandIntent) async throws -> ProtocolCommandResult {
+        let connection = try activeConnection()
+        let transport = connection.transport
+        let command = try RuntimeTransportAdapter.command(for: intent)
+        let result: ProtocolCommandResult
+        do {
+            result = try await transport.send(command)
+        } catch {
+            markRuntimeCommandUnsupportedIfNeeded(command.method, targetID: intent.targetID, error: error)
+            throw error
+        }
+        try ensureCurrentConnection(connection)
+
+        switch intent {
+        case let .evaluate(request):
+            let payload = try RuntimeTransportAdapter.evaluationResult(from: result)
+            runtime.applyEvaluationResult(payload, request: request)
+        case let .releaseObject(key):
+            runtime.releaseObject(key)
+        case let .releaseObjectGroup(targetID, objectGroup):
+            runtime.releaseObjectGroup(objectGroup, targetID: targetID)
+        default:
+            break
+        }
+        return result
+    }
+
+    @discardableResult
+    package func perform(_ intent: ConsoleCommandIntent) async throws -> ProtocolCommandResult {
+        let connection = try activeConnection()
+        let transport = connection.transport
+        let command = try ConsoleTransportAdapter.command(for: intent)
+        do {
+            let result = try await transport.send(command)
+            try ensureCurrentConnection(connection)
+            return result
+        } catch {
+            markConsoleCommandUnsupportedIfNeeded(command.method, targetID: intent.targetID, error: error)
+            throw error
+        }
     }
 
     package func refreshStylesForSelectedNode() async {
@@ -868,6 +935,40 @@ package final class InspectorSession {
             || normalizedMessage.contains("enabled")
     }
 
+    private func markRuntimeCommandUnsupportedIfNeeded(
+        _ method: String,
+        targetID: ProtocolTargetIdentifier,
+        error: any Error
+    ) {
+        guard isUnsupportedProtocolCommandError(error) else {
+            return
+        }
+        runtime.markCommandUnsupported(method, targetID: targetID)
+    }
+
+    private func markConsoleCommandUnsupportedIfNeeded(
+        _ method: String,
+        targetID: ProtocolTargetIdentifier,
+        error: any Error
+    ) {
+        guard isUnsupportedProtocolCommandError(error) else {
+            return
+        }
+        console.markCommandUnsupported(method, targetID: targetID)
+    }
+
+    private func isUnsupportedProtocolCommandError(_ error: any Error) -> Bool {
+        guard case let TransportError.remoteError(_, _, message) = error else {
+            return false
+        }
+        let normalizedMessage = message.lowercased()
+        return normalizedMessage.contains("unrecognized")
+            || normalizedMessage.contains("unsupported")
+            || normalizedMessage.contains("unknown")
+            || normalizedMessage.contains("not found")
+            || normalizedMessage.contains("not implemented")
+    }
+
     private func enableCSSAgentForCompatibility(
         targetID: ProtocolTargetIdentifier,
         connection: InspectorConnection
@@ -914,8 +1015,11 @@ package final class InspectorSession {
         try ensureCurrentConnection(connection)
         _ = try await sendTargetCommand(domain: .dom, method: "DOM.enable", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
-        _ = try await sendTargetCommand(domain: .runtime, method: "Runtime.enable", targetID: mainTargetID, connection: connection)
+        _ = try await connection.transport.send(
+            try RuntimeTransportAdapter.command(for: .enable(targetID: mainTargetID))
+        )
         try ensureCurrentConnection(connection)
+        connection.runtimeEnabledTargetIDs.insert(mainTargetID)
 
         let documentResult = try await sendTargetCommand(domain: .dom, method: "DOM.getDocument", targetID: mainTargetID, connection: connection)
         try ensureCurrentConnection(connection)
@@ -929,6 +1033,13 @@ package final class InspectorSession {
             )
         )
         try ensureCurrentConnection(connection)
+        if dom.targetCapabilities(for: mainTargetID).contains(.console) {
+            _ = try await connection.transport.send(
+                try ConsoleTransportAdapter.command(for: .enable(targetID: mainTargetID))
+            )
+            try ensureCurrentConnection(connection)
+            connection.consoleEnabledTargetIDs.insert(mainTargetID)
+        }
         connection.bootstrappedTargetIDs.insert(mainTargetID)
     }
 
@@ -963,7 +1074,12 @@ package final class InspectorSession {
             await handleTargetEvent(event)
         case .runtime:
             applyEvent(event) {
+                try RuntimeTransportAdapter.applyRuntimeEvent(event, to: $0.runtime)
                 try DOMTransportAdapter.applyRuntimeEvent(event, to: $0.dom)
+            }
+        case .console:
+            applyEvent(event) {
+                try ConsoleTransportAdapter.applyConsoleEvent(event, to: $0.console)
             }
         case .inspector:
             await handleInspectorEvent(event)
@@ -1000,7 +1116,10 @@ package final class InspectorSession {
             let createdTarget = try DOMTransportAdapter.applyTargetEvent(event, to: dom)
             if let destroyedTargetID {
                 cancelDOMDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
+                cancelRuntimeConsoleEnableTask(targetID: destroyedTargetID)
                 css.removeStyles(targetID: destroyedTargetID)
+                runtime.applyTargetDestroyed(destroyedTargetID)
+                console.applyTargetDestroyed(destroyedTargetID)
             }
             applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
             if isAttached,
@@ -1009,6 +1128,7 @@ package final class InspectorSession {
                 if createdTarget.capabilities.contains(.dom) {
                     startDOMDocumentRequest(targetID: createdTarget.id, reason: "frameTargetCreated")
                 }
+                startRuntimeConsoleEnableIfNeeded(targetID: createdTarget.id, reason: "frameTargetCreated")
             }
             if event.method == "Target.didCommitProvisionalTarget",
                dom.currentPageRootNode == nil,
@@ -1020,9 +1140,17 @@ package final class InspectorSession {
                let targetCommit {
                 if let oldTargetID = targetCommit.oldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
+                    cancelRuntimeConsoleEnableTask(targetID: oldTargetID)
                     css.removeStyles(targetID: oldTargetID)
                 }
+                runtime.applyTargetCommitted(oldTargetID: targetCommit.oldTargetID, newTargetID: targetCommit.newTargetID)
+                console.applyTargetCommitted(oldTargetID: targetCommit.oldTargetID, newTargetID: targetCommit.newTargetID)
+                retargetRuntimeConsoleAgentState(
+                    oldTargetID: targetCommit.oldTargetID,
+                    newTargetID: targetCommit.newTargetID
+                )
                 startFrameTargetDocumentRequestAfterCommit(targetID: targetCommit.newTargetID)
+                startRuntimeConsoleEnableIfNeeded(targetID: targetCommit.newTargetID, reason: "frameTargetCommit")
             }
         } catch {
             lastError = InspectorSessionError("\(event.method): \(error)")
@@ -1035,6 +1163,120 @@ package final class InspectorSession {
             && target.capabilities.contains(.dom)
             && target.currentDocumentID == nil {
             startDOMDocumentRequest(targetID: target.id, reason: "attachedFrameTarget")
+        }
+    }
+
+    private func startRuntimeConsoleEnableForAttachedTargets() {
+        for target in dom.snapshot().targetsByID.values
+        where target.kind == .frame && target.isProvisional == false {
+            startRuntimeConsoleEnableIfNeeded(targetID: target.id, reason: "attachedTarget")
+        }
+    }
+
+    private func startRuntimeConsoleEnableIfNeeded(targetID: ProtocolTargetIdentifier, reason: String) {
+        guard isAttached,
+              let connection,
+              connection.runtimeConsoleEnableTasksByTargetID[targetID] == nil,
+              shouldEnableConsoleAgents(targetID: targetID, connection: connection) else {
+            return
+        }
+
+        let task = Task { @MainActor [weak self, connection] in
+            guard let self else {
+                return
+            }
+            defer {
+                connection.runtimeConsoleEnableTasksByTargetID.removeValue(forKey: targetID)
+            }
+            do {
+                try await enableRuntimeConsoleIfNeeded(targetID: targetID, connection: connection)
+            } catch is CancellationError {
+            } catch {
+                InspectorRuntimeLog.warning("runtimeConsoleEnable.failed target=\(targetID.rawValue) reason=\(reason) error=\(error)")
+                lastError = InspectorSessionError(String(describing: error))
+            }
+        }
+        connection.runtimeConsoleEnableTasksByTargetID[targetID] = task
+    }
+
+    private func shouldEnableConsoleAgents(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection
+    ) -> Bool {
+        guard let target = dom.snapshot().targetsByID[targetID],
+              target.isProvisional == false,
+              target.capabilities.contains(.console),
+              connection.consoleEnabledTargetIDs.contains(targetID) == false,
+              console.supportsCommand("Console.enable", targetID: targetID) else {
+            return false
+        }
+        return true
+    }
+
+    private func enableRuntimeConsoleIfNeeded(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection
+    ) async throws {
+        guard let target = dom.snapshot().targetsByID[targetID],
+              target.isProvisional == false,
+              target.capabilities.contains(.console) else {
+            return
+        }
+
+        if target.capabilities.contains(.runtime),
+           connection.runtimeEnabledTargetIDs.contains(targetID) == false,
+           runtime.supportsCommand("Runtime.enable", targetID: targetID) {
+            do {
+                _ = try await connection.transport.send(try RuntimeTransportAdapter.command(for: .enable(targetID: targetID)))
+                try ensureCurrentConnection(connection)
+                connection.runtimeEnabledTargetIDs.insert(targetID)
+            } catch {
+                markRuntimeCommandUnsupportedIfNeeded("Runtime.enable", targetID: targetID, error: error)
+                throw error
+            }
+        }
+
+        guard connection.consoleEnabledTargetIDs.contains(targetID) == false,
+              console.supportsCommand("Console.enable", targetID: targetID) else {
+            return
+        }
+        do {
+            _ = try await connection.transport.send(try ConsoleTransportAdapter.command(for: .enable(targetID: targetID)))
+            try ensureCurrentConnection(connection)
+            connection.consoleEnabledTargetIDs.insert(targetID)
+        } catch {
+            markConsoleCommandUnsupportedIfNeeded("Console.enable", targetID: targetID, error: error)
+            throw error
+        }
+    }
+
+    private func cancelRuntimeConsoleEnableTask(targetID: ProtocolTargetIdentifier) {
+        guard let connection else {
+            return
+        }
+        connection.runtimeConsoleEnableTasksByTargetID.removeValue(forKey: targetID)?.cancel()
+    }
+
+    private func cancelRuntimeConsoleEnableTasks(_ connection: InspectorConnection) {
+        for task in connection.runtimeConsoleEnableTasksByTargetID.values {
+            task.cancel()
+        }
+        connection.runtimeConsoleEnableTasksByTargetID.removeAll()
+    }
+
+    private func retargetRuntimeConsoleAgentState(
+        oldTargetID: ProtocolTargetIdentifier?,
+        newTargetID: ProtocolTargetIdentifier
+    ) {
+        guard let oldTargetID,
+              let connection else {
+            return
+        }
+        if connection.runtimeEnabledTargetIDs.remove(oldTargetID) != nil {
+            connection.runtimeEnabledTargetIDs.insert(newTargetID)
+        }
+        if connection.consoleEnabledTargetIDs.remove(oldTargetID) != nil {
+            connection.consoleEnabledTargetIDs.insert(newTargetID)
         }
     }
 
@@ -1691,6 +1933,12 @@ package final class InspectorSession {
         }
         for record in snapshot.executionContextsByID.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
             dom.applyExecutionContextCreated(record)
+        }
+    }
+
+    private func seedRuntimeSession(from snapshot: TransportSnapshot) {
+        for record in snapshot.executionContextsByID.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+            runtime.applyExecutionContextCreated(record)
         }
     }
 

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1123,12 +1123,12 @@ package final class InspectorSession {
             }
             applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
             if isAttached,
-               let createdTarget,
-               createdTarget.kind == .frame {
-                if createdTarget.capabilities.contains(.dom) {
+               let createdTarget {
+                if createdTarget.kind == .frame,
+                   createdTarget.capabilities.contains(.dom) {
                     startDOMDocumentRequest(targetID: createdTarget.id, reason: "frameTargetCreated")
                 }
-                startRuntimeConsoleEnableIfNeeded(targetID: createdTarget.id, reason: "frameTargetCreated")
+                startRuntimeConsoleEnableIfNeeded(targetID: createdTarget.id, reason: "targetCreated")
             }
             if event.method == "Target.didCommitProvisionalTarget",
                dom.currentPageRootNode == nil,
@@ -1168,7 +1168,7 @@ package final class InspectorSession {
 
     private func startRuntimeConsoleEnableForAttachedTargets() {
         for target in dom.snapshot().targetsByID.values
-        where target.kind == .frame && target.isProvisional == false {
+        where target.isProvisional == false {
             startRuntimeConsoleEnableIfNeeded(targetID: target.id, reason: "attachedTarget")
         }
     }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1281,15 +1281,12 @@ package final class InspectorSession {
         newTargetID: ProtocolTargetIdentifier
     ) {
         guard let oldTargetID,
+              oldTargetID != newTargetID,
               let connection else {
             return
         }
-        if connection.runtimeEnabledTargetIDs.remove(oldTargetID) != nil {
-            connection.runtimeEnabledTargetIDs.insert(newTargetID)
-        }
-        if connection.consoleEnabledTargetIDs.remove(oldTargetID) != nil {
-            connection.consoleEnabledTargetIDs.insert(newTargetID)
-        }
+        connection.runtimeEnabledTargetIDs.remove(oldTargetID)
+        connection.consoleEnabledTargetIDs.remove(oldTargetID)
     }
 
     private func startFrameTargetDocumentRequestAfterCommit(targetID: ProtocolTargetIdentifier) {

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1146,17 +1146,18 @@ package final class InspectorSession {
             }
             if event.method == "Target.didCommitProvisionalTarget",
                let targetCommit {
-                if let oldTargetID = targetCommit.oldTargetID {
+                if targetCommit.consumesOldTarget,
+                   let oldTargetID = targetCommit.oldTargetID {
                     cancelDOMDocumentRequest(targetID: oldTargetID, reason: "frameTargetCommit")
                     cancelRuntimeConsoleEnableTask(targetID: oldTargetID)
                     css.removeStyles(targetID: oldTargetID)
+                    runtime.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: targetCommit.newTargetID)
+                    console.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: targetCommit.newTargetID)
+                    retargetRuntimeConsoleAgentState(
+                        oldTargetID: oldTargetID,
+                        newTargetID: targetCommit.newTargetID
+                    )
                 }
-                runtime.applyTargetCommitted(oldTargetID: targetCommit.oldTargetID, newTargetID: targetCommit.newTargetID)
-                console.applyTargetCommitted(oldTargetID: targetCommit.oldTargetID, newTargetID: targetCommit.newTargetID)
-                retargetRuntimeConsoleAgentState(
-                    oldTargetID: targetCommit.oldTargetID,
-                    newTargetID: targetCommit.newTargetID
-                )
                 startFrameTargetDocumentRequestAfterCommit(targetID: targetCommit.newTargetID)
                 startRuntimeConsoleEnableIfNeeded(targetID: targetCommit.newTargetID, reason: "frameTargetCommit")
             }
@@ -1781,6 +1782,7 @@ package final class InspectorSession {
             clearElementPickerState(invalidatePendingSelection: true)
         case "Target.didCommitProvisionalTarget":
             guard let targetCommit,
+                  targetCommit.consumesOldTarget,
                   targetCommit.oldTargetID == activeTargetID else {
                 return
             }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1033,13 +1033,7 @@ package final class InspectorSession {
             )
         )
         try ensureCurrentConnection(connection)
-        if dom.targetCapabilities(for: mainTargetID).contains(.console) {
-            _ = try await connection.transport.send(
-                try ConsoleTransportAdapter.command(for: .enable(targetID: mainTargetID))
-            )
-            try ensureCurrentConnection(connection)
-            connection.consoleEnabledTargetIDs.insert(mainTargetID)
-        }
+        try await enableConsoleAgentIfSupported(targetID: mainTargetID, connection: connection, force: true)
         connection.bootstrappedTargetIDs.insert(mainTargetID)
     }
 
@@ -1240,12 +1234,30 @@ package final class InspectorSession {
               console.supportsCommand("Console.enable", targetID: targetID) else {
             return
         }
+        try await enableConsoleAgentIfSupported(targetID: targetID, connection: connection)
+    }
+
+    private func enableConsoleAgentIfSupported(
+        targetID: ProtocolTargetIdentifier,
+        connection: InspectorConnection,
+        force: Bool = false
+    ) async throws {
+        guard dom.targetCapabilities(for: targetID).contains(.console),
+              console.supportsCommand("Console.enable", targetID: targetID) else {
+            return
+        }
+        guard force || connection.consoleEnabledTargetIDs.contains(targetID) == false else {
+            return
+        }
         do {
             _ = try await connection.transport.send(try ConsoleTransportAdapter.command(for: .enable(targetID: targetID)))
             try ensureCurrentConnection(connection)
             connection.consoleEnabledTargetIDs.insert(targetID)
         } catch {
             markConsoleCommandUnsupportedIfNeeded("Console.enable", targetID: targetID, error: error)
+            if isUnsupportedProtocolCommandError(error) {
+                return
+            }
             throw error
         }
     }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1481,9 +1481,17 @@ package final class InspectorSession {
         eventTargetID: ProtocolTargetIdentifier?,
         activeTargetID: ProtocolTargetIdentifier
     ) -> ProtocolTargetIdentifier {
-        if let executionContextID = remoteObject.injectedScriptID,
-           let targetID = dom.snapshot().executionContextsByID[executionContextID]?.targetID {
-            return targetID
+        if let executionContextID = remoteObject.injectedScriptID {
+            let snapshot = dom.snapshot()
+            if let targetID = snapshot.executionContext(
+                runtimeAgentTargetID: eventTargetID ?? activeTargetID,
+                contextID: executionContextID
+            )?.targetID {
+                return targetID
+            }
+            if let targetID = snapshot.uniqueExecutionContext(contextID: executionContextID)?.targetID {
+                return targetID
+            }
         }
         return eventTargetID ?? activeTargetID
     }
@@ -1971,13 +1979,13 @@ package final class InspectorSession {
                     && record.parentFrameID == nil
             )
         }
-        for record in snapshot.executionContextsByID.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+        for record in snapshot.executionContextsByKey.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
             dom.applyExecutionContextCreated(record)
         }
     }
 
     private func seedRuntimeSession(from snapshot: TransportSnapshot) {
-        for record in snapshot.executionContextsByID.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+        for record in snapshot.executionContextsByKey.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
             runtime.applyExecutionContextCreated(record)
         }
     }

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1254,7 +1254,9 @@ package final class InspectorSession {
                 connection.runtimeEnabledTargetIDs.insert(targetID)
             } catch {
                 markRuntimeCommandUnsupportedIfNeeded("Runtime.enable", targetID: targetID, error: error)
-                throw error
+                if isUnsupportedProtocolCommandError(error) == false {
+                    throw error
+                }
             }
         }
 

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1201,21 +1201,23 @@ package final class InspectorSession {
                 try DOMTransportAdapter.applyRuntimeEvent(event, to: $0.dom)
             }
         case .console:
-            applyEvent(event) {
+            applyEvent(event) { session in
                 if let targetID = event.targetID,
                    let message = try ConsoleTransportAdapter.messagePayload(from: event) {
-                    for parameter in message.parameters {
-                        $0.runtime.registerRemoteObject(
+                    let parameters = message.parameters.map { parameter in
+                        session.runtime.registerRemoteObject(
                             parameter,
                             runtimeAgentTargetID: targetID,
                             objectGroup: .console
                         )
                     }
+                    session.console.applyMessageAdded(message, targetID: targetID, parameters: parameters)
+                    return
                 }
-                try ConsoleTransportAdapter.applyConsoleEvent(event, to: $0.console)
+                try ConsoleTransportAdapter.applyConsoleEvent(event, to: session.console)
                 if event.method == "Console.messagesCleared",
                    let targetID = event.targetID {
-                    $0.runtime.releaseObjectGroup(.console, runtimeAgentTargetID: targetID)
+                    session.runtime.releaseObjectGroup(.console, runtimeAgentTargetID: targetID)
                 }
             }
         case .inspector:

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1074,6 +1074,10 @@ package final class InspectorSession {
         case .console:
             applyEvent(event) {
                 try ConsoleTransportAdapter.applyConsoleEvent(event, to: $0.console)
+                if event.method == "Console.messagesCleared",
+                   let targetID = event.targetID {
+                    $0.runtime.releaseObjectGroup(.console, targetID: targetID)
+                }
             }
         case .inspector:
             await handleInspectorEvent(event)

--- a/Sources/WebInspectorTransport/ConsoleTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/ConsoleTransportAdapter.swift
@@ -1,0 +1,90 @@
+import Foundation
+import WebInspectorCore
+
+package enum ConsoleTransportAdapter {
+    package static func command(for intent: ConsoleCommandIntent) throws -> ProtocolCommand {
+        switch intent {
+        case let .enable(targetID):
+            return ProtocolCommand(domain: .console, method: "Console.enable", routing: .target(targetID))
+        case let .disable(targetID):
+            return ProtocolCommand(domain: .console, method: "Console.disable", routing: .target(targetID))
+        case let .clearMessages(targetID):
+            return ProtocolCommand(domain: .console, method: "Console.clearMessages", routing: .target(targetID))
+        case let .setConsoleClearAPIEnabled(targetID, enabled):
+            return ProtocolCommand(
+                domain: .console,
+                method: "Console.setConsoleClearAPIEnabled",
+                routing: .target(targetID),
+                parametersData: try data(["enable": enabled])
+            )
+        case let .getLoggingChannels(targetID):
+            return ProtocolCommand(domain: .console, method: "Console.getLoggingChannels", routing: .target(targetID))
+        case let .setLoggingChannelLevel(targetID, source, level):
+            return ProtocolCommand(
+                domain: .console,
+                method: "Console.setLoggingChannelLevel",
+                routing: .target(targetID),
+                parametersData: try data([
+                    "source": source.rawValue,
+                    "level": level.rawValue,
+                ])
+            )
+        }
+    }
+
+    package static func loggingChannels(from result: ProtocolCommandResult) throws -> [ConsoleLoggingChannelPayload] {
+        let payload = try TransportMessageParser.decode(LoggingChannelsResult.self, from: result.resultData)
+        return payload.channels
+    }
+
+    package static func messagePayload(from event: ProtocolEventEnvelope) throws -> ConsoleMessagePayload? {
+        guard event.method == "Console.messageAdded" else {
+            return nil
+        }
+        let params = try TransportMessageParser.decode(MessageAddedParams.self, from: event.paramsData)
+        return params.message
+    }
+
+    @MainActor
+    package static func applyConsoleEvent(_ event: ProtocolEventEnvelope, to session: ConsoleSession) throws {
+        guard event.domain == .console,
+              let targetID = event.targetID else {
+            return
+        }
+
+        switch event.method {
+        case "Console.messageAdded":
+            let params = try TransportMessageParser.decode(MessageAddedParams.self, from: event.paramsData)
+            session.applyMessageAdded(params.message, targetID: targetID)
+        case "Console.messageRepeatCountUpdated":
+            let params = try TransportMessageParser.decode(MessageRepeatCountUpdatedParams.self, from: event.paramsData)
+            session.applyRepeatCountUpdated(count: params.count, timestamp: params.timestamp, targetID: targetID)
+        case "Console.messagesCleared":
+            let params = try TransportMessageParser.decode(MessagesClearedParams.self, from: event.paramsData)
+            session.applyMessagesCleared(reason: params.reason, targetID: targetID)
+        default:
+            break
+        }
+    }
+
+    private static func data(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [])
+    }
+}
+
+private struct LoggingChannelsResult: Decodable {
+    var channels: [ConsoleLoggingChannelPayload]
+}
+
+private struct MessageAddedParams: Decodable {
+    var message: ConsoleMessagePayload
+}
+
+private struct MessageRepeatCountUpdatedParams: Decodable {
+    var count: Int
+    var timestamp: Double?
+}
+
+private struct MessagesClearedParams: Decodable {
+    var reason: ConsoleClearReason
+}

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -146,14 +146,35 @@ package enum DOMTransportAdapter {
 
     @MainActor
     package static func applyRuntimeEvent(_ event: ProtocolEventEnvelope, to session: DOMSession) throws {
-        guard event.method == "Runtime.executionContextCreated",
-              let targetID = event.targetID else {
+        guard event.domain == .runtime else {
             return
         }
-        let params = try TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: event.paramsData)
-        session.applyExecutionContextCreated(
-            .init(id: params.context.id, targetID: targetID, frameID: params.context.frameId)
-        )
+        switch event.method {
+        case "Runtime.executionContextCreated":
+            guard let targetID = event.targetID else {
+                return
+            }
+            let params = try TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: event.paramsData)
+            session.applyExecutionContextCreated(
+                .init(
+                    id: params.context.id,
+                    targetID: targetID,
+                    type: params.context.type ?? .normal,
+                    name: params.context.name ?? "",
+                    frameID: params.context.frameId
+                )
+            )
+        case "Runtime.executionContextDestroyed":
+            let params = try TransportMessageParser.decode(RuntimeExecutionContextDestroyedParams.self, from: event.paramsData)
+            session.applyExecutionContextDestroyed(params.executionContextId)
+        case "Runtime.executionContextsCleared":
+            guard let targetID = event.targetID else {
+                return
+            }
+            session.applyExecutionContextsCleared(targetID: targetID)
+        default:
+            return
+        }
     }
 
     @MainActor
@@ -424,10 +445,16 @@ private struct TargetCommittedParams: Decodable {
 private struct RuntimeExecutionContextCreatedParams: Decodable {
     struct Context: Decodable {
         var id: ExecutionContextID
+        var type: RuntimeExecutionContextType?
+        var name: String?
         var frameId: DOMFrameIdentifier?
     }
 
     var context: Context
+}
+
+private struct RuntimeExecutionContextDestroyedParams: Decodable {
+    var executionContextId: ExecutionContextID
 }
 
 private struct GetDocumentResult: Decodable {

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -5,6 +5,7 @@ package enum DOMTransportAdapter {
     package struct TargetCommitResolution: Equatable, Sendable {
         package var oldTargetID: ProtocolTargetIdentifier?
         package var newTargetID: ProtocolTargetIdentifier
+        package var consumesOldTarget: Bool
     }
 
     package static func command(for intent: DOMCommandIntent) throws -> ProtocolCommand {
@@ -138,9 +139,13 @@ package enum DOMTransportAdapter {
             return nil
         }
         let params = try TransportMessageParser.decode(TargetCommittedParams.self, from: event.paramsData)
+        let oldTargetID = params.oldTargetId ?? inferredOldTargetIDForOldlessCommit(params, snapshot: snapshot)
         return TargetCommitResolution(
-            oldTargetID: params.oldTargetId ?? inferredOldTargetIDForOldlessCommit(params, snapshot: snapshot),
-            newTargetID: params.newTargetId
+            oldTargetID: oldTargetID,
+            newTargetID: params.newTargetId,
+            consumesOldTarget: oldTargetID.map {
+                targetCommitConsumesOldTarget(oldTargetID: $0, newTargetID: params.newTargetId, snapshot: snapshot)
+            } ?? false
         )
     }
 
@@ -369,6 +374,22 @@ package enum DOMTransportAdapter {
             .filter { $0.value.isProvisional }
             .map(\.key)
         return provisionalTargetIDs.count == 1 ? provisionalTargetIDs[0] : nil
+    }
+
+    private static func targetCommitConsumesOldTarget(
+        oldTargetID: ProtocolTargetIdentifier,
+        newTargetID: ProtocolTargetIdentifier,
+        snapshot: DOMSessionSnapshot
+    ) -> Bool {
+        guard oldTargetID != newTargetID else {
+            return false
+        }
+        if snapshot.currentPageTargetID == oldTargetID,
+           let newTarget = snapshot.targetsByID[newTargetID],
+           (newTarget.kind != .page || newTarget.parentFrameID != nil) {
+            return false
+        }
+        return true
     }
 
     private static func injectedScriptID(from objectID: String) -> ExecutionContextID? {

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -5,7 +5,7 @@ package enum DOMTransportAdapter {
     package struct TargetCommitResolution: Equatable, Sendable {
         package var oldTargetID: ProtocolTargetIdentifier?
         package var newTargetID: ProtocolTargetIdentifier
-        package var consumesOldTarget: Bool
+        package var consumedOldTargetID: ProtocolTargetIdentifier?
     }
 
     package static func command(for intent: DOMCommandIntent) throws -> ProtocolCommand {
@@ -113,7 +113,7 @@ package enum DOMTransportAdapter {
             guard let commit = try targetCommitResolution(from: event, snapshot: snapshotBeforeCommit) else {
                 return nil
             }
-            if let oldTargetID = commit.oldTargetID {
+            if let oldTargetID = commit.consumedOldTargetID {
                 session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: commit.newTargetID)
             } else {
                 session.applyTargetCommitted(targetID: commit.newTargetID)
@@ -143,9 +143,9 @@ package enum DOMTransportAdapter {
         return TargetCommitResolution(
             oldTargetID: oldTargetID,
             newTargetID: params.newTargetId,
-            consumesOldTarget: oldTargetID.map {
-                targetCommitConsumesOldTarget(oldTargetID: $0, newTargetID: params.newTargetId, snapshot: snapshot)
-            } ?? false
+            consumedOldTargetID: oldTargetID.flatMap {
+                targetCommitConsumesOldTarget(oldTargetID: $0, newTargetID: params.newTargetId, snapshot: snapshot) ? $0 : nil
+            }
         )
     }
 

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -159,6 +159,7 @@ package enum DOMTransportAdapter {
                 .init(
                     id: params.context.id,
                     targetID: targetID,
+                    runtimeAgentTargetID: event.sourceTargetID ?? targetID,
                     type: params.context.type ?? .normal,
                     name: params.context.name ?? "",
                     frameID: params.context.frameId
@@ -171,7 +172,7 @@ package enum DOMTransportAdapter {
             guard let targetID = event.targetID else {
                 return
             }
-            session.applyExecutionContextsCleared(targetID: targetID)
+            session.applyExecutionContextsCleared(runtimeAgentTargetID: event.sourceTargetID ?? targetID)
         default:
             return
         }

--- a/Sources/WebInspectorTransport/DOMTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/DOMTransportAdapter.swift
@@ -166,8 +166,16 @@ package enum DOMTransportAdapter {
                 )
             )
         case "Runtime.executionContextDestroyed":
+            guard let targetID = event.targetID else {
+                return
+            }
             let params = try TransportMessageParser.decode(RuntimeExecutionContextDestroyedParams.self, from: event.paramsData)
-            session.applyExecutionContextDestroyed(params.executionContextId)
+            session.applyExecutionContextDestroyed(
+                RuntimeExecutionContextKey(
+                    runtimeAgentTargetID: event.sourceTargetID ?? targetID,
+                    contextID: params.executionContextId
+                )
+            )
         case "Runtime.executionContextsCleared":
             guard let targetID = event.targetID else {
                 return

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -121,13 +121,27 @@ package enum RuntimeTransportAdapter {
 
     @MainActor
     package static func applyRuntimeEvent(_ event: ProtocolEventEnvelope, to session: RuntimeSession) throws {
-        guard event.domain == .runtime,
-              event.method == "Runtime.executionContextCreated",
-              let targetID = event.targetID else {
+        guard event.domain == .runtime else {
             return
         }
-        let params = try TransportMessageParser.decode(ExecutionContextCreatedParams.self, from: event.paramsData)
-        session.applyExecutionContextCreated(params.context, targetID: targetID)
+        switch event.method {
+        case "Runtime.executionContextCreated":
+            guard let targetID = event.targetID else {
+                return
+            }
+            let params = try TransportMessageParser.decode(ExecutionContextCreatedParams.self, from: event.paramsData)
+            session.applyExecutionContextCreated(params.context, targetID: targetID)
+        case "Runtime.executionContextDestroyed":
+            let params = try TransportMessageParser.decode(ExecutionContextDestroyedParams.self, from: event.paramsData)
+            session.applyExecutionContextDestroyed(params.executionContextId)
+        case "Runtime.executionContextsCleared":
+            guard let targetID = event.targetID else {
+                return
+            }
+            session.applyExecutionContextsCleared(targetID: targetID)
+        default:
+            return
+        }
     }
 
     private static func evaluationParameters(_ request: RuntimeEvaluationRequest) -> [String: Any] {
@@ -193,4 +207,8 @@ package enum RuntimeTransportAdapter {
 
 private struct ExecutionContextCreatedParams: Decodable {
     var context: RuntimeExecutionContextPayload
+}
+
+private struct ExecutionContextDestroyedParams: Decodable {
+    var executionContextId: ExecutionContextID
 }

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -10,21 +10,21 @@ package enum RuntimeTransportAdapter {
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.evaluate",
-                routing: .target(request.targetID),
+                routing: .target(request.runtimeAgentTargetID),
                 parametersData: try data(evaluationParameters(request))
             )
         case let .getPreview(object):
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.getPreview",
-                routing: .target(object.targetID),
+                routing: .target(object.runtimeAgentTargetID),
                 parametersData: try data(["objectId": object.objectID.rawValue])
             )
         case let .getProperties(object, ownProperties, fetchStart, fetchCount, generatePreview):
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.getProperties",
-                routing: .target(object.targetID),
+                routing: .target(object.runtimeAgentTargetID),
                 parametersData: try data(
                     objectParameters(
                         object,
@@ -39,7 +39,7 @@ package enum RuntimeTransportAdapter {
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.getDisplayableProperties",
-                routing: .target(object.targetID),
+                routing: .target(object.runtimeAgentTargetID),
                 parametersData: try data(
                     objectParameters(
                         object,
@@ -57,7 +57,7 @@ package enum RuntimeTransportAdapter {
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.getCollectionEntries",
-                routing: .target(object.targetID),
+                routing: .target(object.runtimeAgentTargetID),
                 parametersData: try data(parameters)
             )
         case let .saveResult(targetID, argument, contextID):
@@ -86,14 +86,14 @@ package enum RuntimeTransportAdapter {
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.releaseObject",
-                routing: .target(object.targetID),
+                routing: .target(object.runtimeAgentTargetID),
                 parametersData: try data(["objectId": object.objectID.rawValue])
             )
-        case let .releaseObjectGroup(targetID, objectGroup):
+        case let .releaseObjectGroup(runtimeAgentTargetID, objectGroup):
             return ProtocolCommand(
                 domain: .runtime,
                 method: "Runtime.releaseObjectGroup",
-                routing: .target(targetID),
+                routing: .target(runtimeAgentTargetID),
                 parametersData: try data(["objectGroup": objectGroup.rawValue])
             )
         }

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -131,7 +131,7 @@ package enum RuntimeTransportAdapter {
             }
             let params = try TransportMessageParser.decode(ExecutionContextCreatedParams.self, from: event.paramsData)
             session.applyExecutionContextCreated(
-                RuntimeExecutionContext(
+                RuntimeExecutionContextRecord(
                     id: params.context.id,
                     targetID: targetID,
                     runtimeAgentTargetID: event.sourceTargetID ?? targetID,

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -141,8 +141,16 @@ package enum RuntimeTransportAdapter {
                 )
             )
         case "Runtime.executionContextDestroyed":
+            guard let targetID = event.targetID else {
+                return
+            }
             let params = try TransportMessageParser.decode(ExecutionContextDestroyedParams.self, from: event.paramsData)
-            session.applyExecutionContextDestroyed(params.executionContextId)
+            session.applyExecutionContextDestroyed(
+                RuntimeExecutionContextKey(
+                    runtimeAgentTargetID: event.sourceTargetID ?? targetID,
+                    contextID: params.executionContextId
+                )
+            )
         case "Runtime.executionContextsCleared":
             guard let targetID = event.targetID else {
                 return

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -1,0 +1,196 @@
+import Foundation
+import WebInspectorCore
+
+package enum RuntimeTransportAdapter {
+    package static func command(for intent: RuntimeCommandIntent) throws -> ProtocolCommand {
+        switch intent {
+        case let .enable(targetID):
+            return ProtocolCommand(domain: .runtime, method: "Runtime.enable", routing: .target(targetID))
+        case let .evaluate(request):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.evaluate",
+                routing: .target(request.targetID),
+                parametersData: try data(evaluationParameters(request))
+            )
+        case let .getPreview(object):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.getPreview",
+                routing: .target(object.targetID),
+                parametersData: try data(["objectId": object.objectID.rawValue])
+            )
+        case let .getProperties(object, ownProperties, fetchStart, fetchCount, generatePreview):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.getProperties",
+                routing: .target(object.targetID),
+                parametersData: try data(
+                    objectParameters(
+                        object,
+                        ownProperties: ownProperties,
+                        fetchStart: fetchStart,
+                        fetchCount: fetchCount,
+                        generatePreview: generatePreview
+                    )
+                )
+            )
+        case let .getDisplayableProperties(object, fetchStart, fetchCount, generatePreview):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.getDisplayableProperties",
+                routing: .target(object.targetID),
+                parametersData: try data(
+                    objectParameters(
+                        object,
+                        fetchStart: fetchStart,
+                        fetchCount: fetchCount,
+                        generatePreview: generatePreview
+                    )
+                )
+            )
+        case let .getCollectionEntries(object, objectGroup, fetchStart, fetchCount):
+            var parameters = objectParameters(object, fetchStart: fetchStart, fetchCount: fetchCount)
+            if let objectGroup {
+                parameters["objectGroup"] = objectGroup.rawValue
+            }
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.getCollectionEntries",
+                routing: .target(object.targetID),
+                parametersData: try data(parameters)
+            )
+        case let .saveResult(targetID, argument, contextID):
+            var parameters: [String: Any] = ["value": argument.parametersObject]
+            if let contextID {
+                parameters["contextId"] = contextID.rawValue
+            }
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.saveResult",
+                routing: .target(targetID),
+                parametersData: try data(parameters)
+            )
+        case let .setSavedResultAlias(targetID, alias):
+            var parameters: [String: Any] = [:]
+            if let alias {
+                parameters["alias"] = alias
+            }
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.setSavedResultAlias",
+                routing: .target(targetID),
+                parametersData: try data(parameters)
+            )
+        case let .releaseObject(object):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.releaseObject",
+                routing: .target(object.targetID),
+                parametersData: try data(["objectId": object.objectID.rawValue])
+            )
+        case let .releaseObjectGroup(targetID, objectGroup):
+            return ProtocolCommand(
+                domain: .runtime,
+                method: "Runtime.releaseObjectGroup",
+                routing: .target(targetID),
+                parametersData: try data(["objectGroup": objectGroup.rawValue])
+            )
+        }
+    }
+
+    package static func evaluationResult(from result: ProtocolCommandResult) throws -> RuntimeEvaluationResultPayload {
+        try TransportMessageParser.decode(RuntimeEvaluationResultPayload.self, from: result.resultData)
+    }
+
+    package static func previewResult(from result: ProtocolCommandResult) throws -> RuntimePreviewResultPayload {
+        try TransportMessageParser.decode(RuntimePreviewResultPayload.self, from: result.resultData)
+    }
+
+    package static func propertiesResult(from result: ProtocolCommandResult) throws -> RuntimePropertiesResultPayload {
+        try TransportMessageParser.decode(RuntimePropertiesResultPayload.self, from: result.resultData)
+    }
+
+    package static func collectionEntriesResult(from result: ProtocolCommandResult) throws -> RuntimeCollectionEntriesResultPayload {
+        try TransportMessageParser.decode(RuntimeCollectionEntriesResultPayload.self, from: result.resultData)
+    }
+
+    package static func saveResult(from result: ProtocolCommandResult) throws -> RuntimeSaveResultPayload {
+        try TransportMessageParser.decode(RuntimeSaveResultPayload.self, from: result.resultData)
+    }
+
+    @MainActor
+    package static func applyRuntimeEvent(_ event: ProtocolEventEnvelope, to session: RuntimeSession) throws {
+        guard event.domain == .runtime,
+              event.method == "Runtime.executionContextCreated",
+              let targetID = event.targetID else {
+            return
+        }
+        let params = try TransportMessageParser.decode(ExecutionContextCreatedParams.self, from: event.paramsData)
+        session.applyExecutionContextCreated(params.context, targetID: targetID)
+    }
+
+    private static func evaluationParameters(_ request: RuntimeEvaluationRequest) -> [String: Any] {
+        var parameters: [String: Any] = [
+            "expression": request.expression,
+        ]
+        if let objectGroup = request.objectGroup {
+            parameters["objectGroup"] = objectGroup.rawValue
+        }
+        if let includeCommandLineAPI = request.includeCommandLineAPI {
+            parameters["includeCommandLineAPI"] = includeCommandLineAPI
+        }
+        if let doNotPauseOnExceptionsAndMuteConsole = request.doNotPauseOnExceptionsAndMuteConsole {
+            parameters["doNotPauseOnExceptionsAndMuteConsole"] = doNotPauseOnExceptionsAndMuteConsole
+        }
+        if let contextID = request.contextID {
+            parameters["contextId"] = contextID.rawValue
+        }
+        if let returnByValue = request.returnByValue {
+            parameters["returnByValue"] = returnByValue
+        }
+        if let generatePreview = request.generatePreview {
+            parameters["generatePreview"] = generatePreview
+        }
+        if let saveResult = request.saveResult {
+            parameters["saveResult"] = saveResult
+        }
+        if let emulateUserGesture = request.emulateUserGesture {
+            parameters["emulateUserGesture"] = emulateUserGesture
+        }
+        return parameters
+    }
+
+    private static func objectParameters(
+        _ object: RuntimeRemoteObjectIdentifierKey,
+        ownProperties: Bool? = nil,
+        fetchStart: Int? = nil,
+        fetchCount: Int? = nil,
+        generatePreview: Bool? = nil
+    ) -> [String: Any] {
+        var parameters: [String: Any] = [
+            "objectId": object.objectID.rawValue,
+        ]
+        if let ownProperties {
+            parameters["ownProperties"] = ownProperties
+        }
+        if let fetchStart {
+            parameters["fetchStart"] = fetchStart
+        }
+        if let fetchCount {
+            parameters["fetchCount"] = fetchCount
+        }
+        if let generatePreview {
+            parameters["generatePreview"] = generatePreview
+        }
+        return parameters
+    }
+
+    private static func data(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [])
+    }
+}
+
+private struct ExecutionContextCreatedParams: Decodable {
+    var context: RuntimeExecutionContextPayload
+}

--- a/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
+++ b/Sources/WebInspectorTransport/RuntimeTransportAdapter.swift
@@ -130,7 +130,16 @@ package enum RuntimeTransportAdapter {
                 return
             }
             let params = try TransportMessageParser.decode(ExecutionContextCreatedParams.self, from: event.paramsData)
-            session.applyExecutionContextCreated(params.context, targetID: targetID)
+            session.applyExecutionContextCreated(
+                RuntimeExecutionContext(
+                    id: params.context.id,
+                    targetID: targetID,
+                    runtimeAgentTargetID: event.sourceTargetID ?? targetID,
+                    type: params.context.type ?? .normal,
+                    name: params.context.name ?? "",
+                    frameID: params.context.frameID
+                )
+            )
         case "Runtime.executionContextDestroyed":
             let params = try TransportMessageParser.decode(ExecutionContextDestroyedParams.self, from: event.paramsData)
             session.applyExecutionContextDestroyed(params.executionContextId)
@@ -138,7 +147,7 @@ package enum RuntimeTransportAdapter {
             guard let targetID = event.targetID else {
                 return
             }
-            session.applyExecutionContextsCleared(targetID: targetID)
+            session.applyExecutionContextsCleared(runtimeAgentTargetID: event.sourceTargetID ?? targetID)
         default:
             return
         }

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -470,7 +470,12 @@ package actor TransportSession {
         }
 
         updateRegistryFromTargetEvent(method: method, targetID: targetID, paramsData: parsed.paramsData)
-        await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetID, paramsData: parsed.paramsData)
+        let emittedTargetID = targetIDForTargetEvent(
+            method: method,
+            deliveredTargetID: targetID,
+            paramsData: parsed.paramsData
+        )
+        await emit(domain: ProtocolDomain(method: method), method: method, targetID: emittedTargetID, paramsData: parsed.paramsData)
     }
 
     private func resolve(_ pending: PendingReply, parsed: ParsedProtocolMessage) async {
@@ -779,6 +784,18 @@ package actor TransportSession {
                 return nil
             }
         }
+    }
+
+    private func targetIDForTargetEvent(
+        method: String,
+        deliveredTargetID: ProtocolTargetIdentifier,
+        paramsData: Data
+    ) -> ProtocolTargetIdentifier {
+        guard method == "Runtime.executionContextCreated",
+              let frameID = (try? TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: paramsData))?.context.frameId else {
+            return deliveredTargetID
+        }
+        return resolvedTargetIDForRuntimeContext(deliveredTargetID: deliveredTargetID, frameID: frameID)
     }
 
     private func targetIDForCSSStyleSheetAdded(paramsData: Data) -> ProtocolTargetIdentifier? {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -555,6 +555,8 @@ package actor TransportSession {
         executionContextsByID[params.context.id] = ExecutionContextRecord(
             id: params.context.id,
             targetID: resolvedTargetID,
+            type: params.context.type ?? .normal,
+            name: params.context.name ?? "",
             frameID: frameID
         )
         if let frameID {
@@ -694,11 +696,9 @@ package actor TransportSession {
         }
         if let oldTargetID = committedOldTargetID {
             for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
-                executionContextsByID[contextID] = ExecutionContextRecord(
-                    id: record.id,
-                    targetID: newTargetID,
-                    frameID: record.frameID
-                )
+                var movedRecord = record
+                movedRecord.targetID = newTargetID
+                executionContextsByID[contextID] = movedRecord
             }
             if currentMainPageTargetID == oldTargetID,
                newRecord.isTopLevelPage {
@@ -1089,6 +1089,8 @@ private struct TargetCommittedParams: Decodable {
 private struct RuntimeExecutionContextCreatedParams: Decodable {
     struct Context: Decodable {
         var id: ExecutionContextID
+        var type: RuntimeExecutionContextType?
+        var name: String?
         var frameId: DOMFrameIdentifier?
     }
 

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -435,8 +435,20 @@ package actor TransportSession {
         }
 
         let targetID = targetIDForRootEvent(method: method, paramsData: parsed.paramsData)
-        await updateRegistryFromRootEvent(method: method, targetID: targetID, paramsData: parsed.paramsData)
-        await emit(domain: ProtocolDomain(method: method), method: method, targetID: targetID, paramsData: parsed.paramsData)
+        let sourceTargetID = sourceTargetIDForRootEvent(method: method, targetID: targetID)
+        await updateRegistryFromRootEvent(
+            method: method,
+            targetID: targetID,
+            sourceTargetID: sourceTargetID,
+            paramsData: parsed.paramsData
+        )
+        await emit(
+            domain: ProtocolDomain(method: method),
+            method: method,
+            targetID: targetID,
+            sourceTargetID: sourceTargetID,
+            paramsData: parsed.paramsData
+        )
         await emitPendingResolvedStyleSheetAddedEvents()
         await dispatchCommittedProvisionalTargetMessagesIfNeeded(method: method, paramsData: parsed.paramsData)
     }
@@ -469,13 +481,24 @@ package actor TransportSession {
             return
         }
 
-        updateRegistryFromTargetEvent(method: method, targetID: targetID, paramsData: parsed.paramsData)
         let emittedTargetID = targetIDForTargetEvent(
             method: method,
             deliveredTargetID: targetID,
             paramsData: parsed.paramsData
         )
-        await emit(domain: ProtocolDomain(method: method), method: method, targetID: emittedTargetID, paramsData: parsed.paramsData)
+        updateRegistryFromTargetEvent(
+            method: method,
+            targetID: emittedTargetID,
+            sourceTargetID: targetID,
+            paramsData: parsed.paramsData
+        )
+        await emit(
+            domain: ProtocolDomain(method: method),
+            method: method,
+            targetID: emittedTargetID,
+            sourceTargetID: targetID,
+            paramsData: parsed.paramsData
+        )
     }
 
     private func resolve(_ pending: PendingReply, parsed: ParsedProtocolMessage) async {
@@ -508,6 +531,7 @@ package actor TransportSession {
     private func updateRegistryFromRootEvent(
         method: String,
         targetID: ProtocolTargetIdentifier?,
+        sourceTargetID: ProtocolTargetIdentifier?,
         paramsData: Data
     ) async {
         switch method {
@@ -527,7 +551,12 @@ package actor TransportSession {
             }
             applyTargetCommitted(oldTargetID: params.oldTargetId, newTargetID: params.newTargetId)
         case "Runtime.executionContextCreated", "Runtime.executionContextDestroyed", "Runtime.executionContextsCleared":
-            updateRegistryFromTargetEvent(method: method, targetID: targetID, paramsData: paramsData)
+            updateRegistryFromTargetEvent(
+                method: method,
+                targetID: targetID,
+                sourceTargetID: sourceTargetID,
+                paramsData: paramsData
+            )
         case "CSS.styleSheetAdded", "CSS.styleSheetRemoved":
             updateCSSStyleSheetRegistry(method: method, targetID: targetID, paramsData: paramsData)
         default:
@@ -535,7 +564,12 @@ package actor TransportSession {
         }
     }
 
-    private func updateRegistryFromTargetEvent(method: String, targetID: ProtocolTargetIdentifier?, paramsData: Data) {
+    private func updateRegistryFromTargetEvent(
+        method: String,
+        targetID: ProtocolTargetIdentifier?,
+        sourceTargetID: ProtocolTargetIdentifier? = nil,
+        paramsData: Data
+    ) {
         guard let targetID else {
             return
         }
@@ -556,6 +590,7 @@ package actor TransportSession {
             executionContextsByID[params.context.id] = RuntimeExecutionContext(
                 id: params.context.id,
                 targetID: resolvedTargetID,
+                runtimeAgentTargetID: sourceTargetID ?? resolvedTargetID,
                 type: params.context.type ?? .normal,
                 name: params.context.name ?? "",
                 frameID: frameID
@@ -569,7 +604,8 @@ package actor TransportSession {
             }
             executionContextsByID.removeValue(forKey: params.executionContextId)
         case "Runtime.executionContextsCleared":
-            executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+            let runtimeAgentTargetID = sourceTargetID ?? targetID
+            executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
         default:
             return
         }
@@ -650,7 +686,9 @@ package actor TransportSession {
         provisionalTargetMessagesByTargetID.removeValue(forKey: targetID)
         frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != targetID }
         styleSheetTargetIDsByStyleSheetID = styleSheetTargetIDsByStyleSheetID.filter { $0.value != targetID }
-        executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+        executionContextsByID = executionContextsByID.filter {
+            $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
+        }
         let pendingReplies = targetReplies.keys
             .filter { $0.targetID == targetID }
             .compactMap { removeTargetReply(for: $0) }
@@ -710,6 +748,9 @@ package actor TransportSession {
                 var movedRecord = record
                 movedRecord.targetID = newTargetID
                 executionContextsByID[contextID] = movedRecord
+            }
+            for (contextID, record) in executionContextsByID where record.runtimeAgentTargetID == oldTargetID {
+                executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
             }
             if currentMainPageTargetID == oldTargetID,
                newRecord.isTopLevelPage {
@@ -794,6 +835,18 @@ package actor TransportSession {
             default:
                 return nil
             }
+        }
+    }
+
+    private func sourceTargetIDForRootEvent(
+        method: String,
+        targetID: ProtocolTargetIdentifier?
+    ) -> ProtocolTargetIdentifier? {
+        switch ProtocolDomain(method: method) {
+        case .runtime:
+            return currentMainPageTargetID ?? targetID
+        default:
+            return targetID
         }
     }
 
@@ -917,7 +970,13 @@ package actor TransportSession {
         return nextCommandID
     }
 
-    private func emit(domain: ProtocolDomain, method: String, targetID: ProtocolTargetIdentifier?, paramsData: Data) async {
+    private func emit(
+        domain: ProtocolDomain,
+        method: String,
+        targetID: ProtocolTargetIdentifier?,
+        sourceTargetID: ProtocolTargetIdentifier? = nil,
+        paramsData: Data
+    ) async {
         nextSequence &+= 1
         lastSequenceByDomain[domain] = nextSequence
         let envelope = ProtocolEventEnvelope(
@@ -925,6 +984,7 @@ package actor TransportSession {
             domain: domain,
             method: method,
             targetID: targetID,
+            sourceTargetID: sourceTargetID,
             receivedDomainSequences: lastSequenceByDomain,
             paramsData: paramsData
         )

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -778,7 +778,7 @@ package actor TransportSession {
             return nil
         default:
             switch ProtocolDomain(method: method) {
-            case .dom, .runtime, .css, .network, .page, .storage:
+            case .dom, .runtime, .css, .console, .network, .page, .storage:
                 return currentMainPageTargetID
             default:
                 return nil

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -15,6 +15,112 @@ package actor TransportSession {
         var paramsData: Data
     }
 
+    private struct RuntimeContextAgentState: Sendable {
+        var targetID: ProtocolTargetIdentifier
+        var contextsByID: [ExecutionContextID: RuntimeExecutionContextRecord] = [:]
+
+        var isEmpty: Bool {
+            contextsByID.isEmpty
+        }
+    }
+
+    private struct RuntimeContextRegistry: Sendable {
+        private var agentStatesByID: [ProtocolTargetIdentifier: RuntimeContextAgentState] = [:]
+
+        var contextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord] {
+            Dictionary(
+                uniqueKeysWithValues: agentStatesByID.values.flatMap { state in
+                    state.contextsByID.values.map { ($0.key, $0) }
+                }
+            )
+        }
+
+        func targetID(for key: RuntimeExecutionContextKey) -> ProtocolTargetIdentifier? {
+            agentStatesByID[key.runtimeAgentTargetID]?.contextsByID[key.contextID]?.targetID
+        }
+
+        mutating func record(_ context: RuntimeExecutionContextRecord) {
+            var state = agentState(for: context.runtimeAgentTargetID)
+            state.contextsByID[context.id] = context
+            store(state)
+        }
+
+        mutating func remove(_ key: RuntimeExecutionContextKey) {
+            guard var state = agentStatesByID[key.runtimeAgentTargetID] else {
+                return
+            }
+            state.contextsByID.removeValue(forKey: key.contextID)
+            store(state)
+        }
+
+        mutating func clear(runtimeAgentTargetID: ProtocolTargetIdentifier) {
+            guard var state = agentStatesByID[runtimeAgentTargetID] else {
+                return
+            }
+            state.contextsByID.removeAll()
+            store(state)
+        }
+
+        mutating func removeTarget(_ targetID: ProtocolTargetIdentifier) {
+            agentStatesByID.removeValue(forKey: targetID)
+            for agentID in Array(agentStatesByID.keys) {
+                guard var state = agentStatesByID[agentID] else {
+                    continue
+                }
+                state.contextsByID = state.contextsByID.filter { $0.value.targetID != targetID }
+                store(state)
+            }
+        }
+
+        mutating func retarget(oldTargetID: ProtocolTargetIdentifier, newTargetID: ProtocolTargetIdentifier) {
+            let currentContexts = contextsByKey
+            var nextContexts = currentContexts
+            for (contextKey, context) in currentContexts {
+                var movedContext = context
+                if movedContext.targetID == oldTargetID {
+                    movedContext.targetID = newTargetID
+                }
+                if movedContext.runtimeAgentTargetID == oldTargetID {
+                    movedContext.runtimeAgentTargetID = newTargetID
+                }
+                guard movedContext != context else {
+                    continue
+                }
+                nextContexts.removeValue(forKey: contextKey)
+                if nextContexts[movedContext.key] == nil {
+                    nextContexts[movedContext.key] = movedContext
+                }
+            }
+            replace(with: nextContexts)
+        }
+
+        private func agentState(for targetID: ProtocolTargetIdentifier) -> RuntimeContextAgentState {
+            agentStatesByID[targetID] ?? RuntimeContextAgentState(targetID: targetID)
+        }
+
+        private mutating func store(_ state: RuntimeContextAgentState) {
+            if state.isEmpty {
+                agentStatesByID.removeValue(forKey: state.targetID)
+            } else {
+                agentStatesByID[state.targetID] = state
+            }
+        }
+
+        private mutating func replace(with contextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord]) {
+            for agentID in agentStatesByID.keys {
+                agentStatesByID[agentID]?.contextsByID.removeAll()
+            }
+            for context in contextsByKey.values {
+                record(context)
+            }
+            for agentID in Array(agentStatesByID.keys) {
+                if let state = agentStatesByID[agentID] {
+                    store(state)
+                }
+            }
+        }
+    }
+
     package typealias ResponseTimeoutSleep = @Sendable (Duration) async throws -> Void
 
     private let backend: any TransportBackend
@@ -36,7 +142,7 @@ package actor TransportSession {
     private var unresolvedStyleSheetFrameIDsByStyleSheetID: [CSSStyleSheetIdentifier: DOMFrameIdentifier]
     private var unresolvedStyleSheetAddedParamsDataByStyleSheetID: [CSSStyleSheetIdentifier: Data]
     private var pendingResolvedStyleSheetAddedEvents: [ResolvedStyleSheetAddedEvent]
-    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    private var runtimeContextRegistry: RuntimeContextRegistry
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
     private var orderedSubscribers: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]
@@ -69,7 +175,7 @@ package actor TransportSession {
         unresolvedStyleSheetFrameIDsByStyleSheetID = [:]
         unresolvedStyleSheetAddedParamsDataByStyleSheetID = [:]
         pendingResolvedStyleSheetAddedEvents = []
-        executionContextsByKey = [:]
+        runtimeContextRegistry = RuntimeContextRegistry()
         currentMainPageTargetID = nil
         subscribers = [:]
         orderedSubscribers = [:]
@@ -218,14 +324,14 @@ package actor TransportSession {
             currentMainPageTargetID: currentMainPageTargetID,
             targetsByID: targetsByID,
             frameTargetIDsByFrameID: frameTargetIDsByFrameID,
-            executionContextsByKey: executionContextsByKey,
+            executionContextsByKey: runtimeContextRegistry.contextsByKey,
             pendingRootReplyIDs: rootReplies.keys.sorted(),
             pendingTargetReplyKeys: targetReplies.keys.sorted()
         )
     }
 
     package func targetIdentifier(forExecutionContext key: RuntimeExecutionContextKey) -> ProtocolTargetIdentifier? {
-        executionContextsByKey[key]?.targetID
+        runtimeContextRegistry.targetID(for: key)
     }
 
     package func targetIdentifier(forFrameID frameID: DOMFrameIdentifier) -> ProtocolTargetIdentifier? {
@@ -587,7 +693,7 @@ package actor TransportSession {
                 deliveredTargetID: targetID,
                 frameID: frameID
             )
-            let context = RuntimeExecutionContext(
+            let context = RuntimeExecutionContextRecord(
                 id: params.context.id,
                 targetID: resolvedTargetID,
                 runtimeAgentTargetID: sourceTargetID ?? targetID,
@@ -595,7 +701,7 @@ package actor TransportSession {
                 name: params.context.name ?? "",
                 frameID: frameID
             )
-            executionContextsByKey[context.key] = context
+            runtimeContextRegistry.record(context)
             if let frameID {
                 frameTargetIDsByFrameID[frameID] = resolvedTargetID
             }
@@ -604,15 +710,15 @@ package actor TransportSession {
                 return
             }
             let runtimeAgentTargetID = sourceTargetID ?? targetID
-            executionContextsByKey.removeValue(
-                forKey: RuntimeExecutionContextKey(
+            runtimeContextRegistry.remove(
+                RuntimeExecutionContextKey(
                     runtimeAgentTargetID: runtimeAgentTargetID,
                     contextID: params.executionContextId
                 )
             )
         case "Runtime.executionContextsCleared":
             let runtimeAgentTargetID = sourceTargetID ?? targetID
-            executionContextsByKey = executionContextsByKey.filter { $0.key.runtimeAgentTargetID != runtimeAgentTargetID }
+            runtimeContextRegistry.clear(runtimeAgentTargetID: runtimeAgentTargetID)
         default:
             return
         }
@@ -693,9 +799,7 @@ package actor TransportSession {
         provisionalTargetMessagesByTargetID.removeValue(forKey: targetID)
         frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != targetID }
         styleSheetTargetIDsByStyleSheetID = styleSheetTargetIDsByStyleSheetID.filter { $0.value != targetID }
-        executionContextsByKey = executionContextsByKey.filter {
-            $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
-        }
+        runtimeContextRegistry.removeTarget(targetID)
         let pendingReplies = targetReplies.keys
             .filter { $0.targetID == targetID }
             .compactMap { removeTargetReply(for: $0) }
@@ -751,20 +855,7 @@ package actor TransportSession {
             resolvePendingStyleSheets(frameID: frameID, targetID: newTargetID)
         }
         if let oldTargetID = committedOldTargetID {
-            for (contextKey, record) in Array(executionContextsByKey) {
-                var movedRecord = record
-                if movedRecord.targetID == oldTargetID {
-                    movedRecord.targetID = newTargetID
-                }
-                if movedRecord.runtimeAgentTargetID == oldTargetID {
-                    movedRecord.runtimeAgentTargetID = newTargetID
-                }
-                guard movedRecord != record else {
-                    continue
-                }
-                executionContextsByKey.removeValue(forKey: contextKey)
-                executionContextsByKey[movedRecord.key] = movedRecord
-            }
+            runtimeContextRegistry.retarget(oldTargetID: oldTargetID, newTargetID: newTargetID)
             if currentMainPageTargetID == oldTargetID,
                newRecord.isTopLevelPage {
                 currentMainPageTargetID = newTargetID

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -36,7 +36,7 @@ package actor TransportSession {
     private var unresolvedStyleSheetFrameIDsByStyleSheetID: [CSSStyleSheetIdentifier: DOMFrameIdentifier]
     private var unresolvedStyleSheetAddedParamsDataByStyleSheetID: [CSSStyleSheetIdentifier: Data]
     private var pendingResolvedStyleSheetAddedEvents: [ResolvedStyleSheetAddedEvent]
-    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    private var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
     private var orderedSubscribers: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]
@@ -69,7 +69,7 @@ package actor TransportSession {
         unresolvedStyleSheetFrameIDsByStyleSheetID = [:]
         unresolvedStyleSheetAddedParamsDataByStyleSheetID = [:]
         pendingResolvedStyleSheetAddedEvents = []
-        executionContextsByID = [:]
+        executionContextsByKey = [:]
         currentMainPageTargetID = nil
         subscribers = [:]
         orderedSubscribers = [:]
@@ -218,14 +218,14 @@ package actor TransportSession {
             currentMainPageTargetID: currentMainPageTargetID,
             targetsByID: targetsByID,
             frameTargetIDsByFrameID: frameTargetIDsByFrameID,
-            executionContextsByID: executionContextsByID,
+            executionContextsByKey: executionContextsByKey,
             pendingRootReplyIDs: rootReplies.keys.sorted(),
             pendingTargetReplyKeys: targetReplies.keys.sorted()
         )
     }
 
-    package func targetIdentifier(forExecutionContext contextID: ExecutionContextID) -> ProtocolTargetIdentifier? {
-        executionContextsByID[contextID]?.targetID
+    package func targetIdentifier(forExecutionContext key: RuntimeExecutionContextKey) -> ProtocolTargetIdentifier? {
+        executionContextsByKey[key]?.targetID
     }
 
     package func targetIdentifier(forFrameID frameID: DOMFrameIdentifier) -> ProtocolTargetIdentifier? {
@@ -587,14 +587,15 @@ package actor TransportSession {
                 deliveredTargetID: targetID,
                 frameID: frameID
             )
-            executionContextsByID[params.context.id] = RuntimeExecutionContext(
+            let context = RuntimeExecutionContext(
                 id: params.context.id,
                 targetID: resolvedTargetID,
-                runtimeAgentTargetID: sourceTargetID ?? resolvedTargetID,
+                runtimeAgentTargetID: sourceTargetID ?? targetID,
                 type: params.context.type ?? .normal,
                 name: params.context.name ?? "",
                 frameID: frameID
             )
+            executionContextsByKey[context.key] = context
             if let frameID {
                 frameTargetIDsByFrameID[frameID] = resolvedTargetID
             }
@@ -602,10 +603,16 @@ package actor TransportSession {
             guard let params = try? TransportMessageParser.decode(RuntimeExecutionContextDestroyedParams.self, from: paramsData) else {
                 return
             }
-            executionContextsByID.removeValue(forKey: params.executionContextId)
+            let runtimeAgentTargetID = sourceTargetID ?? targetID
+            executionContextsByKey.removeValue(
+                forKey: RuntimeExecutionContextKey(
+                    runtimeAgentTargetID: runtimeAgentTargetID,
+                    contextID: params.executionContextId
+                )
+            )
         case "Runtime.executionContextsCleared":
             let runtimeAgentTargetID = sourceTargetID ?? targetID
-            executionContextsByID = executionContextsByID.filter { $0.value.runtimeAgentTargetID != runtimeAgentTargetID }
+            executionContextsByKey = executionContextsByKey.filter { $0.key.runtimeAgentTargetID != runtimeAgentTargetID }
         default:
             return
         }
@@ -686,7 +693,7 @@ package actor TransportSession {
         provisionalTargetMessagesByTargetID.removeValue(forKey: targetID)
         frameTargetIDsByFrameID = frameTargetIDsByFrameID.filter { $0.value != targetID }
         styleSheetTargetIDsByStyleSheetID = styleSheetTargetIDsByStyleSheetID.filter { $0.value != targetID }
-        executionContextsByID = executionContextsByID.filter {
+        executionContextsByKey = executionContextsByKey.filter {
             $0.value.targetID != targetID && $0.value.runtimeAgentTargetID != targetID
         }
         let pendingReplies = targetReplies.keys
@@ -744,13 +751,19 @@ package actor TransportSession {
             resolvePendingStyleSheets(frameID: frameID, targetID: newTargetID)
         }
         if let oldTargetID = committedOldTargetID {
-            for (contextID, record) in executionContextsByID where record.targetID == oldTargetID {
+            for (contextKey, record) in Array(executionContextsByKey) {
                 var movedRecord = record
-                movedRecord.targetID = newTargetID
-                executionContextsByID[contextID] = movedRecord
-            }
-            for (contextID, record) in executionContextsByID where record.runtimeAgentTargetID == oldTargetID {
-                executionContextsByID[contextID]?.runtimeAgentTargetID = newTargetID
+                if movedRecord.targetID == oldTargetID {
+                    movedRecord.targetID = newTargetID
+                }
+                if movedRecord.runtimeAgentTargetID == oldTargetID {
+                    movedRecord.runtimeAgentTargetID = newTargetID
+                }
+                guard movedRecord != record else {
+                    continue
+                }
+                executionContextsByKey.removeValue(forKey: contextKey)
+                executionContextsByKey[movedRecord.key] = movedRecord
             }
             if currentMainPageTargetID == oldTargetID,
                newRecord.isTopLevelPage {

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -36,7 +36,7 @@ package actor TransportSession {
     private var unresolvedStyleSheetFrameIDsByStyleSheetID: [CSSStyleSheetIdentifier: DOMFrameIdentifier]
     private var unresolvedStyleSheetAddedParamsDataByStyleSheetID: [CSSStyleSheetIdentifier: Data]
     private var pendingResolvedStyleSheetAddedEvents: [ResolvedStyleSheetAddedEvent]
-    private var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+    private var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     private var currentMainPageTargetID: ProtocolTargetIdentifier?
     private var subscribers: [ProtocolDomain: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]]
     private var orderedSubscribers: [UInt64: AsyncStream<ProtocolEventEnvelope>.Continuation]
@@ -526,7 +526,7 @@ package actor TransportSession {
                 return
             }
             applyTargetCommitted(oldTargetID: params.oldTargetId, newTargetID: params.newTargetId)
-        case "Runtime.executionContextCreated":
+        case "Runtime.executionContextCreated", "Runtime.executionContextDestroyed", "Runtime.executionContextsCleared":
             updateRegistryFromTargetEvent(method: method, targetID: targetID, paramsData: paramsData)
         case "CSS.styleSheetAdded", "CSS.styleSheetRemoved":
             updateCSSStyleSheetRegistry(method: method, targetID: targetID, paramsData: paramsData)
@@ -543,24 +543,35 @@ package actor TransportSession {
             updateCSSStyleSheetRegistry(method: method, targetID: targetID, paramsData: paramsData)
             return
         }
-        guard method == "Runtime.executionContextCreated",
-              let params = try? TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: paramsData) else {
+        switch method {
+        case "Runtime.executionContextCreated":
+            guard let params = try? TransportMessageParser.decode(RuntimeExecutionContextCreatedParams.self, from: paramsData) else {
+                return
+            }
+            let frameID = params.context.frameId
+            let resolvedTargetID = resolvedTargetIDForRuntimeContext(
+                deliveredTargetID: targetID,
+                frameID: frameID
+            )
+            executionContextsByID[params.context.id] = RuntimeExecutionContext(
+                id: params.context.id,
+                targetID: resolvedTargetID,
+                type: params.context.type ?? .normal,
+                name: params.context.name ?? "",
+                frameID: frameID
+            )
+            if let frameID {
+                frameTargetIDsByFrameID[frameID] = resolvedTargetID
+            }
+        case "Runtime.executionContextDestroyed":
+            guard let params = try? TransportMessageParser.decode(RuntimeExecutionContextDestroyedParams.self, from: paramsData) else {
+                return
+            }
+            executionContextsByID.removeValue(forKey: params.executionContextId)
+        case "Runtime.executionContextsCleared":
+            executionContextsByID = executionContextsByID.filter { $0.value.targetID != targetID }
+        default:
             return
-        }
-        let frameID = params.context.frameId
-        let resolvedTargetID = resolvedTargetIDForRuntimeContext(
-            deliveredTargetID: targetID,
-            frameID: frameID
-        )
-        executionContextsByID[params.context.id] = ExecutionContextRecord(
-            id: params.context.id,
-            targetID: resolvedTargetID,
-            type: params.context.type ?? .normal,
-            name: params.context.name ?? "",
-            frameID: frameID
-        )
-        if let frameID {
-            frameTargetIDsByFrameID[frameID] = resolvedTargetID
         }
     }
 
@@ -1095,6 +1106,10 @@ private struct RuntimeExecutionContextCreatedParams: Decodable {
     }
 
     var context: Context
+}
+
+private struct RuntimeExecutionContextDestroyedParams: Decodable {
+    var executionContextId: ExecutionContextID
 }
 
 private struct CSSStyleSheetAddedParams: Decodable {

--- a/Sources/WebInspectorTransport/TransportTypes.swift
+++ b/Sources/WebInspectorTransport/TransportTypes.swift
@@ -127,6 +127,7 @@ package struct ProtocolEventEnvelope: Equatable, Sendable {
     package var domain: ProtocolDomain
     package var method: String
     package var targetID: ProtocolTargetIdentifier?
+    package var sourceTargetID: ProtocolTargetIdentifier?
     package var receivedDomainSequences: [ProtocolDomain: UInt64]
     package var paramsData: Data
 
@@ -135,6 +136,7 @@ package struct ProtocolEventEnvelope: Equatable, Sendable {
         domain: ProtocolDomain,
         method: String,
         targetID: ProtocolTargetIdentifier?,
+        sourceTargetID: ProtocolTargetIdentifier? = nil,
         receivedDomainSequences: [ProtocolDomain: UInt64] = [:],
         paramsData: Data
     ) {
@@ -142,6 +144,7 @@ package struct ProtocolEventEnvelope: Equatable, Sendable {
         self.domain = domain
         self.method = method
         self.targetID = targetID
+        self.sourceTargetID = sourceTargetID
         self.receivedDomainSequences = receivedDomainSequences
         self.paramsData = paramsData
     }

--- a/Sources/WebInspectorTransport/TransportTypes.swift
+++ b/Sources/WebInspectorTransport/TransportTypes.swift
@@ -155,7 +155,7 @@ package struct TransportSnapshot: Equatable, Sendable {
     package var currentMainPageTargetID: ProtocolTargetIdentifier?
     package var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord]
     package var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
-    package var executionContextsByID: [ExecutionContextID: ExecutionContextRecord]
+    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
     package var pendingRootReplyIDs: [UInt64]
     package var pendingTargetReplyKeys: [TargetReplyKey]
 
@@ -163,7 +163,7 @@ package struct TransportSnapshot: Equatable, Sendable {
         currentMainPageTargetID: ProtocolTargetIdentifier?,
         targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord],
         frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier],
-        executionContextsByID: [ExecutionContextID: ExecutionContextRecord],
+        executionContextsByID: [ExecutionContextID: RuntimeExecutionContext],
         pendingRootReplyIDs: [UInt64],
         pendingTargetReplyKeys: [TargetReplyKey]
     ) {

--- a/Sources/WebInspectorTransport/TransportTypes.swift
+++ b/Sources/WebInspectorTransport/TransportTypes.swift
@@ -158,7 +158,7 @@ package struct TransportSnapshot: Equatable, Sendable {
     package var currentMainPageTargetID: ProtocolTargetIdentifier?
     package var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord]
     package var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
-    package var executionContextsByID: [ExecutionContextID: RuntimeExecutionContext]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
     package var pendingRootReplyIDs: [UInt64]
     package var pendingTargetReplyKeys: [TargetReplyKey]
 
@@ -166,14 +166,14 @@ package struct TransportSnapshot: Equatable, Sendable {
         currentMainPageTargetID: ProtocolTargetIdentifier?,
         targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord],
         frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier],
-        executionContextsByID: [ExecutionContextID: RuntimeExecutionContext],
+        executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext],
         pendingRootReplyIDs: [UInt64],
         pendingTargetReplyKeys: [TargetReplyKey]
     ) {
         self.currentMainPageTargetID = currentMainPageTargetID
         self.targetsByID = targetsByID
         self.frameTargetIDsByFrameID = frameTargetIDsByFrameID
-        self.executionContextsByID = executionContextsByID
+        self.executionContextsByKey = executionContextsByKey
         self.pendingRootReplyIDs = pendingRootReplyIDs
         self.pendingTargetReplyKeys = pendingTargetReplyKeys
     }

--- a/Sources/WebInspectorTransport/TransportTypes.swift
+++ b/Sources/WebInspectorTransport/TransportTypes.swift
@@ -158,7 +158,7 @@ package struct TransportSnapshot: Equatable, Sendable {
     package var currentMainPageTargetID: ProtocolTargetIdentifier?
     package var targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord]
     package var frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier]
-    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext]
+    package var executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord]
     package var pendingRootReplyIDs: [UInt64]
     package var pendingTargetReplyKeys: [TargetReplyKey]
 
@@ -166,7 +166,7 @@ package struct TransportSnapshot: Equatable, Sendable {
         currentMainPageTargetID: ProtocolTargetIdentifier?,
         targetsByID: [ProtocolTargetIdentifier: ProtocolTargetRecord],
         frameTargetIDsByFrameID: [DOMFrameIdentifier: ProtocolTargetIdentifier],
-        executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContext],
+        executionContextsByKey: [RuntimeExecutionContextKey: RuntimeExecutionContextRecord],
         pendingRootReplyIDs: [UInt64],
         pendingTargetReplyKeys: [TargetReplyKey]
     ) {

--- a/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
+++ b/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
@@ -102,10 +102,16 @@ package final class RegularTabContentViewController: UINavigationController {
     }
 
     private func renderSelection(_ selectedDisplayItem: TabDisplayItem?) {
-        segmentedControl.selectedSegmentIndex = selectedDisplayItem.flatMap {
+        let selectedSegmentIndex = selectedDisplayItem.flatMap {
             segmentDisplayItemIDs.firstIndex(of: $0.id)
         } ?? UISegmentedControl.noSegment
+        if segmentedControl.selectedSegmentIndex != selectedSegmentIndex {
+            segmentedControl.selectedSegmentIndex = selectedSegmentIndex
+        }
         guard let selectedDisplayItem else {
+            guard displayedDisplayItemID != nil || viewControllers.isEmpty == false else {
+                return
+            }
             displayedDisplayItemID = nil
             setViewControllers([], animated: false)
             return

--- a/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
+++ b/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
@@ -153,8 +153,14 @@ package final class DOMNavigationItems: NSObject {
     }
 
     private func renderPickItem(session: InspectorSession) {
-        pickItem.isEnabled = session.canSelectElement
-        pickItem.tintColor = session.isSelectingElement ? .tintColor : .label
+        let isEnabled = session.canSelectElement
+        if pickItem.isEnabled != isEnabled {
+            pickItem.isEnabled = isEnabled
+        }
+        let tintColor: UIColor = session.isSelectingElement ? .tintColor : .label
+        if pickItem.tintColor != tintColor {
+            pickItem.tintColor = tintColor
+        }
     }
 }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -21,7 +21,6 @@ package final class DOMElementViewController: UIViewController {
 
     private weak var session: InspectorSession?
     private let observationScope = ObservationScope()
-    private let selectedStylesObservationScope = ObservationScope()
     private var expandedUnusedVariableSectionIDs = Set<CSSStyleSectionIdentifier>()
 
 #if DEBUG
@@ -77,8 +76,8 @@ package final class DOMElementViewController: UIViewController {
     }
 
     isolated deinit {
+        session?.setSelectedNodeStyleHydrationActive(false)
         observationScope.cancelAll()
-        selectedStylesObservationScope.cancelAll()
     }
 
     override package func viewDidLoad() {
@@ -91,7 +90,13 @@ package final class DOMElementViewController: UIViewController {
 
     override package func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
+        session?.setSelectedNodeStyleHydrationActive(true)
         render()
+    }
+
+    override package func viewDidDisappear(_ animated: Bool) {
+        session?.setSelectedNodeStyleHydrationActive(false)
+        super.viewDidDisappear(animated)
     }
 
     private static func makeLayout() -> UICollectionViewLayout {
@@ -207,7 +212,6 @@ package final class DOMElementViewController: UIViewController {
         }
 
         observationScope.observe(css) { [weak self] _, _ in
-            self?.observeSelectedNodeStyles()
             self?.render()
         }
 
@@ -215,19 +219,6 @@ package final class DOMElementViewController: UIViewController {
             observationScope.observe(session) { [weak self] _, session in
                 self?.render(session: session)
             }
-        }
-
-        observeSelectedNodeStyles()
-    }
-
-    private func observeSelectedNodeStyles() {
-        selectedStylesObservationScope.cancelAll()
-        guard let selectedNodeStyles = css.selectedNodeStyles else {
-            return
-        }
-
-        selectedStylesObservationScope.observe(selectedNodeStyles) { [weak self] _, _ in
-            self?.render()
         }
     }
 
@@ -240,14 +231,11 @@ package final class DOMElementViewController: UIViewController {
             return
         }
 
-        _ = dom.treeRevision
-        _ = dom.selectionRevision
-
         guard session?.isAttached != false else {
             showPlaceholder(
                 text: webInspectorLocalized("dom.element.loading.title", default: "Loading DOM..."),
                 secondaryText: nil,
-                image: UIImage(systemName: "arrow.clockwise")
+                imageName: "arrow.clockwise"
             )
             return
         }
@@ -256,7 +244,7 @@ package final class DOMElementViewController: UIViewController {
             showPlaceholder(
                 text: webInspectorLocalized("dom.element.loading.title", default: "Loading DOM..."),
                 secondaryText: nil,
-                image: UIImage(systemName: "arrow.clockwise")
+                imageName: "arrow.clockwise"
             )
             return
         }
@@ -272,7 +260,6 @@ package final class DOMElementViewController: UIViewController {
     private func renderStyles(for identity: CSSNodeStyleIdentity) {
         guard let nodeStyles = css.selectedNodeStyles,
               nodeStyles.identity == identity else {
-            requestStylesRefresh()
             showEmptyStyleList()
             return
         }
@@ -283,7 +270,6 @@ package final class DOMElementViewController: UIViewController {
         case .loaded:
             showLoadedStyles(nodeStyles)
         case .needsRefresh:
-            requestStylesRefresh()
             if nodeStyles.sections.isEmpty {
                 showEmptyStyleList()
             } else {
@@ -295,7 +281,7 @@ package final class DOMElementViewController: UIViewController {
             showPlaceholder(
                 text: webInspectorLocalized("dom.element.styles.failed.title", default: "Couldn’t load styles"),
                 secondaryText: message,
-                image: UIImage(systemName: "exclamationmark.triangle")
+                imageName: "exclamationmark.triangle"
             )
         }
     }
@@ -309,7 +295,7 @@ package final class DOMElementViewController: UIViewController {
                     "dom.element.styles.empty.description",
                     default: "This element has no editable or matched CSS declarations."
                 ),
-                image: UIImage(systemName: "curlybraces")
+                imageName: "curlybraces"
             )
             return
         }
@@ -318,15 +304,22 @@ package final class DOMElementViewController: UIViewController {
     }
 
     private func showStyleList(_ nodeStyles: CSSNodeStyles) {
-        contentUnavailableConfiguration = nil
-        collectionView.isHidden = false
+        showCollectionView()
         applySnapshot(for: nodeStyles)
     }
 
     private func showEmptyStyleList() {
-        contentUnavailableConfiguration = nil
-        collectionView.isHidden = false
+        showCollectionView()
         applyEmptySnapshot()
+    }
+
+    private func showCollectionView() {
+        if contentUnavailableConfiguration != nil {
+            contentUnavailableConfiguration = nil
+        }
+        if collectionView.isHidden {
+            collectionView.isHidden = false
+        }
     }
 
     private func showUnavailable(_ reason: CSSNodeStylesUnavailableReason) {
@@ -338,7 +331,7 @@ package final class DOMElementViewController: UIViewController {
                     "dom.element.no_selection.description",
                     default: "Choose an element in the DOM tree to inspect its styles."
                 ),
-                image: UIImage(systemName: "scope")
+                imageName: "scope"
             )
         case .nonElementNode:
             showPlaceholder(
@@ -347,7 +340,7 @@ package final class DOMElementViewController: UIViewController {
                     "dom.element.styles.non_element.description",
                     default: "CSS styles are only available for element nodes."
                 ),
-                image: UIImage(systemName: "curlybraces")
+                imageName: "curlybraces"
             )
         case .staleNode:
             showPlaceholder(
@@ -356,7 +349,7 @@ package final class DOMElementViewController: UIViewController {
                     "dom.element.styles.stale.description",
                     default: "The selected node is no longer available."
                 ),
-                image: UIImage(systemName: "curlybraces")
+                imageName: "curlybraces"
             )
         case .cssUnavailableForTarget:
             showPlaceholder(
@@ -365,18 +358,26 @@ package final class DOMElementViewController: UIViewController {
                     "dom.element.styles.target_unavailable.description",
                     default: "This target does not expose CSS styles."
                 ),
-                image: UIImage(systemName: "curlybraces")
+                imageName: "curlybraces"
             )
         }
     }
 
-    private func showPlaceholder(text: String, secondaryText: String?, image: UIImage?) {
+    private func showPlaceholder(text: String, secondaryText: String?, imageName: String?) {
+        if collectionView.isHidden,
+           let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
+           configuration.text == text,
+           configuration.secondaryText == secondaryText {
+            return
+        }
         applyEmptySnapshot()
-        collectionView.isHidden = true
+        if collectionView.isHidden == false {
+            collectionView.isHidden = true
+        }
         var configuration = UIContentUnavailableConfiguration.empty()
         configuration.text = text
         configuration.secondaryText = secondaryText
-        configuration.image = image
+        configuration.image = imageName.flatMap(UIImage.init(systemName:))
         contentUnavailableConfiguration = configuration
     }
 
@@ -457,10 +458,6 @@ package final class DOMElementViewController: UIViewController {
         }
         expandedUnusedVariableSectionIDs.insert(sectionID)
         applySnapshot(for: nodeStyles, animatingDifferences: true)
-    }
-
-    private func requestStylesRefresh() {
-        session?.requestRefreshStylesForSelectedNode()
     }
 
     private func toggleAction() -> DOMElementStylePropertyView.ToggleAction? {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -93,7 +93,6 @@ package final class DOMTreeViewController: UIViewController {
         guard let session else {
             return
         }
-        _ = session.dom.treeRevision
         let currentPageRootNode = session.dom.currentPageRootNode
         guard viewIfLoaded?.window != nil,
               !isEnsuringDOMDocumentLoaded,

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -43,7 +43,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     override package func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        syncStack(hasSelection: model.selectedRequestID != nil, animated: false)
+        syncStack(hasSelection: model.selectedRequest != nil, animated: false)
         startObservingSelection()
     }
 
@@ -59,7 +59,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     ) {
         guard isSyncingStack == false,
               viewController === listViewController,
-              model.selectedRequestID != nil else {
+              model.selectedRequest != nil else {
             return
         }
         model.selectRequest(nil)
@@ -69,7 +69,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         observationScope.cancelAll()
         observationScope.observe(model) { [weak self] event, model in
             self?.syncStack(
-                hasSelection: model.selectedRequestID != nil,
+                hasSelection: model.selectedRequest != nil,
                 animated: event.kind != .initial
             )
         }
@@ -149,7 +149,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         isStackSyncScheduledAfterTransition = false
         let shouldAnimate = pendingStackSyncAnimates
         pendingStackSyncAnimates = false
-        syncStack(hasSelection: model.selectedRequestID != nil, animated: shouldAnimate)
+        syncStack(hasSelection: model.selectedRequest != nil, animated: shouldAnimate)
     }
 }
 #endif

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -43,7 +43,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     override package func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        syncStack(with: model.selectedRequest, animated: false)
+        syncStack(hasSelection: model.selectedRequestID != nil, animated: false)
         startObservingSelection()
     }
 
@@ -59,7 +59,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     ) {
         guard isSyncingStack == false,
               viewController === listViewController,
-              model.selectedRequest != nil else {
+              model.selectedRequestID != nil else {
             return
         }
         model.selectRequest(nil)
@@ -69,7 +69,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         observationScope.cancelAll()
         observationScope.observe(model) { [weak self] event, model in
             self?.syncStack(
-                with: model.selectedRequest,
+                hasSelection: model.selectedRequestID != nil,
                 animated: event.kind != .initial
             )
         }
@@ -79,12 +79,12 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         observationScope.cancelAll()
     }
 
-    private func syncStack(with request: NetworkRequest?, animated: Bool) {
+    private func syncStack(hasSelection: Bool, animated: Bool) {
         guard scheduleStackSyncAfterCurrentTransitionIfNeeded(animated: animated) == false else {
             return
         }
 
-        guard request != nil else {
+        guard hasSelection else {
             popRequestDetailIfNeeded(animated: animated)
             return
         }
@@ -149,7 +149,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         isStackSyncScheduledAfterTransition = false
         let shouldAnimate = pendingStackSyncAnimates
         pendingStackSyncAnimates = false
-        syncStack(with: model.selectedRequest, animated: shouldAnimate)
+        syncStack(hasSelection: model.selectedRequestID != nil, animated: shouldAnimate)
     }
 }
 #endif

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -31,6 +31,10 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     func display(body: NetworkBody?) {
+        guard self.body !== body else {
+            renderBody(body)
+            return
+        }
         self.body = body
         startObserving(body: body)
         renderBody(body)

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -219,6 +219,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         }
         guard let request else {
             showEmptySelection()
+            modeMenu.render(selectedRequest: nil)
             return
         }
 

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -29,7 +29,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     }
 
     private enum ItemIdentifier: Hashable {
-        case overview
+        case overview(NetworkRequest.ID)
         case requestHeader(HeaderField)
         case requestHeadersEmpty
         case responseHeader(HeaderField)
@@ -38,7 +38,6 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
     private let model: NetworkPanelModel
     private let observationScope = ObservationScope()
-    private let selectedRequestObservationScope = ObservationScope()
     private let bodyViewController = NetworkBodyViewController()
     private lazy var modeMenu = NetworkDetailModeMenu(
         detailViewController: self,
@@ -72,10 +71,6 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     package init(model: NetworkPanelModel) {
         self.model = model
         super.init(nibName: nil, bundle: nil)
-
-        observationScope.observe(model) { [weak self] _, model in
-            self?.display(model.selectedRequest, reloadData: true)
-        }
     }
 
     @available(*, unavailable)
@@ -85,7 +80,6 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
     isolated deinit {
         observationScope.cancelAll()
-        selectedRequestObservationScope.cancelAll()
     }
 
     override package func viewDidLoad() {
@@ -94,11 +88,17 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         configureNavigationItem()
         installCollectionView()
         installBodyViewController()
-        display(model.selectedRequest, reloadData: true)
+        startObservingModel()
     }
 
     package func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         false
+    }
+
+    private func startObservingModel() {
+        observationScope.observe(model) { [weak self] event, model in
+            self?.render(selectedRequest: model.selectedRequest, reloadData: event.kind == .initial)
+        }
     }
 
     private func configureNavigationItem() {
@@ -211,44 +211,22 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         return dataSource
     }
 
-    private func display(_ request: NetworkRequest?, reloadData: Bool) {
+    private func render(selectedRequest request: NetworkRequest?, reloadData: Bool) {
         title = request?.displayName
 
         guard isViewLoaded else {
             return
         }
         guard let request else {
-            selectedRequestObservationScope.cancelAll()
-            collectionView.isHidden = true
-            bodyViewController.view.isHidden = true
-            bodyViewController.display(body: nil)
-            var configuration = UIContentUnavailableConfiguration.empty()
-            configuration.text = webInspectorLocalized("network.empty.selection.title", default: "No request selected")
-            configuration.secondaryText = webInspectorLocalized(
-                "network.empty.selection.description",
-                default: "Select a request from the list to inspect details."
-            )
-            configuration.image = UIImage(systemName: "list.bullet.rectangle")
-            contentUnavailableConfiguration = configuration
-            applySnapshotUsingReloadData()
+            showEmptySelection()
             return
         }
 
-        contentUnavailableConfiguration = nil
-        startObserving(request)
-        renderCurrentMode(reloadData: reloadData)
-    }
-
-    private func startObserving(_ request: NetworkRequest) {
-        selectedRequestObservationScope.cancelAll()
-        selectedRequestObservationScope.observe(request) { [weak self] _, request in
-            guard let self, self.selectedRequest?.id == request.id else {
-                return
-            }
-            self.title = request.displayName
-            self.renderCurrentMode(reloadData: false)
-            self.modeMenu.render()
+        if contentUnavailableConfiguration != nil {
+            contentUnavailableConfiguration = nil
         }
+        renderCurrentMode(reloadData: reloadData)
+        modeMenu.render(selectedRequest: request)
     }
 
     private func renderCurrentMode(reloadData: Bool) {
@@ -264,24 +242,64 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
         switch mode {
         case .overview:
-            bodyViewController.display(body: nil)
-            bodyViewController.view.isHidden = true
-            collectionView.isHidden = false
+            showOverview()
             if reloadData {
                 applySnapshotUsingReloadData()
             } else {
                 applySnapshot()
             }
         case .requestBody, .responseBody:
-            collectionView.isHidden = true
-            bodyViewController.view.isHidden = false
             guard let role = mode.bodyRole else {
                 return
             }
+            showBody()
             if role == .response {
                 model.fetchResponseBodyIfNeeded(for: selectedRequest)
             }
             bodyViewController.display(body: body(in: selectedRequest, for: role))
+        }
+    }
+
+    private func showEmptySelection() {
+        if collectionView.isHidden == false {
+            collectionView.isHidden = true
+        }
+        if bodyViewController.view.isHidden == false {
+            bodyViewController.view.isHidden = true
+        }
+        bodyViewController.display(body: nil)
+        if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
+           configuration.text == webInspectorLocalized("network.empty.selection.title", default: "No request selected") {
+            applyEmptySnapshotUsingReloadData()
+            return
+        }
+        var configuration = UIContentUnavailableConfiguration.empty()
+        configuration.text = webInspectorLocalized("network.empty.selection.title", default: "No request selected")
+        configuration.secondaryText = webInspectorLocalized(
+            "network.empty.selection.description",
+            default: "Select a request from the list to inspect details."
+        )
+        configuration.image = UIImage(systemName: "list.bullet.rectangle")
+        contentUnavailableConfiguration = configuration
+        applyEmptySnapshotUsingReloadData()
+    }
+
+    private func showOverview() {
+        if bodyViewController.view.isHidden == false {
+            bodyViewController.view.isHidden = true
+        }
+        if collectionView.isHidden {
+            collectionView.isHidden = false
+        }
+        bodyViewController.display(body: nil)
+    }
+
+    private func showBody() {
+        if collectionView.isHidden == false {
+            collectionView.isHidden = true
+        }
+        if bodyViewController.view.isHidden {
+            bodyViewController.view.isHidden = false
         }
     }
 
@@ -325,10 +343,9 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
         var snapshot = NSDiffableDataSourceSnapshot<SectionIdentifier, ItemIdentifier>()
         snapshot.appendSections(SectionIdentifier.allCases)
-        snapshot.appendItems([.overview], toSection: .overview)
+        snapshot.appendItems([.overview(selectedRequest.id)], toSection: .overview)
         snapshot.appendItems(requestItems, toSection: .request)
         snapshot.appendItems(responseItems, toSection: .response)
-        snapshot.reconfigureItems(snapshot.itemIdentifiers)
         return snapshot
     }
 
@@ -349,6 +366,11 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
             return
         }
         let snapshot = makeSnapshot()
+        let currentSnapshot = dataSource.snapshot()
+        guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
+            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
+            return
+        }
         Task {
             await self.dataSource.apply(snapshot, animatingDifferences: false)
         }
@@ -359,6 +381,20 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
             return
         }
         let snapshot = makeSnapshot()
+        Task {
+            await self.dataSource.applySnapshotUsingReloadData(snapshot)
+        }
+    }
+
+    private func applyEmptySnapshotUsingReloadData() {
+        guard isViewLoaded else {
+            return
+        }
+        let snapshot = NSDiffableDataSourceSnapshot<SectionIdentifier, ItemIdentifier>()
+        let currentSnapshot = dataSource.snapshot()
+        guard currentSnapshot.numberOfItems != 0 || currentSnapshot.numberOfSections != 0 else {
+            return
+        }
         Task {
             await self.dataSource.applySnapshotUsingReloadData(snapshot)
         }
@@ -386,37 +422,12 @@ private final class NetworkDetailModeMenu {
 
     private weak var detailViewController: NetworkDetailViewController?
     private let model: NetworkPanelModel
-    private let observationScope = ObservationScope()
-    private let selectedRequestObservationScope = ObservationScope()
     private var compactItem: UIBarButtonItem?
     private var regularItem: UIBarButtonItem?
 
     init(detailViewController: NetworkDetailViewController, model: NetworkPanelModel) {
         self.detailViewController = detailViewController
         self.model = model
-
-        observationScope.observe(model) { [weak self] _, model in
-            self?.observeBodyAvailability(in: model.selectedRequest)
-            self?.render()
-        }
-    }
-
-    isolated deinit {
-        observationScope.cancelAll()
-        selectedRequestObservationScope.cancelAll()
-    }
-
-    private func observeBodyAvailability(in request: NetworkRequest?) {
-        selectedRequestObservationScope.cancelAll()
-        guard let request else {
-            return
-        }
-        selectedRequestObservationScope.observe(request) { [weak self] _, request in
-            guard let self, self.model.selectedRequest?.id == request.id else {
-                return
-            }
-            self.render(selectedRequest: request)
-        }
     }
 
     fileprivate func render(selectedRequest: NetworkRequest? = nil) {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkOverviewCell.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkOverviewCell.swift
@@ -41,12 +41,18 @@ final class NetworkOverviewCell: UICollectionViewListCell {
         guard var content = contentConfiguration as? UIListContentConfiguration else {
             return
         }
+        guard content.secondaryText != url else {
+            return
+        }
         content.secondaryText = url
         contentConfiguration = content
     }
 
     private func renderMetrics(_ metricsText: NSAttributedString) {
         guard var content = contentConfiguration as? UIListContentConfiguration else {
+            return
+        }
+        guard content.attributedText?.isEqual(to: metricsText) != true else {
             return
         }
         content.attributedText = metricsText

--- a/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
@@ -80,8 +80,14 @@ package final class NetworkListCell: UICollectionViewListCell {
     }
 
     private func renderAccessories(request: NetworkRequest) {
-        statusIndicatorView.backgroundColor = request.statusSeverity.color
-        fileTypeLabel.text = request.fileTypeLabel
+        let color = request.statusSeverity.color
+        if statusIndicatorView.backgroundColor?.isEqual(color) != true {
+            statusIndicatorView.backgroundColor = color
+        }
+        let fileTypeLabelText = request.fileTypeLabel
+        if fileTypeLabel.text != fileTypeLabelText {
+            fileTypeLabel.text = fileTypeLabelText
+        }
     }
 
     private static func makeContentConfiguration() -> UIListContentConfiguration {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -18,7 +18,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private struct PendingSnapshotUpdate {
-        var displayRequests: [NetworkRequest]
+        var requestIDs: [NetworkRequest.ID]
         var mode: SnapshotApplyMode
     }
 
@@ -38,6 +38,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private var needsSnapshotReloadOnNextAppearance = false
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
+    private var applyingSnapshotRequestIDs: [NetworkRequest.ID]?
     private var isApplyingSnapshotUpdate = false
     private var isApplyingSearchPresentation = false
     private var activeSearchController: UISearchController?
@@ -145,10 +146,15 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
 
         observationScope.observe(model) { [weak self] _, model in
-            self?.renderModelControls(
-                searchText: model.searchText,
-                effectiveResourceFilters: model.effectiveResourceFilters
-            )
+            self?.renderSearchText(model.searchText)
+        }
+
+        observationScope.observe(model) { [weak self] _, model in
+            self?.resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
+        }
+
+        observationScope.observe(model) { [weak self] _, model in
+            self?.renderOverflowMenu(isNetworkEmpty: model.isEmpty)
         }
     }
 
@@ -167,10 +173,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         ]
         navigationItem.additionalOverflowItems = makeOverflowMenuElement()
 
-        renderModelControls(
-            searchText: model.searchText,
-            effectiveResourceFilters: model.effectiveResourceFilters
-        )
+        renderSearchText(model.searchText)
+        resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
     }
 
     package func updateSearchResults(for searchController: UISearchController) {
@@ -245,14 +249,6 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         filterItem.isSelected = effectiveResourceFilters.isEmpty == false
     }
 
-    private func renderModelControls(
-        searchText: String,
-        effectiveResourceFilters: Set<NetworkResourceFilter>
-    ) {
-        renderSearchText(searchText)
-        resourceFilterSelectionDidChange(effectiveResourceFilters: effectiveResourceFilters)
-    }
-
     private func resourceFilterSelectionDidChange(effectiveResourceFilters: Set<NetworkResourceFilter>) {
         if isViewLoaded {
             filterHostingMenu.setNeedsUpdate()
@@ -293,9 +289,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func makeSnapshot(
-        displayRequests: [NetworkRequest]
+        requestIDs: [NetworkRequest.ID]
     ) -> NSDiffableDataSourceSnapshot<SectionIdentifier, NetworkRequest.ID> {
-        let requestIDs = displayRequests.map(\.id)
         precondition(
             requestIDs.count == Set(requestIDs).count,
             "Duplicate row IDs detected in NetworkListViewController"
@@ -312,12 +307,29 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func requestSnapshotUpdate(displayRequests: [NetworkRequest]) {
+        requestSnapshotUpdate(requestIDs: displayRequests.map(\.id))
+    }
+
+    private func requestSnapshotUpdate(requestIDs: [NetworkRequest.ID]) {
+        precondition(
+            requestIDs.count == Set(requestIDs).count,
+            "Duplicate row IDs detected in NetworkListViewController"
+        )
+        if let applyingSnapshotRequestIDs {
+            if applyingSnapshotRequestIDs == requestIDs {
+                pendingSnapshotUpdate = nil
+                return
+            }
+        } else if dataSource.snapshot().itemIdentifiers == requestIDs {
+            pendingSnapshotUpdate = nil
+            return
+        }
         guard isCollectionViewVisible else {
             needsSnapshotReloadOnNextAppearance = true
             return
         }
         needsSnapshotReloadOnNextAppearance = false
-        enqueueSnapshotUpdate(displayRequests: displayRequests, mode: .apply)
+        enqueueSnapshotUpdate(requestIDs: requestIDs, mode: .apply)
     }
 
     private func flushPendingSnapshotUpdateIfNeeded() {
@@ -325,11 +337,21 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             return
         }
         needsSnapshotReloadOnNextAppearance = false
-        enqueueSnapshotUpdate(displayRequests: model.displayRequests, mode: .reloadData)
+        enqueueSnapshotUpdate(requestIDs: model.displayRequests.map(\.id), mode: .reloadData)
     }
 
-    private func enqueueSnapshotUpdate(displayRequests: [NetworkRequest], mode: SnapshotApplyMode) {
-        pendingSnapshotUpdate = PendingSnapshotUpdate(displayRequests: displayRequests, mode: mode)
+    private func enqueueSnapshotUpdate(requestIDs: [NetworkRequest.ID], mode: SnapshotApplyMode) {
+        if let pendingSnapshotUpdate, pendingSnapshotUpdate.requestIDs == requestIDs {
+            self.pendingSnapshotUpdate = PendingSnapshotUpdate(
+                requestIDs: requestIDs,
+                mode: pendingSnapshotUpdate.mode == .reloadData || mode == .reloadData ? .reloadData : .apply
+            )
+            return
+        }
+        guard applyingSnapshotRequestIDs != nil || dataSource.snapshot().itemIdentifiers != requestIDs || mode == .reloadData else {
+            return
+        }
+        pendingSnapshotUpdate = PendingSnapshotUpdate(requestIDs: requestIDs, mode: mode)
         applyPendingSnapshotUpdateIfNeeded()
     }
 
@@ -339,9 +361,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
         pendingSnapshotUpdate = nil
         isApplyingSnapshotUpdate = true
+        applyingSnapshotRequestIDs = update.requestIDs
 
-        let snapshot = makeSnapshot(displayRequests: update.displayRequests)
-        Task { [weak self, snapshot, mode = update.mode] in
+        let snapshot = makeSnapshot(requestIDs: update.requestIDs)
+        Task { [weak self, snapshot, requestIDs = update.requestIDs, mode = update.mode] in
             guard let self else {
                 return
             }
@@ -351,6 +374,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             case .reloadData:
                 await dataSource.applySnapshotUsingReloadData(snapshot)
             }
+            applyingSnapshotRequestIDs = nil
             isApplyingSnapshotUpdate = false
             applyPendingSnapshotUpdateIfNeeded()
         }
@@ -359,11 +383,22 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private func reloadDataFromModel(displayRequests: [NetworkRequest]? = nil) {
         let resolvedDisplayRequests = displayRequests ?? model.displayRequests
         requestSnapshotUpdate(displayRequests: resolvedDisplayRequests)
-        overflowHostingMenu.requestUpdate()
+        renderEmptyState(isEmpty: resolvedDisplayRequests.isEmpty)
+    }
 
-        let shouldShowEmptyState = resolvedDisplayRequests.isEmpty
-        collectionView.isHidden = shouldShowEmptyState
-        if shouldShowEmptyState {
+    private func renderOverflowMenu(isNetworkEmpty: Bool) {
+        overflowHostingMenu.requestUpdate()
+    }
+
+    private func renderEmptyState(isEmpty: Bool) {
+        if collectionView.isHidden != isEmpty {
+            collectionView.isHidden = isEmpty
+        }
+        if isEmpty {
+            if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
+               configuration.text == webInspectorLocalized("network.empty.title", default: "No requests yet") {
+                return
+            }
             var configuration = UIContentUnavailableConfiguration.empty()
             configuration.text = webInspectorLocalized("network.empty.title", default: "No requests yet")
             configuration.secondaryText = webInspectorLocalized(
@@ -372,7 +407,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             )
             configuration.image = UIImage(systemName: "waveform.path.ecg.rectangle")
             contentUnavailableConfiguration = configuration
-        } else {
+        } else if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
     }

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -7,6 +7,7 @@ func protocolTargetCapabilitiesTreatPageTargetsAsCSSCapable() {
     #expect(ProtocolTargetCapabilities.pageDefault.contains(.css))
     #expect(ProtocolTargetCapabilities.pageDefault.contains(.console))
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .page).contains(.css))
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .worker).contains(.console))
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .serviceWorker).contains(.console))
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.css) == false)
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.console) == false)

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -1046,6 +1046,70 @@ func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() throws {
     #expect(selectedFrameStyles.sections[0].style.cssProperties[0].value == "10px")
 }
 
+@Test
+@MainActor
+func cssSessionPreservesSelectedStylesObjectWhenTargetBecomesStale() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(css.beginRefresh(identity: identity))
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: "body",
+                    properties: [
+                        CSSPropertyPayload(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+    let selectedStyles = try #require(css.selectedNodeStyles)
+
+    css.removeStyles(targetID: identity.targetID)
+
+    #expect(css.selectedNodeStyles === selectedStyles)
+    #expect(css.selectedState == .unavailable(.staleNode(identity.nodeID)))
+    #expect(selectedStyles.state == .unavailable(.staleNode(identity.nodeID)))
+    #expect(css.refreshState(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
+}
+
+@Test
+@MainActor
+func cssSessionMarksSelectedStylesUnavailableWithoutReplacingObject() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    let token = try #require(css.beginRefresh(identity: identity))
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: "body",
+                    properties: [
+                        CSSPropertyPayload(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+    let selectedStyles = try #require(css.selectedNodeStyles)
+
+    css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+
+    #expect(css.selectedNodeStyles === selectedStyles)
+    #expect(css.selectedState == .unavailable(.staleNode(identity.nodeID)))
+    #expect(selectedStyles.state == .unavailable(.staleNode(identity.nodeID)))
+    #expect(css.refreshState(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
+}
+
 private func cssIdentity(
     targetID: ProtocolTargetIdentifier = ProtocolTargetIdentifier("page"),
     nodeRawID: Int = 2

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -1125,6 +1125,21 @@ func cssSessionDoesNotDowngradeStaleSelectionToNoSelection() throws {
     #expect(selectedStyles.state == .unavailable(.staleNode(identity.nodeID)))
 }
 
+@Test
+@MainActor
+func cssSessionCancelsActiveRefreshBackToNeedsRefresh() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+
+    _ = try #require(css.beginRefresh(identity: identity))
+    #expect(css.selectedState == .loading)
+
+    css.cancelRefresh(identity: identity)
+
+    #expect(css.selectedState == .needsRefresh)
+    #expect(css.refreshState(forSelected: identity) == .needsRefresh)
+}
+
 private func cssIdentity(
     targetID: ProtocolTargetIdentifier = ProtocolTargetIdentifier("page"),
     nodeRawID: Int = 2

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -5,11 +5,17 @@ import Testing
 func protocolTargetCapabilitiesTreatPageTargetsAsCSSCapable() {
     #expect(ProtocolTargetKind(protocolType: "web-page") == .page)
     #expect(ProtocolTargetCapabilities.pageDefault.contains(.css))
+    #expect(ProtocolTargetCapabilities.pageDefault.contains(.console))
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .page).contains(.css))
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .serviceWorker).contains(.console))
     #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.css) == false)
-    #expect(ProtocolTargetCapabilities(domainNames: ["DOM", "CSS"]).contains(.css))
+    #expect(ProtocolTargetCapabilities.protocolDefault(for: .frame).contains(.console) == false)
+    #expect(ProtocolTargetCapabilities(domainNames: ["DOM", "CSS", "Console"]).contains(.css))
+    #expect(ProtocolTargetCapabilities(domainNames: ["DOM", "CSS", "Console"]).contains(.console))
     #expect(ProtocolTargetCapabilities.resolved(for: .page, domainNames: ["DOM"]).contains(.css))
+    #expect(ProtocolTargetCapabilities.resolved(for: .page, domainNames: ["DOM"]).contains(.console))
     #expect(ProtocolTargetCapabilities.resolved(for: .frame, domainNames: ["DOM"]).contains(.css) == false)
+    #expect(ProtocolTargetCapabilities.resolved(for: .frame, domainNames: ["DOM"]).contains(.console) == false)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -1110,6 +1110,21 @@ func cssSessionMarksSelectedStylesUnavailableWithoutReplacingObject() throws {
     #expect(css.refreshState(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
 }
 
+@Test
+@MainActor
+func cssSessionDoesNotDowngradeStaleSelectionToNoSelection() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+    let selectedStyles = try #require(css.selectedNodeStyles)
+
+    css.markSelectedNodeUnavailable(.noSelection)
+
+    #expect(css.selectedNodeStyles === selectedStyles)
+    #expect(css.selectedState == .unavailable(.staleNode(identity.nodeID)))
+    #expect(selectedStyles.state == .unavailable(.staleNode(identity.nodeID)))
+}
+
 private func cssIdentity(
     targetID: ProtocolTargetIdentifier = ProtocolTargetIdentifier("page"),
     nodeRawID: Int = 2

--- a/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
+++ b/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
@@ -162,3 +162,37 @@ func consoleTargetCommitKeepsRepeatUpdatesPointedAtNewestMessage() throws {
     #expect(snapshot.messagesByID[newMessageID]?.timestamp == 12)
     #expect(snapshot.warningCountByTargetID[newTargetID] == 5)
 }
+
+@Test
+@MainActor
+func consoleTargetCommitPreservesDisplayParametersWithoutRekeyingStaleObjectHandles() throws {
+    let session = ConsoleSession()
+    let oldTargetID = ProtocolTargetIdentifier("page-old")
+    let newTargetID = ProtocolTargetIdentifier("page-new")
+    let objectID = RuntimeRemoteObjectIdentifier("old-agent-object")
+
+    let oldMessageID = session.applyMessageAdded(
+        ConsoleMessagePayload(
+            source: .consoleAPI,
+            level: .log,
+            text: "old object",
+            type: .log,
+            parameters: [
+                RuntimeRemoteObjectPayload(type: .object, description: "stale", objectID: objectID),
+            ]
+        ),
+        targetID: oldTargetID
+    )
+
+    session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+
+    let retargetedMessageID = ConsoleMessageIdentifier(
+        targetID: newTargetID,
+        ordinal: oldMessageID.ordinal
+    )
+    let message = try #require(session.message(for: retargetedMessageID))
+    let parameter = try #require(message.parameters.first)
+    #expect(parameter.payload.objectID == objectID)
+    #expect(parameter.payload.description == "stale")
+    #expect(parameter.remoteObjectKey == nil)
+}

--- a/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
+++ b/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
@@ -94,3 +94,71 @@ func consoleTargetStateKeepsStableObservableIdentity() throws {
     #expect(targetState.warningCount == 1)
     #expect(didChange.withLock { $0 })
 }
+
+@Test
+@MainActor
+func consoleMessageParametersUseObservableRuntimeObjects() throws {
+    let session = ConsoleSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let objectID = RuntimeRemoteObjectIdentifier("console-object")
+
+    let messageID = session.applyMessageAdded(
+        ConsoleMessagePayload(
+            source: .consoleAPI,
+            level: .log,
+            text: "object",
+            type: .log,
+            parameters: [
+                RuntimeRemoteObjectPayload(type: .object, description: "before", objectID: objectID),
+            ]
+        ),
+        targetID: targetID
+    )
+
+    let message = try #require(session.message(for: messageID))
+    let parameter = try #require(message.parameters.first)
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = parameter.payload.description
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    parameter.payload = RuntimeRemoteObjectPayload(type: .object, description: "after", objectID: objectID)
+
+    #expect(parameter.remoteObjectKey == RuntimeRemoteObjectIdentifierKey(runtimeAgentTargetID: targetID, objectID: objectID))
+    #expect(message.parameters.first === parameter)
+    #expect(session.snapshot().messagesByID[messageID]?.parameters.first?.description == "after")
+    #expect(didChange.withLock { $0 })
+}
+
+@Test
+@MainActor
+func consoleTargetCommitKeepsRepeatUpdatesPointedAtNewestMessage() throws {
+    let session = ConsoleSession()
+    let oldTargetID = ProtocolTargetIdentifier("page-old")
+    let newTargetID = ProtocolTargetIdentifier("page-new")
+
+    let oldMessageID = session.applyMessageAdded(
+        ConsoleMessagePayload(source: .consoleAPI, level: .warning, text: "old", type: .log),
+        targetID: oldTargetID
+    )
+    let newMessageID = session.applyMessageAdded(
+        ConsoleMessagePayload(source: .consoleAPI, level: .warning, text: "new", type: .log),
+        targetID: newTargetID
+    )
+
+    session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+    session.applyRepeatCountUpdated(count: 4, timestamp: 12, targetID: newTargetID)
+
+    let snapshot = session.snapshot()
+    let retargetedOldMessageID = ConsoleMessageIdentifier(
+        targetID: newTargetID,
+        ordinal: oldMessageID.ordinal
+    )
+    #expect(snapshot.messagesByID[retargetedOldMessageID]?.repeatCount == 1)
+    #expect(snapshot.messagesByID[newMessageID]?.repeatCount == 4)
+    #expect(snapshot.messagesByID[newMessageID]?.timestamp == 12)
+    #expect(snapshot.warningCountByTargetID[newTargetID] == 5)
+}

--- a/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
+++ b/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import WebInspectorCore
+
+@Test
+@MainActor
+func consoleSessionAppendsMessagesUpdatesTargetScopedRepeatsAndClearsByTarget() throws {
+    let session = ConsoleSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+
+    let pageMessageID = session.applyMessageAdded(
+        ConsoleMessagePayload(
+            source: .consoleAPI,
+            level: .warning,
+            text: "Repeated warning",
+            type: .log,
+            networkRequestID: NetworkRequestIdentifier("request-1")
+        ),
+        targetID: pageTargetID
+    )
+    _ = session.applyMessageAdded(
+        ConsoleMessagePayload(source: .javascript, level: .error, text: "Frame error", type: .log),
+        targetID: frameTargetID
+    )
+    session.applyRepeatCountUpdated(count: 3, timestamp: 42, targetID: pageTargetID)
+
+    var snapshot = session.snapshot()
+    let pageMessage = try #require(snapshot.messagesByID[pageMessageID])
+    #expect(pageMessage.repeatCount == 3)
+    #expect(pageMessage.timestamp == 42)
+    #expect(pageMessage.networkRequestKey == NetworkRequestIdentifierKey(targetID: pageTargetID, requestID: .init("request-1")))
+    #expect(snapshot.warningCount == 3)
+    #expect(snapshot.errorCount == 1)
+    #expect(snapshot.warningCountByTargetID[pageTargetID] == 3)
+    #expect(snapshot.errorCountByTargetID[frameTargetID] == 1)
+
+    session.applyMessagesCleared(reason: .frontend, targetID: pageTargetID)
+    snapshot = session.snapshot()
+    #expect(snapshot.orderedMessageIDs.map(\.targetID) == [frameTargetID])
+    #expect(snapshot.lastClearReasonByTargetID[pageTargetID] == .frontend)
+    #expect(snapshot.warningCount == 0)
+    #expect(snapshot.errorCount == 1)
+}

--- a/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
+++ b/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
@@ -63,3 +63,34 @@ func consoleSessionMessagesInvalidatesObserversWhenNormalMessageIsAdded() {
 
     #expect(didChange.withLock { $0 })
 }
+
+@Test
+@MainActor
+func consoleTargetStateKeepsStableObservableIdentity() throws {
+    let session = ConsoleSession()
+    let targetID = ProtocolTargetIdentifier("page")
+
+    session.applyMessageAdded(
+        ConsoleMessagePayload(source: .consoleAPI, level: .log, text: "first", type: .log),
+        targetID: targetID
+    )
+
+    let targetState = try #require(session.targetState(for: targetID))
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = targetState.messages.count
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    session.applyMessageAdded(
+        ConsoleMessagePayload(source: .consoleAPI, level: .warning, text: "second", type: .log),
+        targetID: targetID
+    )
+
+    #expect(session.targetState(for: targetID) === targetState)
+    #expect(targetState.messages.map(\.text) == ["first", "second"])
+    #expect(targetState.warningCount == 1)
+    #expect(didChange.withLock { $0 })
+}

--- a/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
+++ b/Tests/WebInspectorCoreTests/ConsoleModelTests.swift
@@ -1,3 +1,5 @@
+import Observation
+import Synchronization
 import Testing
 @testable import WebInspectorCore
 
@@ -40,4 +42,24 @@ func consoleSessionAppendsMessagesUpdatesTargetScopedRepeatsAndClearsByTarget() 
     #expect(snapshot.lastClearReasonByTargetID[pageTargetID] == .frontend)
     #expect(snapshot.warningCount == 0)
     #expect(snapshot.errorCount == 1)
+}
+
+@Test
+@MainActor
+func consoleSessionMessagesInvalidatesObserversWhenNormalMessageIsAdded() {
+    let session = ConsoleSession()
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = session.messages.count
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    session.applyMessageAdded(
+        ConsoleMessagePayload(source: .consoleAPI, level: .log, text: "hello", type: .log),
+        targetID: ProtocolTargetIdentifier("page")
+    )
+
+    #expect(didChange.withLock { $0 })
 }

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -77,6 +77,28 @@ func provisionalPageCommitUpdatesMainPageTargetWithoutKeepingOldDocument() async
 }
 
 @Test
+func targetCommitPreservesCommittedExecutionContextWhenIDsCollide() async throws {
+    let oldTargetID = ProtocolTarget.ID("page-old")
+    let newTargetID = ProtocolTarget.ID("page-new")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: oldTargetID, kind: .page, isProvisional: true), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: newTargetID, kind: .page))
+    await session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(7), targetID: oldTargetID, name: "old")
+    )
+    await session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(7), targetID: newTargetID, name: "new")
+    )
+
+    await session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+    let snapshot = await session.snapshot()
+
+    #expect(snapshot.executionContextsByKey[contextKey(oldTargetID, 7)] == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(newTargetID, 7)]?.name == "new")
+}
+
+@Test
 func provisionalFrameCommitDoesNotResetParentPageDocument() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let mainFrameID = DOMFrame.ID("main-frame")
@@ -142,7 +164,7 @@ func targetDestroyedRemovesExecutionContextsOwnedByRuntimeAgentTarget() async th
     await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
     await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID, parentFrameID: mainFrameID))
     await session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(7),
             targetID: frameTargetID,
             runtimeAgentTargetID: pageTargetID,

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -153,7 +153,7 @@ func targetDestroyedRemovesExecutionContextsOwnedByRuntimeAgentTarget() async th
     await session.applyTargetDestroyed(pageTargetID)
 
     let snapshot = await session.snapshot()
-    #expect(snapshot.executionContextsByID[ExecutionContextID(7)] == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(pageTargetID, 7)] == nil)
 }
 
 @Test
@@ -1556,6 +1556,10 @@ private func frameDocument(
             ),
         ]
     )
+}
+
+private func contextKey(_ runtimeAgentTargetID: ProtocolTargetIdentifier, _ contextID: Int) -> RuntimeExecutionContextKey {
+    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: ExecutionContextID(contextID))
 }
 
 private extension DOMNodePayload {

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -132,6 +132,31 @@ func frameTargetCreationLinksProtocolTargetToFrame() async throws {
 }
 
 @Test
+func targetDestroyedRemovesExecutionContextsOwnedByRuntimeAgentTarget() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let mainFrameID = DOMFrame.ID("main-frame")
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let frameID = DOMFrame.ID("frame-ad")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page, frameID: mainFrameID), makeCurrentMainPage: true)
+    await session.applyTargetCreated(.init(id: frameTargetID, kind: .frame, frameID: frameID, parentFrameID: mainFrameID))
+    await session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(7),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            frameID: frameID
+        )
+    )
+
+    await session.applyTargetDestroyed(pageTargetID)
+
+    let snapshot = await session.snapshot()
+    #expect(snapshot.executionContextsByID[ExecutionContextID(7)] == nil)
+}
+
+@Test
 func beginInspectSelectionRequestUsesExplicitProtocolTarget() async throws {
     let frameTargetID = ProtocolTarget.ID("frame-ad-target")
     let frameID = DOMFrame.ID("frame-ad")

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -68,6 +68,30 @@ func runtimeEvaluateIntentDoesNotUseActiveContextFromAnotherTarget() throws {
 
 @Test
 @MainActor
+func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(2),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            frameID: DOMFrameIdentifier("frame")
+        )
+    )
+
+    let intent = session.evaluateIntent(expression: "window.location.href", targetID: frameTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.targetID == pageTargetID)
+    #expect(request.contextID == ExecutionContextID(2))
+}
+
+@Test
+@MainActor
 func runtimeSessionPreservesTransportSeededContextMetadata() {
     let session = RuntimeSession()
     let targetID = ProtocolTargetIdentifier("page")
@@ -121,6 +145,29 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
     #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == otherFrameTargetID)
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
     #expect(snapshot.normalContextIDByTargetID[otherFrameTargetID] == ExecutionContextID(2))
+}
+
+@Test
+@MainActor
+func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(1),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            frameID: DOMFrameIdentifier("frame")
+        )
+    )
+
+    session.applyTargetDestroyed(pageTargetID)
+    let snapshot = session.snapshot()
+
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
+    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
+    #expect(snapshot.activeContextID == nil)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import WebInspectorCore
+
+@Test
+@MainActor
+func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalContext() {
+    let session = RuntimeSession()
+    let frameTargetID = ProtocolTargetIdentifier("frame-target")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextPayload(
+            id: ExecutionContextID(1),
+            type: .normal,
+            name: "Frame",
+            frameID: DOMFrameIdentifier("frame")
+        ),
+        targetID: frameTargetID
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextPayload(
+            id: ExecutionContextID(2),
+            type: .normal,
+            name: "Frame replacement",
+            frameID: DOMFrameIdentifier("frame")
+        ),
+        targetID: frameTargetID
+    )
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == frameTargetID)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.frameID == DOMFrameIdentifier("frame"))
+    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(2))
+    #expect(snapshot.activeContextID == ExecutionContextID(2))
+}
+
+@Test
+@MainActor
+func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+    let objectID = RuntimeRemoteObjectIdentifier("object-1")
+    let pageObject = RuntimeRemoteObjectPayload(
+        type: .object,
+        description: "page object",
+        objectID: objectID
+    )
+    let frameObject = RuntimeRemoteObjectPayload(
+        type: .object,
+        description: "frame object",
+        objectID: objectID
+    )
+
+    session.registerRemoteObject(pageObject, targetID: pageTargetID, objectGroup: RuntimeObjectGroup("console"))
+    session.registerRemoteObject(frameObject, targetID: frameTargetID, objectGroup: RuntimeObjectGroup("console"))
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.remoteObjectsByID[.init(targetID: pageTargetID, objectID: objectID)]?.description == "page object")
+    #expect(snapshot.remoteObjectsByID[.init(targetID: frameTargetID, objectID: objectID)]?.description == "frame object")
+    #expect(snapshot.objectGroupByRemoteObjectID[.init(targetID: pageTargetID, objectID: objectID)] == RuntimeObjectGroup("console"))
+    #expect(snapshot.objectGroupTargetsByGroup[RuntimeObjectGroup("console")] == [pageTargetID, frameTargetID])
+}

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -57,6 +57,47 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
 
 @Test
 @MainActor
+func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page-target")
+    let frameTargetID = ProtocolTargetIdentifier("frame-target")
+    let objectID = RuntimeRemoteObjectIdentifier("page-agent-object")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(1),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            type: .normal,
+            name: "Frame",
+            frameID: DOMFrameIdentifier("frame-a")
+        )
+    )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
+        runtimeAgentTargetID: pageTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(1)
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(2),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: frameTargetID,
+            type: .normal,
+            name: "Frame",
+            frameID: DOMFrameIdentifier("frame-a")
+        )
+    )
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.runtimeAgentTargetID == pageTargetID)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.runtimeAgentTargetID == frameTargetID)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: objectID)] != nil)
+}
+
+@Test
+@MainActor
 func runtimeEvaluateIntentDoesNotUseActiveContextFromAnotherTarget() throws {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -11,8 +11,8 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
         RuntimeExecutionContextPayload(
             id: ExecutionContextID(1),
             type: .normal,
-            name: "Frame",
-            frameID: DOMFrameIdentifier("frame")
+            name: "Frame A",
+            frameID: DOMFrameIdentifier("frame-a")
         ),
         targetID: frameTargetID
     )
@@ -20,8 +20,17 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
         RuntimeExecutionContextPayload(
             id: ExecutionContextID(2),
             type: .normal,
-            name: "Frame replacement",
-            frameID: DOMFrameIdentifier("frame")
+            name: "Frame B",
+            frameID: DOMFrameIdentifier("frame-b")
+        ),
+        targetID: frameTargetID
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextPayload(
+            id: ExecutionContextID(3),
+            type: .normal,
+            name: "Frame A",
+            frameID: DOMFrameIdentifier("frame-a")
         ),
         targetID: frameTargetID
     )
@@ -29,9 +38,30 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
     let snapshot = session.snapshot()
     #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
     #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == frameTargetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.frameID == DOMFrameIdentifier("frame"))
-    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(2))
-    #expect(snapshot.activeContextID == ExecutionContextID(2))
+    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.frameID == DOMFrameIdentifier("frame-b"))
+    #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.targetID == frameTargetID)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.frameID == DOMFrameIdentifier("frame-a"))
+    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(3))
+    #expect(snapshot.activeContextID == ExecutionContextID(3))
+}
+
+@Test
+@MainActor
+func runtimeEvaluateIntentDoesNotUseActiveContextFromAnotherTarget() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextPayload(id: ExecutionContextID(1), type: .normal, frameID: DOMFrameIdentifier("main-frame")),
+        targetID: pageTargetID
+    )
+
+    let intent = session.evaluateIntent(expression: "1 + 1", targetID: frameTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == nil)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -44,13 +44,13 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
     )
 
     let snapshot = session.snapshot()
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == frameTargetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.frameID == DOMFrameIdentifier("frame-b"))
-    #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.targetID == frameTargetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.frameID == DOMFrameIdentifier("frame-a"))
-    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(3))
-    #expect(snapshot.selectedContextID == ExecutionContextID(3))
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 1)] == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 2)]?.targetID == frameTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 2)]?.frameID == DOMFrameIdentifier("frame-b"))
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 3)]?.targetID == frameTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 3)]?.frameID == DOMFrameIdentifier("frame-a"))
+    #expect(snapshot.normalContextKeyByTargetID[frameTargetID] == contextKey(frameTargetID, 3))
+    #expect(snapshot.selectedContextKey == contextKey(frameTargetID, 3))
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: frameTargetID, objectID: RuntimeRemoteObjectIdentifier("frame-a-object"))] == nil)
     #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
 }
@@ -81,7 +81,7 @@ func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
     )
     session.applyExecutionContextCreated(
         RuntimeExecutionContext(
-            id: ExecutionContextID(2),
+            id: ExecutionContextID(1),
             targetID: frameTargetID,
             runtimeAgentTargetID: frameTargetID,
             type: .normal,
@@ -91,8 +91,8 @@ func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
     )
 
     let snapshot = session.snapshot()
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.runtimeAgentTargetID == pageTargetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.runtimeAgentTargetID == frameTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(pageTargetID, 1)]?.runtimeAgentTargetID == pageTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(frameTargetID, 1)]?.runtimeAgentTargetID == frameTargetID)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: objectID)] != nil)
 }
 
@@ -169,7 +169,7 @@ func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() 
         return
     }
     #expect(request.contextID == ExecutionContextID(1))
-    #expect(session.snapshot().normalContextIDByTargetID[pageTargetID] == ExecutionContextID(1))
+    #expect(session.snapshot().normalContextKeyByTargetID[pageTargetID] == contextKey(pageTargetID, 1))
 }
 
 @Test
@@ -194,7 +194,7 @@ func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throw
         )
     )
 
-    session.selectExecutionContext(ExecutionContextID(2))
+    session.selectExecutionContext(contextKey(targetID, 2))
 
     let intent = session.evaluateIntent(expression: "window.location.href", targetID: targetID)
     guard case let .evaluate(request) = intent else {
@@ -202,7 +202,7 @@ func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throw
         return
     }
     #expect(request.contextID == ExecutionContextID(2))
-    #expect(session.snapshot().selectedContextID == ExecutionContextID(2))
+    #expect(session.snapshot().selectedContextKey == contextKey(targetID, 2))
 }
 
 @Test
@@ -222,10 +222,10 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
     )
 
     let snapshot = session.snapshot()
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.type == .internal)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.name == "Isolated World")
-    #expect(snapshot.normalContextIDByTargetID[targetID] == nil)
-    #expect(snapshot.selectedContextID == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(targetID, 1)]?.type == .internal)
+    #expect(snapshot.executionContextsByKey[contextKey(targetID, 1)]?.name == "Isolated World")
+    #expect(snapshot.normalContextKeyByTargetID[targetID] == nil)
+    #expect(snapshot.selectedContextKey == nil)
 }
 
 @Test
@@ -273,10 +273,10 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
     session.applyExecutionContextsCleared(runtimeAgentTargetID: pageTargetID)
     let snapshot = session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == otherFrameTargetID)
-    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
-    #expect(snapshot.normalContextIDByTargetID[otherFrameTargetID] == ExecutionContextID(2))
+    #expect(snapshot.executionContextsByKey[contextKey(pageTargetID, 1)] == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(otherFrameTargetID, 2)]?.targetID == otherFrameTargetID)
+    #expect(snapshot.normalContextKeyByTargetID[frameTargetID] == nil)
+    #expect(snapshot.normalContextKeyByTargetID[otherFrameTargetID] == contextKey(otherFrameTargetID, 2))
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-object"))] == nil)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-console-object"))] == nil)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: otherFrameTargetID, objectID: RuntimeRemoteObjectIdentifier("other-object"))] != nil)
@@ -307,9 +307,9 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
     session.applyTargetDestroyed(pageTargetID)
     let snapshot = session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
-    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
-    #expect(snapshot.selectedContextID == nil)
+    #expect(snapshot.executionContextsByKey[contextKey(pageTargetID, 1)] == nil)
+    #expect(snapshot.normalContextKeyByTargetID[frameTargetID] == nil)
+    #expect(snapshot.selectedContextKey == nil)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-object"))] == nil)
     #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
 }
@@ -335,8 +335,8 @@ func runtimeSessionTargetCommitDropsOldRuntimeAgentObjects() {
     session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
     let snapshot = session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.targetID == newTargetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.runtimeAgentTargetID == newTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(newTargetID, 1)]?.targetID == newTargetID)
+    #expect(snapshot.executionContextsByKey[contextKey(newTargetID, 1)]?.runtimeAgentTargetID == newTargetID)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: oldTargetID, objectID: objectID)] == nil)
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: newTargetID, objectID: objectID)] == nil)
     #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
@@ -432,4 +432,8 @@ func runtimeObjectGroupTargetsAreDerivedFromCurrentRemoteObjects() {
     let snapshot = session.snapshot()
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: targetID, objectID: objectID)]?.objectGroup == nil)
     #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[objectGroup] == nil)
+}
+
+private func contextKey(_ runtimeAgentTargetID: ProtocolTargetIdentifier, _ contextID: Int) -> RuntimeExecutionContextKey {
+    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: ExecutionContextID(contextID))
 }

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -64,7 +64,7 @@ func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
     let objectID = RuntimeRemoteObjectIdentifier("page-agent-object")
 
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: frameTargetID,
             runtimeAgentTargetID: pageTargetID,
@@ -80,7 +80,7 @@ func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
         executionContextID: ExecutionContextID(1)
     )
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: frameTargetID,
             runtimeAgentTargetID: frameTargetID,
@@ -122,7 +122,7 @@ func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
     let pageTargetID = ProtocolTargetIdentifier("page")
     let frameTargetID = ProtocolTargetIdentifier("frame")
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(2),
             targetID: frameTargetID,
             runtimeAgentTargetID: pageTargetID,
@@ -145,7 +145,7 @@ func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() 
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: pageTargetID,
             type: .normal,
@@ -154,7 +154,7 @@ func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() 
         )
     )
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(2),
             targetID: pageTargetID,
             type: .normal,
@@ -178,7 +178,7 @@ func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throw
     let session = RuntimeSession()
     let targetID = ProtocolTargetIdentifier("page")
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: targetID,
             type: .normal,
@@ -186,7 +186,7 @@ func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throw
         )
     )
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(2),
             targetID: targetID,
             type: .user,
@@ -212,7 +212,7 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
     let targetID = ProtocolTargetIdentifier("page")
 
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: targetID,
             type: .internal,
@@ -237,7 +237,7 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
     let otherFrameTargetID = ProtocolTargetIdentifier("other-frame")
 
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: frameTargetID,
             runtimeAgentTargetID: pageTargetID,
@@ -245,7 +245,7 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
         )
     )
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(2),
             targetID: otherFrameTargetID,
             runtimeAgentTargetID: otherFrameTargetID,
@@ -290,7 +290,7 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
     let pageTargetID = ProtocolTargetIdentifier("page")
     let frameTargetID = ProtocolTargetIdentifier("frame")
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(
+        RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
             targetID: frameTargetID,
             runtimeAgentTargetID: pageTargetID,
@@ -323,7 +323,7 @@ func runtimeSessionTargetCommitDropsOldRuntimeAgentObjects() {
     let objectID = RuntimeRemoteObjectIdentifier("old-object")
 
     session.applyExecutionContextCreated(
-        RuntimeExecutionContext(id: ExecutionContextID(1), targetID: oldTargetID)
+        RuntimeExecutionContextRecord(id: ExecutionContextID(1), targetID: oldTargetID)
     )
     session.registerRemoteObject(
         RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
@@ -344,6 +344,44 @@ func runtimeSessionTargetCommitDropsOldRuntimeAgentObjects() {
 
 @Test
 @MainActor
+func runtimeSessionTargetCommitPreservesCommittedContextWhenIDsCollide() {
+    let session = RuntimeSession()
+    let oldTargetID = ProtocolTargetIdentifier("page-old")
+    let newTargetID = ProtocolTargetIdentifier("page-new")
+    let oldContextKey = contextKey(oldTargetID, 1)
+    let newContextKey = contextKey(newTargetID, 1)
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: oldTargetID,
+            name: "old"
+        )
+    )
+    session.selectExecutionContext(oldContextKey)
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: newTargetID,
+            name: "new"
+        )
+    )
+    let oldContext = session.executionContext(for: oldContextKey)
+    let newContext = session.executionContext(for: newContextKey)
+
+    session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+    let snapshot = session.snapshot()
+
+    #expect(snapshot.executionContextsByKey[oldContextKey] == nil)
+    #expect(snapshot.executionContextsByKey[newContextKey]?.name == "new")
+    #expect(snapshot.normalContextKeyByTargetID[newTargetID] == newContextKey)
+    #expect(snapshot.selectedContextKey == newContextKey)
+    #expect(session.executionContext(for: newContextKey) === newContext)
+    #expect(session.executionContext(for: newContextKey) !== oldContext)
+}
+
+@Test
+@MainActor
 func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
     let session = RuntimeSession()
     let didChange = Mutex(false)
@@ -360,6 +398,128 @@ func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
         objectGroup: RuntimeObjectGroup("console")
     )
 
+    #expect(didChange.withLock { $0 })
+}
+
+@Test
+@MainActor
+func runtimeTargetAndAgentStatesKeepStableObservableIdentity() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(1), targetID: targetID, name: "page")
+    )
+
+    let targetState = try #require(session.targetState(for: targetID))
+    let agentState = try #require(session.runtimeAgentState(for: targetID))
+    let targetDidChange = Mutex(false)
+    let agentDidChange = Mutex(false)
+
+    withObservationTracking {
+        _ = targetState.normalContextKey
+    } onChange: {
+        targetDidChange.withLock { $0 = true }
+    }
+    withObservationTracking {
+        _ = agentState.executionContexts.count
+    } onChange: {
+        agentDidChange.withLock { $0 = true }
+    }
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(2), targetID: targetID, name: "page")
+    )
+
+    #expect(session.targetState(for: targetID) === targetState)
+    #expect(session.runtimeAgentState(for: targetID) === agentState)
+    #expect(targetState.normalContextKey == contextKey(targetID, 2))
+    #expect(agentState.executionContexts.map(\.id) == [ExecutionContextID(2)])
+    #expect(targetDidChange.withLock { $0 })
+    #expect(agentDidChange.withLock { $0 })
+}
+
+@Test
+@MainActor
+func runtimeExecutionContextKeepsStableObservableIdentityWhenUpdated() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(1), targetID: targetID, name: "before")
+    )
+
+    let agentState = try #require(session.runtimeAgentState(for: targetID))
+    let context = try #require(agentState.executionContexts.first)
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = context.name
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(1), targetID: targetID, name: "after")
+    )
+
+    #expect(agentState.executionContexts.first === context)
+    #expect(context.name == "after")
+    #expect(didChange.withLock { $0 })
+}
+
+@Test
+@MainActor
+func runtimeExecutionContextKeepsStableObservableIdentityWhenRetargeted() throws {
+    let session = RuntimeSession()
+    let oldTargetID = ProtocolTargetIdentifier("page-old")
+    let newTargetID = ProtocolTargetIdentifier("page-new")
+    let oldContextKey = contextKey(oldTargetID, 1)
+    let newContextKey = contextKey(newTargetID, 1)
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(id: ExecutionContextID(1), targetID: oldTargetID, name: "page")
+    )
+
+    let context = try #require(session.executionContext(for: oldContextKey))
+    session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+
+    #expect(session.executionContext(for: newContextKey) === context)
+    #expect(context.targetID == newTargetID)
+    #expect(context.runtimeAgentTargetID == newTargetID)
+}
+
+@Test
+@MainActor
+func runtimeRemoteObjectKeepsStableObservableIdentity() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let objectID = RuntimeRemoteObjectIdentifier("object-1")
+
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, description: "before", objectID: objectID),
+        runtimeAgentTargetID: targetID,
+        objectGroup: RuntimeObjectGroup("console")
+    )
+
+    let agentState = try #require(session.runtimeAgentState(for: targetID))
+    let remoteObject = try #require(agentState.remoteObjects.first)
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = remoteObject.payload.description
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, description: "after", objectID: objectID),
+        runtimeAgentTargetID: targetID
+    )
+
+    #expect(agentState.remoteObjects.first === remoteObject)
+    #expect(remoteObject.payload.description == "after")
+    #expect(remoteObject.objectGroup == nil)
     #expect(didChange.withLock { $0 })
 }
 

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -66,6 +66,29 @@ func runtimeEvaluateIntentDoesNotUseActiveContextFromAnotherTarget() throws {
 
 @Test
 @MainActor
+func runtimeSessionPreservesTransportSeededContextMetadata() {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+
+    session.applyExecutionContextCreated(
+        ExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: targetID,
+            type: .internal,
+            name: "Isolated World",
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.type == .internal)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.name == "Isolated World")
+    #expect(snapshot.normalContextIDByTargetID[targetID] == nil)
+    #expect(snapshot.activeContextID == nil)
+}
+
+@Test
+@MainActor
 func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -100,6 +100,39 @@ func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
 
 @Test
 @MainActor
+func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(1),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Main",
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(2),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Subframe",
+            frameID: DOMFrameIdentifier("ad-frame")
+        )
+    )
+
+    let intent = session.evaluateIntent(expression: "document.URL", targetID: pageTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == ExecutionContextID(1))
+    #expect(session.snapshot().normalContextIDByTargetID[pageTargetID] == ExecutionContextID(1))
+}
+
+@Test
+@MainActor
 func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throws {
     let session = RuntimeSession()
     let targetID = ProtocolTargetIdentifier("page")

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -91,6 +91,40 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
 
 @Test
 @MainActor
+func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+    let otherFrameTargetID = ProtocolTargetIdentifier("other-frame")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(1),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            frameID: DOMFrameIdentifier("frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(2),
+            targetID: otherFrameTargetID,
+            runtimeAgentTargetID: otherFrameTargetID,
+            frameID: DOMFrameIdentifier("other-frame")
+        )
+    )
+
+    session.applyExecutionContextsCleared(runtimeAgentTargetID: pageTargetID)
+    let snapshot = session.snapshot()
+
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == otherFrameTargetID)
+    #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
+    #expect(snapshot.normalContextIDByTargetID[otherFrameTargetID] == ExecutionContextID(2))
+}
+
+@Test
+@MainActor
 func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
     let session = RuntimeSession()
     let didChange = Mutex(false)

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -71,7 +71,7 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
     let targetID = ProtocolTargetIdentifier("page")
 
     session.applyExecutionContextCreated(
-        ExecutionContextRecord(
+        RuntimeExecutionContext(
             id: ExecutionContextID(1),
             targetID: targetID,
             type: .internal,

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -98,6 +98,36 @@ func runtimeSessionKeepsSameFrameNormalContextsFromDifferentRuntimeAgents() {
 
 @Test
 @MainActor
+func runtimeExecutionContextStableOrderIncludesRuntimeAgentTarget() {
+    let pageTargetID = ProtocolTargetIdentifier("page-target")
+    let frameTargetID = ProtocolTargetIdentifier("frame-target")
+    let records = [
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: frameTargetID,
+            runtimeAgentTargetID: frameTargetID,
+            name: "Frame",
+            frameID: DOMFrameIdentifier("frame")
+        ),
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: pageTargetID,
+            runtimeAgentTargetID: pageTargetID,
+            name: "Page",
+            frameID: DOMFrameIdentifier("page")
+        ),
+    ]
+
+    let orderedKeys = records.sorted(by: RuntimeExecutionContextRecord.stableOrder).map(\.key)
+
+    #expect(orderedKeys == [
+        contextKey(frameTargetID, 1),
+        contextKey(pageTargetID, 1),
+    ])
+}
+
+@Test
+@MainActor
 func runtimeEvaluateIntentDoesNotUseActiveContextFromAnotherTarget() throws {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")
@@ -144,6 +174,13 @@ func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
 func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() throws {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")
+    session.applyTargetCreated(
+        ProtocolTargetRecord(
+            id: pageTargetID,
+            kind: .page,
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
     session.applyExecutionContextCreated(
         RuntimeExecutionContextRecord(
             id: ExecutionContextID(1),
@@ -170,6 +207,131 @@ func runtimeEvaluateIntentKeepsPageDefaultContextWhenFrameContextsShareTarget() 
     }
     #expect(request.contextID == ExecutionContextID(1))
     #expect(session.snapshot().normalContextKeyByTargetID[pageTargetID] == contextKey(pageTargetID, 1))
+}
+
+@Test
+@MainActor
+func runtimeEvaluateIntentPromotesTargetFrameContextWhenItArrivesAfterSubframeContext() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    session.applyTargetCreated(
+        ProtocolTargetRecord(
+            id: pageTargetID,
+            kind: .page,
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Subframe",
+            frameID: DOMFrameIdentifier("ad-frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(2),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Main",
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+
+    let intent = session.evaluateIntent(expression: "document.URL", targetID: pageTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == ExecutionContextID(2))
+    #expect(session.snapshot().normalContextKeyByTargetID[pageTargetID] == contextKey(pageTargetID, 2))
+    #expect(session.snapshot().selectedContextKey == contextKey(pageTargetID, 2))
+}
+
+@Test
+@MainActor
+func runtimeEvaluateIntentDoesNotOverrideExplicitSelectedContextWhenTargetFrameContextArrives() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    session.applyTargetCreated(
+        ProtocolTargetRecord(
+            id: pageTargetID,
+            kind: .page,
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Subframe",
+            frameID: DOMFrameIdentifier("ad-frame")
+        )
+    )
+    session.selectExecutionContext(contextKey(pageTargetID, 1))
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(2),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Main",
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+
+    let intent = session.evaluateIntent(expression: "document.URL", targetID: pageTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == ExecutionContextID(1))
+    #expect(session.snapshot().normalContextKeyByTargetID[pageTargetID] == contextKey(pageTargetID, 2))
+    #expect(session.snapshot().selectedContextKey == contextKey(pageTargetID, 1))
+}
+
+@Test
+@MainActor
+func runtimeTargetFrameMetadataPromotesExistingMatchingContext() throws {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(1),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Subframe",
+            frameID: DOMFrameIdentifier("ad-frame")
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContextRecord(
+            id: ExecutionContextID(2),
+            targetID: pageTargetID,
+            type: .normal,
+            name: "Main",
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+
+    session.applyTargetCreated(
+        ProtocolTargetRecord(
+            id: pageTargetID,
+            kind: .page,
+            frameID: DOMFrameIdentifier("main-frame")
+        )
+    )
+
+    let intent = session.evaluateIntent(expression: "document.URL", targetID: pageTargetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == ExecutionContextID(2))
+    #expect(session.snapshot().normalContextKeyByTargetID[pageTargetID] == contextKey(pageTargetID, 2))
+    #expect(session.snapshot().selectedContextKey == contextKey(pageTargetID, 2))
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -27,6 +27,12 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
         ),
         targetID: frameTargetID
     )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("frame-a-object")),
+        runtimeAgentTargetID: frameTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(1)
+    )
     session.applyExecutionContextCreated(
         RuntimeExecutionContextPayload(
             id: ExecutionContextID(3),
@@ -45,6 +51,8 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
     #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.frameID == DOMFrameIdentifier("frame-a"))
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(3))
     #expect(snapshot.selectedContextID == ExecutionContextID(3))
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: frameTargetID, objectID: RuntimeRemoteObjectIdentifier("frame-a-object"))] == nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
 }
 
 @Test
@@ -234,6 +242,34 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
 
 @Test
 @MainActor
+func runtimeSessionTargetCommitDropsOldRuntimeAgentObjects() {
+    let session = RuntimeSession()
+    let oldTargetID = ProtocolTargetIdentifier("page-old")
+    let newTargetID = ProtocolTargetIdentifier("page-new")
+    let objectID = RuntimeRemoteObjectIdentifier("old-object")
+
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(id: ExecutionContextID(1), targetID: oldTargetID)
+    )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
+        runtimeAgentTargetID: oldTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(1)
+    )
+
+    session.applyTargetCommitted(oldTargetID: oldTargetID, newTargetID: newTargetID)
+    let snapshot = session.snapshot()
+
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.targetID == newTargetID)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.runtimeAgentTargetID == newTargetID)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: oldTargetID, objectID: objectID)] == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: newTargetID, objectID: objectID)] == nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
+}
+
+@Test
+@MainActor
 func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
     let session = RuntimeSession()
     let didChange = Mutex(false)
@@ -298,5 +334,28 @@ func runtimeReleaseObjectDropsEmptyObjectGroupTargets() {
 
     let snapshot = session.snapshot()
     #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: targetID, objectID: objectID)] == nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[objectGroup] == nil)
+}
+
+@Test
+@MainActor
+func runtimeObjectGroupTargetsAreDerivedFromCurrentRemoteObjects() {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let objectGroup = RuntimeObjectGroup("console")
+    let objectID = RuntimeRemoteObjectIdentifier("object-1")
+
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
+        runtimeAgentTargetID: targetID,
+        objectGroup: objectGroup
+    )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
+        runtimeAgentTargetID: targetID
+    )
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: targetID, objectID: objectID)]?.objectGroup == nil)
     #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[objectGroup] == nil)
 }

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -86,7 +86,7 @@ func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
         Issue.record("Expected evaluate intent")
         return
     }
-    #expect(request.targetID == pageTargetID)
+    #expect(request.runtimeAgentTargetID == pageTargetID)
     #expect(request.contextID == ExecutionContextID(2))
 }
 
@@ -170,6 +170,23 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
             frameID: DOMFrameIdentifier("other-frame")
         )
     )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("page-object")),
+        runtimeAgentTargetID: pageTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(1)
+    )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("page-console-object")),
+        runtimeAgentTargetID: pageTargetID,
+        objectGroup: .console
+    )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("other-object")),
+        runtimeAgentTargetID: otherFrameTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(2)
+    )
 
     session.applyExecutionContextsCleared(runtimeAgentTargetID: pageTargetID)
     let snapshot = session.snapshot()
@@ -178,6 +195,10 @@ func runtimeSessionClearsExecutionContextsByRuntimeAgentTarget() {
     #expect(snapshot.executionContextsByID[ExecutionContextID(2)]?.targetID == otherFrameTargetID)
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
     #expect(snapshot.normalContextIDByTargetID[otherFrameTargetID] == ExecutionContextID(2))
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-object"))] == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-console-object"))] == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: otherFrameTargetID, objectID: RuntimeRemoteObjectIdentifier("other-object"))] != nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == [otherFrameTargetID])
 }
 
 @Test
@@ -194,6 +215,12 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
             frameID: DOMFrameIdentifier("frame")
         )
     )
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("page-object")),
+        runtimeAgentTargetID: pageTargetID,
+        objectGroup: .console,
+        executionContextID: ExecutionContextID(1)
+    )
 
     session.applyTargetDestroyed(pageTargetID)
     let snapshot = session.snapshot()
@@ -201,6 +228,8 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
     #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
     #expect(snapshot.selectedContextID == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: RuntimeRemoteObjectIdentifier("page-object"))] == nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil)
 }
 
 @Test
@@ -217,7 +246,7 @@ func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
 
     session.registerRemoteObject(
         RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("object-1")),
-        targetID: ProtocolTargetIdentifier("page"),
+        runtimeAgentTargetID: ProtocolTargetIdentifier("page"),
         objectGroup: RuntimeObjectGroup("console")
     )
 
@@ -226,7 +255,7 @@ func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
 
 @Test
 @MainActor
-func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
+func runtimeRemoteObjectIdentityIncludesRuntimeAgentTargetAndObjectID() {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")
     let frameTargetID = ProtocolTargetIdentifier("frame")
@@ -242,14 +271,14 @@ func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
         objectID: objectID
     )
 
-    session.registerRemoteObject(pageObject, targetID: pageTargetID, objectGroup: RuntimeObjectGroup("console"))
-    session.registerRemoteObject(frameObject, targetID: frameTargetID, objectGroup: RuntimeObjectGroup("console"))
+    session.registerRemoteObject(pageObject, runtimeAgentTargetID: pageTargetID, objectGroup: RuntimeObjectGroup("console"))
+    session.registerRemoteObject(frameObject, runtimeAgentTargetID: frameTargetID, objectGroup: RuntimeObjectGroup("console"))
 
     let snapshot = session.snapshot()
-    #expect(snapshot.remoteObjectsByID[.init(targetID: pageTargetID, objectID: objectID)]?.description == "page object")
-    #expect(snapshot.remoteObjectsByID[.init(targetID: frameTargetID, objectID: objectID)]?.description == "frame object")
-    #expect(snapshot.objectGroupByRemoteObjectID[.init(targetID: pageTargetID, objectID: objectID)] == RuntimeObjectGroup("console"))
-    #expect(snapshot.objectGroupTargetsByGroup[RuntimeObjectGroup("console")] == [pageTargetID, frameTargetID])
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: objectID)]?.payload.description == "page object")
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: frameTargetID, objectID: objectID)]?.payload.description == "frame object")
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: pageTargetID, objectID: objectID)]?.objectGroup == RuntimeObjectGroup("console"))
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[RuntimeObjectGroup("console")] == [pageTargetID, frameTargetID])
 }
 
 @Test
@@ -262,13 +291,12 @@ func runtimeReleaseObjectDropsEmptyObjectGroupTargets() {
 
     session.registerRemoteObject(
         RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
-        targetID: targetID,
+        runtimeAgentTargetID: targetID,
         objectGroup: objectGroup
     )
-    session.releaseObject(.init(targetID: targetID, objectID: objectID))
+    session.releaseObject(.init(runtimeAgentTargetID: targetID, objectID: objectID))
 
     let snapshot = session.snapshot()
-    #expect(snapshot.remoteObjectsByID[.init(targetID: targetID, objectID: objectID)] == nil)
-    #expect(snapshot.objectGroupByRemoteObjectID[.init(targetID: targetID, objectID: objectID)] == nil)
-    #expect(snapshot.objectGroupTargetsByGroup[objectGroup] == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: targetID, objectID: objectID)] == nil)
+    #expect(snapshot.objectGroupRuntimeAgentTargetsByGroup[objectGroup] == nil)
 }

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -44,7 +44,7 @@ func runtimeSessionTracksTargetOwnedExecutionContextsAndReplacesFrameNormalConte
     #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.targetID == frameTargetID)
     #expect(snapshot.executionContextsByID[ExecutionContextID(3)]?.frameID == DOMFrameIdentifier("frame-a"))
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == ExecutionContextID(3))
-    #expect(snapshot.activeContextID == ExecutionContextID(3))
+    #expect(snapshot.selectedContextID == ExecutionContextID(3))
 }
 
 @Test
@@ -92,6 +92,39 @@ func runtimeEvaluateIntentRoutesSelectedContextToRuntimeAgentTarget() throws {
 
 @Test
 @MainActor
+func runtimeEvaluateIntentHonorsSelectedContextBeforeTargetNormalContext() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(1),
+            targetID: targetID,
+            type: .normal,
+            name: "Page"
+        )
+    )
+    session.applyExecutionContextCreated(
+        RuntimeExecutionContext(
+            id: ExecutionContextID(2),
+            targetID: targetID,
+            type: .user,
+            name: "Selected Isolated World"
+        )
+    )
+
+    session.selectExecutionContext(ExecutionContextID(2))
+
+    let intent = session.evaluateIntent(expression: "window.location.href", targetID: targetID)
+    guard case let .evaluate(request) = intent else {
+        Issue.record("Expected evaluate intent")
+        return
+    }
+    #expect(request.contextID == ExecutionContextID(2))
+    #expect(session.snapshot().selectedContextID == ExecutionContextID(2))
+}
+
+@Test
+@MainActor
 func runtimeSessionPreservesTransportSeededContextMetadata() {
     let session = RuntimeSession()
     let targetID = ProtocolTargetIdentifier("page")
@@ -110,7 +143,7 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
     #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.type == .internal)
     #expect(snapshot.executionContextsByID[ExecutionContextID(1)]?.name == "Isolated World")
     #expect(snapshot.normalContextIDByTargetID[targetID] == nil)
-    #expect(snapshot.activeContextID == nil)
+    #expect(snapshot.selectedContextID == nil)
 }
 
 @Test
@@ -167,7 +200,7 @@ func runtimeSessionTargetDestroyedClearsExecutionContextsByRuntimeAgentTarget() 
 
     #expect(snapshot.executionContextsByID[ExecutionContextID(1)] == nil)
     #expect(snapshot.normalContextIDByTargetID[frameTargetID] == nil)
-    #expect(snapshot.activeContextID == nil)
+    #expect(snapshot.selectedContextID == nil)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
+++ b/Tests/WebInspectorCoreTests/RuntimeModelTests.swift
@@ -1,3 +1,5 @@
+import Observation
+import Synchronization
 import Testing
 @testable import WebInspectorCore
 
@@ -89,6 +91,27 @@ func runtimeSessionPreservesTransportSeededContextMetadata() {
 
 @Test
 @MainActor
+func runtimeSessionSnapshotInvalidatesObserversWhenRemoteObjectIsRegistered() {
+    let session = RuntimeSession()
+    let didChange = Mutex(false)
+
+    withObservationTracking {
+        _ = session.snapshot().remoteObjectsByID.count
+    } onChange: {
+        didChange.withLock { $0 = true }
+    }
+
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("object-1")),
+        targetID: ProtocolTargetIdentifier("page"),
+        objectGroup: RuntimeObjectGroup("console")
+    )
+
+    #expect(didChange.withLock { $0 })
+}
+
+@Test
+@MainActor
 func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")
@@ -113,4 +136,25 @@ func runtimeRemoteObjectIdentityIncludesTargetAndObjectID() {
     #expect(snapshot.remoteObjectsByID[.init(targetID: frameTargetID, objectID: objectID)]?.description == "frame object")
     #expect(snapshot.objectGroupByRemoteObjectID[.init(targetID: pageTargetID, objectID: objectID)] == RuntimeObjectGroup("console"))
     #expect(snapshot.objectGroupTargetsByGroup[RuntimeObjectGroup("console")] == [pageTargetID, frameTargetID])
+}
+
+@Test
+@MainActor
+func runtimeReleaseObjectDropsEmptyObjectGroupTargets() {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let objectGroup = RuntimeObjectGroup("console")
+    let objectID = RuntimeRemoteObjectIdentifier("object-1")
+
+    session.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: objectID),
+        targetID: targetID,
+        objectGroup: objectGroup
+    )
+    session.releaseObject(.init(targetID: targetID, objectID: objectID))
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.remoteObjectsByID[.init(targetID: targetID, objectID: objectID)] == nil)
+    #expect(snapshot.objectGroupByRemoteObjectID[.init(targetID: targetID, objectID: objectID)] == nil)
+    #expect(snapshot.objectGroupTargetsByGroup[objectGroup] == nil)
 }

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -235,10 +235,10 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":81,"type":"normal","frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(81)]
+        await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
     }
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(81)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
     }
 
     await receiveTargetDispatch(
@@ -247,8 +247,8 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         message: #"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":81}}"#
     )
     _ = try await waitUntil {
-        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(81)]
-        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(81)]
+        let runtimeContext = await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
+        let domContext = await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
         return runtimeContext == nil && domContext == nil ? true : nil
     }
 
@@ -258,7 +258,7 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":82,"type":"normal","frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(82)]
+        await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
     }
     await receiveTargetDispatch(
         transport,
@@ -266,8 +266,8 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         message: #"{"method":"Runtime.executionContextsCleared","params":{}}"#
     )
     _ = try await waitUntil {
-        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(82)]
-        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(82)]
+        let runtimeContext = await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
+        let domContext = await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
         return runtimeContext == nil && domContext == nil ? true : nil
     }
 }
@@ -293,20 +293,20 @@ func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws
 
     let runtimeSnapshot: RuntimeSessionSnapshot = try await waitUntil {
         let snapshot = await session.runtime.snapshot()
-        guard snapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd else {
+        guard snapshot.executionContextsByKey[contextKey(.pageMain, 77)]?.targetID == .frameAd else {
             return nil
         }
         return snapshot
     }
     let domSnapshot: DOMSessionSnapshot = try await waitUntil {
         let snapshot = await session.dom.snapshot()
-        guard snapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd else {
+        guard snapshot.executionContextsByKey[contextKey(.pageMain, 77)]?.targetID == .frameAd else {
             return nil
         }
         return snapshot
     }
-    #expect(runtimeSnapshot.normalContextIDByTargetID[.frameAd] == ExecutionContextID(77))
-    #expect(domSnapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd)
+    #expect(runtimeSnapshot.normalContextKeyByTargetID[.frameAd] == contextKey(.pageMain, 77))
+    #expect(domSnapshot.executionContextsByKey[contextKey(.pageMain, 77)]?.targetID == .frameAd)
 }
 
 @Test
@@ -327,8 +327,8 @@ func rootRuntimeClearRemovesFrameContextOwnedByPageRuntimeAgent() async throws {
     )
 
     let _: Bool = try await waitUntil {
-        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(78)]
-        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(78)]
+        let runtimeContext = await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
+        let domContext = await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         guard runtimeContext?.targetID == .frameAd,
               runtimeContext?.runtimeAgentTargetID == .pageMain,
               domContext?.targetID == .frameAd,
@@ -340,8 +340,8 @@ func rootRuntimeClearRemovesFrameContextOwnedByPageRuntimeAgent() async throws {
 
     await transport.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
     let _: Bool = try await waitUntil {
-        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(78)]
-        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(78)]
+        let runtimeContext = await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
+        let domContext = await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         return runtimeContext == nil && domContext == nil ? true : nil
     }
 }
@@ -2373,12 +2373,12 @@ func requestNodeWaitsForPathPushBeforeSelectingNode() async throws {
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     _ = try await waitUntil {
-        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
-    #expect(await session.runtime.snapshot().executionContextsByID[ExecutionContextID(7)]?.targetID == .pageMain)
+    #expect(await session.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]?.targetID == .pageMain)
     let intent = await session.dom.beginInspectSelectionRequest(
         targetID: .pageMain,
         objectID: "selected-object"
@@ -2577,7 +2577,7 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     let intent = await session.dom.beginInspectSelectionRequest(
         targetID: .pageMain,
@@ -2776,7 +2776,7 @@ func elementPickerIgnoresInspectEventBeforeInspectModeReply() async throws {
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
 
     let sentCount = await backend.sentTargetMessages().count
@@ -2859,7 +2859,7 @@ func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() asyn
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
 
     let sentCountBeforeFirstBegin = await backend.sentTargetMessages().count
@@ -2980,7 +2980,7 @@ func staleInspectEventCompletionDoesNotCancelRestartedPicker() async throws {
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
 
@@ -3060,7 +3060,7 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
@@ -3120,7 +3120,7 @@ func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
@@ -3192,7 +3192,7 @@ func inspectorInspectRecordedExecutionContextOverridesEventTargetHint() async th
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":77,"frameId":"ad-frame"}}}"#
     )
     _ = try await waitUntil {
-        await session.dom.snapshot().executionContextsByID[ExecutionContextID(77)]
+        await session.dom.snapshot().executionContextsByKey[contextKey(.frameAd, 77)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
@@ -4583,6 +4583,13 @@ private func expectProtocolEventApplied(
 
 private func pendingTargetReplyKeys(_ transport: TransportSession) async -> [TargetReplyKey] {
     await transport.snapshot().pendingTargetReplyKeys
+}
+
+private func contextKey(
+    _ runtimeAgentTargetID: ProtocolTargetIdentifier,
+    _ contextID: Int
+) -> RuntimeExecutionContextKey {
+    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: ExecutionContextID(contextID))
 }
 
 private func targetDispatchMessage(

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -161,14 +161,25 @@ func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
     let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
 
-    await session.runtime.registerRemoteObject(
-        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("console-object")),
+    await receiveTargetDispatch(
+        transport,
         targetID: .pageMain,
-        objectGroup: .console
+        message: #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"log","text":"hello","type":"log","parameters":[{"type":"object","objectId":"console-object","description":"Object"}]}}}"#
     )
-    #expect(await session.runtime.snapshot().remoteObjectsByID[
-        .init(targetID: .pageMain, objectID: RuntimeRemoteObjectIdentifier("console-object"))
-    ] != nil)
+
+    let objectKey = RuntimeRemoteObjectIdentifierKey(
+        runtimeAgentTargetID: .pageMain,
+        objectID: RuntimeRemoteObjectIdentifier("console-object")
+    )
+    let _: Bool = try await waitUntil {
+        let runtimeSnapshot = await session.runtime.snapshot()
+        let consoleSnapshot = await session.console.snapshot()
+        guard runtimeSnapshot.remoteObjectsByID[objectKey]?.objectGroup == .console,
+              consoleSnapshot.orderedMessageIDs.isEmpty == false else {
+            return nil
+        }
+        return true
+    }
 
     await receiveTargetDispatch(
         transport,
@@ -179,13 +190,8 @@ func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
     let _: Bool = try await waitUntil {
         let runtimeSnapshot = await session.runtime.snapshot()
         let consoleSnapshot = await session.console.snapshot()
-        let objectKey = RuntimeRemoteObjectIdentifierKey(
-            targetID: .pageMain,
-            objectID: RuntimeRemoteObjectIdentifier("console-object")
-        )
         guard runtimeSnapshot.remoteObjectsByID[objectKey] == nil,
-              runtimeSnapshot.objectGroupByRemoteObjectID[objectKey] == nil,
-              runtimeSnapshot.objectGroupTargetsByGroup[.console] == nil,
+              runtimeSnapshot.objectGroupRuntimeAgentTargetsByGroup[.console] == nil,
               consoleSnapshot.lastClearReasonByTargetID[.pageMain] == .consoleAPI else {
             return nil
         }

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -946,6 +946,38 @@ func serviceWorkerTargetCreatedAfterAttachEnablesRuntimeBeforeConsole() async th
 }
 
 @Test
+func workerTargetCreatedAfterAttachEnablesRuntimeBeforeConsoleWithoutDomainMetadata() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let workerTargetID = ProtocolTargetIdentifier("worker-1")
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"worker-1","type":"worker","isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == workerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    #expect(consoleEnable.targetIdentifier == workerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+}
+
+@Test
 func serviceWorkerTargetDiscoveredBeforeAttachEnablesRuntimeBeforeConsoleAfterConnect() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -466,6 +466,36 @@ func selectedElementStyleRefreshLoadsCSSSession() async throws {
 }
 
 @Test
+@MainActor
+func selectedElementStyleHydrationLoadsCSSSessionWhenActive() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    session.setSelectedNodeStyleHydrationActive(true)
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: messages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+
+    let didLoadStyles = try await waitUntil {
+        await session.css.selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadStyles)
+    let styles = try #require(session.css.selectedNodeStyles)
+    #expect(styles.identity.nodeID == bodyID)
+    #expect(styles.sections.map(\.title) == ["element.style", "body"])
+}
+
+@Test
 func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -747,7 +777,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
 }
 
 @Test
-func documentUpdatedClearsSelectedCSSNodeStylesForInvalidatedDocument() async throws {
+func documentUpdatedMarksSelectedCSSNodeStylesUnavailableForInvalidatedDocument() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -771,13 +801,14 @@ func documentUpdatedClearsSelectedCSSNodeStylesForInvalidatedDocument() async th
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
     _ = try await waitUntil {
-        await session.css.selectedNodeStyles == nil ? true : nil
+        await session.css.selectedState == .unavailable(.staleNode(bodyID)) ? true : nil
     }
+    #expect(await session.css.selectedNodeStyles != nil)
     #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
 }
 
 @Test
-func explicitDOMReloadClearsSelectedCSSNodeStylesForReplacedDocument() async throws {
+func explicitDOMReloadMarksSelectedCSSNodeStylesUnavailableForReplacedDocument() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -808,12 +839,12 @@ func explicitDOMReloadClearsSelectedCSSNodeStylesForReplacedDocument() async thr
     )
     try await reloadTask.value
 
-    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedNodeStyles != nil)
     #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
 }
 
 @Test
-func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
+func domMutationRemovingSelectedNodeMarksSelectedCSSNodeStylesUnavailable() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -840,12 +871,12 @@ func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
         await session.dom.selectedNodeID == nil ? true : nil
     }
 
-    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedNodeStyles != nil)
     #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
 }
 
 @Test
-func localDOMDeleteClearsSelectedCSSNodeStylesWithoutBackendMutationEvent() async throws {
+func localDOMDeleteMarksSelectedCSSNodeStylesUnavailableWithoutBackendMutationEvent() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
     let session = await InspectorSession(configuration: .test)
@@ -877,7 +908,7 @@ func localDOMDeleteClearsSelectedCSSNodeStylesWithoutBackendMutationEvent() asyn
     try await deleteTask.value
 
     #expect(await session.dom.selectedNodeID == nil)
-    #expect(await session.css.selectedNodeStyles == nil)
+    #expect(await session.css.selectedNodeStyles != nil)
     #expect(await session.css.selectedState == .unavailable(.staleNode(bodyID)))
 }
 

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -496,6 +496,79 @@ func selectedElementStyleHydrationLoadsCSSSessionWhenActive() async throws {
 }
 
 @Test
+@MainActor
+func selectedElementStyleHydrationCancellationDoesNotPublishFailure() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.setSelectedNodeStyleHydrationActive(true)
+    session.dom.selectNode(bodyID)
+
+    let firstSentCount = await backend.sentTargetMessages().count
+    _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
+
+    let secondSentCount = await backend.sentTargetMessages().count
+    session.dom.selectNode(htmlID)
+    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: secondMessages,
+        selector: "html",
+        styleSheetID: "sheet-html"
+    )
+
+    let didLoadReplacementStyles = try await waitUntil {
+        let selectedNodeID = await session.css.selectedNodeStyles?.identity.nodeID
+        let selectedState = await session.css.selectedState
+        return selectedNodeID == htmlID && selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadReplacementStyles)
+    #expect(session.lastError == nil)
+}
+
+@Test
+@MainActor
+func selectedElementStyleHydrationPreservesStaleStateAfterSelectionDisappears() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    session.setSelectedNodeStyleHydrationActive(true)
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: messages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+    _ = try await waitUntil {
+        await session.css.selectedState == .loaded ? true : nil
+    }
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.childNodeRemoved","params":{"nodeId":4}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.selectedNodeID == nil ? true : nil
+    }
+    try await Task.sleep(for: .milliseconds(10))
+
+    #expect(session.css.selectedNodeStyles != nil)
+    #expect(session.css.selectedState == .unavailable(.staleNode(bodyID)))
+}
+
+@Test
 func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -1116,6 +1189,43 @@ func frameTargetWithUnsupportedRuntimeStillEnablesConsole() async throws {
 
     #expect(await session.runtime.snapshot().unsupportedCommandsByTargetID[.frameAd]?.contains("Runtime.enable") == true)
     #expect(await session.lastError == nil)
+}
+
+@Test
+func consoleEnableTargetNotFoundDoesNotMarkCommandUnsupported() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    #expect(consoleEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetErrorReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        message: "Target not found"
+    )
+
+    let didPublishFailure = try await waitUntil {
+        await session.lastError != nil ? true : nil
+    }
+    #expect(didPublishFailure)
+    #expect(await session.console.snapshot().unsupportedCommandsByTargetID[.frameAd]?.contains("Console.enable") != true)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -265,6 +265,43 @@ func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws
 }
 
 @Test
+func rootRuntimeClearRemovesFrameContextOwnedByPageRuntimeAgent() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime"],"isProvisional":false}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+    await transport.receiveRootMessage(
+        #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":78,"frameId":"ad-frame"}}}"#
+    )
+
+    let _: Bool = try await waitUntil {
+        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(78)]
+        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(78)]
+        guard runtimeContext?.targetID == .frameAd,
+              runtimeContext?.runtimeAgentTargetID == .pageMain,
+              domContext?.targetID == .frameAd,
+              domContext?.runtimeAgentTargetID == .pageMain else {
+            return nil
+        }
+        return true
+    }
+
+    await transport.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
+    let _: Bool = try await waitUntil {
+        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(78)]
+        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(78)]
+        return runtimeContext == nil && domContext == nil ? true : nil
+    }
+}
+
+@Test
 func networkLazyFetchReturnsCommandResultFromRequestTarget() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -961,6 +998,32 @@ func frameTargetWithAdvertisedRuntimeAndConsoleEnablesRuntimeBeforeConsole() asy
         messageID: try messageID(consoleEnable.message),
         result: "{}"
     )
+}
+
+@Test
+func frameTargetWithAdvertisedRuntimeOnlyEnablesRuntimeWithoutConsole() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime"],"isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    try await Task.sleep(for: .milliseconds(5))
+    let messages = await backend.sentTargetMessages().dropFirst(sentCount)
+    #expect(messages.compactMap { try? messageMethod($0.message) }.contains("Console.enable") == false)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -178,6 +178,56 @@ func domainPumpsApplyRootScopedConsoleEventsToMainPageConsoleSession() async thr
 }
 
 @Test
+func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":81,"type":"normal","frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(81)]
+    }
+    _ = try await waitUntil {
+        await session.dom.snapshot().executionContextsByID[ExecutionContextID(81)]
+    }
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":81}}"#
+    )
+    _ = try await waitUntil {
+        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(81)]
+        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(81)]
+        return runtimeContext == nil && domContext == nil ? true : nil
+    }
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":82,"type":"normal","frameId":"main-frame"}}}"#
+    )
+    _ = try await waitUntil {
+        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(82)]
+    }
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextsCleared","params":{}}"#
+    )
+    _ = try await waitUntil {
+        let runtimeContext = await session.runtime.snapshot().executionContextsByID[ExecutionContextID(82)]
+        let domContext = await session.dom.snapshot().executionContextsByID[ExecutionContextID(82)]
+        return runtimeContext == nil && domContext == nil ? true : nil
+    }
+}
+
+@Test
 func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -1145,6 +1195,80 @@ func committedProvisionalFrameWithRuntimeAndConsoleEnablesCommittedTarget() asyn
         transport,
         targetID: consoleEnable.targetIdentifier,
         messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+}
+
+@Test
+func committedNavigatedFrameReEnablesRuntimeAndConsoleOnNewTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":false}}}"#
+    )
+    let firstRuntimeEnable = try await waitForTargetMessage(
+        backend,
+        method: "Runtime.enable",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(firstRuntimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: firstRuntimeEnable.targetIdentifier,
+        messageID: try messageID(firstRuntimeEnable.message),
+        result: "{}"
+    )
+    let firstConsoleEnable = try await waitForTargetMessage(
+        backend,
+        method: "Console.enable",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(firstConsoleEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: firstConsoleEnable.targetIdentifier,
+        messageID: try messageID(firstConsoleEnable.message),
+        result: "{}"
+    )
+
+    let sentCountBeforeNavigation = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-next","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":true}}}"#
+    )
+    try await Task.sleep(for: .milliseconds(5))
+    #expect(await backend.sentTargetMessages().count == sentCountBeforeNavigation)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-ad","newTargetId":"frame-next"}}"#
+    )
+
+    let secondRuntimeEnable = try await waitForTargetMessage(
+        backend,
+        method: "Runtime.enable",
+        after: sentCountBeforeNavigation
+    )
+    #expect(secondRuntimeEnable.targetIdentifier == ProtocolTargetIdentifier("frame-next"))
+    await receiveTargetReply(
+        transport,
+        targetID: secondRuntimeEnable.targetIdentifier,
+        messageID: try messageID(secondRuntimeEnable.message),
+        result: "{}"
+    )
+
+    let secondConsoleEnable = try await waitForTargetMessage(
+        backend,
+        method: "Console.enable",
+        after: sentCountBeforeNavigation
+    )
+    #expect(secondConsoleEnable.targetIdentifier == ProtocolTargetIdentifier("frame-next"))
+    await receiveTargetReply(
+        transport,
+        targetID: secondConsoleEnable.targetIdentifier,
+        messageID: try messageID(secondConsoleEnable.message),
         result: "{}"
     )
 }

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -802,6 +802,77 @@ func frameTargetWithAdvertisedRuntimeAndConsoleEnablesRuntimeBeforeConsole() asy
 }
 
 @Test
+func serviceWorkerTargetCreatedAfterAttachEnablesRuntimeBeforeConsole() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let serviceWorkerTargetID = ProtocolTargetIdentifier("service-worker-1")
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"service-worker-1","type":"service-worker","isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == serviceWorkerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    #expect(consoleEnable.targetIdentifier == serviceWorkerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+}
+
+@Test
+func serviceWorkerTargetDiscoveredBeforeAttachEnablesRuntimeBeforeConsoleAfterConnect() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    let serviceWorkerTargetID = ProtocolTargetIdentifier("service-worker-1")
+
+    await transport.receiveRootMessage(
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
+    )
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"service-worker-1","type":"service-worker","isProvisional":false}}}"#
+    )
+
+    let connectTask = Task {
+        try await session.connect(transport: transport)
+    }
+    let bootstrapMessages = try await completeBootstrap(transport: transport, backend: backend)
+    try await connectTask.value
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: bootstrapMessages.count)
+    #expect(runtimeEnable.targetIdentifier == serviceWorkerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: bootstrapMessages.count)
+    #expect(consoleEnable.targetIdentifier == serviceWorkerTargetID)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+}
+
+@Test
 func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -155,6 +155,45 @@ func domainPumpsApplyConsoleEventsToConsoleSession() async throws {
 }
 
 @Test
+func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await session.runtime.registerRemoteObject(
+        RuntimeRemoteObjectPayload(type: .object, objectID: RuntimeRemoteObjectIdentifier("console-object")),
+        targetID: .pageMain,
+        objectGroup: .console
+    )
+    #expect(await session.runtime.snapshot().remoteObjectsByID[
+        .init(targetID: .pageMain, objectID: RuntimeRemoteObjectIdentifier("console-object"))
+    ] != nil)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Console.messagesCleared","params":{"reason":"console-api"}}"#
+    )
+
+    let _: Bool = try await waitUntil {
+        let runtimeSnapshot = await session.runtime.snapshot()
+        let consoleSnapshot = await session.console.snapshot()
+        let objectKey = RuntimeRemoteObjectIdentifierKey(
+            targetID: .pageMain,
+            objectID: RuntimeRemoteObjectIdentifier("console-object")
+        )
+        guard runtimeSnapshot.remoteObjectsByID[objectKey] == nil,
+              runtimeSnapshot.objectGroupByRemoteObjectID[objectKey] == nil,
+              runtimeSnapshot.objectGroupTargetsByGroup[.console] == nil,
+              consoleSnapshot.lastClearReasonByTargetID[.pageMain] == .consoleAPI else {
+            return nil
+        }
+        return true
+    }
+}
+
+@Test
 func domainPumpsApplyRootScopedConsoleEventsToMainPageConsoleSession() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -532,6 +532,44 @@ func selectedElementStyleHydrationCancellationDoesNotPublishFailure() async thro
 
 @Test
 @MainActor
+func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.dom.selectNode(bodyID)
+
+    let firstSentCount = await backend.sentTargetMessages().count
+    session.setSelectedNodeStyleHydrationActive(true)
+    _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
+    _ = try await waitUntil {
+        await session.css.selectedState == .loading ? true : nil
+    }
+
+    session.setSelectedNodeStyleHydrationActive(false)
+    #expect(session.css.selectedState == .needsRefresh)
+
+    let secondSentCount = await backend.sentTargetMessages().count
+    session.setSelectedNodeStyleHydrationActive(true)
+    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: secondMessages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+
+    let didLoadStyles = try await waitUntil {
+        await session.css.selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadStyles)
+    #expect(session.lastError == nil)
+}
+
+@Test
+@MainActor
 func selectedElementStyleHydrationPreservesStaleStateAfterSelectionDisappears() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -174,8 +174,16 @@ func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
     let _: Bool = try await waitUntil {
         let runtimeSnapshot = await session.runtime.snapshot()
         let consoleSnapshot = await session.console.snapshot()
+        let linkedParameter = await MainActor.run {
+            guard let runtimeObject = session.runtime.runtimeAgentState(for: .pageMain)?.remoteObjects.first,
+                  let parameter = session.console.messages.first?.parameters.first else {
+                return false
+            }
+            return parameter === runtimeObject
+        }
         guard runtimeSnapshot.remoteObjectsByID[objectKey]?.objectGroup == .console,
-              consoleSnapshot.orderedMessageIDs.isEmpty == false else {
+              consoleSnapshot.orderedMessageIDs.isEmpty == false,
+              linkedParameter else {
             return nil
         }
         return true

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -155,6 +155,29 @@ func domainPumpsApplyConsoleEventsToConsoleSession() async throws {
 }
 
 @Test
+func domainPumpsApplyRootScopedConsoleEventsToMainPageConsoleSession() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"error","text":"root hello","type":"log","networkRequestId":"request-root"}}}"#
+    )
+
+    let snapshot: ConsoleSessionSnapshot = try await waitUntil {
+        let snapshot = await session.console.snapshot()
+        guard snapshot.orderedMessageIDs.isEmpty == false else {
+            return nil
+        }
+        return snapshot
+    }
+    let messageID = try #require(snapshot.orderedMessageIDs.first)
+    #expect(snapshot.messagesByID[messageID]?.networkRequestKey == NetworkRequestIdentifierKey(targetID: .pageMain, requestID: .init("request-root")))
+    #expect(snapshot.errorCount == 1)
+}
+
+@Test
 func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -20,6 +20,7 @@ func connectBootstrapsMainPageDocumentInOrder() async throws {
         "Runtime.enable",
         "DOM.getDocument",
         "Network.enable",
+        "Console.enable",
     ])
     #expect(await session.isAttached)
     #expect(await session.dom.snapshot().currentPageTargetID == ProtocolTargetIdentifier.pageMain)
@@ -74,6 +75,31 @@ func domainPumpsApplyNetworkEventsToNetworkSession() async throws {
 
     #expect(request.id.targetID == ProtocolTargetIdentifier.pageMain)
     #expect(request.request.url == "https://example.com/app.js")
+}
+
+@Test
+func domainPumpsApplyConsoleEventsToConsoleSession() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"warning","text":"hello","type":"log","networkRequestId":"request-1"}}}"#
+    )
+
+    let snapshot: ConsoleSessionSnapshot = try await waitUntil {
+        let snapshot = await session.console.snapshot()
+        guard snapshot.orderedMessageIDs.isEmpty == false else {
+            return nil
+        }
+        return snapshot
+    }
+    let messageID = try #require(snapshot.orderedMessageIDs.first)
+    #expect(snapshot.messagesByID[messageID]?.networkRequestKey == NetworkRequestIdentifierKey(targetID: .pageMain, requestID: .init("request-1")))
+    #expect(snapshot.warningCount == 1)
 }
 
 @Test
@@ -745,6 +771,37 @@ func cssOnlyFrameTargetDoesNotSendCSSEnableOnCreation() async throws {
 }
 
 @Test
+func frameTargetWithAdvertisedRuntimeAndConsoleEnablesRuntimeBeforeConsole() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    #expect(consoleEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+}
+
+@Test
 func domCapableFrameTargetDiscoveredBeforeAttachHydratesAfterConnect() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -830,6 +887,51 @@ func provisionalFrameDocumentReplyBeforeCommitRehydratesCommittedFrame() async t
         return snapshot
     }
     #expect(snapshot.targetsByID[provisionalTargetID] == nil)
+}
+
+@Test
+func committedProvisionalFrameWithRuntimeAndConsoleEnablesCommittedTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":true}}}"#
+    )
+    try await Task.sleep(for: .milliseconds(5))
+    #expect(await backend.sentTargetMessages().count == sentCountBeforeFrameTarget)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-ad"}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(
+        backend,
+        method: "Runtime.enable",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(runtimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        result: "{}"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(
+        backend,
+        method: "Console.enable",
+        after: sentCountBeforeFrameTarget
+    )
+    #expect(consoleEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
 }
 
 @Test
@@ -1732,6 +1834,7 @@ func targetCommitBootstrapsCommittedMainPageTarget() async throws {
         "Runtime.enable",
         "DOM.getDocument",
         "Network.enable",
+        "Console.enable",
     ])
 }
 
@@ -1791,6 +1894,10 @@ func requestNodeWaitsForPathPushBeforeSelectingNode() async throws {
     _ = try await waitUntil {
         await session.dom.snapshot().executionContextsByID[ExecutionContextID(7)]
     }
+    _ = try await waitUntil {
+        await session.runtime.snapshot().executionContextsByID[ExecutionContextID(7)]
+    }
+    #expect(await session.runtime.snapshot().executionContextsByID[ExecutionContextID(7)]?.targetID == .pageMain)
     let intent = await session.dom.beginInspectSelectionRequest(
         targetID: .pageMain,
         objectID: "selected-object"
@@ -3727,10 +3834,20 @@ private func completeBootstrap(
 
     let networkMessage = try await waitForTargetMessage(backend, method: "Network.enable", after: sentCount)
     sentMessages.append(networkMessage)
+    sentCount = await backend.sentTargetMessages().count
     await receiveTargetReply(
         transport,
         targetID: networkMessage.targetIdentifier,
         messageID: try messageID(networkMessage.message),
+        result: "{}"
+    )
+
+    let consoleMessage = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    sentMessages.append(consoleMessage)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleMessage.targetIdentifier,
+        messageID: try messageID(consoleMessage.message),
         result: "{}"
     )
     return sentMessages

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -2362,6 +2362,55 @@ func targetCommitBootstrapsCommittedMainPageTarget() async throws {
     ])
 }
 
+@Test
+func runtimeEvaluationResultUsesCommittedReplyTargetAfterNavigationCommit() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCountBeforeEvaluate = await backend.sentTargetMessages().count
+    let intent = await session.runtime.evaluateIntent(expression: "window", targetID: .pageMain)
+    let evaluateTask = Task {
+        try await session.perform(intent)
+    }
+    let evaluateMessage = try await waitForTargetMessage(
+        backend,
+        method: "Runtime.evaluate",
+        after: sentCountBeforeEvaluate
+    )
+    let sentCountBeforeCommit = await backend.sentTargetMessages().count
+
+    await transport.receiveRootMessage(
+        cssCapablePageTargetCreatedMessage(targetID: "page-next", isProvisional: true)
+    )
+    let commitSequence = await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
+    )
+    await expectProtocolEventApplied(commitSequence, in: session)
+
+    await receiveTargetReply(
+        transport,
+        targetID: .pageNext,
+        messageID: try messageID(evaluateMessage.message),
+        result: #"{"result":{"type":"object","objectId":"eval-object","description":"Window"}}"#
+    )
+    let result = try await evaluateTask.value
+
+    let objectID = RuntimeRemoteObjectIdentifier("eval-object")
+    let snapshot = await session.runtime.snapshot()
+    #expect(result.targetID == ProtocolTargetIdentifier.pageNext)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: .pageMain, objectID: objectID)] == nil)
+    #expect(snapshot.remoteObjectsByID[.init(runtimeAgentTargetID: .pageNext, objectID: objectID)]?.payload.description == "Window")
+
+    try await completeBootstrap(
+        transport: transport,
+        backend: backend,
+        after: sentCountBeforeCommit,
+        documentResult: manualReloadDocumentResult
+    )
+}
+
 @Test("Regression: provisional DOM events from link navigation are ignored before committed document reload")
 func linkNavigationBuffersProvisionalDOMEventsUntilCommit() async throws {
     let backend = FakeTransportBackend()

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -1046,6 +1046,40 @@ func frameTargetWithAdvertisedRuntimeAndConsoleEnablesRuntimeBeforeConsole() asy
 }
 
 @Test
+func frameTargetWithUnsupportedRuntimeStillEnablesConsole() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":false}}}"#
+    )
+
+    let runtimeEnable = try await waitForTargetMessage(backend, method: "Runtime.enable", after: sentCount)
+    #expect(runtimeEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetErrorReply(
+        transport,
+        targetID: runtimeEnable.targetIdentifier,
+        messageID: try messageID(runtimeEnable.message),
+        message: "Unknown command: Runtime.enable"
+    )
+
+    let consoleEnable = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    #expect(consoleEnable.targetIdentifier == ProtocolTargetIdentifier.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleEnable.targetIdentifier,
+        messageID: try messageID(consoleEnable.message),
+        result: "{}"
+    )
+
+    #expect(await session.runtime.snapshot().unsupportedCommandsByTargetID[.frameAd]?.contains("Runtime.enable") == true)
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func frameTargetWithAdvertisedRuntimeOnlyEnablesRuntimeWithoutConsole() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -28,6 +28,58 @@ func connectBootstrapsMainPageDocumentInOrder() async throws {
 }
 
 @Test
+func connectToleratesUnsupportedConsoleEnableForDefaultPageTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    await transport.receiveRootMessage(
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
+    )
+
+    let connectTask = Task {
+        try await session.connect(transport: transport)
+    }
+    var sentCount = 0
+    for method in ["Inspector.enable", "Inspector.initialized", "Runtime.enable"] {
+        let sent = try await waitForTargetMessage(backend, method: method, after: sentCount)
+        sentCount = await backend.sentTargetMessages().count
+        await receiveTargetReply(
+            transport,
+            targetID: sent.targetIdentifier,
+            messageID: try messageID(sent.message),
+            result: "{}"
+        )
+    }
+    let documentMessage = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: documentMessage.targetIdentifier,
+        messageID: try messageID(documentMessage.message),
+        result: mainDocumentResult
+    )
+    let networkMessage = try await waitForTargetMessage(backend, method: "Network.enable", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: networkMessage.targetIdentifier,
+        messageID: try messageID(networkMessage.message),
+        result: "{}"
+    )
+    let consoleMessage = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    await receiveTargetErrorReply(
+        transport,
+        targetID: consoleMessage.targetIdentifier,
+        messageID: try messageID(consoleMessage.message),
+        message: "Unknown command: Console.enable"
+    )
+
+    try await connectTask.value
+    #expect(await session.isAttached)
+    #expect(await session.console.snapshot().unsupportedCommandsByTargetID[.pageMain]?.contains("Console.enable") == true)
+}
+
+@Test
 func connectBootstrapsWebPageTargetWithoutDomainMetadataAsCSSCapable() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -100,6 +152,43 @@ func domainPumpsApplyConsoleEventsToConsoleSession() async throws {
     let messageID = try #require(snapshot.orderedMessageIDs.first)
     #expect(snapshot.messagesByID[messageID]?.networkRequestKey == NetworkRequestIdentifierKey(targetID: .pageMain, requestID: .init("request-1")))
     #expect(snapshot.warningCount == 1)
+}
+
+@Test
+func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime"],"isProvisional":false}}}"#
+    )
+    _ = try await waitUntil {
+        await session.dom.snapshot().targetsByID[.frameAd]
+    }
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":77,"frameId":"ad-frame"}}}"#
+    )
+
+    let runtimeSnapshot: RuntimeSessionSnapshot = try await waitUntil {
+        let snapshot = await session.runtime.snapshot()
+        guard snapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd else {
+            return nil
+        }
+        return snapshot
+    }
+    let domSnapshot: DOMSessionSnapshot = try await waitUntil {
+        let snapshot = await session.dom.snapshot()
+        guard snapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(runtimeSnapshot.normalContextIDByTargetID[.frameAd] == ExecutionContextID(77))
+    #expect(domSnapshot.executionContextsByID[ExecutionContextID(77)]?.targetID == .frameAd)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -1416,6 +1416,49 @@ func committedNavigatedFrameReEnablesRuntimeAndConsoleOnNewTarget() async throws
 }
 
 @Test
+func subframeCommitDoesNotRetargetPageRuntimeOrConsoleState() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"type":"normal","frameId":"main-frame"}}}"#
+    )
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"log","text":"page message","type":"log"}}}"#
+    )
+    let _: Bool = try await waitUntil {
+        let runtimeSnapshot = await session.runtime.snapshot()
+        let consoleSnapshot = await session.console.snapshot()
+        guard runtimeSnapshot.executionContextsByKey[contextKey(.pageMain, 7)]?.targetID == .pageMain,
+              consoleSnapshot.orderedMessageIDs.first?.targetID == .pageMain else {
+            return nil
+        }
+        return true
+    }
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-committed","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":true}}}"#
+    )
+    let commitSequence = await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"frame-committed"}}"#
+    )
+    await expectProtocolEventApplied(commitSequence, in: session)
+    let runtimeSnapshot = await session.runtime.snapshot()
+    let consoleSnapshot = await session.console.snapshot()
+
+    #expect(runtimeSnapshot.executionContextsByKey[contextKey(.pageMain, 7)]?.targetID == .pageMain)
+    #expect(runtimeSnapshot.executionContextsByKey[contextKey(ProtocolTargetIdentifier("frame-committed"), 7)] == nil)
+    #expect(consoleSnapshot.orderedMessageIDs.first?.targetID == .pageMain)
+    #expect(consoleSnapshot.orderedMessageIDs.contains { $0.targetID == ProtocolTargetIdentifier("frame-committed") } == false)
+}
+
+@Test
 func provisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydrating() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -2720,6 +2763,26 @@ func targetCommitClearsElementPickerForOldTarget() async throws {
         documentResult: manualReloadDocumentResult
     )
     #expect(bootstrapMessages.map(\.targetIdentifier).allSatisfy { $0 == .pageNext })
+}
+
+@Test
+func subframeCommitDoesNotClearPageElementPicker() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    #expect(await session.isSelectingElement)
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-committed","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM","Runtime","Console"],"isProvisional":true}}}"#
+    )
+    let commitSequence = await transport.receiveRootMessage(
+        #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"frame-committed"}}"#
+    )
+    await expectProtocolEventApplied(commitSequence, in: session)
+
+    #expect(await session.isSelectingElement)
 }
 
 @Test

--- a/Tests/WebInspectorTransportTests/ConsoleTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/ConsoleTransportAdapterTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import WebInspectorCore
+@testable import WebInspectorTransport
+
+@Test
+func consoleTransportAdapterBuildsCommandsAndDecodesLoggingChannels() throws {
+    let targetID = ProtocolTargetIdentifier("page")
+    let enableCommand = try ConsoleTransportAdapter.command(for: .enable(targetID: targetID))
+    #expect(enableCommand.domain == .console)
+    #expect(enableCommand.method == "Console.enable")
+    #expect(enableCommand.routing == .target(targetID))
+
+    let channelCommand = try ConsoleTransportAdapter.command(
+        for: .setLoggingChannelLevel(targetID: targetID, source: .network, level: .verbose)
+    )
+    let channelParameters = try consoleParametersObject(channelCommand.parametersData)
+    #expect(channelCommand.method == "Console.setLoggingChannelLevel")
+    #expect(channelParameters["source"] as? String == "network")
+    #expect(channelParameters["level"] as? String == "verbose")
+
+    let result = ProtocolCommandResult(
+        domain: .console,
+        method: "Console.getLoggingChannels",
+        targetID: targetID,
+        resultData: Data(#"{"channels":[{"source":"network","level":"verbose"}]}"#.utf8)
+    )
+    #expect(try ConsoleTransportAdapter.loggingChannels(from: result) == [
+        ConsoleLoggingChannelPayload(source: .network, level: .verbose),
+    ])
+}
+
+@Test
+@MainActor
+func consoleTransportAdapterAppliesTargetScopedConsoleEvents() throws {
+    let session = ConsoleSession()
+    let targetID = ProtocolTargetIdentifier("frame")
+
+    try ConsoleTransportAdapter.applyConsoleEvent(
+        ProtocolEventEnvelope(
+            sequence: 1,
+            domain: .console,
+            method: "Console.messageAdded",
+            targetID: targetID,
+            paramsData: Data(#"{"message":{"source":"network","level":"error","text":"Load failed","type":"log","parameters":[{"type":"object","objectId":"object-1","description":"Error"}],"networkRequestId":"request-1","timestamp":10}}"#.utf8)
+        ),
+        to: session
+    )
+    try ConsoleTransportAdapter.applyConsoleEvent(
+        ProtocolEventEnvelope(
+            sequence: 2,
+            domain: .console,
+            method: "Console.messageRepeatCountUpdated",
+            targetID: targetID,
+            paramsData: Data(#"{"count":4,"timestamp":11}"#.utf8)
+        ),
+        to: session
+    )
+
+    var snapshot = session.snapshot()
+    let messageID = try #require(snapshot.orderedMessageIDs.first)
+    let message = try #require(snapshot.messagesByID[messageID])
+    #expect(messageID.targetID == targetID)
+    #expect(message.level == .error)
+    #expect(message.repeatCount == 4)
+    #expect(message.parameters.first?.objectID == RuntimeRemoteObjectIdentifier("object-1"))
+    #expect(message.networkRequestKey == NetworkRequestIdentifierKey(targetID: targetID, requestID: .init("request-1")))
+    #expect(snapshot.errorCount == 4)
+
+    try ConsoleTransportAdapter.applyConsoleEvent(
+        ProtocolEventEnvelope(
+            sequence: 3,
+            domain: .console,
+            method: "Console.messagesCleared",
+            targetID: targetID,
+            paramsData: Data(#"{"reason":"frontend"}"#.utf8)
+        ),
+        to: session
+    )
+    snapshot = session.snapshot()
+    #expect(snapshot.orderedMessageIDs.isEmpty)
+    #expect(snapshot.lastClearReasonByTargetID[targetID] == .frontend)
+}
+
+@Test
+@MainActor
+func consoleSessionTracksUnsupportedOptionalCommandsPerTarget() {
+    let session = ConsoleSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+
+    #expect(session.supportsCommand("Console.getLoggingChannels", targetID: pageTargetID))
+    session.markCommandUnsupported("Console.getLoggingChannels", targetID: pageTargetID)
+    #expect(session.supportsCommand("Console.getLoggingChannels", targetID: pageTargetID) == false)
+    #expect(session.supportsCommand("Console.getLoggingChannels", targetID: frameTargetID))
+}
+
+private func consoleParametersObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
@@ -8,7 +8,7 @@ func runtimeTransportAdapterBuildsEvaluateCommandAndDecodesResult() throws {
     let targetID = ProtocolTargetIdentifier("page")
     let intent = RuntimeCommandIntent.evaluate(
         RuntimeEvaluationRequest(
-            targetID: targetID,
+            runtimeAgentTargetID: targetID,
             expression: "document.title",
             objectGroup: RuntimeObjectGroup("console"),
             includeCommandLineAPI: true,
@@ -47,7 +47,7 @@ func runtimeTransportAdapterBuildsEvaluateCommandAndDecodesResult() throws {
 @Test
 func runtimeTransportAdapterBuildsObjectCommandsAndDecodesPropertiesAndCollections() throws {
     let key = RuntimeRemoteObjectIdentifierKey(
-        targetID: ProtocolTargetIdentifier("frame"),
+        runtimeAgentTargetID: ProtocolTargetIdentifier("frame"),
         objectID: RuntimeRemoteObjectIdentifier("object-1")
     )
 
@@ -63,7 +63,7 @@ func runtimeTransportAdapterBuildsObjectCommandsAndDecodesPropertiesAndCollectio
     let propertiesResult = ProtocolCommandResult(
         domain: .runtime,
         method: "Runtime.getProperties",
-        targetID: key.targetID,
+        targetID: key.runtimeAgentTargetID,
         resultData: Data(#"{"properties":[{"name":"length","value":{"type":"number","value":3}}],"internalProperties":[{"name":"[[Prototype]]","value":{"type":"object","objectId":"proto"}}]}"#.utf8)
     )
     let properties = try RuntimeTransportAdapter.propertiesResult(from: propertiesResult)
@@ -74,7 +74,7 @@ func runtimeTransportAdapterBuildsObjectCommandsAndDecodesPropertiesAndCollectio
     let entriesResult = ProtocolCommandResult(
         domain: .runtime,
         method: "Runtime.getCollectionEntries",
-        targetID: key.targetID,
+        targetID: key.runtimeAgentTargetID,
         resultData: Data(#"{"entries":[{"key":{"type":"string","value":"k"},"value":{"type":"number","value":1}}]}"#.utf8)
     )
     let entries = try RuntimeTransportAdapter.collectionEntriesResult(from: entriesResult)

--- a/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import WebInspectorCore
+@testable import WebInspectorTransport
+
+@Test
+func runtimeTransportAdapterBuildsEvaluateCommandAndDecodesResult() throws {
+    let targetID = ProtocolTargetIdentifier("page")
+    let intent = RuntimeCommandIntent.evaluate(
+        RuntimeEvaluationRequest(
+            targetID: targetID,
+            expression: "document.title",
+            objectGroup: RuntimeObjectGroup("console"),
+            includeCommandLineAPI: true,
+            doNotPauseOnExceptionsAndMuteConsole: false,
+            contextID: ExecutionContextID(7),
+            returnByValue: false,
+            generatePreview: true,
+            saveResult: true,
+            emulateUserGesture: true
+        )
+    )
+    let command = try RuntimeTransportAdapter.command(for: intent)
+    let parameters = try parametersObject(command.parametersData)
+
+    #expect(command.domain == .runtime)
+    #expect(command.method == "Runtime.evaluate")
+    #expect(command.routing == .target(targetID))
+    #expect(parameters["expression"] as? String == "document.title")
+    #expect(parameters["objectGroup"] as? String == "console")
+    #expect(parameters["contextId"] as? Int == 7)
+    #expect(parameters["generatePreview"] as? Bool == true)
+
+    let result = ProtocolCommandResult(
+        domain: .runtime,
+        method: "Runtime.evaluate",
+        targetID: targetID,
+        resultData: Data(#"{"result":{"type":"string","value":"Title","description":"Title"},"savedResultIndex":1}"#.utf8)
+    )
+    let payload = try RuntimeTransportAdapter.evaluationResult(from: result)
+    #expect(payload.result.type == .string)
+    #expect(payload.result.value == .string("Title"))
+    #expect(payload.wasThrown == false)
+    #expect(payload.savedResultIndex == 1)
+}
+
+@Test
+func runtimeTransportAdapterBuildsObjectCommandsAndDecodesPropertiesAndCollections() throws {
+    let key = RuntimeRemoteObjectIdentifierKey(
+        targetID: ProtocolTargetIdentifier("frame"),
+        objectID: RuntimeRemoteObjectIdentifier("object-1")
+    )
+
+    let propertiesCommand = try RuntimeTransportAdapter.command(
+        for: .getDisplayableProperties(object: key, fetchStart: 10, fetchCount: 20, generatePreview: true)
+    )
+    let propertiesParameters = try parametersObject(propertiesCommand.parametersData)
+    #expect(propertiesCommand.method == "Runtime.getDisplayableProperties")
+    #expect(propertiesParameters["objectId"] as? String == "object-1")
+    #expect(propertiesParameters["fetchStart"] as? Int == 10)
+    #expect(propertiesParameters["fetchCount"] as? Int == 20)
+
+    let propertiesResult = ProtocolCommandResult(
+        domain: .runtime,
+        method: "Runtime.getProperties",
+        targetID: key.targetID,
+        resultData: Data(#"{"properties":[{"name":"length","value":{"type":"number","value":3}}],"internalProperties":[{"name":"[[Prototype]]","value":{"type":"object","objectId":"proto"}}]}"#.utf8)
+    )
+    let properties = try RuntimeTransportAdapter.propertiesResult(from: propertiesResult)
+    #expect(properties.properties.first?.name == "length")
+    #expect(properties.properties.first?.value?.value == .number(3))
+    #expect(properties.internalProperties.first?.value?.objectID == RuntimeRemoteObjectIdentifier("proto"))
+
+    let entriesResult = ProtocolCommandResult(
+        domain: .runtime,
+        method: "Runtime.getCollectionEntries",
+        targetID: key.targetID,
+        resultData: Data(#"{"entries":[{"key":{"type":"string","value":"k"},"value":{"type":"number","value":1}}]}"#.utf8)
+    )
+    let entries = try RuntimeTransportAdapter.collectionEntriesResult(from: entriesResult)
+    #expect(entries.entries.first?.key?.value == .string("k"))
+    #expect(entries.entries.first?.value.value == .number(1))
+}
+
+@Test
+@MainActor
+func runtimeTransportAdapterAppliesExecutionContextEventToRuntimeSession() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("frame")
+    let event = ProtocolEventEnvelope(
+        sequence: 1,
+        domain: .runtime,
+        method: "Runtime.executionContextCreated",
+        targetID: targetID,
+        paramsData: Data(#"{"context":{"id":42,"type":"normal","name":"Frame","frameId":"frame-1"}}"#.utf8)
+    )
+
+    try RuntimeTransportAdapter.applyRuntimeEvent(event, to: session)
+
+    let snapshot = session.snapshot()
+    #expect(snapshot.executionContextsByID[ExecutionContextID(42)]?.targetID == targetID)
+    #expect(snapshot.executionContextsByID[ExecutionContextID(42)]?.frameID == DOMFrameIdentifier("frame-1"))
+    #expect(snapshot.normalContextIDByTargetID[targetID] == ExecutionContextID(42))
+}
+
+@Test
+@MainActor
+func runtimeSessionTracksUnsupportedOptionalCommandsPerTarget() {
+    let session = RuntimeSession()
+    let pageTargetID = ProtocolTargetIdentifier("page")
+    let frameTargetID = ProtocolTargetIdentifier("frame")
+
+    #expect(session.supportsCommand("Runtime.getDisplayableProperties", targetID: pageTargetID))
+    session.markCommandUnsupported("Runtime.getDisplayableProperties", targetID: pageTargetID)
+    #expect(session.supportsCommand("Runtime.getDisplayableProperties", targetID: pageTargetID) == false)
+    #expect(session.supportsCommand("Runtime.getDisplayableProperties", targetID: frameTargetID))
+}
+
+private func parametersObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}

--- a/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
@@ -105,6 +105,59 @@ func runtimeTransportAdapterAppliesExecutionContextEventToRuntimeSession() throw
 
 @Test
 @MainActor
+func runtimeTransportAdapterAppliesExecutionContextTeardownEvents() throws {
+    let session = RuntimeSession()
+    let targetID = ProtocolTargetIdentifier("frame")
+
+    try RuntimeTransportAdapter.applyRuntimeEvent(
+        ProtocolEventEnvelope(
+            sequence: 1,
+            domain: .runtime,
+            method: "Runtime.executionContextCreated",
+            targetID: targetID,
+            paramsData: Data(#"{"context":{"id":42,"type":"normal","frameId":"frame-1"}}"#.utf8)
+        ),
+        to: session
+    )
+    try RuntimeTransportAdapter.applyRuntimeEvent(
+        ProtocolEventEnvelope(
+            sequence: 2,
+            domain: .runtime,
+            method: "Runtime.executionContextDestroyed",
+            targetID: targetID,
+            paramsData: Data(#"{"executionContextId":42}"#.utf8)
+        ),
+        to: session
+    )
+    #expect(session.snapshot().executionContextsByID[ExecutionContextID(42)] == nil)
+    #expect(session.snapshot().normalContextIDByTargetID[targetID] == nil)
+
+    try RuntimeTransportAdapter.applyRuntimeEvent(
+        ProtocolEventEnvelope(
+            sequence: 3,
+            domain: .runtime,
+            method: "Runtime.executionContextCreated",
+            targetID: targetID,
+            paramsData: Data(#"{"context":{"id":43,"type":"normal","frameId":"frame-1"}}"#.utf8)
+        ),
+        to: session
+    )
+    try RuntimeTransportAdapter.applyRuntimeEvent(
+        ProtocolEventEnvelope(
+            sequence: 4,
+            domain: .runtime,
+            method: "Runtime.executionContextsCleared",
+            targetID: targetID,
+            paramsData: Data("{}".utf8)
+        ),
+        to: session
+    )
+    #expect(session.snapshot().executionContextsByID[ExecutionContextID(43)] == nil)
+    #expect(session.snapshot().normalContextIDByTargetID[targetID] == nil)
+}
+
+@Test
+@MainActor
 func runtimeSessionTracksUnsupportedOptionalCommandsPerTarget() {
     let session = RuntimeSession()
     let pageTargetID = ProtocolTargetIdentifier("page")

--- a/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
+++ b/Tests/WebInspectorTransportTests/RuntimeTransportAdapterTests.swift
@@ -98,9 +98,9 @@ func runtimeTransportAdapterAppliesExecutionContextEventToRuntimeSession() throw
     try RuntimeTransportAdapter.applyRuntimeEvent(event, to: session)
 
     let snapshot = session.snapshot()
-    #expect(snapshot.executionContextsByID[ExecutionContextID(42)]?.targetID == targetID)
-    #expect(snapshot.executionContextsByID[ExecutionContextID(42)]?.frameID == DOMFrameIdentifier("frame-1"))
-    #expect(snapshot.normalContextIDByTargetID[targetID] == ExecutionContextID(42))
+    #expect(snapshot.executionContextsByKey[contextKey(targetID, 42)]?.targetID == targetID)
+    #expect(snapshot.executionContextsByKey[contextKey(targetID, 42)]?.frameID == DOMFrameIdentifier("frame-1"))
+    #expect(snapshot.normalContextKeyByTargetID[targetID] == contextKey(targetID, 42))
 }
 
 @Test
@@ -129,8 +129,8 @@ func runtimeTransportAdapterAppliesExecutionContextTeardownEvents() throws {
         ),
         to: session
     )
-    #expect(session.snapshot().executionContextsByID[ExecutionContextID(42)] == nil)
-    #expect(session.snapshot().normalContextIDByTargetID[targetID] == nil)
+    #expect(session.snapshot().executionContextsByKey[contextKey(targetID, 42)] == nil)
+    #expect(session.snapshot().normalContextKeyByTargetID[targetID] == nil)
 
     try RuntimeTransportAdapter.applyRuntimeEvent(
         ProtocolEventEnvelope(
@@ -152,8 +152,8 @@ func runtimeTransportAdapterAppliesExecutionContextTeardownEvents() throws {
         ),
         to: session
     )
-    #expect(session.snapshot().executionContextsByID[ExecutionContextID(43)] == nil)
-    #expect(session.snapshot().normalContextIDByTargetID[targetID] == nil)
+    #expect(session.snapshot().executionContextsByKey[contextKey(targetID, 43)] == nil)
+    #expect(session.snapshot().normalContextKeyByTargetID[targetID] == nil)
 }
 
 @Test
@@ -171,4 +171,8 @@ func runtimeSessionTracksUnsupportedOptionalCommandsPerTarget() {
 
 private func parametersObject(_ data: Data) throws -> [String: Any] {
     try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func contextKey(_ runtimeAgentTargetID: ProtocolTargetIdentifier, _ contextID: Int) -> RuntimeExecutionContextKey {
+    RuntimeExecutionContextKey(runtimeAgentTargetID: runtimeAgentTargetID, contextID: ExecutionContextID(contextID))
 }

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -615,7 +615,7 @@ func rootScopedRuntimeDOMAndConsoleEventsResolveToCurrentPageTarget() async thro
     await session.receiveRootMessage(#"{"method":"Console.messageAdded","params":{"message":{"text":"hello"}}}"#)
     let snapshot = await session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(11)]?.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(snapshot.executionContextsByKey[contextKey("page-main", 11)]?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await runtimeTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await domTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await consoleTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
@@ -660,7 +660,7 @@ func runtimeExecutionContextMapsToDeliveringTarget() async throws {
     )
     let snapshot = await session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(snapshot.executionContextsByKey[contextKey("frame-A", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
     #expect(await session.targetIdentifier(forFrameID: .init("frame-A")) == ProtocolTargetIdentifier("frame-A"))
 }
 
@@ -678,7 +678,7 @@ func runtimeContextOnPagePreservesExistingFrameTargetRoute() async throws {
     )
     let snapshot = await session.snapshot()
 
-    #expect(snapshot.executionContextsByID[ExecutionContextID(7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(snapshot.executionContextsByKey[contextKey("page-main", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
     #expect(await session.targetIdentifier(forFrameID: .init("frame-A")) == ProtocolTargetIdentifier("frame-A"))
 }
 
@@ -697,15 +697,46 @@ func rootScopedRuntimeClearRemovesRetargetedContextsFromPageRuntimeAgent() async
     )
 
     let beforeClear = await session.snapshot()
-    #expect(beforeClear.executionContextsByID[ExecutionContextID(7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
-    #expect(beforeClear.executionContextsByID[ExecutionContextID(7)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("page-main"))
-    #expect(beforeClear.executionContextsByID[ExecutionContextID(8)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(beforeClear.executionContextsByKey[contextKey("page-main", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(beforeClear.executionContextsByKey[contextKey("page-main", 7)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(beforeClear.executionContextsByKey[contextKey("frame-A", 8)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("frame-A"))
 
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
     let afterClear = await session.snapshot()
 
-    #expect(afterClear.executionContextsByID[ExecutionContextID(7)] == nil)
-    #expect(afterClear.executionContextsByID[ExecutionContextID(8)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(afterClear.executionContextsByKey[contextKey("page-main", 7)] == nil)
+    #expect(afterClear.executionContextsByKey[contextKey("frame-A", 8)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+}
+
+@Test
+func runtimeExecutionContextRegistryScopesDuplicateIDsByRuntimeAgentTarget() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","parentFrameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"frame-A"}}}"#)
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-A"),
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"frame-A"}}}"#
+    )
+
+    let snapshot = await session.snapshot()
+    #expect(snapshot.executionContextsByKey[contextKey("page-main", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(snapshot.executionContextsByKey[contextKey("frame-A", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-A"),
+        message: #"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":7}}"#
+    )
+    let afterFrameDestroy = await session.snapshot()
+    #expect(afterFrameDestroy.executionContextsByKey[contextKey("page-main", 7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(afterFrameDestroy.executionContextsByKey[contextKey("frame-A", 7)] == nil)
+
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
+    #expect(await session.snapshot().executionContextsByKey[contextKey("page-main", 7)] == nil)
 }
 
 @Test
@@ -716,7 +747,7 @@ func runtimeExecutionContextRegistryPreservesContextMetadata() async throws {
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":9,"type":"internal","name":"Isolated World","frameId":"main-frame"}}}"#)
     let snapshot = await session.snapshot()
-    let record = try #require(snapshot.executionContextsByID[ExecutionContextID(9)])
+    let record = try #require(snapshot.executionContextsByKey[contextKey("page-main", 9)])
 
     #expect(record.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(record.type == .internal)
@@ -732,11 +763,11 @@ func runtimeExecutionContextRegistryAppliesTeardownEvents() async throws {
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":9,"type":"normal","frameId":"main-frame"}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":9}}"#)
-    #expect(await session.snapshot().executionContextsByID[ExecutionContextID(9)] == nil)
+    #expect(await session.snapshot().executionContextsByKey[contextKey("page-main", 9)] == nil)
 
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":10,"type":"normal","frameId":"main-frame"}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
-    #expect(await session.snapshot().executionContextsByID[ExecutionContextID(10)] == nil)
+    #expect(await session.snapshot().executionContextsByKey[contextKey("page-main", 10)] == nil)
 }
 
 @Test
@@ -1734,6 +1765,13 @@ private func messageMethod(_ message: String) throws -> String? {
 
 private func jsonObject(from data: Data) throws -> [String: Any] {
     try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func contextKey(_ runtimeAgentTargetID: String, _ contextID: Int) -> RuntimeExecutionContextKey {
+    RuntimeExecutionContextKey(
+        runtimeAgentTargetID: ProtocolTargetIdentifier(runtimeAgentTargetID),
+        contextID: ExecutionContextID(contextID)
+    )
 }
 
 private func integerValue(_ value: Any?) -> Int? {

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -740,6 +740,31 @@ func runtimeExecutionContextRegistryScopesDuplicateIDsByRuntimeAgentTarget() asy
 }
 
 @Test
+func runtimeExecutionContextRegistryPreservesCommittedContextWhenIDsCollide() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-old","type":"page","frameId":"old-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-new","type":"page","isProvisional":false}}}"#)
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("page-old"),
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"type":"normal","name":"old","frameId":"old-frame"}}}"#
+    )
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("page-new"),
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"type":"normal","name":"new"}}}"#
+    )
+
+    await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-old","newTargetId":"page-new"}}"#)
+    let snapshot = await session.snapshot()
+
+    #expect(snapshot.executionContextsByKey[contextKey("page-old", 7)] == nil)
+    #expect(snapshot.executionContextsByKey[contextKey("page-new", 7)]?.name == "new")
+}
+
+@Test
 func runtimeExecutionContextRegistryPreservesContextMetadata() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -699,6 +699,21 @@ func runtimeExecutionContextRegistryPreservesContextMetadata() async throws {
 }
 
 @Test
+func runtimeExecutionContextRegistryAppliesTeardownEvents() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":9,"type":"normal","frameId":"main-frame"}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":9}}"#)
+    #expect(await session.snapshot().executionContextsByID[ExecutionContextID(9)] == nil)
+
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":10,"type":"normal","frameId":"main-frame"}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
+    #expect(await session.snapshot().executionContextsByID[ExecutionContextID(10)] == nil)
+}
+
+@Test
 func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -599,22 +599,26 @@ func ambiguousTargetCommitPreservesExistingMetadataAndDoesNotInventTarget() asyn
 }
 
 @Test
-func rootScopedRuntimeAndDOMMutationEventsResolveToCurrentPageTarget() async throws {
+func rootScopedRuntimeDOMAndConsoleEventsResolveToCurrentPageTarget() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let runtimeStream = await session.events(for: .runtime)
     let domStream = await session.events(for: .dom)
+    let consoleStream = await session.events(for: .console)
     let runtimeTask = firstEvent(from: runtimeStream)
     let domTask = firstEvent(from: domStream)
+    let consoleTask = firstEvent(from: consoleStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":11,"frameId":"main-frame"}}}"#)
     await session.receiveRootMessage(#"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":1,"childNodeCount":2}}"#)
+    await session.receiveRootMessage(#"{"method":"Console.messageAdded","params":{"message":{"text":"hello"}}}"#)
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByID[ExecutionContextID(11)]?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await runtimeTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
     #expect(await domTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(await consoleTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
 }
 
 @Test

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -683,6 +683,22 @@ func runtimeContextOnPagePreservesExistingFrameTargetRoute() async throws {
 }
 
 @Test
+func runtimeExecutionContextRegistryPreservesContextMetadata() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":9,"type":"internal","name":"Isolated World","frameId":"main-frame"}}}"#)
+    let snapshot = await session.snapshot()
+    let record = try #require(snapshot.executionContextsByID[ExecutionContextID(9)])
+
+    #expect(record.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(record.type == .internal)
+    #expect(record.name == "Isolated World")
+    #expect(record.frameID == DOMFrameIdentifier("main-frame"))
+}
+
+@Test
 func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -683,6 +683,32 @@ func runtimeContextOnPagePreservesExistingFrameTargetRoute() async throws {
 }
 
 @Test
+func rootScopedRuntimeClearRemovesRetargetedContextsFromPageRuntimeAgent() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend)
+
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","parentFrameId":"main-frame","isProvisional":false}}}"#)
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"frame-A"}}}"#)
+    await receiveTargetDispatch(
+        session,
+        targetID: .init("frame-A"),
+        message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":8,"frameId":"frame-A"}}}"#
+    )
+
+    let beforeClear = await session.snapshot()
+    #expect(beforeClear.executionContextsByID[ExecutionContextID(7)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+    #expect(beforeClear.executionContextsByID[ExecutionContextID(7)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("page-main"))
+    #expect(beforeClear.executionContextsByID[ExecutionContextID(8)]?.runtimeAgentTargetID == ProtocolTargetIdentifier("frame-A"))
+
+    await session.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
+    let afterClear = await session.snapshot()
+
+    #expect(afterClear.executionContextsByID[ExecutionContextID(7)] == nil)
+    #expect(afterClear.executionContextsByID[ExecutionContextID(8)]?.targetID == ProtocolTargetIdentifier("frame-A"))
+}
+
+@Test
 func runtimeExecutionContextRegistryPreservesContextMetadata() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -147,6 +147,37 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func detailModeMenuDisablesWhenSelectedRequestDisappears() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/form",
+                postData: "name=Jane+Doe"
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didEnableMenu = await waitUntil {
+            viewController.navigationItem.trailingItemGroups.first?.barButtonItems.first?.isEnabled == true
+        }
+        #expect(didEnableMenu)
+
+        network.reset()
+
+        let didDisableMenu = await waitUntil {
+            viewController.navigationItem.trailingItemGroups.first?.barButtonItems.first?.isEnabled == false
+                && viewController.contentUnavailableConfiguration != nil
+        }
+        #expect(didDisableMenu)
+    }
+
+    @Test
     func responseBodyModeRequestsRuntimeFetchWhenBodyIsAvailable() async throws {
         let network = NetworkSession()
         let request = try #require(
@@ -198,6 +229,37 @@ struct NetworkDetailViewControllerTests {
         #expect(didPush)
 
         model.selectRequest(nil)
+        let didPop = await waitUntilAllowingAnimations {
+            navigationController.viewControllers == [listViewController]
+        }
+        #expect(didPop)
+    }
+
+    @Test
+    func compactContainerPopsDetailWhenSelectedRequestDisappears() async throws {
+        let network = NetworkSession()
+        let request = try #require(applyRequest(to: network, requestID: "1", url: "https://example.com/app.js"))
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = NetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        let window = showInWindow(navigationController)
+        defer { window.isHidden = true }
+
+        model.selectRequest(request)
+        let didPush = await waitUntil {
+            navigationController.viewControllers.last === detailViewController
+        }
+        #expect(didPush)
+
+        network.reset()
+        #expect(model.selectedRequestID == request.id)
+        #expect(model.selectedRequest == nil)
+
         let didPop = await waitUntilAllowingAnimations {
             navigationController.viewControllers == [listViewController]
         }


### PR DESCRIPTION
## Summary
- Add first-class Runtime and Console core models/protocol payloads, including target-scoped runtime objects, execution contexts, console messages, counts, repeat handling, and clear state.
- Add Runtime and Console transport adapters and wire Runtime/Console bootstrap, target capability metadata, frame-target enablement, and provisional target handling into InspectorSession and TransportSession.
- Move shared stack trace payloads out of Network ownership and update DOM/CSS integration around runtime-agent target ownership.
- Align DOM and Network UI rendering with ObservationBridge direct rendering so selected style hydration and request detail changes update only the affected native surfaces.
- Update research/architecture docs and add coverage across core, transport, runtime, and UI reset/selection behavior.

## Testing
- swift test --filter WebInspectorCoreTests
- swift test --filter WebInspectorTransportTests
- swift test --filter WebInspectorRuntimeTests
- swift test
- git diff --check
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- codex-review against main: clean

## Screenshots
- Not applicable; this PR does not add Console UI.

## Related
- None