### PR TITLE
Make timeout-sensitive tests deterministic

### DIFF
--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -131,6 +131,7 @@ private final class InspectorTarget {
     var isBootstrapped: Bool
     private var enabledDomains: ProtocolTargetCapabilities
     private var runtimeConsoleEnableTask: Task<Void, Never>?
+    private var runtimeConsoleEnableTaskWaiters: [CheckedContinuation<Void, Never>]
 
     init(snapshot: ProtocolTargetSnapshot) {
         id = snapshot.id
@@ -143,6 +144,7 @@ private final class InspectorTarget {
         isBootstrapped = false
         enabledDomains = []
         runtimeConsoleEnableTask = nil
+        runtimeConsoleEnableTaskWaiters = []
     }
 
     func update(from snapshot: ProtocolTargetSnapshot) {
@@ -191,11 +193,34 @@ private final class InspectorTarget {
 
     func finishRuntimeConsoleEnableTask() {
         runtimeConsoleEnableTask = nil
+        resumeRuntimeConsoleEnableTaskWaiters()
     }
 
     func cancelRuntimeConsoleEnableTask() {
         runtimeConsoleEnableTask?.cancel()
         runtimeConsoleEnableTask = nil
+        resumeRuntimeConsoleEnableTaskWaiters()
+    }
+
+    func waitUntilRuntimeConsoleEnableTaskFinished() async {
+        guard runtimeConsoleEnableTask != nil else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if runtimeConsoleEnableTask == nil {
+                continuation.resume()
+            } else {
+                runtimeConsoleEnableTaskWaiters.append(continuation)
+            }
+        }
+    }
+
+    private func resumeRuntimeConsoleEnableTaskWaiters() {
+        let waiters = runtimeConsoleEnableTaskWaiters
+        runtimeConsoleEnableTaskWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 
@@ -244,6 +269,14 @@ private final class InspectorTargetRegistry {
         for target in targetsByID.values {
             target.cancelRuntimeConsoleEnableTask()
         }
+    }
+
+    func waitUntilRuntimeConsoleEnableTaskFinished(targetID: ProtocolTargetIdentifier) async -> Bool {
+        guard let target = targetsByID[targetID] else {
+            return false
+        }
+        await target.waitUntilRuntimeConsoleEnableTaskFinished()
+        return true
     }
 }
 
@@ -761,6 +794,13 @@ package final class InspectorSession {
             return false
         }
         return await eventPump.waitUntilApplied(sequence)
+    }
+
+    package func waitUntilRuntimeConsoleEnableFinished(targetID: ProtocolTargetIdentifier) async -> Bool {
+        guard let connection else {
+            return false
+        }
+        return await connection.targets.waitUntilRuntimeConsoleEnableTaskFinished(targetID: targetID)
     }
 
     @discardableResult

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -122,10 +122,12 @@ package actor TransportSession {
     }
 
     package typealias ResponseTimeoutSleep = @Sendable (Duration) async throws -> Void
+    package typealias ResponseTimeoutDidFire = @Sendable () async -> Void
 
     private let backend: any TransportBackend
     private let responseTimeout: Duration?
     private let responseTimeoutSleep: ResponseTimeoutSleep
+    private let responseTimeoutDidFire: ResponseTimeoutDidFire
     private var nextCommandID: UInt64
     private var nextSequence: UInt64
     private var lastSequenceByDomain: [ProtocolDomain: UInt64]
@@ -154,11 +156,13 @@ package actor TransportSession {
     package init(
         backend: any TransportBackend,
         responseTimeout: Duration? = .seconds(5),
-        responseTimeoutSleep: ResponseTimeoutSleep? = nil
+        responseTimeoutSleep: ResponseTimeoutSleep? = nil,
+        responseTimeoutDidFire: ResponseTimeoutDidFire? = nil
     ) {
         self.backend = backend
         self.responseTimeout = responseTimeout
         self.responseTimeoutSleep = responseTimeoutSleep ?? { try await Task.sleep(for: $0) }
+        self.responseTimeoutDidFire = responseTimeoutDidFire ?? {}
         nextCommandID = 0
         nextSequence = 0
         lastSequenceByDomain = [:]
@@ -480,6 +484,7 @@ package actor TransportSession {
     ) async throws -> ProtocolCommandResult {
         let timeoutTask: Task<Void, Never>? = responseTimeout.map { responseTimeout in
             let responseTimeoutSleep = self.responseTimeoutSleep
+            let responseTimeoutDidFire = self.responseTimeoutDidFire
             return Task {
                 do {
                     try await responseTimeoutSleep(responseTimeout)
@@ -490,6 +495,7 @@ package actor TransportSession {
                     key,
                     error: TransportError.replyTimeout(method: method, targetID: targetID)
                 )
+                await responseTimeoutDidFire()
             }
         }
         defer {

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -600,7 +600,9 @@ func selectedElementStyleHydrationPreservesStaleStateAfterSelectionDisappears() 
     _ = try await waitUntil {
         await session.dom.selectedNodeID == nil ? true : nil
     }
-    try await Task.sleep(for: .milliseconds(10))
+    _ = try await waitUntil {
+        await session.css.selectedState == .unavailable(.staleNode(bodyID)) ? true : nil
+    }
 
     #expect(session.css.selectedNodeStyles != nil)
     #expect(session.css.selectedState == .unavailable(.staleNode(bodyID)))
@@ -1155,10 +1157,10 @@ func cssOnlyFrameTargetDoesNotSendCSSEnableOnCreation() async throws {
     try await connect(session, transport: transport, backend: backend)
 
     let sentCount = await backend.sentTargetMessages().count
-    await transport.receiveRootMessage(
+    let targetCreatedSequence = await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-css-race","type":"frame","frameId":"css-frame-race","parentFrameId":"main-frame","domains":["CSS"],"isProvisional":false}}}"#
     )
-    try await Task.sleep(for: .milliseconds(5))
+    await expectProtocolEventApplied(targetCreatedSequence, in: session)
 
     #expect(await backend.sentTargetMessages().count == sentCount)
     #expect(await session.lastError == nil)
@@ -1287,7 +1289,7 @@ func frameTargetWithAdvertisedRuntimeOnlyEnablesRuntimeWithoutConsole() async th
         result: "{}"
     )
 
-    try await Task.sleep(for: .milliseconds(5))
+    #expect(await session.waitUntilRuntimeConsoleEnableFinished(targetID: .frameAd))
     let messages = await backend.sentTargetMessages().dropFirst(sentCount)
     #expect(messages.compactMap { try? messageMethod($0.message) }.contains("Console.enable") == false)
 }
@@ -1491,10 +1493,10 @@ func committedProvisionalFrameWithRuntimeAndConsoleEnablesCommittedTarget() asyn
     try await connect(session, transport: transport, backend: backend)
 
     let sentCountBeforeFrameTarget = await backend.sentTargetMessages().count
-    await transport.receiveRootMessage(
+    let targetCreatedSequence = await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":true}}}"#
     )
-    try await Task.sleep(for: .milliseconds(5))
+    await expectProtocolEventApplied(targetCreatedSequence, in: session)
     #expect(await backend.sentTargetMessages().count == sentCountBeforeFrameTarget)
 
     await transport.receiveRootMessage(
@@ -1565,10 +1567,10 @@ func committedNavigatedFrameReEnablesRuntimeAndConsoleOnNewTarget() async throws
     )
 
     let sentCountBeforeNavigation = await backend.sentTargetMessages().count
-    await transport.receiveRootMessage(
+    let targetCreatedSequence = await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-next","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime","Console"],"isProvisional":true}}}"#
     )
-    try await Task.sleep(for: .milliseconds(5))
+    await expectProtocolEventApplied(targetCreatedSequence, in: session)
     #expect(await backend.sentTargetMessages().count == sentCountBeforeNavigation)
 
     await transport.receiveRootMessage(

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -218,9 +218,7 @@ func remoteErrorAndTimeoutFailPendingReplies() async throws {
         )
     }
     _ = try await waitForRootMessage(timeoutBackend)
-    _ = try await waitUntil {
-        await responseTimeout.hasPendingSleep ? true : nil
-    }
+    await responseTimeout.waitUntilSuspended()
     await responseTimeout.fireNext()
     await #expect(throws: TransportError.replyTimeout(method: "Target.setPauseOnStart", targetID: nil)) {
         _ = try await timeoutTask.value
@@ -445,7 +443,14 @@ func provisionalTargetReplyIsBufferedUntilCommit() async throws {
 @Test
 func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
+    let responseTimeout = ManualResponseTimeout()
+    let session = TransportSession(
+        backend: backend,
+        responseTimeout: .milliseconds(20),
+        responseTimeoutSleep: { duration in
+            try await responseTimeout.sleep(for: duration)
+        }
+    )
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
 
     let sendTask = Task {
@@ -461,7 +466,8 @@ func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async t
         targetID: .init("frame-provisional"),
         message: ##"{"id":\##(innerID),"result":{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document"}}}"##
     )
-    try await Task.sleep(for: .milliseconds(50))
+    await responseTimeout.waitUntilSuspended()
+    await responseTimeout.fireNext()
 
     #expect(await session.snapshot().pendingTargetReplyKeys == [
         TargetReplyKey(targetID: .init("frame-provisional"), commandID: innerID),
@@ -1711,9 +1717,12 @@ private func waitUntil<Value: Sendable>(_ body: @escaping @Sendable () async -> 
 private actor ManualResponseTimeout {
     private var nextSleepID: UInt64 = 0
     private var continuations: [UInt64: CheckedContinuation<Void, Error>] = [:]
+    private var nextSuspensionID: UInt64 = 0
+    private var suspensionContinuations: [UInt64: SuspensionContinuation] = [:]
 
-    var hasPendingSleep: Bool {
-        !continuations.isEmpty
+    private struct SuspensionContinuation {
+        var minimumSleeps: Int
+        var continuation: CheckedContinuation<Void, Never>
     }
 
     func sleep(for _: Duration) async throws {
@@ -1722,6 +1731,10 @@ private actor ManualResponseTimeout {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 continuations[sleepID] = continuation
+                let suspensionContinuations = popReadySuspensionContinuations()
+                for suspensionContinuation in suspensionContinuations {
+                    suspensionContinuation.resume()
+                }
             }
         } onCancel: {
             Task {
@@ -1738,11 +1751,53 @@ private actor ManualResponseTimeout {
         continuation.resume()
     }
 
+    func waitUntilSuspended(by minimumSleeps: Int = 1) async {
+        precondition(minimumSleeps > 0, "minimumSleeps must be positive")
+        guard continuations.count < minimumSleeps else {
+            return
+        }
+
+        nextSuspensionID &+= 1
+        let suspensionID = nextSuspensionID
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if continuations.count >= minimumSleeps {
+                    continuation.resume()
+                } else {
+                    suspensionContinuations[suspensionID] = SuspensionContinuation(
+                        minimumSleeps: minimumSleeps,
+                        continuation: continuation
+                    )
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancelSuspension(suspensionID)
+            }
+        }
+    }
+
     private func cancel(_ sleepID: UInt64) {
         guard let continuation = continuations.removeValue(forKey: sleepID) else {
             return
         }
         continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelSuspension(_ suspensionID: UInt64) {
+        guard let continuation = suspensionContinuations.removeValue(forKey: suspensionID)?.continuation else {
+            return
+        }
+        continuation.resume()
+    }
+
+    private func popReadySuspensionContinuations() -> [CheckedContinuation<Void, Never>] {
+        let readySuspensionIDs = suspensionContinuations.compactMap { suspensionID, suspensionContinuation in
+            continuations.count >= suspensionContinuation.minimumSleeps ? suspensionID : nil
+        }
+        return readySuspensionIDs.compactMap { suspensionID in
+            suspensionContinuations.removeValue(forKey: suspensionID)?.continuation
+        }
     }
 }
 

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -449,6 +449,9 @@ func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async t
         responseTimeout: .milliseconds(20),
         responseTimeoutSleep: { duration in
             try await responseTimeout.sleep(for: duration)
+        },
+        responseTimeoutDidFire: {
+            await responseTimeout.recordHandledTimeout()
         }
     )
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
@@ -468,6 +471,7 @@ func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async t
     )
     await responseTimeout.waitUntilSuspended()
     await responseTimeout.fireNext()
+    await responseTimeout.waitUntilHandledTimeout()
 
     #expect(await session.snapshot().pendingTargetReplyKeys == [
         TargetReplyKey(targetID: .init("frame-provisional"), commandID: innerID),
@@ -1719,6 +1723,8 @@ private actor ManualResponseTimeout {
     private var continuations: [UInt64: CheckedContinuation<Void, Error>] = [:]
     private var nextSuspensionID: UInt64 = 0
     private var suspensionContinuations: [UInt64: SuspensionContinuation] = [:]
+    private var handledTimeoutCount: Int = 0
+    private var handledTimeoutContinuation: CheckedContinuation<Void, Never>?
 
     private struct SuspensionContinuation {
         var minimumSleeps: Int
@@ -1773,6 +1779,25 @@ private actor ManualResponseTimeout {
         } onCancel: {
             Task {
                 await self.cancelSuspension(suspensionID)
+            }
+        }
+    }
+
+    func recordHandledTimeout() {
+        handledTimeoutCount += 1
+        handledTimeoutContinuation?.resume()
+        handledTimeoutContinuation = nil
+    }
+
+    func waitUntilHandledTimeout() async {
+        guard handledTimeoutCount == 0 else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if handledTimeoutCount > 0 {
+                continuation.resume()
+            } else {
+                handledTimeoutContinuation = continuation
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace the provisional target timeout test's real-time race with manual timeout suspension, firing, and handled-timeout synchronization.
- Convert related runtime tests from fixed sleeps to deterministic protocol event or task-completion waits.
- Keep default production timeout behavior unchanged; the added timeout hook is package-scoped and defaults to a no-op.

## Testing
- `swift test --filter bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit`
- `swift test --filter WebInspectorTransportTests`
- `swift test --filter InspectorSessionTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- `codex-review --base main` (findings 0 after follow-up fix)

## Screenshots
- Not applicable; test synchronization changes only.

## Related
- CI job: https://github.com/lynnswap/WebInspectorKit/actions/runs/26477140997/job/77965509267