### PR TITLE
Update SyntaxEditorUI and prewarm network body syntax

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8bde912eec7e4eca3d5d866177b53b5ca546da980d53c942c0adb87005efef1d",
+  "originHash" : "ceb27894cc5c9181db84611e79857c0a8282131fd151b5f95d220c2b8b33d6e5",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "982b31e8e1d51e19874aef52879f41899687f747",
-        "version" : "0.8.2"
+        "revision" : "b76c502ea4c03495077a98fe755cccae6a5688f2",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "12020873b4412bfe377af90273adbf60fea232f6d485ae0d24bafb0275719c38",
+  "originHash" : "77078920ac5dd8202229e0bf550e90149b86fc3bb2d6322c0b151071b635d7ac",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "982b31e8e1d51e19874aef52879f41899687f747",
-        "version" : "0.8.2"
+        "revision" : "b76c502ea4c03495077a98fe755cccae6a5688f2",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.8.2"
+            exact: "0.9.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
@@ -52,11 +52,16 @@ package final class NetworkSplitViewController: UISplitViewController {
 
     private func configureNavigationItem() {
         let item = detailViewController.makeRegularModeItem()
+        let bodyFetchIndicatorItem = detailViewController.makeRegularBodyFetchIndicatorItem()
         if #available(iOS 26.0, *) {
             item.hidesSharedBackground = true
+            bodyFetchIndicatorItem.hidesSharedBackground = true
         }
         let group = UIBarButtonItemGroup(
-            barButtonItems: [item],
+            barButtonItems: [
+                item,
+                bodyFetchIndicatorItem,
+            ],
             representativeItem: nil
         )
         navigationItem.trailingItemGroups = [

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -85,12 +85,9 @@ final class NetworkBodyViewController: UIViewController {
         }
 
         switch body.fetchState {
-        case .available:
-            displayText = webInspectorLocalized("network.body.available", default: "Body available")
-            syntaxKind = .plainText
-        case .fetching:
-            displayText = webInspectorLocalized("network.body.fetching", default: "Fetching body...")
-            syntaxKind = .plainText
+        case .available, .fetching:
+            displayText = ""
+            syntaxKind = body.textRepresentationSyntaxKind
         case .loaded:
             displayText = body.textRepresentation
                 ?? webInspectorLocalized("network.body.unavailable", default: "Body unavailable")

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -11,7 +11,8 @@ final class NetworkBodyViewController: UIViewController {
         language: .json,
         isEditable: false,
         lineWrappingEnabled: true,
-        colorTheme: .v2WebInspectorPlainText
+        colorTheme: .v2WebInspectorPlainText,
+        drawsBackground: false
     )
     private lazy var syntaxView = SyntaxEditorView(
         document: syntaxDocument,
@@ -46,7 +47,6 @@ final class NetworkBodyViewController: UIViewController {
         syntaxView.isSelectable = true
         syntaxView.isScrollEnabled = true
         syntaxView.alwaysBounceVertical = true
-        syntaxView.backgroundColor = .clear
         syntaxView.contentInsetAdjustmentBehavior = .automatic
         syntaxView.keyboardDismissMode = .onDrag
         syntaxView.accessibilityIdentifier = "WebInspector.Network.BodyView"

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -38,10 +38,26 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
     private let model: NetworkPanelModel
     private let observationScope = ObservationScope()
+    private let bodyObservationScope = ObservationScope()
     private let bodyViewController = NetworkBodyViewController()
+    private weak var observedBody: NetworkBody?
     private lazy var modeMenu = NetworkDetailModeMenu(
         detailViewController: self,
         model: model
+    )
+    private lazy var compactBodyFetchIndicator = makeBodyFetchIndicator(
+        accessibilityIdentifier: "WebInspector.Network.BodyFetchIndicator.Compact"
+    )
+    private lazy var regularBodyFetchIndicator = makeBodyFetchIndicator(
+        accessibilityIdentifier: "WebInspector.Network.BodyFetchIndicator.Regular"
+    )
+    private lazy var compactBodyFetchIndicatorItem = makeBodyFetchIndicatorItem(
+        activityIndicator: compactBodyFetchIndicator,
+        accessibilityIdentifier: "WebInspector.Network.BodyFetchIndicatorItem"
+    )
+    private lazy var regularBodyFetchIndicatorItem = makeBodyFetchIndicatorItem(
+        activityIndicator: regularBodyFetchIndicator,
+        accessibilityIdentifier: "WebInspector.Network.BodyFetchIndicatorItem.Regular"
     )
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: Self.makeListLayout())
@@ -80,6 +96,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
     isolated deinit {
         observationScope.cancelAll()
+        bodyObservationScope.cancelAll()
     }
 
     override package func viewDidLoad() {
@@ -104,10 +121,35 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     private func configureNavigationItem() {
         navigationItem.trailingItemGroups = [
             UIBarButtonItemGroup(
-                barButtonItems: [modeMenu.makeCompactItem()],
+                barButtonItems: [
+                    modeMenu.makeCompactItem(),
+                    compactBodyFetchIndicatorItem,
+                ],
                 representativeItem: nil
             ),
         ]
+    }
+
+    private func makeBodyFetchIndicator(accessibilityIdentifier: String) -> UIActivityIndicatorView {
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.accessibilityIdentifier = accessibilityIdentifier
+        activityIndicator.accessibilityLabel = webInspectorLocalized(
+            "network.body.fetching.accessibility_label",
+            default: "Fetching response body"
+        )
+        activityIndicator.stopAnimating()
+        return activityIndicator
+    }
+
+    private func makeBodyFetchIndicatorItem(
+        activityIndicator: UIActivityIndicatorView,
+        accessibilityIdentifier: String
+    ) -> UIBarButtonItem {
+        let item = UIBarButtonItem(customView: activityIndicator)
+        item.accessibilityIdentifier = accessibilityIdentifier
+        item.isHidden = true
+        return item
     }
 
     private func installCollectionView() {
@@ -253,11 +295,13 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
             guard let role = mode.bodyRole else {
                 return
             }
+            let body = body(in: selectedRequest, for: role)
             showBody()
+            bodyViewController.display(body: body)
+            observeDisplayedBody(body)
             if role == .response {
                 model.fetchResponseBodyIfNeeded(for: selectedRequest)
             }
-            bodyViewController.display(body: body(in: selectedRequest, for: role))
         }
     }
 
@@ -268,6 +312,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         if bodyViewController.view.isHidden == false {
             bodyViewController.view.isHidden = true
         }
+        observeDisplayedBody(nil)
         bodyViewController.display(body: nil)
         if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
            configuration.text == webInspectorLocalized("network.empty.selection.title", default: "No request selected") {
@@ -292,6 +337,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         if collectionView.isHidden {
             collectionView.isHidden = false
         }
+        observeDisplayedBody(nil)
         bodyViewController.display(body: nil)
     }
 
@@ -319,12 +365,67 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         modeMenu.makeRegularItem()
     }
 
+    package func makeRegularBodyFetchIndicatorItem() -> UIBarButtonItem {
+        regularBodyFetchIndicatorItem
+    }
+
     private func body(in request: NetworkRequest, for role: NetworkBodyRole) -> NetworkBody? {
         switch role {
         case .request:
             request.requestBody
         case .response:
             request.responseBody
+        }
+    }
+
+    private func observeDisplayedBody(_ body: NetworkBody?) {
+        guard observedBody !== body else {
+            updateBodyFetchIndicator(for: body)
+            return
+        }
+
+        bodyObservationScope.cancelAll()
+        observedBody = body
+        updateBodyFetchIndicator(for: body)
+
+        guard let body else {
+            return
+        }
+        bodyObservationScope.observe(body) { [weak self] _, body in
+            self?.updateBodyFetchIndicator(for: body)
+        }
+    }
+
+    private func updateBodyFetchIndicator(for body: NetworkBody?) {
+        let isFetching: Bool
+        if let body, case .fetching = body.fetchState {
+            isFetching = true
+        } else {
+            isFetching = false
+        }
+
+        updateBodyFetchIndicatorItem(
+            compactBodyFetchIndicatorItem,
+            activityIndicator: compactBodyFetchIndicator,
+            isFetching: isFetching
+        )
+        updateBodyFetchIndicatorItem(
+            regularBodyFetchIndicatorItem,
+            activityIndicator: regularBodyFetchIndicator,
+            isFetching: isFetching
+        )
+    }
+
+    private func updateBodyFetchIndicatorItem(
+        _ item: UIBarButtonItem,
+        activityIndicator: UIActivityIndicatorView,
+        isFetching: Bool
+    ) {
+        item.isHidden = !isFetching
+        if isFetching {
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
         }
     }
 

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -19,6 +19,7 @@ package final class NetworkPanelModel {
     }
     package private(set) var effectiveResourceFilters: Set<NetworkResourceFilter> = []
     @ObservationIgnored private let responseBodyFetchAction: ResponseBodyFetchAction?
+    @ObservationIgnored private var responseBodyFetchesInFlight: Set<NetworkRequest.ID> = []
 
     package init(
         network: NetworkSession,
@@ -95,10 +96,15 @@ package final class NetworkPanelModel {
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
         guard request.canFetchResponseBody,
+              responseBodyFetchesInFlight.contains(request.id) == false,
               let responseBodyFetchAction else {
             return
         }
+        responseBodyFetchesInFlight.insert(request.id)
         Task { @MainActor in
+            defer {
+                responseBodyFetchesInFlight.remove(request.id)
+            }
             await responseBodyFetchAction(request.id)
         }
     }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -193,6 +193,7 @@ struct NetworkDetailViewControllerTests {
         var fetchedIDs: [NetworkRequest.ID] = []
         let model = NetworkPanelModel(network: network) { id in
             fetchedIDs.append(id)
+            request.markResponseBodyFetching()
         }
         model.selectRequest(request)
         let viewController = NetworkDetailViewController(model: model)
@@ -206,6 +207,62 @@ struct NetworkDetailViewControllerTests {
             fetchedIDs == [request.id]
         }
         #expect(didFetch)
+    }
+
+    @Test
+    func responseBodyModePrewarmsSyntaxAndShowsNavigationActivityWhileFetching() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        var fetchedIDs: [NetworkRequest.ID] = []
+        let model = NetworkPanelModel(network: network) { id in
+            fetchedIDs.append(id)
+            request.markResponseBodyFetching()
+        }
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let indicatorItem = try #require(bodyFetchIndicatorItem(in: viewController))
+        viewController.setModeForTesting(.responseBody)
+
+        let didStartFetching = await waitUntil {
+            guard let activityIndicator = indicatorItem.customView as? UIActivityIndicatorView else {
+                return false
+            }
+            return fetchedIDs == [request.id]
+                && viewController.currentModeForTesting == .responseBody
+                && viewController.bodyTextViewForTesting.text.isEmpty
+                && viewController.bodyTextViewForTesting.configuration.language == .json
+                && indicatorItem.isHidden == false
+                && activityIndicator.isAnimating
+        }
+        #expect(didStartFetching)
+
+        request.applyResponseBody(
+            NetworkBodyPayload(
+                body: #"{"ok":true}"#,
+                base64Encoded: false
+            )
+        )
+
+        let didRenderBody = await waitUntil {
+            guard let activityIndicator = indicatorItem.customView as? UIActivityIndicatorView else {
+                return false
+            }
+            return viewController.bodyTextViewForTesting.text.contains(#""ok""#)
+                && indicatorItem.isHidden
+                && activityIndicator.isAnimating == false
+        }
+        #expect(didRenderBody)
     }
 
     @Test
@@ -224,6 +281,7 @@ struct NetworkDetailViewControllerTests {
         var fetchedIDs: [NetworkRequest.ID] = []
         let model = NetworkPanelModel(network: network) { id in
             fetchedIDs.append(id)
+            request.markResponseBodyFetching()
         }
         model.selectRequest(request)
         let viewController = NetworkDetailViewController(model: model)
@@ -429,6 +487,14 @@ struct NetworkDetailViewControllerTests {
             }
         }
         return nil
+    }
+
+    private func bodyFetchIndicatorItem(in viewController: NetworkDetailViewController) -> UIBarButtonItem? {
+        viewController.navigationItem.trailingItemGroups
+            .flatMap(\.barButtonItems)
+            .first {
+                $0.accessibilityIdentifier == "WebInspector.Network.BodyFetchIndicatorItem"
+            }
     }
 
     private func listCellText(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -142,6 +142,7 @@ struct NetworkDetailViewControllerTests {
         let didSwitch = await waitUntil {
             viewController.currentModeForTesting == .requestBody
                 && viewController.bodyTextViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
+                && viewController.bodyTextViewForTesting.configuration.drawsBackground == false
         }
         #expect(didSwitch)
     }

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "042d057b568d5d3bd3e1f07a9052d29adc7a7102825ac574144c44f544ebefec",
+  "originHash" : "f381ef4e0ea64fd4600ff20b81946a47fee3211c9bfb4f2333ba2755a03a6225",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "982b31e8e1d51e19874aef52879f41899687f747",
-        "version" : "0.8.2"
+        "revision" : "b76c502ea4c03495077a98fe755cccae6a5688f2",
+        "version" : "0.9.0"
       }
     },
     {


### PR DESCRIPTION

## Summary
- Update SyntaxEditorUI to v0.9.0 and refresh all SwiftPM lockfiles.
- Configure the network body syntax editor to let surrounding UI own the background.
- Keep the response body editor mounted while fetching, prewarm the known syntax, move fetch progress into navigation items, and prevent duplicate response body fetch scheduling.

## Testing
- git diff --check
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- codex-review --base main (no findings)

## Screenshots
- Not included; behavior is covered by existing and added tests.
