### PR TITLE
Add WebInspector background drawing policy

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
@@ -50,7 +50,10 @@ final class BrowserInspectorWindowHostingController: UIViewController {
         removeInspectorContainerIfNeeded()
 
         placeholderLabel.removeFromSuperview()
-        let container = WebInspectorViewController(session: inspectorContext.inspectorSession)
+        let container = WebInspectorViewController(
+            session: inspectorContext.inspectorSession,
+            drawsBackground: true
+        )
         addChild(container)
         container.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(container.view)
@@ -86,4 +89,12 @@ final class BrowserInspectorWindowHostingController: UIViewController {
         ])
     }
 }
+
+#if DEBUG
+extension BrowserInspectorWindowHostingController {
+    var inspectorContainerForTesting: WebInspectorViewController? {
+        inspectorContainer
+    }
+}
+#endif
 #endif

--- a/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
@@ -50,10 +50,7 @@ final class BrowserInspectorWindowHostingController: UIViewController {
         removeInspectorContainerIfNeeded()
 
         placeholderLabel.removeFromSuperview()
-        let container = WebInspectorViewController(
-            session: inspectorContext.inspectorSession,
-            drawsBackground: true
-        )
+        let container = WebInspectorViewController(session: inspectorContext.inspectorSession)
         addChild(container)
         container.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(container.view)

--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -265,10 +265,10 @@ final class BrowserInspectorCoordinator {
         }
 
         let anchor = resolvePresentationAnchor(from: presenter)
-        let sheetController = WebInspectorViewController(
-            session: inspectorSession,
-            drawsBackground: Self.sheetDrawsInspectorBackground
-        )
+        let sheetController = WebInspectorViewController(session: inspectorSession)
+        if #available(iOS 26.0, *) {
+            sheetController.drawsBackground = false
+        }
         sheetController.modalPresentationStyle = .pageSheet
         applyDefaultDetents(to: sheetController)
         presentedSheetController = sheetController
@@ -364,10 +364,6 @@ final class BrowserInspectorCoordinator {
         presentedSheetController
     }
 
-    static var sheetDrawsInspectorBackgroundForTesting: Bool {
-        sheetDrawsInspectorBackground
-    }
-
     static var inspectorWindowSceneActivityType: String {
         BrowserInspectorWindowContext.sceneActivityType
     }
@@ -423,14 +419,6 @@ final class BrowserInspectorCoordinator {
         let userActivity = NSUserActivity(activityType: BrowserInspectorWindowContext.sceneActivityType)
         userActivity.targetContentIdentifier = BrowserInspectorWindowContext.sceneActivityType
         return userActivity
-    }
-
-    private static var sheetDrawsInspectorBackground: Bool {
-        if #available(iOS 26.0, *) {
-            false
-        } else {
-            true
-        }
     }
 
     private func resolvePresentationAnchor(from presenter: UIViewController) -> UIViewController {

--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -1,10 +1,6 @@
 import Foundation
 import WebInspectorKit
 
-#if canImport(Darwin)
-import Darwin
-#endif
-
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -430,32 +426,11 @@ final class BrowserInspectorCoordinator {
     }
 
     private static var sheetDrawsInspectorBackground: Bool {
-        runtimeLiquidGlassEnabled == false
-    }
-
-    private static let runtimeLiquidGlassEnabled: Bool = {
-#if canImport(Darwin)
-        let defaultLookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
-        return runtimeLiquidGlassSymbolName.withCString { symbolName in
-            guard let symbol = dlsym(defaultLookupHandle, symbolName) else {
-                return false
-            }
-            typealias RuntimeFlagFunction = @convention(c) () -> Bool
-            return unsafeBitCast(symbol, to: RuntimeFlagFunction.self)()
+        if #available(iOS 26.0, *) {
+            false
+        } else {
+            true
         }
-#else
-        return false
-#endif
-    }()
-
-    private static var runtimeLiquidGlassSymbolName: String {
-        let key: UInt8 = 0x5a
-        // Original: _UISolariumEnabled
-        let obfuscatedBytes: [UInt8] = [
-            5, 15, 19, 9, 53, 54, 59, 40, 51,
-            47, 55, 31, 52, 59, 56, 54, 63, 62,
-        ]
-        return String(decoding: obfuscatedBytes.map { $0 ^ key }, as: UTF8.self)
     }
 
     private func resolvePresentationAnchor(from presenter: UIViewController) -> UIViewController {

--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -1,6 +1,10 @@
 import Foundation
 import WebInspectorKit
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -265,7 +269,10 @@ final class BrowserInspectorCoordinator {
         }
 
         let anchor = resolvePresentationAnchor(from: presenter)
-        let sheetController = WebInspectorViewController(session: inspectorSession)
+        let sheetController = WebInspectorViewController(
+            session: inspectorSession,
+            drawsBackground: Self.sheetDrawsInspectorBackground
+        )
         sheetController.modalPresentationStyle = .pageSheet
         applyDefaultDetents(to: sheetController)
         presentedSheetController = sheetController
@@ -357,6 +364,14 @@ final class BrowserInspectorCoordinator {
         Self.inspectorWindowRegistry.presentationState
     }
 
+    var presentedSheetControllerForTesting: UIViewController? {
+        presentedSheetController
+    }
+
+    static var sheetDrawsInspectorBackgroundForTesting: Bool {
+        sheetDrawsInspectorBackground
+    }
+
     static var inspectorWindowSceneActivityType: String {
         BrowserInspectorWindowContext.sceneActivityType
     }
@@ -412,6 +427,35 @@ final class BrowserInspectorCoordinator {
         let userActivity = NSUserActivity(activityType: BrowserInspectorWindowContext.sceneActivityType)
         userActivity.targetContentIdentifier = BrowserInspectorWindowContext.sceneActivityType
         return userActivity
+    }
+
+    private static var sheetDrawsInspectorBackground: Bool {
+        runtimeLiquidGlassEnabled == false
+    }
+
+    private static let runtimeLiquidGlassEnabled: Bool = {
+#if canImport(Darwin)
+        let defaultLookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
+        return runtimeLiquidGlassSymbolName.withCString { symbolName in
+            guard let symbol = dlsym(defaultLookupHandle, symbolName) else {
+                return false
+            }
+            typealias RuntimeFlagFunction = @convention(c) () -> Bool
+            return unsafeBitCast(symbol, to: RuntimeFlagFunction.self)()
+        }
+#else
+        return false
+#endif
+    }()
+
+    private static var runtimeLiquidGlassSymbolName: String {
+        let key: UInt8 = 0x5a
+        // Original: _UISolariumEnabled
+        let obfuscatedBytes: [UInt8] = [
+            5, 15, 19, 9, 53, 54, 59, 40, 51,
+            47, 55, 31, 52, 59, 56, 54, 63, 62,
+        ]
+        return String(decoding: obfuscatedBytes.map { $0 ^ key }, as: UTF8.self)
     }
 
     private func resolvePresentationAnchor(from presenter: UIViewController) -> UIViewController {

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -216,6 +216,11 @@ struct MonoclyLifecycleTests {
             )
             #expect(didPresent)
             #expect(sheetController.drawsBackground == BrowserInspectorCoordinator.sheetDrawsInspectorBackgroundForTesting)
+            if #available(iOS 26.0, *) {
+                #expect(sheetController.drawsBackground == false)
+            } else {
+                #expect(sheetController.drawsBackground)
+            }
         }
     }
 

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 #if os(iOS)
 import UIKit
+import WebInspectorKit
 
 @Suite(.serialized)
 @MainActor
@@ -192,6 +193,29 @@ struct MonoclyLifecycleTests {
             #expect(didPresent == false)
             #expect(activationCount == 0)
             #expect(coordinator.hasInspectorWindowForTesting == false)
+        }
+    }
+
+    @Test
+    func presentSheetUsesLiquidGlassBackgroundPolicy() throws {
+        try withCleanState { context in
+            let fixture = try makeHostedRootViewController(context: context)
+            let coordinator = BrowserInspectorCoordinator()
+            defer {
+                coordinator.invalidate()
+                fixture.rootViewController.dismiss(animated: false)
+            }
+
+            let didPresent = coordinator.presentSheet(
+                from: fixture.rootViewController,
+                inspectorSession: fixture.rootViewController.inspectorSession
+            )
+
+            let sheetController = try #require(
+                coordinator.presentedSheetControllerForTesting as? WebInspectorViewController
+            )
+            #expect(didPresent)
+            #expect(sheetController.drawsBackground == BrowserInspectorCoordinator.sheetDrawsInspectorBackgroundForTesting)
         }
     }
 
@@ -393,6 +417,7 @@ struct MonoclyLifecycleTests {
             let inspectorWindow = try #require(sceneDelegate.window)
             context.retain(inspectorWindow)
             #expect(inspectorWindow.rootViewController === sceneDelegate.inspectorViewController)
+            #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.drawsBackground == true)
             #expect(coordinator.hasInspectorWindowForTesting)
 
             sceneDelegate.scene(

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -215,11 +215,8 @@ struct MonoclyLifecycleTests {
                 coordinator.presentedSheetControllerForTesting as? WebInspectorViewController
             )
             #expect(didPresent)
-            #expect(sheetController.drawsBackground == BrowserInspectorCoordinator.sheetDrawsInspectorBackgroundForTesting)
             if #available(iOS 26.0, *) {
                 #expect(sheetController.drawsBackground == false)
-            } else {
-                #expect(sheetController.drawsBackground)
             }
         }
     }
@@ -422,7 +419,9 @@ struct MonoclyLifecycleTests {
             let inspectorWindow = try #require(sceneDelegate.window)
             context.retain(inspectorWindow)
             #expect(inspectorWindow.rootViewController === sceneDelegate.inspectorViewController)
-            #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.drawsBackground == true)
+            if #available(iOS 26.0, *) {
+                #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.drawsBackground == true)
+            }
             #expect(coordinator.hasInspectorWindowForTesting)
 
             sceneDelegate.scene(

--- a/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
+++ b/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
@@ -31,8 +31,10 @@ package final class CompactTabBarController: UITabBarController, UITabBarControl
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { tabBarController in
+                tabBarController.applyBackgroundFromTraits()
+            }
         }
         tabBar.scrollEdgeAppearance = tabBar.standardAppearance
     }

--- a/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
+++ b/Sources/WebInspectorUI/Containers/CompactTabBarController.swift
@@ -30,8 +30,15 @@ package final class CompactTabBarController: UITabBarController, UITabBarControl
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     package func tabBarController(

--- a/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
+++ b/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
@@ -49,8 +49,10 @@ package final class RegularTabContentViewController: UINavigationController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { navigationController in
+                navigationController.applyBackgroundFromTraits()
+            }
         }
     }
 

--- a/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
+++ b/Sources/WebInspectorUI/Containers/RegularTabContentViewController.swift
@@ -31,7 +31,7 @@ package final class RegularTabContentViewController: UINavigationController {
         super.init(nibName: nil, bundle: nil)
 
         navigationBar.prefersLargeTitles = false
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
 
         renderTabsAndSelection()
         bindInterface()
@@ -48,7 +48,15 @@ package final class RegularTabContentViewController: UINavigationController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+        webInspectorApplyNavigationControllerBackground(to: self)
     }
 
     @objc

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -31,7 +31,7 @@ public final class WebInspectorViewController: UIViewController {
     public init(session: WebInspectorSession = WebInspectorSession()) {
         self.session = session
         super.init(nibName: nil, bundle: nil)
-        traitOverrides.webInspectorDrawsBackground = drawsBackgroundStorage
+        webInspectorSetDrawsBackgroundTraitOverride(drawsBackgroundStorage)
     }
 
     public convenience init(tabs: [WebInspectorTab]) {
@@ -50,8 +50,10 @@ public final class WebInspectorViewController: UIViewController {
         registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
             self.handleHorizontalSizeClassChange()
         }
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
     }
 
@@ -80,8 +82,8 @@ public final class WebInspectorViewController: UIViewController {
             return
         }
         drawsBackgroundStorage = drawsBackground
-        traitOverrides.webInspectorDrawsBackground = drawsBackground
-        activeHost?.traitOverrides.webInspectorDrawsBackground = drawsBackground
+        webInspectorSetDrawsBackgroundTraitOverride(drawsBackground)
+        activeHost?.webInspectorSetDrawsBackgroundTraitOverride(drawsBackground)
         if isViewLoaded {
             applyBackgroundFromTraits()
         }
@@ -111,7 +113,7 @@ public final class WebInspectorViewController: UIViewController {
         case .regular:
             host = RegularTabContentViewController(session: session)
         }
-        host.traitOverrides.webInspectorDrawsBackground = drawsBackgroundStorage
+        host.webInspectorSetDrawsBackgroundTraitOverride(drawsBackgroundStorage)
 
         addChild(host)
         host.view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -12,6 +12,18 @@ public final class WebInspectorViewController: UIViewController {
     }
 
     public let session: WebInspectorSession
+    public var drawsBackground: Bool {
+        didSet {
+            guard drawsBackground != oldValue else {
+                return
+            }
+            traitOverrides.webInspectorDrawsBackground = drawsBackground
+            activeHost?.traitOverrides.webInspectorDrawsBackground = drawsBackground
+            if isViewLoaded {
+                applyBackgroundFromTraits()
+            }
+        }
+    }
 
     private var activeHost: UIViewController?
     private var activeHostKind: HostKind?
@@ -21,13 +33,24 @@ public final class WebInspectorViewController: UIViewController {
         }
     }
 
-    public init(session: WebInspectorSession = WebInspectorSession()) {
+    public init(
+        session: WebInspectorSession = WebInspectorSession(),
+        drawsBackground: Bool = true
+    ) {
         self.session = session
+        self.drawsBackground = drawsBackground
         super.init(nibName: nil, bundle: nil)
+        traitOverrides.webInspectorDrawsBackground = drawsBackground
     }
 
-    public convenience init(tabs: [WebInspectorTab]) {
-        self.init(session: WebInspectorSession(tabs: tabs))
+    public convenience init(
+        tabs: [WebInspectorTab],
+        drawsBackground: Bool = true
+    ) {
+        self.init(
+            session: WebInspectorSession(tabs: tabs),
+            drawsBackground: drawsBackground
+        )
     }
 
     @available(*, unavailable)
@@ -37,10 +60,13 @@ public final class WebInspectorViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
         rebuildLayout(forceHostReplacement: true)
         registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
             self.handleHorizontalSizeClassChange()
+        }
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
         }
     }
 
@@ -58,6 +84,10 @@ public final class WebInspectorViewController: UIViewController {
 
     private func handleHorizontalSizeClassChange() {
         rebuildLayout()
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     private func rebuildLayout(forceHostReplacement: Bool = false) {
@@ -84,6 +114,7 @@ public final class WebInspectorViewController: UIViewController {
         case .regular:
             host = RegularTabContentViewController(session: session)
         }
+        host.traitOverrides.webInspectorDrawsBackground = drawsBackground
 
         addChild(host)
         host.view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -12,17 +12,12 @@ public final class WebInspectorViewController: UIViewController {
     }
 
     public let session: WebInspectorSession
+    private var drawsBackgroundStorage = true
+
+    @available(iOS 26.0, *)
     public var drawsBackground: Bool {
-        didSet {
-            guard drawsBackground != oldValue else {
-                return
-            }
-            traitOverrides.webInspectorDrawsBackground = drawsBackground
-            activeHost?.traitOverrides.webInspectorDrawsBackground = drawsBackground
-            if isViewLoaded {
-                applyBackgroundFromTraits()
-            }
-        }
+        get { drawsBackgroundStorage }
+        set { setDrawsBackground(newValue) }
     }
 
     private var activeHost: UIViewController?
@@ -33,24 +28,14 @@ public final class WebInspectorViewController: UIViewController {
         }
     }
 
-    public init(
-        session: WebInspectorSession = WebInspectorSession(),
-        drawsBackground: Bool = true
-    ) {
+    public init(session: WebInspectorSession = WebInspectorSession()) {
         self.session = session
-        self.drawsBackground = drawsBackground
         super.init(nibName: nil, bundle: nil)
-        traitOverrides.webInspectorDrawsBackground = drawsBackground
+        traitOverrides.webInspectorDrawsBackground = drawsBackgroundStorage
     }
 
-    public convenience init(
-        tabs: [WebInspectorTab],
-        drawsBackground: Bool = true
-    ) {
-        self.init(
-            session: WebInspectorSession(tabs: tabs),
-            drawsBackground: drawsBackground
-        )
+    public convenience init(tabs: [WebInspectorTab]) {
+        self.init(session: WebInspectorSession(tabs: tabs))
     }
 
     @available(*, unavailable)
@@ -90,6 +75,18 @@ public final class WebInspectorViewController: UIViewController {
         view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
+    private func setDrawsBackground(_ drawsBackground: Bool) {
+        guard drawsBackgroundStorage != drawsBackground else {
+            return
+        }
+        drawsBackgroundStorage = drawsBackground
+        traitOverrides.webInspectorDrawsBackground = drawsBackground
+        activeHost?.traitOverrides.webInspectorDrawsBackground = drawsBackground
+        if isViewLoaded {
+            applyBackgroundFromTraits()
+        }
+    }
+
     private func rebuildLayout(forceHostReplacement: Bool = false) {
         let targetHostKind = effectiveHostKind
         guard forceHostReplacement || activeHostKind != targetHostKind else {
@@ -114,7 +111,7 @@ public final class WebInspectorViewController: UIViewController {
         case .regular:
             host = RegularTabContentViewController(session: session)
         }
-        host.traitOverrides.webInspectorDrawsBackground = drawsBackground
+        host.traitOverrides.webInspectorDrawsBackground = drawsBackgroundStorage
 
         addChild(host)
         host.view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
@@ -9,9 +9,8 @@ package final class DOMCompactNavigationController: UINavigationController {
     package override init(rootViewController: UIViewController) {
         rootViewController.webInspectorDetachFromContainerForReuse()
         super.init(rootViewController: rootViewController)
-        view.backgroundColor = .clear
         navigationBar.prefersLargeTitles = false
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
         rootViewController.navigationItem.style = .browser
     }
 
@@ -21,9 +20,8 @@ package final class DOMCompactNavigationController: UINavigationController {
     ) {
         rootViewController.webInspectorDetachFromContainerForReuse()
         super.init(rootViewController: rootViewController)
-        view.backgroundColor = .clear
         navigationBar.prefersLargeTitles = false
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
         rootViewController.navigationItem.style = .browser
         let treeViewController = rootViewController as? DOMTreeViewController
         let navigationItems = DOMNavigationItems(session: session)
@@ -36,6 +34,18 @@ package final class DOMCompactNavigationController: UINavigationController {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
+    }
+
+    override package func viewDidLoad() {
+        super.viewDidLoad()
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
+    }
+
+    private func applyBackgroundFromTraits() {
+        webInspectorApplyNavigationControllerBackground(to: self)
     }
 }
 

--- a/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
@@ -39,8 +39,10 @@ package final class DOMCompactNavigationController: UINavigationController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { navigationController in
+                navigationController.applyBackgroundFromTraits()
+            }
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
@@ -42,8 +42,10 @@ package final class DOMSplitViewController: UISplitViewController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { splitViewController in
+                splitViewController.applyBackgroundFromTraits()
+            }
         }
         configureSplitViewLayout()
         configureNavigationItem()

--- a/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
@@ -41,9 +41,16 @@ package final class DOMSplitViewController: UISplitViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         configureSplitViewLayout()
         configureNavigationItem()
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     private func configureSplitViewLayout() {

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -82,7 +82,10 @@ package final class DOMElementViewController: UIViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         configureCollectionView()
         startObservingState()
         render()
@@ -118,7 +121,7 @@ package final class DOMElementViewController: UIViewController {
 
     private func configureCollectionView() {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.backgroundColor = .clear
+        collectionView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
         collectionView.alwaysBounceVertical = true
         collectionView.keyboardDismissMode = .onDrag
         collectionView.accessibilityIdentifier = "WebInspector.DOM.Element.StylesList"
@@ -130,6 +133,12 @@ package final class DOMElementViewController: UIViewController {
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    private func applyBackgroundFromTraits() {
+        let backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+        view.backgroundColor = backgroundColor
+        collectionView.backgroundColor = backgroundColor
     }
 
     private func makeDataSource() -> UICollectionViewDiffableDataSource<CSSStyleSectionIdentifier, ItemIdentifier> {

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -83,8 +83,10 @@ package final class DOMElementViewController: UIViewController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
         configureCollectionView()
         startObservingState()

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -73,8 +73,10 @@ package final class DOMTreeViewController: UIViewController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
         if let session {
             startObservingDOMRoot(session: session)

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -65,16 +65,24 @@ package final class DOMTreeViewController: UIViewController {
     }
 
     override package func loadView() {
-        treeView.backgroundColor = .clear
+        treeView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
         treeView.accessibilityIdentifier = "WebInspector.DOM.Tree.NativeTextView"
         view = treeView
     }
 
     override package func viewDidLoad() {
         super.viewDidLoad()
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         if let session {
             startObservingDOMRoot(session: session)
         }
+    }
+
+    private func applyBackgroundFromTraits() {
+        treeView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     override package func viewIsAppearing(_ animated: Bool) {

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -49,8 +49,10 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { navigationController in
+                navigationController.applyBackgroundFromTraits()
+            }
         }
     }
 

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -23,9 +23,8 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         self.detailViewController = detailViewController
         listViewController.webInspectorDetachFromContainerForReuse()
         super.init(rootViewController: listViewController)
-        view.backgroundColor = .clear
         navigationBar.prefersLargeTitles = false
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
         delegate = self
         listViewController.setRequestSelectionAction { [weak model] request in
             model?.selectRequest(request)
@@ -45,6 +44,14 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         super.viewWillAppear(animated)
         syncStack(hasSelection: model.selectedRequest != nil, animated: false)
         startObservingSelection()
+    }
+
+    override package func viewDidLoad() {
+        super.viewDidLoad()
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
     }
 
     override package func viewDidDisappear(_ animated: Bool) {
@@ -150,6 +157,10 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         let shouldAnimate = pendingStackSyncAnimates
         pendingStackSyncAnimates = false
         syncStack(hasSelection: model.selectedRequest != nil, animated: shouldAnimate)
+    }
+
+    private func applyBackgroundFromTraits() {
+        webInspectorApplyNavigationControllerBackground(to: self)
     }
 }
 #endif

--- a/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
@@ -62,6 +62,8 @@ extension UIViewController {
 func webInspectorApplyNavigationControllerBackground(to navigationController: UINavigationController) {
     let backgroundPolicy = navigationController.webInspectorBackgroundPolicy
     navigationController.view.backgroundColor = backgroundPolicy.backgroundColor
+    // Leave UINavigationBarAppearance to UIKit. For Liquid Glass window presentations,
+    // forcing transparent/default appearances here changes the system chrome material.
 }
 
 @MainActor

--- a/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
@@ -1,17 +1,20 @@
 #if canImport(UIKit)
 import UIKit
 
+@available(iOS 26.0, *)
 package struct WebInspectorDrawsBackgroundTrait: UITraitDefinition {
     package static let defaultValue = true
 }
 
 extension UITraitCollection {
+    @available(iOS 26.0, *)
     package var webInspectorDrawsBackground: Bool {
         self[WebInspectorDrawsBackgroundTrait.self]
     }
 }
 
 extension UIMutableTraits {
+    @available(iOS 26.0, *)
     package var webInspectorDrawsBackground: Bool {
         get { self[WebInspectorDrawsBackgroundTrait.self] }
         set { self[WebInspectorDrawsBackgroundTrait.self] = newValue }
@@ -34,9 +37,27 @@ package struct WebInspectorBackgroundPolicy: Equatable {
 extension UIViewController {
     @MainActor
     package var webInspectorBackgroundPolicy: WebInspectorBackgroundPolicy {
-        WebInspectorBackgroundPolicy(
-            drawsBackground: traitCollection.webInspectorDrawsBackground
-        )
+        if #available(iOS 26.0, *) {
+            return WebInspectorBackgroundPolicy(
+                drawsBackground: traitCollection.webInspectorDrawsBackground
+            )
+        }
+        return WebInspectorBackgroundPolicy(drawsBackground: true)
+    }
+
+    @MainActor
+    package func webInspectorSetDrawsBackgroundTraitOverride(_ drawsBackground: Bool) {
+        if #available(iOS 26.0, *) {
+            traitOverrides.webInspectorDrawsBackground = drawsBackground
+        }
+    }
+
+    @available(iOS 26.0, *)
+    @MainActor
+    package func webInspectorRegisterForBackgroundTraitChanges(_ action: @escaping (Self) -> Void) {
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (viewController: Self, _) in
+            action(viewController)
+        }
     }
 
     func webInspectorDetachFromContainerForReuse() {
@@ -88,8 +109,10 @@ final class RegularSplitColumnNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
         webInspectorApplyNavigationControllerBackground(to: self)
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            webInspectorApplyNavigationControllerBackground(to: self)
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { navigationController in
+                webInspectorApplyNavigationControllerBackground(to: navigationController)
+            }
         }
     }
 }
@@ -112,8 +135,10 @@ package final class RegularSplitRootViewController: UIViewController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
         installContentViewController()
     }

--- a/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
@@ -62,8 +62,8 @@ extension UIViewController {
 func webInspectorApplyNavigationControllerBackground(to navigationController: UINavigationController) {
     let backgroundPolicy = navigationController.webInspectorBackgroundPolicy
     navigationController.view.backgroundColor = backgroundPolicy.backgroundColor
-    // Leave UINavigationBarAppearance to UIKit. For Liquid Glass window presentations,
-    // forcing transparent/default appearances here changes the system chrome material.
+    // This policy owns WebInspector view backgrounds, not UIKit chrome. Leave
+    // UINavigationBarAppearance to UIKit so each presentation keeps its system material.
 }
 
 @MainActor

--- a/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
@@ -1,7 +1,44 @@
 #if canImport(UIKit)
 import UIKit
 
+package struct WebInspectorDrawsBackgroundTrait: UITraitDefinition {
+    package static let defaultValue = true
+}
+
+extension UITraitCollection {
+    package var webInspectorDrawsBackground: Bool {
+        self[WebInspectorDrawsBackgroundTrait.self]
+    }
+}
+
+extension UIMutableTraits {
+    package var webInspectorDrawsBackground: Bool {
+        get { self[WebInspectorDrawsBackgroundTrait.self] }
+        set { self[WebInspectorDrawsBackgroundTrait.self] = newValue }
+    }
+}
+
+@MainActor
+package struct WebInspectorBackgroundPolicy: Equatable {
+    package var drawsBackground: Bool
+
+    package init(drawsBackground: Bool) {
+        self.drawsBackground = drawsBackground
+    }
+
+    package var backgroundColor: UIColor {
+        drawsBackground ? .systemBackground : .clear
+    }
+}
+
 extension UIViewController {
+    @MainActor
+    package var webInspectorBackgroundPolicy: WebInspectorBackgroundPolicy {
+        WebInspectorBackgroundPolicy(
+            drawsBackground: traitCollection.webInspectorDrawsBackground
+        )
+    }
+
     func webInspectorDetachFromContainerForReuse() {
         if let navigationController = parent as? UINavigationController,
            navigationController.viewControllers.contains(where: { $0 === self }) {
@@ -22,20 +59,9 @@ extension UIViewController {
 }
 
 @MainActor
-func webInspectorApplyClearNavigationBarStyle(to navigationController: UINavigationController) {
-    navigationController.view.backgroundColor = .clear
-    navigationController.navigationBar.isTranslucent = true
-
-    let appearance = UINavigationBarAppearance()
-    appearance.configureWithTransparentBackground()
-    appearance.backgroundColor = .clear
-    appearance.backgroundEffect = nil
-    appearance.shadowColor = nil
-
-    navigationController.navigationBar.standardAppearance = appearance
-    navigationController.navigationBar.scrollEdgeAppearance = appearance
-    navigationController.navigationBar.compactAppearance = appearance
-    navigationController.navigationBar.compactScrollEdgeAppearance = appearance
+func webInspectorApplyNavigationControllerBackground(to navigationController: UINavigationController) {
+    let backgroundPolicy = navigationController.webInspectorBackgroundPolicy
+    navigationController.view.backgroundColor = backgroundPolicy.backgroundColor
 }
 
 @MainActor
@@ -43,7 +69,7 @@ final class RegularSplitColumnNavigationController: UINavigationController {
     override init(rootViewController: UIViewController) {
         rootViewController.webInspectorDetachFromContainerForReuse()
         super.init(rootViewController: rootViewController)
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
         setNavigationBarHidden(true, animated: false)
     }
 
@@ -55,6 +81,14 @@ final class RegularSplitColumnNavigationController: UINavigationController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNavigationBarHidden(true, animated: false)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        webInspectorApplyNavigationControllerBackground(to: self)
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            webInspectorApplyNavigationControllerBackground(to: self)
+        }
     }
 }
 
@@ -75,8 +109,15 @@ package final class RegularSplitRootViewController: UIViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         installContentViewController()
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     private func installContentViewController() {

--- a/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
@@ -36,8 +36,10 @@ package final class NetworkSplitViewController: UISplitViewController {
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { splitViewController in
+                splitViewController.applyBackgroundFromTraits()
+            }
         }
         configureNavigationItem()
     }
@@ -100,8 +102,10 @@ private final class NetworkListColumnNavigationController: UINavigationControlle
     override func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { navigationController in
+                navigationController.applyBackgroundFromTraits()
+            }
         }
     }
 

--- a/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkSplitViewController.swift
@@ -35,8 +35,15 @@ package final class NetworkSplitViewController: UISplitViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         configureNavigationItem()
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     private func configureSplitViewLayout() {
@@ -75,7 +82,7 @@ private final class NetworkListColumnNavigationController: UINavigationControlle
     override init(rootViewController: UIViewController) {
         rootViewController.webInspectorDetachFromContainerForReuse()
         super.init(rootViewController: rootViewController)
-        webInspectorApplyClearNavigationBarStyle(to: self)
+        webInspectorApplyNavigationControllerBackground(to: self)
         navigationBar.prefersLargeTitles = false
         setNavigationBarHidden(false, animated: false)
     }
@@ -88,6 +95,18 @@ private final class NetworkListColumnNavigationController: UINavigationControlle
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setNavigationBarHidden(false, animated: false)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
+    }
+
+    private func applyBackgroundFromTraits() {
+        webInspectorApplyNavigationControllerBackground(to: self)
     }
 }
 

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -24,8 +24,10 @@ final class NetworkBodyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
         configureSyntaxView()
     }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -23,7 +23,10 @@ final class NetworkBodyViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         configureSyntaxView()
     }
 
@@ -58,6 +61,10 @@ final class NetworkBodyViewController: UIViewController {
             syntaxView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             syntaxView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    private func applyBackgroundFromTraits() {
+        view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     private func startObserving(body: NetworkBody?) {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -102,8 +102,10 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
         configureNavigationItem()
         installCollectionView()

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -62,7 +62,7 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: Self.makeListLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.backgroundColor = .clear
+        collectionView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
         collectionView.alwaysBounceVertical = true
         collectionView.accessibilityIdentifier = "WebInspector.Network.Detail"
         collectionView.delegate = self
@@ -101,7 +101,10 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
 
     override package func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
         configureNavigationItem()
         installCollectionView()
         installBodyViewController()
@@ -116,6 +119,12 @@ package final class NetworkDetailViewController: UIViewController, UICollectionV
         observationScope.observe(model) { [weak self] event, model in
             self?.render(selectedRequest: model.selectedRequest, reloadData: event.kind == .initial)
         }
+    }
+
+    private func applyBackgroundFromTraits() {
+        let backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+        view.backgroundColor = backgroundColor
+        collectionView.backgroundColor = backgroundColor
     }
 
     private func configureNavigationItem() {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -88,8 +88,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         title = nil
         view.accessibilityIdentifier = "WebInspector.Network.ListPane"
         applyBackgroundFromTraits()
-        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
-            self.applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
         }
 
         collectionView.alwaysBounceVertical = true

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -87,6 +87,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         super.viewDidLoad()
         title = nil
         view.accessibilityIdentifier = "WebInspector.Network.ListPane"
+        applyBackgroundFromTraits()
+        registerForTraitChanges([WebInspectorDrawsBackgroundTrait.self]) { (self: Self, _) in
+            self.applyBackgroundFromTraits()
+        }
 
         collectionView.alwaysBounceVertical = true
         collectionView.keyboardDismissMode = .onDrag
@@ -171,6 +175,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
         renderSearchText(model.searchText)
         resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
+    }
+
+    private func applyBackgroundFromTraits() {
+        collectionView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
     }
 
     package func updateSearchResults(for searchController: UISearchController) {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -23,6 +23,10 @@ struct DOMContainerTests {
 
     @Test
     func elementViewControllerCanDisableBackgroundDrawing() {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+
         let dom = makeDOMSession()
         let viewController = DOMElementViewController(dom: dom)
         viewController.traitOverrides.webInspectorDrawsBackground = false

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -15,10 +15,22 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        #expect(viewController.view.backgroundColor == .clear)
+        #expect(viewController.view.backgroundColor == .systemBackground)
         let contentUnavailableConfiguration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
         #expect(contentUnavailableConfiguration?.text == "Select an element")
         #expect(viewController.collectionViewForTesting.isHidden)
+    }
+
+    @Test
+    func elementViewControllerCanDisableBackgroundDrawing() {
+        let dom = makeDOMSession()
+        let viewController = DOMElementViewController(dom: dom)
+        viewController.traitOverrides.webInspectorDrawsBackground = false
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.view.backgroundColor == .clear)
+        #expect(viewController.collectionViewForTesting.backgroundColor == .clear)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -20,6 +20,10 @@ struct NetworkDetailViewControllerTests {
 
     @Test
     func detailCanDisableBackgroundDrawing() {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+
         let model = NetworkPanelModel(network: NetworkSession())
         let viewController = NetworkDetailViewController(model: model)
         viewController.traitOverrides.webInspectorDrawsBackground = false
@@ -32,6 +36,10 @@ struct NetworkDetailViewControllerTests {
 
     @Test
     func listCanDisableBackgroundDrawing() {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+
         let model = NetworkPanelModel(network: NetworkSession())
         let viewController = NetworkListViewController(model: model)
         viewController.traitOverrides.webInspectorDrawsBackground = false

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -19,6 +19,29 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func detailCanDisableBackgroundDrawing() {
+        let model = NetworkPanelModel(network: NetworkSession())
+        let viewController = NetworkDetailViewController(model: model)
+        viewController.traitOverrides.webInspectorDrawsBackground = false
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.view.backgroundColor == .clear)
+        #expect(viewController.collectionViewForTesting.backgroundColor == .clear)
+    }
+
+    @Test
+    func listCanDisableBackgroundDrawing() {
+        let model = NetworkPanelModel(network: NetworkSession())
+        let viewController = NetworkListViewController(model: model)
+        viewController.traitOverrides.webInspectorDrawsBackground = false
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.collectionViewForTesting.backgroundColor == .clear)
+    }
+
+    @Test
     func detailRendersOverviewRequestAndResponseHeaders() async throws {
         let network = NetworkSession()
         let request = try #require(

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -15,7 +15,9 @@ struct ParentContainerTests {
 
         #expect(session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
         #expect(viewController.session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
-        #expect(viewController.drawsBackground)
+        if #available(iOS 26.0, *) {
+            #expect(viewController.drawsBackground)
+        }
     }
 
     @Test
@@ -24,17 +26,20 @@ struct ParentContainerTests {
 
         viewController.loadViewIfNeeded()
 
-        #expect(viewController.drawsBackground)
+        if #available(iOS 26.0, *) {
+            #expect(viewController.drawsBackground)
+        }
         #expect(viewController.view.backgroundColor == .systemBackground)
     }
 
     @Test
-    func viewControllerCanDisableBackgroundDrawingFromSessionInitializer() {
-        let viewController = WebInspectorViewController(
-            session: WebInspectorSession(),
-            drawsBackground: false
-        )
+    func viewControllerCanDisableBackgroundDrawingAfterInitialization() {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
 
+        let viewController = WebInspectorViewController(session: WebInspectorSession())
+        viewController.drawsBackground = false
         viewController.loadViewIfNeeded()
 
         #expect(viewController.drawsBackground == false)
@@ -42,17 +47,16 @@ struct ParentContainerTests {
     }
 
     @Test
-    func viewControllerCanDisableBackgroundDrawingFromTabsInitializer() {
-        let viewController = WebInspectorViewController(
-            tabs: [.network],
-            drawsBackground: false
-        )
+    func tabsInitializerKeepsBackgroundDrawingEnabledByDefault() {
+        let viewController = WebInspectorViewController(tabs: [.network])
 
         viewController.loadViewIfNeeded()
 
-        #expect(viewController.drawsBackground == false)
+        if #available(iOS 26.0, *) {
+            #expect(viewController.drawsBackground)
+        }
         #expect(viewController.session.interface.tabs.map(\.id) == [WebInspectorTab.network.id])
-        #expect(viewController.view.backgroundColor == .clear)
+        #expect(viewController.view.backgroundColor == .systemBackground)
     }
 
     @Test
@@ -93,7 +97,12 @@ struct ParentContainerTests {
 
     @Test
     func topLevelContainerPropagatesBackgroundDrawingTraitToHosts() throws {
-        let viewController = WebInspectorViewController(drawsBackground: false)
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+
+        let viewController = WebInspectorViewController()
+        viewController.drawsBackground = false
         viewController.loadViewIfNeeded()
 
         viewController.horizontalSizeClassOverrideForTesting = .compact

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -15,6 +15,44 @@ struct ParentContainerTests {
 
         #expect(session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
         #expect(viewController.session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
+        #expect(viewController.drawsBackground)
+    }
+
+    @Test
+    func viewControllerBackgroundDrawingDefaultsToSystemBackground() {
+        let viewController = WebInspectorViewController()
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.drawsBackground)
+        #expect(viewController.view.backgroundColor == .systemBackground)
+    }
+
+    @Test
+    func viewControllerCanDisableBackgroundDrawingFromSessionInitializer() {
+        let viewController = WebInspectorViewController(
+            session: WebInspectorSession(),
+            drawsBackground: false
+        )
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.drawsBackground == false)
+        #expect(viewController.view.backgroundColor == .clear)
+    }
+
+    @Test
+    func viewControllerCanDisableBackgroundDrawingFromTabsInitializer() {
+        let viewController = WebInspectorViewController(
+            tabs: [.network],
+            drawsBackground: false
+        )
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.drawsBackground == false)
+        #expect(viewController.session.interface.tabs.map(\.id) == [WebInspectorTab.network.id])
+        #expect(viewController.view.backgroundColor == .clear)
     }
 
     @Test
@@ -51,6 +89,23 @@ struct ParentContainerTests {
 
         viewController.horizontalSizeClassOverrideForTesting = .regular
         #expect(viewController.activeHostViewControllerForTesting is RegularTabContentViewController)
+    }
+
+    @Test
+    func topLevelContainerPropagatesBackgroundDrawingTraitToHosts() throws {
+        let viewController = WebInspectorViewController(drawsBackground: false)
+        viewController.loadViewIfNeeded()
+
+        viewController.horizontalSizeClassOverrideForTesting = .compact
+        let compactHost = try #require(viewController.activeHostViewControllerForTesting as? CompactTabBarController)
+        compactHost.loadViewIfNeeded()
+        #expect(compactHost.view.backgroundColor == .clear)
+
+        viewController.drawsBackground = true
+        viewController.horizontalSizeClassOverrideForTesting = .regular
+        let regularHost = try #require(viewController.activeHostViewControllerForTesting as? RegularTabContentViewController)
+        regularHost.loadViewIfNeeded()
+        #expect(regularHost.view.backgroundColor == .systemBackground)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add an iOS 26+ `WebInspectorViewController.drawsBackground` post-initialization option backed by trait propagation.
- Keep default background drawing enabled for normal/window presentations, while allowing Monocly sheet presentation to opt out on iOS 26+.
- Update WebInspectorUI and Monocly tests for the new API shape and sheet/window behavior.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:MonoclyTests`
- `codex-review --base main`