### PR TITLE
fix(network): stop response body fetch retry loop

### DIFF
--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -108,9 +108,9 @@ package final class NetworkBody {
 
     package var needsFetch: Bool {
         switch fetchState {
-        case .available, .failed:
+        case .available:
             full == nil
-        case .fetching, .loaded:
+        case .fetching, .loaded, .failed:
             false
         }
     }

--- a/Sources/WebInspectorCore/Network/NetworkModel.swift
+++ b/Sources/WebInspectorCore/Network/NetworkModel.swift
@@ -175,6 +175,13 @@ package final class NetworkRequest {
         responseBody?.apply(payload)
     }
 
+    package var canFetchResponseBody: Bool {
+        guard state == .finished else {
+            return false
+        }
+        return responseBody?.needsFetch == true
+    }
+
     package func markResponseBodyFetching() {
         ensureResponseBody()
         responseBody?.markFetching()
@@ -591,7 +598,7 @@ package final class NetworkSession {
 
     package func responseBodyCommandIntent(for id: NetworkRequest.ID) -> NetworkCommandIntent? {
         guard let request = requestsByID[id],
-              request.responseBody != nil else {
+              request.canFetchResponseBody else {
             return nil
         }
         return .getResponseBody(

--- a/Sources/WebInspectorRuntime/InspectorSession.swift
+++ b/Sources/WebInspectorRuntime/InspectorSession.swift
@@ -1275,7 +1275,7 @@ package final class InspectorSession {
         guard let request = network.request(for: id) else {
             return
         }
-        guard request.responseBody?.needsFetch == true else {
+        guard request.canFetchResponseBody else {
             return
         }
         guard let intent = network.responseBodyCommandIntent(for: id) else {

--- a/Sources/WebInspectorTransport/TransportBackend.swift
+++ b/Sources/WebInspectorTransport/TransportBackend.swift
@@ -20,20 +20,26 @@ package struct SentTargetMessage: Equatable, Sendable {
 
 package actor FakeTransportBackend: TransportBackend {
     private struct TargetMessageWaiter: Sendable {
+        var id: UInt64
         var method: String
+        var ordinal: Int
         var after: Int
-        var continuation: CheckedContinuation<SentTargetMessage, Never>
+        var continuation: CheckedContinuation<SentTargetMessage, Error>
     }
 
     private var messages: [String]
     private var sendError: (any Error)?
     private var detached: Bool
     private var targetMessageWaiters: [TargetMessageWaiter]
+    private var nextTargetMessageWaiterID: UInt64
+    private var cancelledTargetMessageWaiterIDs: Set<UInt64>
 
     package init() {
         messages = []
         detached = false
         targetMessageWaiters = []
+        nextTargetMessageWaiterID = 0
+        cancelledTargetMessageWaiterIDs = []
     }
 
     package func sendJSONString(_ message: String) async throws {
@@ -60,20 +66,31 @@ package actor FakeTransportBackend: TransportBackend {
         messages.compactMap { Self.sentTargetMessage(from: $0) }
     }
 
-    package func waitForTargetMessage(method: String, after count: Int = 0) async -> SentTargetMessage {
-        if let message = firstTargetMessage(method: method, after: count) {
+    package func waitForTargetMessage(method: String, ordinal: Int = 0, after count: Int = 0) async throws -> SentTargetMessage {
+        try Task.checkCancellation()
+        if let message = targetMessage(method: method, ordinal: ordinal, after: count) {
             return message
         }
 
-        return await withCheckedContinuation { continuation in
-            targetMessageWaiters.append(
-                TargetMessageWaiter(
+        nextTargetMessageWaiterID &+= 1
+        let waiterID = nextTargetMessageWaiterID
+        let message = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                registerTargetMessageWaiter(
+                    id: waiterID,
                     method: method,
+                    ordinal: ordinal,
                     after: count,
                     continuation: continuation
                 )
-            )
+            }
+        } onCancel: {
+            Task {
+                await self.cancelTargetMessageWaiter(waiterID)
+            }
         }
+        try Task.checkCancellation()
+        return message
     }
 
     package func isDetached() -> Bool {
@@ -83,7 +100,9 @@ package actor FakeTransportBackend: TransportBackend {
     private func resumeTargetMessageWaiters() {
         var remainingWaiters: [TargetMessageWaiter] = []
         for waiter in targetMessageWaiters {
-            if let message = firstTargetMessage(method: waiter.method, after: waiter.after) {
+            if cancelledTargetMessageWaiterIDs.remove(waiter.id) != nil {
+                waiter.continuation.resume(throwing: CancellationError())
+            } else if let message = targetMessage(method: waiter.method, ordinal: waiter.ordinal, after: waiter.after) {
                 waiter.continuation.resume(returning: message)
             } else {
                 remainingWaiters.append(waiter)
@@ -92,10 +111,49 @@ package actor FakeTransportBackend: TransportBackend {
         targetMessageWaiters = remainingWaiters
     }
 
-    private func firstTargetMessage(method: String, after count: Int) -> SentTargetMessage? {
-        sentTargetMessages().dropFirst(count).first { sentMessage in
+    private func registerTargetMessageWaiter(
+        id: UInt64,
+        method: String,
+        ordinal: Int,
+        after count: Int,
+        continuation: CheckedContinuation<SentTargetMessage, Error>
+    ) {
+        guard cancelledTargetMessageWaiterIDs.remove(id) == nil else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        if let message = targetMessage(method: method, ordinal: ordinal, after: count) {
+            continuation.resume(returning: message)
+            return
+        }
+        targetMessageWaiters.append(
+            TargetMessageWaiter(
+                id: id,
+                method: method,
+                ordinal: ordinal,
+                after: count,
+                continuation: continuation
+            )
+        )
+    }
+
+    private func cancelTargetMessageWaiter(_ id: UInt64) {
+        guard let index = targetMessageWaiters.firstIndex(where: { $0.id == id }) else {
+            cancelledTargetMessageWaiterIDs.insert(id)
+            return
+        }
+        let waiter = targetMessageWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func targetMessage(method: String, ordinal: Int, after count: Int) -> SentTargetMessage? {
+        let matches = sentTargetMessages().dropFirst(count).filter { sentMessage in
             Self.messageMethod(from: sentMessage.message) == method
         }
+        guard matches.indices.contains(ordinal) else {
+            return nil
+        }
+        return matches[ordinal]
     }
 
     private static func sentTargetMessage(from message: String) -> SentTargetMessage? {

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -94,7 +94,7 @@ package final class NetworkPanelModel {
     }
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
-        guard request.responseBody?.needsFetch == true,
+        guard request.canFetchResponseBody,
               let responseBodyFetchAction else {
             return
         }

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -121,8 +121,12 @@ func backendResourceIdentifierPropagatesToLazyCommandIntents() async throws {
         response: .init(url: "https://example.com/app.js", status: 200),
         timestamp: 2
     )
-    let bodyIntent = await session.responseBodyCommandIntent(for: key)
+    let bodyIntentBeforeFinish = await session.responseBodyCommandIntent(for: key)
     let certificateIntent = await session.serializedCertificateCommandIntent(for: key)
+
+    #expect(bodyIntentBeforeFinish == nil)
+    await session.applyLoadingFinished(targetID: targetID, requestID: requestID, timestamp: 3)
+    let bodyIntent = await session.responseBodyCommandIntent(for: key)
 
     #expect(bodyIntent == .getResponseBody(requestKey: key, backendResourceIdentifier: backendResourceIdentifier))
     #expect(certificateIntent == .getSerializedCertificate(requestKey: key, backendResourceIdentifier: backendResourceIdentifier))
@@ -200,6 +204,77 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() thro
     #expect(body.textRepresentation?.contains("\n") == true)
     #expect(body.textRepresentation?.contains(#""name""#) == true)
     #expect(body.textRepresentationSyntaxKind == .json)
+}
+
+@Test
+@MainActor
+func responseBodyFetchFailureIsTerminal() throws {
+    let session = NetworkSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let requestID = NetworkRequestIdentifier("0.response-body-failure")
+
+    let key = session.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: requestID,
+        frameID: .init("main-frame"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: .init(url: "https://example.com/api/data.json"),
+        timestamp: 1
+    )
+    session.applyResponseReceived(
+        targetID: targetID,
+        requestID: requestID,
+        response: .init(url: "https://example.com/api/data.json", status: 200),
+        timestamp: 2
+    )
+    session.applyLoadingFinished(targetID: targetID, requestID: requestID, timestamp: 3)
+
+    let request = try #require(session.request(for: key))
+    let body = try #require(request.responseBody)
+    #expect(request.canFetchResponseBody)
+
+    request.markResponseBodyFailed(.unavailable)
+
+    #expect(body.needsFetch == false)
+    #expect(request.canFetchResponseBody == false)
+    #expect(session.responseBodyCommandIntent(for: key) == nil)
+}
+
+@Test
+@MainActor
+func failedNetworkRequestCannotFetchResponseBody() throws {
+    let session = NetworkSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let requestID = NetworkRequestIdentifier("0.failed-response-body")
+
+    let key = session.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: requestID,
+        frameID: .init("main-frame"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: .init(url: "https://example.com/api/data.json"),
+        timestamp: 1
+    )
+    session.applyResponseReceived(
+        targetID: targetID,
+        requestID: requestID,
+        response: .init(url: "https://example.com/api/data.json", status: 200),
+        timestamp: 2
+    )
+    session.applyLoadingFailed(
+        targetID: targetID,
+        requestID: requestID,
+        timestamp: 3,
+        errorText: "cancelled",
+        canceled: true
+    )
+
+    let request = try #require(session.request(for: key))
+    #expect(request.responseBody != nil)
+    #expect(request.canFetchResponseBody == false)
+    #expect(session.responseBodyCommandIntent(for: key) == nil)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -415,6 +415,16 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
     let body = try #require(responseBody)
     #expect(await body.fetchState == .available)
 
+    let sentCountBeforeFinish = await backend.sentTargetMessages().count
+    await session.fetchResponseBody(for: request.id)
+    #expect(await backend.sentTargetMessages().count == sentCountBeforeFinish)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.loadingFinished","params":{"requestId":"request-2","timestamp":3}}"#
+    )
+
     let sentCount = await backend.sentTargetMessages().count
     let fetchTask = Task {
         await session.fetchResponseBody(for: request.id)
@@ -431,6 +441,58 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
     #expect(await body.fetchState == .loaded)
     #expect(await body.textRepresentation?.contains("\n") == true)
     #expect(await body.textRepresentation?.contains(#""ok""#) == true)
+}
+
+@Test
+func networkResponseBodyFetchErrorDoesNotRetry() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-error","frameId":"main-frame","request":{"url":"https://example.com/api.json"},"timestamp":1}}"#
+    )
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.responseReceived","params":{"requestId":"request-error","timestamp":2,"type":"XHR","response":{"url":"https://example.com/api.json","status":200,"mimeType":"application/json","headers":{"content-type":"application/json"}}}}"#
+    )
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.loadingFinished","params":{"requestId":"request-error","timestamp":3}}"#
+    )
+    let request = try await waitUntil {
+        await session.network.request(for: .init(targetID: .pageMain, requestID: .init("request-error")))
+    }
+    let responseBody = await request.responseBody
+    let body = try #require(responseBody)
+    #expect(await body.fetchState == .available)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let fetchTask = Task {
+        await session.fetchResponseBody(for: request.id)
+    }
+    let sent = try await waitForTargetMessage(backend, method: "Network.getResponseBody", after: sentCount)
+    await receiveTargetErrorReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        message: "Not yet implemented"
+    )
+    await fetchTask.value
+
+    guard case .failed = await body.fetchState else {
+        Issue.record("Expected response body fetch to fail")
+        return
+    }
+
+    let sentCountAfterFailure = await backend.sentTargetMessages().count
+    await session.fetchResponseBody(for: request.id)
+    #expect(await backend.sentTargetMessages().count == sentCountAfterFailure)
 }
 
 @Test

--- a/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorRuntimeTests/InspectorSessionTests.swift
@@ -4248,7 +4248,7 @@ func reloadDOMDocumentCancelsQueuedDeleteUndoOperationsBeforeTheySend() async th
 
     let countBeforeQueuedOperations = await backend.sentTargetMessages().count
     let reloadReplyTask = Task {
-        let getDocument = await backend.waitForTargetMessage(method: "DOM.getDocument", after: countBeforeQueuedOperations)
+        let getDocument = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: countBeforeQueuedOperations)
         await receiveTargetReply(
             transport,
             targetID: getDocument.targetIdentifier,
@@ -4763,32 +4763,56 @@ private func targetMessageMethods(_ backend: FakeTransportBackend) async -> [Str
 private func waitForTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
-    after count: Int = 0
+    after count: Int = 0,
+    timeout: Duration = .seconds(5)
 ) async throws -> SentTargetMessage {
-    try await waitUntil(timeoutError: TransportError.replyTimeout(method: method, targetID: nil)) {
-        let messages = await backend.sentTargetMessages()
-        return messages.dropFirst(count).first { sent in
-            (try? messageMethod(sent.message)) == method
-        }
-    }
+    try await waitForBackendTargetMessage(
+        backend,
+        method: method,
+        ordinal: 0,
+        after: count,
+        timeout: timeout
+    )
 }
 
 private func waitForTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
     ordinal: Int,
-    after count: Int = 0
+    after count: Int = 0,
+    timeout: Duration = .seconds(5)
 ) async throws -> SentTargetMessage {
-    try await waitUntil(timeoutError: TransportError.replyTimeout(method: method, targetID: nil)) {
-        let matches = await backend.sentTargetMessages()
-            .dropFirst(count)
-            .filter { sent in
-                (try? messageMethod(sent.message)) == method
-            }
-        guard matches.indices.contains(ordinal) else {
-            return nil
+    try await waitForBackendTargetMessage(
+        backend,
+        method: method,
+        ordinal: ordinal,
+        after: count,
+        timeout: timeout
+    )
+}
+
+private func waitForBackendTargetMessage(
+    _ backend: FakeTransportBackend,
+    method: String,
+    ordinal: Int,
+    after count: Int,
+    timeout: Duration
+) async throws -> SentTargetMessage {
+    try await withThrowingTaskGroup(of: SentTargetMessage.self) { group in
+        defer { group.cancelAll() }
+
+        group.addTask {
+            try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
         }
-        return matches[ordinal]
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw TransportError.replyTimeout(method: method, targetID: nil)
+        }
+
+        guard let message = try await group.next() else {
+            throw TransportError.replyTimeout(method: method, targetID: nil)
+        }
+        return message
     }
 }
 

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -250,6 +250,60 @@ func cancellationFailsPendingReplyImmediately() async throws {
 }
 
 @Test
+func fakeBackendTargetMessageWaiterUsesAfterAndOrdinal() async throws {
+    let backend = FakeTransportBackend()
+
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 1, innerID: 1, method: "DOM.getDocument"))
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 2, innerID: 2, method: "CSS.getMatchedStylesForNode"))
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 3, innerID: 3, method: "DOM.getDocument"))
+
+    let secondDocumentByOrdinal = try await backend.waitForTargetMessage(method: "DOM.getDocument", ordinal: 1)
+    let secondDocumentByOffset = try await backend.waitForTargetMessage(method: "DOM.getDocument", after: 1)
+
+    #expect(try messageID(secondDocumentByOrdinal.message) == 3)
+    #expect(try messageID(secondDocumentByOffset.message) == 3)
+}
+
+@Test
+func fakeBackendTargetMessageWaiterResumesFutureOrdinalMatch() async throws {
+    let backend = FakeTransportBackend()
+    let waitTask = Task {
+        try await backend.waitForTargetMessage(method: "DOM.getDocument", ordinal: 1)
+    }
+    await Task.yield()
+
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 1, innerID: 1, method: "DOM.getDocument"))
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 2, innerID: 2, method: "CSS.getMatchedStylesForNode"))
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 3, innerID: 3, method: "DOM.getDocument"))
+
+    let message = try await waitTask.value
+    #expect(try messageID(message.message) == 3)
+}
+
+@Test
+func fakeBackendTargetMessageWaiterCancellationDoesNotResumeWithLaterMessage() async throws {
+    let backend = FakeTransportBackend()
+    let waitTask = Task {
+        try await backend.waitForTargetMessage(method: "DOM.getDocument")
+    }
+    await Task.yield()
+
+    waitTask.cancel()
+    try await backend.sendJSONString(targetCommandWrapperMessage(outerID: 1, innerID: 1, method: "DOM.getDocument"))
+
+    do {
+        _ = try await waitTask.value
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+    } catch {
+        Issue.record("Expected CancellationError, got \(error)")
+    }
+
+    let message = try await backend.waitForTargetMessage(method: "DOM.getDocument")
+    #expect(try messageID(message.message) == 1)
+}
+
+@Test
 func detachFailsPendingRepliesAndClosesStreams() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
@@ -1841,6 +1895,17 @@ private func targetDispatchMessage(
     let escapedTargetID = jsonEscapedString(targetID.rawValue)
     let escapedMessage = jsonEscapedString(message)
     return #"{"method":"Target.dispatchMessageFromTarget","params":{"targetId":"\#(escapedTargetID)","message":"\#(escapedMessage)"}}"#
+}
+
+private func targetCommandWrapperMessage(
+    outerID: UInt64,
+    targetID: ProtocolTargetIdentifier = .init("page-main"),
+    innerID: UInt64,
+    method: String
+) -> String {
+    let escapedTargetID = jsonEscapedString(targetID.rawValue)
+    let escapedMessage = jsonEscapedString(#"{"id":\#(innerID),"method":"\#(method)"}"#)
+    return #"{"id":\#(outerID),"method":"Target.sendMessageToTarget","params":{"targetId":"\#(escapedTargetID)","message":"\#(escapedMessage)"}}"#
 }
 
 private func jsonEscapedString(_ string: String) -> String {

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -208,6 +208,84 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func responseBodyModeWaitsForLoadingFinishedBeforeFetching() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json",
+                finishes: false
+            )
+        )
+        var fetchedIDs: [NetworkRequest.ID] = []
+        let model = NetworkPanelModel(network: network) { id in
+            fetchedIDs.append(id)
+        }
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+        #expect(fetchedIDs.isEmpty)
+
+        network.applyLoadingFinished(
+            targetID: request.id.targetID,
+            requestID: request.id.requestID,
+            timestamp: 3
+        )
+
+        let didFetch = await waitUntil {
+            fetchedIDs == [request.id]
+        }
+        #expect(didFetch)
+    }
+
+    @Test
+    func failedResponseBodyDoesNotRefetchFromRendering() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        request.markResponseBodyFailed(.unavailable)
+
+        var fetchedIDs: [NetworkRequest.ID] = []
+        let model = NetworkPanelModel(network: network) { id in
+            fetchedIDs.append(id)
+        }
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setModeForTesting(.responseBody)
+
+        let didRenderFailure = await waitUntil {
+            viewController.currentModeForTesting == .responseBody
+                && viewController.bodyTextViewForTesting.text.contains("Body unavailable")
+        }
+        #expect(didRenderFailure)
+        #expect(fetchedIDs.isEmpty)
+
+        request.markResponseBodyFailed(.unknown("Still unavailable"))
+
+        let didStayIdle = await waitUntil {
+            viewController.bodyTextViewForTesting.text.contains("Still unavailable")
+                && fetchedIDs.isEmpty
+        }
+        #expect(didStayIdle)
+    }
+
+    @Test
     func compactContainerPushesAndPopsDetailFromSelection() async throws {
         let network = NetworkSession()
         let request = try #require(applyRequest(to: network, requestID: "1", url: "https://example.com/app.js"))
@@ -290,7 +368,8 @@ struct NetworkDetailViewControllerTests {
         requestHeaders: [String: String] = [:],
         postData: String? = nil,
         responseHeaders: [String: String] = ["content-type": "text/javascript"],
-        responseMimeType: String = "text/javascript"
+        responseMimeType: String = "text/javascript",
+        finishes: Bool = true
     ) -> NetworkRequest? {
         let targetID = ProtocolTargetIdentifier("page")
         let requestID = NetworkRequestIdentifier(rawRequestID)
@@ -322,11 +401,13 @@ struct NetworkDetailViewControllerTests {
             ),
             timestamp: 2
         )
-        network.applyLoadingFinished(
-            targetID: targetID,
-            requestID: requestID,
-            timestamp: 3
-        )
+        if finishes {
+            network.applyLoadingFinished(
+                targetID: targetID,
+                requestID: requestID,
+                timestamp: 3
+            )
+        }
         return network.request(for: key)
     }
 


### PR DESCRIPTION
## Summary
- Gate `Network.getResponseBody` through `NetworkRequest.canFetchResponseBody` so native body fetches only start after `loadingFinished`.
- Treat response body fetch failures as terminal by keeping failed `NetworkBody` values out of `needsFetch`.
- Replace Runtime test target-command waits with the `FakeTransportBackend` send-event waiter, including method/after/ordinal matching and cancellation cleanup, so `DOM.requestNode` assertions no longer depend on 5ms polling.
- Add Transport regression coverage for immediate matches, future ordinal matches, and cancellation races.

## Testing
- `swift test --filter inspectorInspectOpaqueObjectIDFallsBackToPickerTarget`
- `swift test --filter fakeBackendTargetMessageWaiter`
- `swift test --filter WebInspectorRuntimeTests`
- `swift test --filter WebInspectorTransportTests`
- `for i in {1..50}; do swift test --filter inspectorInspectOpaqueObjectIDFallsBackToPickerTarget || exit 1; done`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- Xcode Issue Navigator error check: 0 errors
- `codex-review --base main`: findingCount 0