### PR TITLE
Stabilize DOM element style rendering

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "1ee629798da1913416216f2f7b46acf2723327e3",
-        "version" : "0.10.1"
+        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
+        "version" : "0.11.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2e7ff31516ae22d1cebd8580364e6e0acfc1c1ff",
-        "version" : "0.10.0"
+        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
+        "version" : "0.10.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6fb8faafa970d5baeaddfedbd828baf834209ed56e506701122c5382a3cabbe5",
+  "originHash" : "58da797e284649ea79f2a604ab188bde3869272ec8ff6aaa79e8e12015eb85df",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "1ee629798da1913416216f2f7b46acf2723327e3",
-        "version" : "0.10.1"
+        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
+        "version" : "0.11.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2e7ff31516ae22d1cebd8580364e6e0acfc1c1ff",
-        "version" : "0.10.0"
+        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
+        "version" : "0.10.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/lynnswap/ObservationBridge.git",
-            exact: "0.10.1"
+            exact: "0.11.0"
         ),
         .package(
             url: "https://github.com/lynnswap/UIHostingMenu.git",
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.10.0"
+            exact: "0.10.1"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -465,10 +465,7 @@ package final class CSSSession {
     package func selectNodeStyles(identity: CSSNodeStyleIdentity) {
         selectedIdentity = identity
         selectedUnavailableReason = .noSelection
-        guard let nodeStyles = nodeStyles(for: identity) else {
-            selectedNodeStyles = nil
-            return
-        }
+        let nodeStyles = ensureNodeStyles(for: identity, initialState: .needsRefresh)
         selectCurrentNodeStyles(nodeStyles)
     }
 
@@ -485,8 +482,7 @@ package final class CSSSession {
         identity: CSSNodeStyleIdentity,
         reason: CSSNodeStylesUnavailableReason
     ) {
-        let nodeStyles = stylesByNodeID[identity.nodeID] ?? CSSNodeStyles(identity: identity)
-        stylesByNodeID[identity.nodeID] = nodeStyles
+        let nodeStyles = ensureNodeStyles(for: identity)
         nodeStyles.state = .unavailable(reason)
         activeRefreshSequenceByNodeID.removeValue(forKey: identity.nodeID)
         guard selectedIdentity == identity || selectedNodeStyles === nodeStyles else {
@@ -507,8 +503,7 @@ package final class CSSSession {
         }
 
         nextRefreshSequence &+= 1
-        let nodeStyles = stylesByNodeID[identity.nodeID] ?? CSSNodeStyles(identity: identity)
-        stylesByNodeID[identity.nodeID] = nodeStyles
+        let nodeStyles = ensureNodeStyles(for: identity)
         nodeStyles.state = .loading
         selectedIdentity = identity
         selectCurrentNodeStyles(nodeStyles)
@@ -543,8 +538,7 @@ package final class CSSSession {
         nodeStyles.state = .loaded
         activeRefreshSequenceByNodeID.removeValue(forKey: token.identity.nodeID)
         if selectedIdentity == token.identity {
-            selectedNodeStyles = nodeStyles
-            selectedUnavailableReason = .noSelection
+            selectCurrentNodeStyles(nodeStyles)
         }
     }
 
@@ -583,7 +577,7 @@ package final class CSSSession {
         }
         nodeStyles.state = .needsRefresh
         if selectedIdentity == identity {
-            selectedNodeStyles = nodeStyles
+            selectCurrentNodeStyles(nodeStyles)
         }
     }
 
@@ -687,10 +681,29 @@ package final class CSSSession {
     private func selectCurrentNodeStyles(_ nodeStyles: CSSNodeStyles) {
         switch nodeStyles.state {
         case .unavailable, .failed:
+            guard selectedNodeStyles != nil else {
+                return
+            }
             selectedNodeStyles = nil
         case .loading, .loaded, .needsRefresh:
+            selectedUnavailableReason = .noSelection
+            guard selectedNodeStyles !== nodeStyles else {
+                return
+            }
             selectedNodeStyles = nodeStyles
         }
+    }
+
+    private func ensureNodeStyles(
+        for identity: CSSNodeStyleIdentity,
+        initialState: CSSNodeStylesState = .loading
+    ) -> CSSNodeStyles {
+        if let nodeStyles = nodeStyles(for: identity) {
+            return nodeStyles
+        }
+        let nodeStyles = CSSNodeStyles(identity: identity, state: initialState)
+        stylesByNodeID[identity.nodeID] = nodeStyles
+        return nodeStyles
     }
 
     package func applySetStyleTextResult(

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1406,6 +1406,7 @@ package final class DOMSession {
            existingNodeID != DOMNode.ID(documentID: document.id, nodeID: payload.nodeID) {
             removeNodeSubtree(existingNodeID, detachFromParent: true)
         }
+        pruneOmittedOwnedChildren(fromExistingSubtreeMatching: payload, in: document)
         let oldNodeIDs = Set(document.nodesByID.keys)
         let oldCurrentNodeIDByProtocolNodeID = document.currentNodeIDByProtocolNodeID
         var nodesByID = document.nodesByID
@@ -1424,6 +1425,21 @@ package final class DOMSession {
             document.currentNodeIDByProtocolNodeID = currentNodeIDByProtocolNodeID
         }
         return nodeID
+    }
+
+    private func pruneOmittedOwnedChildren(fromExistingSubtreeMatching payload: DOMNodePayload, in document: DOMDocument) {
+        let nodeID = DOMNode.ID(documentID: document.id, nodeID: payload.nodeID)
+        guard let node = document.nodesByID[nodeID] else {
+            return
+        }
+        let payloadChildren = payloadOwnedChildren(payload)
+        let retainedChildIDs = Set(payloadChildren.map { DOMNode.ID(documentID: document.id, nodeID: $0.nodeID) })
+        for childID in node.protocolOwnedChildren where retainedChildIDs.contains(childID) == false {
+            removeNodeSubtree(childID, detachFromParent: false)
+        }
+        for childPayload in payloadChildren {
+            pruneOmittedOwnedChildren(fromExistingSubtreeMatching: childPayload, in: document)
+        }
     }
 
     private func removeDocuments(for targetID: ProtocolTarget.ID) {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -300,6 +300,20 @@ package final class DOMNode {
         self.shadowRootType = payload.shadowRootType
     }
 
+    package func update(from payload: DOMNodePayload, parentID: ID?) {
+        nodeType = payload.nodeType
+        nodeName = payload.nodeName
+        localName = payload.localName
+        nodeValue = payload.nodeValue
+        ownerFrameID = payload.ownerFrameID
+        documentURL = payload.documentURL
+        baseURL = payload.baseURL
+        attributes = payload.attributes
+        self.parentID = parentID
+        pseudoType = payload.pseudoType
+        shadowRootType = payload.shadowRootType
+    }
+
     package var isFrameOwner: Bool {
         let lowercasedName = nodeName.lowercased()
         return lowercasedName == "iframe" || lowercasedName == "frame"
@@ -695,8 +709,15 @@ package final class DOMSession {
             document.removeChildNodesTransactions(parentRawNodeID: parent.protocolNodeID)
             return
         }
+        let incomingRawNodeIDs = Set(payloads.map(\.nodeID))
+        let childIDsToRemove = parent.regularChildren.loadedChildren.filter { childID in
+            guard let child = document.nodesByID[childID] else {
+                return true
+            }
+            return incomingRawNodeIDs.contains(child.protocolNodeID) == false
+        }
         var replacementOwnerKeys: [ProtocolTarget.ID: DOMNodeCurrentKey] = [:]
-        for childID in parent.regularChildren.loadedChildren {
+        for childID in childIDsToRemove {
             replacementOwnerKeys.merge(projectedFrameOwnerKeys(inSubtree: childID)) { current, _ in current }
             removeNodeSubtree(childID, detachFromParent: false)
         }
@@ -1325,8 +1346,14 @@ package final class DOMSession {
         currentNodeIDByProtocolNodeID: inout [DOMProtocolNodeID: DOMNode.ID]
     ) -> DOMNode.ID {
         let nodeID = DOMNode.ID(documentID: documentID, nodeID: payload.nodeID)
-        let node = DOMNode(id: nodeID, payload: payload, parentID: parentID)
-        nodesByID[nodeID] = node
+        let node: DOMNode
+        if let existingNode = nodesByID[nodeID] {
+            node = existingNode
+            node.update(from: payload, parentID: parentID)
+        } else {
+            node = DOMNode(id: nodeID, payload: payload, parentID: parentID)
+            nodesByID[nodeID] = node
+        }
         currentNodeIDByProtocolNodeID[payload.nodeID] = nodeID
 
         switch payload.regularChildren {
@@ -1379,6 +1406,8 @@ package final class DOMSession {
            existingNodeID != DOMNode.ID(documentID: document.id, nodeID: payload.nodeID) {
             removeNodeSubtree(existingNodeID, detachFromParent: true)
         }
+        let oldNodeIDs = Set(document.nodesByID.keys)
+        let oldCurrentNodeIDByProtocolNodeID = document.currentNodeIDByProtocolNodeID
         var nodesByID = document.nodesByID
         var currentNodeIDByProtocolNodeID = document.currentNodeIDByProtocolNodeID
         let nodeID = buildSubtree(
@@ -1388,8 +1417,12 @@ package final class DOMSession {
             nodesByID: &nodesByID,
             currentNodeIDByProtocolNodeID: &currentNodeIDByProtocolNodeID
         )
-        document.nodesByID = nodesByID
-        document.currentNodeIDByProtocolNodeID = currentNodeIDByProtocolNodeID
+        if Set(nodesByID.keys) != oldNodeIDs {
+            document.nodesByID = nodesByID
+        }
+        if currentNodeIDByProtocolNodeID != oldCurrentNodeIDByProtocolNodeID {
+            document.currentNodeIDByProtocolNodeID = currentNodeIDByProtocolNodeID
+        }
         return nodeID
     }
 
@@ -1563,11 +1596,18 @@ package final class DOMSession {
                   let parent = document.nodesByID[parentID] else {
                 continue
             }
-            let replacementOwnerKeys = parent.regularChildren.loadedChildren
+            let incomingRawNodeIDs = Set(fragments.map(\.nodeID))
+            let childIDsToRemove = parent.regularChildren.loadedChildren.filter { childID in
+                guard let child = document.nodesByID[childID] else {
+                    return true
+                }
+                return incomingRawNodeIDs.contains(child.protocolNodeID) == false
+            }
+            let replacementOwnerKeys = childIDsToRemove
                 .reduce(into: [ProtocolTarget.ID: DOMNodeCurrentKey]()) { partialResult, childID in
                     partialResult.merge(projectedFrameOwnerKeys(inSubtree: childID)) { current, _ in current }
                 }
-            for childID in parent.regularChildren.loadedChildren {
+            for childID in childIDsToRemove {
                 removeNodeSubtree(childID, detachFromParent: false)
             }
             parent.regularChildren = .loaded(fragments.map {

--- a/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionComponents.swift
@@ -61,22 +61,27 @@ package final class TargetGraph {
     }
 
     package func upsertTarget(from record: ProtocolTargetRecord) {
-        let target = targetsByID[record.id] ?? ProtocolTarget(
-            id: record.id,
-            kind: record.kind,
-            frameID: record.frameID,
-            parentFrameID: record.parentFrameID,
-            capabilities: record.capabilities,
-            isProvisional: record.isProvisional,
-            isPaused: record.isPaused
-        )
+        let target: ProtocolTarget
+        if let existingTarget = targetsByID[record.id] {
+            target = existingTarget
+        } else {
+            target = ProtocolTarget(
+                id: record.id,
+                kind: record.kind,
+                frameID: record.frameID,
+                parentFrameID: record.parentFrameID,
+                capabilities: record.capabilities,
+                isProvisional: record.isProvisional,
+                isPaused: record.isPaused
+            )
+            targetsByID[record.id] = target
+        }
         target.kind = record.kind
         target.frameID = record.frameID
         target.parentFrameID = record.parentFrameID
         target.capabilities = record.capabilities
         target.isProvisional = record.isProvisional
         target.isPaused = record.isPaused
-        targetsByID[record.id] = target
     }
 
     package func removeTarget(_ targetID: ProtocolTarget.ID) -> TargetRemoval? {
@@ -105,22 +110,27 @@ package final class TargetGraph {
         let existingNewTarget = targetsByID[newTargetID]
         let frameID = existingNewTarget?.frameID ?? oldTarget.frameID
         let parentFrameID = existingNewTarget?.parentFrameID ?? oldTarget.parentFrameID
-        let committedTarget = existingNewTarget ?? ProtocolTarget(
-            id: newTargetID,
-            kind: oldTarget.kind,
-            frameID: frameID,
-            parentFrameID: parentFrameID,
-            capabilities: oldTarget.capabilities,
-            isProvisional: false,
-            isPaused: oldTarget.isPaused
-        )
+        let committedTarget: ProtocolTarget
+        if let existingNewTarget {
+            committedTarget = existingNewTarget
+        } else {
+            committedTarget = ProtocolTarget(
+                id: newTargetID,
+                kind: oldTarget.kind,
+                frameID: frameID,
+                parentFrameID: parentFrameID,
+                capabilities: oldTarget.capabilities,
+                isProvisional: false,
+                isPaused: oldTarget.isPaused
+            )
+            targetsByID[newTargetID] = committedTarget
+        }
         committedTarget.kind = existingNewTarget?.kind ?? oldTarget.kind
         committedTarget.frameID = frameID
         committedTarget.parentFrameID = parentFrameID
         committedTarget.capabilities = existingNewTarget?.capabilities ?? oldTarget.capabilities
         committedTarget.isProvisional = false
         committedTarget.isPaused = existingNewTarget?.isPaused ?? oldTarget.isPaused
-        targetsByID[newTargetID] = committedTarget
         if let frameID {
             retargetFrame(frameID, from: oldTargetID, to: newTargetID)
         }
@@ -155,9 +165,14 @@ package final class TargetGraph {
     }
 
     private func frameWithID(_ frameID: DOMFrame.ID, parentFrameID: DOMFrame.ID?) -> DOMFrame {
-        let frame = framesByID[frameID] ?? DOMFrame(id: frameID, parentFrameID: parentFrameID)
+        let frame: DOMFrame
+        if let existingFrame = framesByID[frameID] {
+            frame = existingFrame
+        } else {
+            frame = DOMFrame(id: frameID, parentFrameID: parentFrameID)
+            framesByID[frameID] = frame
+        }
         frame.parentFrameID = parentFrameID
-        framesByID[frameID] = frame
         if let parentFrameID {
             let parent = frameWithID(parentFrameID, parentFrameID: nil)
             parent.childFrameIDs.insert(frameID)
@@ -349,7 +364,10 @@ package final class DOMDocumentStore {
     }
 
     package func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {
-        let state = targetStatesByID[targetID] ?? DOMTargetState(targetID: targetID)
+        if let state = targetStatesByID[targetID] {
+            return state
+        }
+        let state = DOMTargetState(targetID: targetID)
         targetStatesByID[targetID] = state
         return state
     }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -2,15 +2,6 @@ import Foundation
 import ObservationBridge
 import WebInspectorTransport
 
-private enum SelectedNodeStyleHydrationState {
-    case detached
-    case waitingForDocument
-    case unavailable(CSSNodeStylesUnavailableReason)
-    case needsRefresh(CSSNodeStyleIdentity)
-    case refreshing(CSSNodeStyleIdentity)
-    case current(CSSNodeStyleIdentity)
-}
-
 @MainActor
 final class DOMSessionHighlightController {
     var targetID: ProtocolTargetIdentifier?
@@ -30,7 +21,7 @@ final class DOMSessionDocumentRequestController {
 
 @MainActor
 final class DOMSessionElementStyleHydrationController {
-    var observationTask: Task<Void, Never>?
+    let observationScope = ObservationScope()
     var refreshTask: Task<Void, Never>?
     var refreshIdentity: CSSNodeStyleIdentity?
     var isActive = false
@@ -539,58 +530,40 @@ extension DOMSession {
     }
 
     private func startSelectedNodeStyleHydration() {
-        styleHydration.observationTask?.cancel()
-        styleHydration.observationTask = Task { @MainActor [weak self] in
-            let stream = makeObservationBridgeStream {
-                self?.selectedNodeStyleHydrationState() ?? .detached
-            }
-            for await state in stream {
-                guard let self else {
-                    return
-                }
-                self.applySelectedNodeStyleHydrationState(state)
-            }
+        styleHydration.observationScope.cancelAll()
+        styleHydration.observationScope.observe(self) { [weak self] _, _ in
+            self?.reconcileSelectedNodeStyleHydration()
         }
     }
 
     private func stopSelectedNodeStyleHydration() {
-        styleHydration.observationTask?.cancel()
-        styleHydration.observationTask = nil
+        styleHydration.observationScope.cancelAll()
         cancelSelectedNodeStyleHydrationRefresh()
     }
 
-    private func selectedNodeStyleHydrationState() -> SelectedNodeStyleHydrationState {
+    private func reconcileSelectedNodeStyleHydration() {
         guard commandChannel != nil else {
-            return .detached
+            return
         }
         guard currentPageRootNode != nil else {
-            return .waitingForDocument
+            return
         }
 
         switch selectedCSSNodeStyleIdentity() {
         case let .success(identity):
-            switch elementStyles.refreshState(forSelected: identity) {
-            case nil, .needsRefresh:
-                return .needsRefresh(identity)
-            case .loading:
-                return .refreshing(identity)
-            case .loaded, .failed(_), .unavailable(_):
-                return .current(identity)
-            }
+            reconcileSelectedNodeStyles(identity)
         case let .failure(reason):
-            return .unavailable(reason)
+            cancelSelectedNodeStyleHydrationRefresh()
+            elementStyles.markSelectedNodeUnavailable(reason)
         }
     }
 
-    private func applySelectedNodeStyleHydrationState(_ state: SelectedNodeStyleHydrationState) {
-        switch state {
-        case .detached, .waitingForDocument, .refreshing, .current:
-            return
-        case .unavailable(let reason):
-            cancelSelectedNodeStyleHydrationRefresh()
-            elementStyles.markSelectedNodeUnavailable(reason)
-        case .needsRefresh(let identity):
+    private func reconcileSelectedNodeStyles(_ identity: CSSNodeStyleIdentity) {
+        switch elementStyles.refreshState(forSelected: identity) {
+        case nil, .needsRefresh:
             hydrateSelectedNodeStyles(identity)
+        case .loading, .loaded, .failed(_), .unavailable(_):
+            return
         }
     }
 

--- a/Sources/WebInspectorCore/Docs/CSSModelResearch.md
+++ b/Sources/WebInspectorCore/Docs/CSSModelResearch.md
@@ -128,8 +128,9 @@ valid for user-agent, attribute, inline, source-less, or non-editable styles.
   name plus a 1-based line number. Columns are shown only for large columns
   (`SourceCodeLocation.LargeColumnNumber` is 80).
 - `displayNameForURL` uses a decoded last path component when present, then a
-  host fallback, then the original URL. This is why a Google search URL appears
-  as a compact `search:<line>` style label rather than the full request URL.
+  host fallback, then the original URL. This is why a URL ending in a stylesheet
+  path appears as a compact `<file>:<line>` style label rather than the full
+  request URL.
 - Long source/origin text is constrained in WebKit UI rather than allowed to
   grow section headers: `.spreadsheet-css-declaration .origin` uses one-line
   overflow ellipsis, and generic details-section headers also use `nowrap` plus

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -471,7 +471,6 @@ package final class RuntimeState {
         }
         let agentState = ensureRuntimeAgentState(for: record.runtimeAgentTargetID)
         agentState.recordExecutionContext(record)
-        storeRuntimeAgentState(agentState)
         if record.type == .normal {
             let targetState = ensureTargetState(for: record.targetID)
             let previousDefaultContextKey = targetState.normalContextKey
@@ -514,7 +513,6 @@ package final class RuntimeState {
         let removedTargetIDs = Set(removedContexts.map(\.targetID))
         agentState.clearExecutionContexts()
         agentState.clearRemoteObjects()
-        storeRuntimeAgentState(agentState)
         for targetID in removedTargetIDs {
             if let normalContextKey = targetStatesByID[targetID]?.normalContextKey,
                removedContextKeys.contains(normalContextKey) {
@@ -562,7 +560,6 @@ package final class RuntimeState {
                     agentState.releaseRemoteObjects(executionContextKey: context.key)
                 }
             }
-            storeRuntimeAgentState(agentState)
         }
         let removedContextKeys = Set(removedContexts.map(\.key))
         let removedTargetIDs = Set(removedContexts.map(\.targetID))
@@ -614,7 +611,6 @@ package final class RuntimeState {
                oldAgentState.unsupportedCommandSnapshot.isEmpty == false {
                 let newAgentState = ensureRuntimeAgentState(for: newTargetID)
                 newAgentState.mergeUnsupportedCommands(oldAgentState.unsupportedCommandSnapshot)
-                storeRuntimeAgentState(newAgentState)
             }
         }
     }
@@ -632,7 +628,6 @@ package final class RuntimeState {
             objectGroup: objectGroup,
             executionContextID: executionContextID
         )
-        storeRuntimeAgentState(agentState)
         return remoteObject
     }
 
@@ -654,7 +649,6 @@ package final class RuntimeState {
             return
         }
         agentState.releaseRemoteObject(key.objectID)
-        storeRuntimeAgentState(agentState)
     }
 
     package func releaseObjectGroup(_ objectGroup: RuntimeObjectGroup, runtimeAgentTargetID: ProtocolTargetIdentifier) {
@@ -662,13 +656,11 @@ package final class RuntimeState {
             return
         }
         agentState.releaseRemoteObjects(objectGroup: objectGroup)
-        storeRuntimeAgentState(agentState)
     }
 
     package func markCommandUnsupported(_ method: String, targetID: ProtocolTargetIdentifier) {
         let agentState = ensureRuntimeAgentState(for: targetID)
         agentState.markCommandUnsupported(method)
-        storeRuntimeAgentState(agentState)
     }
 
     package func supportsCommand(_ method: String, targetID: ProtocolTargetIdentifier) -> Bool {
@@ -783,10 +775,6 @@ package final class RuntimeState {
         }
     }
 
-    private func storeRuntimeAgentState(_ state: RuntimeAgentState) {
-        runtimeAgentStatesByID[state.targetID] = state
-    }
-
     @discardableResult
     private func removeExecutionContext(
         _ contextKey: RuntimeExecutionContextKey,
@@ -799,7 +787,6 @@ package final class RuntimeState {
         if releaseRemoteObjects {
             agentState.releaseRemoteObjects(executionContextKey: contextKey)
         }
-        storeRuntimeAgentState(agentState)
         return context
     }
 
@@ -839,7 +826,6 @@ package final class RuntimeState {
             guard sourceAgentState.removeExecutionContext(contextID: entry.context.id) != nil else {
                 continue
             }
-            storeRuntimeAgentState(sourceAgentState)
             movedContextKeys[oldKey] = nextKey
 
             if let destinationAgentState = runtimeAgentStatesByID[nextRuntimeAgentTargetID],
@@ -851,7 +837,6 @@ package final class RuntimeState {
             entry.context.runtimeAgentTargetID = nextRuntimeAgentTargetID
             let destinationAgentState = ensureRuntimeAgentState(for: nextRuntimeAgentTargetID)
             destinationAgentState.insertExecutionContext(entry.context)
-            storeRuntimeAgentState(destinationAgentState)
         }
 
         return movedContextKeys

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController+Preview.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController+Preview.swift
@@ -1,0 +1,22 @@
+#if canImport(UIKit)
+import WebInspectorCore
+import UIKit
+
+@MainActor
+enum WebInspectorViewControllerPreviewFixtures {
+    static func makeSession() -> WebInspectorSession {
+        WebInspectorSession(
+            inspector: InspectorSession(
+                attachment: AttachedInspection(
+                    dom: DOMPreviewFixtures.makeDOMSession(),
+                    network: NetworkPreviewFixtures.makeNetworkSession(mode: .detail)
+                )
+            )
+        )
+    }
+}
+
+#Preview("WebInspectorViewController") {
+    WebInspectorViewController(session: WebInspectorViewControllerPreviewFixtures.makeSession())
+}
+#endif

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -134,21 +134,4 @@ public final class WebInspectorViewController: UIViewController {
     }
 }
 
-@MainActor
-enum WebInspectorViewControllerPreviewFixtures {
-    static func makeSession() -> WebInspectorSession {
-        WebInspectorSession(
-            inspector: InspectorSession(
-                attachment: AttachedInspection(
-                    dom: DOMPreviewFixtures.makeDOMSession(),
-                    network: NetworkPreviewFixtures.makeNetworkSession(mode: .detail)
-                )
-            )
-        )
-    }
-}
-
-#Preview("WebInspectorViewController") {
-    WebInspectorViewController(session: WebInspectorViewControllerPreviewFixtures.makeSession())
-}
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -1,9 +1,10 @@
 #if canImport(UIKit)
 import WebInspectorCore
+import Observation
 import SwiftUI
 import UIKit
 
-package enum DOMElementStyleSectionHeaderConfiguration {
+package enum DOMElementStyleSectionHeaderText {
     private static let largeColumnNumber = 80
 
     package static func displayOriginText(for rule: CSSRule) -> String? {
@@ -78,9 +79,14 @@ package enum DOMElementStyleSectionHeaderConfiguration {
 
 @MainActor
 final class DOMElementStyleSectionHeaderView: UICollectionViewListCell {
+    private let model = DOMElementStyleSectionHeaderModel()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        bind(nil)
+        let model = model
+        contentConfiguration = UIHostingConfiguration {
+            DOMElementStyleSectionHeaderContent(model: model)
+        }
     }
 
     @available(*, unavailable)
@@ -88,26 +94,35 @@ final class DOMElementStyleSectionHeaderView: UICollectionViewListCell {
         nil
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        bind(nil)
+    }
+
     func bind(_ section: CSSStyleSection?) {
-        contentConfiguration = UIHostingConfiguration {
-            DOMElementStyleSectionHeaderContent(section: section)
-        }
+        model.section = section
     }
 }
 
-private struct DOMElementStyleSectionHeaderContent: View {
+@MainActor
+@Observable
+private final class DOMElementStyleSectionHeaderModel {
     var section: CSSStyleSection?
+}
+
+private struct DOMElementStyleSectionHeaderContent: View {
+    var model: DOMElementStyleSectionHeaderModel
 
     private var title: String {
-        section?.title ?? ""
+        model.section?.title ?? ""
     }
 
     private var originText: String? {
-        section?.rule.flatMap(DOMElementStyleSectionHeaderConfiguration.displayOriginText(for:))
+        model.section?.rule.flatMap(DOMElementStyleSectionHeaderText.displayOriginText(for:))
     }
 
     private var accessibilityOriginText: String? {
-        section?.rule.flatMap(DOMElementStyleSectionHeaderConfiguration.accessibilityOriginText(for:))
+        model.section?.rule.flatMap(DOMElementStyleSectionHeaderText.accessibilityOriginText(for:))
     }
 
     private var accessibilityLabel: String {
@@ -137,4 +152,26 @@ private struct DOMElementStyleSectionHeaderContent: View {
         .accessibilityLabel(accessibilityLabel)
     }
 }
+
+#if DEBUG
+extension DOMElementStyleSectionHeaderView {
+    package var titleTextForTesting: String {
+        model.titleTextForTesting
+    }
+
+    package var originTextForTesting: String? {
+        model.originTextForTesting
+    }
+}
+
+private extension DOMElementStyleSectionHeaderModel {
+    var titleTextForTesting: String {
+        section?.title ?? ""
+    }
+
+    var originTextForTesting: String? {
+        section?.rule.flatMap(DOMElementStyleSectionHeaderText.displayOriginText(for:))
+    }
+}
+#endif
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController+Preview.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController+Preview.swift
@@ -1,0 +1,347 @@
+#if canImport(UIKit)
+import WebInspectorCore
+import WebInspectorTransport
+import UIKit
+
+#Preview("DOM Element") {
+    DOMElementViewControllerPreview.makeViewController()
+}
+
+@MainActor
+private enum DOMElementViewControllerPreview {
+    private static let targetID = ProtocolTargetIdentifier("preview-page")
+    private static let frameID = DOMFrameIdentifier("preview-frame")
+    private static let styleSheetID = CSSStyleSheetIdentifier("preview")
+    private static let styleID = CSSStyleIdentifier(styleSheetID: styleSheetID, ordinal: 0)
+    private static let ruleID = CSSRuleIdentifier(styleSheetID: styleSheetID, ordinal: 0)
+    private static let previewCSSText = "margin: 0;\nbox-sizing: border-box;\nfont-size: 12px;"
+
+    static func makeViewController() -> UINavigationController {
+        let dom = DOMPreviewFixtures.makeDOMSession()
+        dom.applyTargetCreated(
+            ProtocolTargetRecord(
+                id: targetID,
+                kind: .page,
+                frameID: frameID,
+                capabilities: .pageDefault
+            ),
+            makeCurrentMainPage: true
+        )
+        if let body = firstElement(named: "body", in: dom) {
+            dom.selectNode(body.id)
+        }
+
+        let css = dom.elementStyles
+        if case let .success(identity) = dom.selectedCSSNodeStyleIdentity(),
+           let token = css.beginRefresh(identity: identity) {
+            let style = previewStylePayload(styleID: styleID, cssText: previewCSSText)
+            let matched = previewMatchedStyles(ruleID: ruleID, style: style)
+            let inline = CSSInlineStylesPayload()
+            let computed: [CSSComputedStylePropertyPayload] = []
+            css.applyRefresh(
+                token: token,
+                matched: matched,
+                inline: inline,
+                computed: computed
+            )
+        }
+
+        let inspection = AttachedInspection(dom: dom)
+        installPreviewTransport(on: dom)
+        return UINavigationController(rootViewController: DOMElementViewController(inspection: inspection))
+    }
+
+    private static func installPreviewTransport(on dom: DOMSession) {
+        let backend = DOMElementViewControllerPreviewTransportBackend(
+            styleID: styleID,
+            ruleID: ruleID,
+            cssText: previewCSSText
+        )
+        let transport = TransportSession(backend: backend, responseTimeout: nil)
+        backend.transport = transport
+        seedPreviewTarget(in: transport)
+        let channel = ProtocolCommandChannel(
+            transport: transport,
+            isCurrent: { true },
+            isAttached: { true },
+            appliedSequence: { 0 },
+            shouldEnableCompatibilityCSS: { _ in false },
+            markTargetDomainEnabled: { _, _ in }
+        )
+        dom.bindProtocolChannel(channel, recordError: { _ in })
+    }
+
+    private static func seedPreviewTarget(in transport: TransportSession) {
+        let message = targetCreatedMessage()
+        Task {
+            await transport.receiveRootMessage(message)
+        }
+    }
+
+    nonisolated private static func previewProperties(from styleText: String) -> [CSSPropertyPayload] {
+        styleText
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .compactMap(previewProperty(from:))
+    }
+
+    nonisolated private static func previewStylePayload(
+        styleID: CSSStyleIdentifier,
+        cssText: String
+    ) -> CSSStylePayload {
+        let properties = previewProperties(from: cssText)
+        return CSSStylePayload(
+            id: styleID,
+            cssProperties: properties,
+            cssText: cssText
+        )
+    }
+
+    nonisolated private static func previewMatchedStyles(
+        ruleID: CSSRuleIdentifier,
+        style: CSSStylePayload
+    ) -> CSSMatchedStylesPayload {
+        let selector = CSSSelector(text: "body")
+        let selectorList = CSSSelectorList(selectors: [selector], text: "body")
+        let rule = CSSRulePayload(
+            id: ruleID,
+            selectorList: selectorList,
+            sourceURL: "preview.css",
+            sourceLine: 1,
+            origin: .author,
+            style: style
+        )
+        let matchedRules = [
+            CSSRuleMatchPayload(rule: rule, matchingSelectors: [0]),
+        ]
+        return CSSMatchedStylesPayload(matchedRules: matchedRules)
+    }
+
+    nonisolated private static func previewProperty(from declarationText: String) -> CSSPropertyPayload? {
+        let disabled = declarationText.hasPrefix("/*") && declarationText.hasSuffix("*/")
+        let sourceText = disabled
+            ? String(declarationText.dropFirst(2).dropLast(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+            : declarationText
+        guard let separatorIndex = sourceText.firstIndex(of: ":") else {
+            return nil
+        }
+        let name = sourceText[..<separatorIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        var value = sourceText[sourceText.index(after: separatorIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasSuffix(";") {
+            value.removeLast()
+        }
+        let status: CSSPropertyStatus
+        if disabled {
+            status = .disabled
+        } else if name == "font-size" {
+            status = .inactive
+        } else {
+            status = .active
+        }
+        return CSSPropertyPayload(
+            name: name,
+            value: value,
+            text: declarationText,
+            status: status
+        )
+    }
+
+    private static func firstElement(named localName: String, in dom: DOMSession) -> DOMNode? {
+        guard let rootNode = dom.currentPageRootNode else {
+            return nil
+        }
+        var stack = [rootNode]
+        while let node = stack.popLast() {
+            if node.localName == localName {
+                return node
+            }
+            stack.append(contentsOf: dom.visibleDOMTreeChildren(of: node).reversed())
+        }
+        return nil
+    }
+
+    private static func targetCreatedMessage() -> String {
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"\#(targetID.rawValue)","type":"page","frameId":"\#(frameID.rawValue)","domains":["DOM","Runtime","Target","Inspector","Network","CSS"],"isProvisional":false}}}"#
+    }
+
+    private final class DOMElementViewControllerPreviewTransportBackend: TransportBackend, @unchecked Sendable {
+        private struct TargetCommand {
+            var targetID: ProtocolTargetIdentifier
+            var commandID: UInt64
+            var method: String
+            var message: String
+        }
+
+        private struct TargetSendMessageEnvelope: Decodable {
+            var method: String
+            var params: TargetSendMessageParameters
+        }
+
+        private struct TargetSendMessageParameters: Decodable {
+            var targetId: String
+            var message: String
+        }
+
+        private struct TargetInnerCommandEnvelope: Decodable {
+            var id: UInt64
+            var method: String
+        }
+
+        private struct SetStyleTextCommand: Decodable {
+            var params: SetStyleTextParameters
+        }
+
+        private struct SetStyleTextParameters: Decodable {
+            var text: String
+        }
+
+        private struct TargetDispatchMessage: Encodable {
+            var method = "Target.dispatchMessageFromTarget"
+            var params: TargetDispatchParameters
+        }
+
+        private struct TargetDispatchParameters: Encodable {
+            var targetId: String
+            var message: String
+        }
+
+        private struct SetStyleTextResult: Encodable {
+            var style: CSSStylePayload
+        }
+
+        private struct ComputedStyleResult: Encodable {
+            var computedStyle: [CSSComputedStylePropertyPayload]
+        }
+
+        private let lock = NSLock()
+        private let styleID: CSSStyleIdentifier
+        private let ruleID: CSSRuleIdentifier
+        private var cssText: String
+        private var properties: [CSSPropertyPayload]
+        weak var transport: TransportSession?
+
+        init(styleID: CSSStyleIdentifier, ruleID: CSSRuleIdentifier, cssText: String) {
+            self.styleID = styleID
+            self.ruleID = ruleID
+            self.cssText = cssText
+            self.properties = DOMElementViewControllerPreview.previewProperties(from: cssText)
+        }
+
+        func sendJSONString(_ message: String) async throws {
+            guard let command = Self.targetCommand(from: message) else {
+                return
+            }
+
+            let resultJSON: String
+            switch command.method {
+            case "CSS.setStyleText":
+                guard let text = Self.setStyleText(from: command.message) else {
+                    return
+                }
+                resultJSON = try Self.jsonString(
+                    SetStyleTextResult(style: updateStyleText(text))
+                )
+            case "CSS.getMatchedStylesForNode":
+                resultJSON = try Self.jsonString(matchedStyles())
+            case "CSS.getInlineStylesForNode":
+                resultJSON = try Self.jsonString(CSSInlineStylesPayload())
+            case "CSS.getComputedStyleForNode":
+                resultJSON = try Self.jsonString(ComputedStyleResult(computedStyle: []))
+            default:
+                resultJSON = "{}"
+            }
+
+            await sendTargetReply(
+                targetID: command.targetID,
+                commandID: command.commandID,
+                resultJSON: resultJSON
+            )
+        }
+
+        func detach() async {
+        }
+
+        private func updateStyleText(_ text: String) -> CSSStylePayload {
+            withLockedState {
+                cssText = text
+                properties = DOMElementViewControllerPreview.previewProperties(from: text)
+                return currentStylePayload()
+            }
+        }
+
+        private func matchedStyles() -> CSSMatchedStylesPayload {
+            withLockedState {
+                DOMElementViewControllerPreview.previewMatchedStyles(
+                    ruleID: ruleID,
+                    style: currentStylePayload()
+                )
+            }
+        }
+
+        private func currentStylePayload() -> CSSStylePayload {
+            CSSStylePayload(
+                id: styleID,
+                cssProperties: properties,
+                cssText: cssText
+            )
+        }
+
+        private func withLockedState<T>(_ body: () throws -> T) rethrows -> T {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+            return try body()
+        }
+
+        private func sendTargetReply(
+            targetID: ProtocolTargetIdentifier,
+            commandID: UInt64,
+            resultJSON: String
+        ) async {
+            let targetMessage = #"{"id":\#(commandID),"result":\#(resultJSON)}"#
+            let rootMessage = TargetDispatchMessage(
+                params: TargetDispatchParameters(
+                    targetId: targetID.rawValue,
+                    message: targetMessage
+                )
+            )
+            guard let data = try? JSONEncoder().encode(rootMessage),
+                  let message = String(data: data, encoding: .utf8) else {
+                return
+            }
+            await transport?.receiveRootMessage(message)
+        }
+
+        private static func targetCommand(from message: String) -> TargetCommand? {
+            guard let data = message.data(using: .utf8),
+                  let envelope = try? JSONDecoder().decode(TargetSendMessageEnvelope.self, from: data),
+                  envelope.method == "Target.sendMessageToTarget",
+                  let innerData = envelope.params.message.data(using: .utf8),
+                  let inner = try? JSONDecoder().decode(TargetInnerCommandEnvelope.self, from: innerData) else {
+                return nil
+            }
+            return TargetCommand(
+                targetID: ProtocolTargetIdentifier(envelope.params.targetId),
+                commandID: inner.id,
+                method: inner.method,
+                message: envelope.params.message
+            )
+        }
+
+        private static func setStyleText(from message: String) -> String? {
+            guard let data = message.data(using: .utf8),
+                  let command = try? JSONDecoder().decode(SetStyleTextCommand.self, from: data) else {
+                return nil
+            }
+            return command.params.text
+        }
+
+        private static func jsonString<T: Encodable>(_ value: T) throws -> String {
+            let data = try JSONEncoder().encode(value)
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -5,7 +5,7 @@ import ObservationBridge
 import UIKit
 
 @MainActor
-package final class DOMElementViewController: UIViewController {
+package final class DOMElementViewController: UICollectionViewController {
     private struct ItemIdentifier: Hashable {
         enum Kind: Hashable {
             case property(propertyID: CSSPropertyIdentifier?, propertyIndex: Int)
@@ -18,6 +18,8 @@ package final class DOMElementViewController: UIViewController {
 
     private let inspection: AttachedInspection
     private let observationScope = ObservationScope()
+    private let selectedNodeStyleObservationScope = ObservationScope()
+    private weak var observedNodeStyles: CSSNodeStyles?
     private var expandedUnusedVariableSectionIDs = Set<CSSStyleSectionIdentifier>()
     private var displayedNodeStyles: CSSNodeStyles?
 
@@ -25,15 +27,11 @@ package final class DOMElementViewController: UIViewController {
     package private(set) var lastSnapshotAnimatedForTesting = false
 #endif
 
-    private lazy var collectionView = UICollectionView(
-        frame: .zero,
-        collectionViewLayout: Self.makeLayout()
-    )
     private lazy var dataSource = makeDataSource()
 
     package init(inspection: AttachedInspection) {
         self.inspection = inspection
-        super.init(nibName: nil, bundle: nil)
+        super.init(collectionViewLayout: Self.makeLayout())
     }
 
     @available(*, unavailable)
@@ -44,25 +42,29 @@ package final class DOMElementViewController: UIViewController {
     isolated deinit {
         inspection.dom.setSelectedNodeStyleHydrationActive(false)
         observationScope.cancelAll()
+        selectedNodeStyleObservationScope.cancelAll()
     }
 
     override package func viewDidLoad() {
         super.viewDidLoad()
         applyBackgroundFromTraits()
+        collectionView.alwaysBounceVertical = true
+        collectionView.keyboardDismissMode = .onDrag
+        collectionView.accessibilityIdentifier = "WebInspector.DOM.Element.StylesList"
         if #available(iOS 26.0, *) {
             webInspectorRegisterForBackgroundTraitChanges { viewController in
                 viewController.applyBackgroundFromTraits()
             }
         }
-        configureCollectionView()
+        let selectedNodeStyles = inspection.dom.elementStyles.selectedNodeStyles
+        render(selectedNodeStyles)
+        observeSelectedNodeStyles(selectedNodeStyles)
         startObservingState()
-        render()
     }
 
     override package func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         inspection.dom.setSelectedNodeStyleHydrationActive(true)
-        render()
     }
 
     override package func viewDidDisappear(_ animated: Bool) {
@@ -85,22 +87,6 @@ package final class DOMElementViewController: UIViewController {
             section.contentInsets = contentInsets
             return section
         }
-    }
-
-    private func configureCollectionView() {
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
-        collectionView.alwaysBounceVertical = true
-        collectionView.keyboardDismissMode = .onDrag
-        collectionView.accessibilityIdentifier = "WebInspector.DOM.Element.StylesList"
-
-        view.addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
     }
 
     private func applyBackgroundFromTraits() {
@@ -184,55 +170,84 @@ package final class DOMElementViewController: UIViewController {
     }
 
     private func startObservingState() {
-        observationScope.observe(inspection.dom) { [weak self] _, _ in
-            self?.render()
-        }
-        observationScope.observe(inspection.dom.elementStyles) { [weak self] _, _ in
-            self?.render()
+        observationScope.observe(inspection.dom.elementStyles) { [weak self] _, elementStyles in
+            self?.observeSelectedNodeStyles(elementStyles.selectedNodeStyles)
         }
     }
 
-    private func render() {
-        guard isViewLoaded else {
+    private func observeSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?) {
+        guard observedNodeStyles !== nodeStyles else {
+            return
+        }
+        observedNodeStyles = nodeStyles
+        selectedNodeStyleObservationScope.cancelAll()
+
+        guard let nodeStyles else {
+            render(nil)
             return
         }
 
-        render(inspection.dom.selectedNodeStyles)
+        selectedNodeStyleObservationScope.observe(nodeStyles) { [weak self] _, nodeStyles in
+            guard self?.observedNodeStyles === nodeStyles else {
+                return
+            }
+            self?.render(nodeStyles)
+        }
     }
 
     private func render(_ nodeStyles: CSSNodeStyles?) {
         guard let nodeStyles else {
-            showEmptyStyleList()
+            displayedNodeStyles = nil
+            renderUnavailableStyles()
             return
         }
-        showStyleList(nodeStyles)
+
+        switch nodeStyles.state {
+        case .loaded:
+            displayedNodeStyles = nodeStyles
+            renderStyles(nodeStyles)
+        case .loading, .needsRefresh:
+            renderPendingStyles()
+        case .unavailable, .failed:
+            displayedNodeStyles = nil
+            renderUnavailableStyles()
+        }
     }
 
-    private func showStyleList(_ nodeStyles: CSSNodeStyles) {
-        displayedNodeStyles = nodeStyles
-        showCollectionView()
-        applySnapshot(for: nodeStyles)
-    }
-
-    private func showEmptyStyleList() {
-        displayedNodeStyles = nil
-        showCollectionView()
+    private func renderUnavailableStyles() {
+        if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
+           configuration.text == webInspectorLocalized("dom.element.styles.empty.title", default: "No styles available") {
+            applyEmptySnapshot()
+            return
+        }
+        var configuration = UIContentUnavailableConfiguration.empty()
+        configuration.text = webInspectorLocalized("dom.element.styles.empty.title", default: "No styles available")
+        configuration.secondaryText = webInspectorLocalized(
+            "dom.element.styles.empty.description",
+            default: "Select an element in the DOM tree to inspect CSS styles."
+        )
+        contentUnavailableConfiguration = configuration
         applyEmptySnapshot()
     }
 
-    private func showCollectionView() {
+    private func renderPendingStyles() {
+        guard displayedNodeStyles != nil else {
+            renderUnavailableStyles()
+            return
+        }
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
-        if collectionView.isHidden {
-            collectionView.isHidden = false
+    }
+
+    private func renderStyles(_ nodeStyles: CSSNodeStyles) {
+        if contentUnavailableConfiguration != nil {
+            contentUnavailableConfiguration = nil
         }
+        applySnapshot(for: nodeStyles)
     }
 
     private func applyEmptySnapshot() {
-        guard dataSource.snapshot().numberOfItems != 0 || dataSource.snapshot().numberOfSections != 0 else {
-            return
-        }
         expandedUnusedVariableSectionIDs.removeAll()
         let snapshot = NSDiffableDataSourceSnapshot<CSSStyleSectionIdentifier, ItemIdentifier>()
         dataSource.apply(snapshot, animatingDifferences: false)
@@ -314,14 +329,6 @@ package final class DOMElementViewController: UIViewController {
         }
     }
 }
-
-#if DEBUG
-extension DOMElementViewController {
-    package var collectionViewForTesting: UICollectionView {
-        collectionView
-    }
-}
-#endif
 
 #Preview("DOM Element") {
     DOMElementViewControllerPreview.makeViewController()

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -1,6 +1,5 @@
 #if canImport(UIKit)
 import WebInspectorCore
-import WebInspectorTransport
 import ObservationBridge
 import UIKit
 
@@ -332,82 +331,9 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func toggleAction() -> DOMElementStylePropertyView.ToggleAction? {
-        { [weak inspection] propertyID, enabled in
+        return { [weak inspection] propertyID, enabled in
             inspection?.dom.requestSetCSSProperty(propertyID, enabled: enabled) ?? false
         }
-    }
-}
-
-#Preview("DOM Element") {
-    DOMElementViewControllerPreview.makeViewController()
-}
-
-@MainActor
-private enum DOMElementViewControllerPreview {
-    static func makeViewController() -> UINavigationController {
-        let dom = DOMPreviewFixtures.makeDOMSession()
-        dom.applyTargetCreated(
-            ProtocolTargetRecord(
-                id: ProtocolTargetIdentifier("preview-page"),
-                kind: .page,
-                frameID: DOMFrameIdentifier("preview-frame"),
-                capabilities: .pageDefault
-            ),
-            makeCurrentMainPage: true
-        )
-        if let body = firstElement(named: "body", in: dom) {
-            dom.selectNode(body.id)
-        }
-
-        let css = dom.elementStyles
-        if case let .success(identity) = dom.selectedCSSNodeStyleIdentity(),
-           let token = css.beginRefresh(identity: identity) {
-            css.applyRefresh(
-                token: token,
-                matched: CSSMatchedStylesPayload(
-                    matchedRules: [
-                        CSSRuleMatchPayload(
-                            rule: CSSRulePayload(
-                                id: CSSRuleIdentifier(styleSheetID: CSSStyleSheetIdentifier("preview"), ordinal: 0),
-                                selectorList: CSSSelectorList(selectors: [CSSSelector(text: "body")], text: "body"),
-                                sourceURL: "preview.css",
-                                sourceLine: 1,
-                                origin: .author,
-                                style: CSSStylePayload(
-                                    id: CSSStyleIdentifier(styleSheetID: CSSStyleSheetIdentifier("preview"), ordinal: 0),
-                                    cssProperties: [
-                                        CSSPropertyPayload(name: "margin", value: "0", text: "margin: 0;", status: .active),
-                                        CSSPropertyPayload(name: "box-sizing", value: "border-box", text: "box-sizing: border-box;", status: .active),
-                                        CSSPropertyPayload(name: "font-size", value: "12px", text: "font-size: 12px;", status: .inactive),
-                                    ],
-                                    cssText: "margin: 0;\nbox-sizing: border-box;\nfont-size: 12px;"
-                                )
-                            ),
-                            matchingSelectors: [0]
-                        ),
-                    ]
-                ),
-                inline: CSSInlineStylesPayload(),
-                computed: []
-            )
-        }
-
-        let inspection = AttachedInspection(dom: dom)
-        return UINavigationController(rootViewController: DOMElementViewController(inspection: inspection))
-    }
-
-    private static func firstElement(named localName: String, in dom: DOMSession) -> DOMNode? {
-        guard let rootNode = dom.currentPageRootNode else {
-            return nil
-        }
-        var stack = [rootNode]
-        while let node = stack.popLast() {
-            if node.localName == localName {
-                return node
-            }
-            stack.append(contentsOf: dom.visibleDOMTreeChildren(of: node).reversed())
-        }
-        return nil
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -56,9 +56,6 @@ package final class DOMElementViewController: UICollectionViewController {
                 viewController.applyBackgroundFromTraits()
             }
         }
-        let selectedNodeStyles = inspection.dom.elementStyles.selectedNodeStyles
-        render(selectedNodeStyles)
-        observeSelectedNodeStyles(selectedNodeStyles)
         startObservingState()
     }
 
@@ -170,23 +167,29 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func startObservingState() {
-        observationScope.observe(inspection.dom.elementStyles) { [weak self] _, elementStyles in
-            self?.observeSelectedNodeStyles(elementStyles.selectedNodeStyles)
+        observationScope.observe(inspection.dom.elementStyles, tracking: { elementStyles in
+            _ = elementStyles.selectedNodeStyles
+        }) { [weak self] _, elementStyles in
+            self?.bindSelectedNodeStyles(
+                elementStyles.selectedNodeStyles,
+                unavailableState: elementStyles.selectedState
+            )
         }
     }
 
-    private func observeSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?) {
+    private func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?, unavailableState: CSSNodeStylesState) {
+        guard let nodeStyles else {
+            observedNodeStyles = nil
+            selectedNodeStyleObservationScope.cancelAll()
+            render(unavailableState)
+            return
+        }
+
         guard observedNodeStyles !== nodeStyles else {
             return
         }
         observedNodeStyles = nodeStyles
         selectedNodeStyleObservationScope.cancelAll()
-
-        guard let nodeStyles else {
-            render(nil)
-            return
-        }
-
         selectedNodeStyleObservationScope.observe(nodeStyles) { [weak self] _, nodeStyles in
             guard self?.observedNodeStyles === nodeStyles else {
                 return
@@ -195,17 +198,22 @@ package final class DOMElementViewController: UICollectionViewController {
         }
     }
 
-    private func render(_ nodeStyles: CSSNodeStyles?) {
-        guard let nodeStyles else {
-            displayedNodeStyles = nil
-            renderUnavailableStyles()
-            return
-        }
-
+    private func render(_ nodeStyles: CSSNodeStyles) {
         switch nodeStyles.state {
         case .loaded:
             displayedNodeStyles = nodeStyles
             renderStyles(nodeStyles)
+        case .loading, .needsRefresh:
+            renderPendingStyles()
+        case .unavailable, .failed:
+            render(nodeStyles.state)
+        }
+    }
+
+    private func render(_ state: CSSNodeStylesState) {
+        switch state {
+        case .loaded:
+            return
         case .loading, .needsRefresh:
             renderPendingStyles()
         case .unavailable, .failed:

--- a/Sources/WebInspectorUI/Docs/ViewControllerStructure.md
+++ b/Sources/WebInspectorUI/Docs/ViewControllerStructure.md
@@ -37,11 +37,11 @@ flowchart TD
     NetworkSplit["NetworkSplitViewController<br/>UISplitViewController"]
 
     CompactTree["DOMTreeViewController<br/>UIViewController"]
-    CompactElement["DOMElementViewController<br/>UIViewController"]
+    CompactElement["DOMElementViewController<br/>UICollectionViewController"]
     RegularTreeNavigation["RegularSplitColumnNavigationController<br/>UINavigationController"]
     RegularTree["DOMTreeViewController<br/>UIViewController"]
     RegularElementNavigation["RegularSplitColumnNavigationController<br/>UINavigationController"]
-    RegularElement["DOMElementViewController<br/>UIViewController"]
+    RegularElement["DOMElementViewController<br/>UICollectionViewController"]
 
     NetworkPrimaryNavigation["NetworkListColumnNavigationController<br/>UINavigationController"]
     NetworkSecondaryNavigation["RegularSplitColumnNavigationController<br/>UINavigationController"]

--- a/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
+++ b/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
@@ -28,7 +28,7 @@ enum NetworkPreviewFixtures {
         applyRequest(
             to: network,
             requestID: "1001",
-            url: "https://play.google.com/log?format=json&hasfast=true",
+            url: "https://telemetry.example/log",
             method: "POST",
             resourceType: .xhr,
             responseMimeType: "application/json",
@@ -40,7 +40,7 @@ enum NetworkPreviewFixtures {
         applyRequest(
             to: network,
             requestID: "1002",
-            url: "https://www.gstatic.com/images/icons/material/system/2x/trending_up_grey600_24dp.png",
+            url: "https://static.example/images/icons/trending-up.png",
             resourceType: .image,
             responseMimeType: "image/png",
             status: 200,
@@ -89,7 +89,7 @@ enum NetworkPreviewFixtures {
                 url: url,
                 method: method,
                 headers: method == "POST" ? ["content-type": "application/x-www-form-urlencoded"] : [:],
-                postData: method == "POST" ? "hl=ja&gl=JP&source=wi-preview" : nil
+                postData: method == "POST" ? "sample=true&source=wi-preview" : nil
             ),
             resourceType: resourceType,
             timestamp: timestamp,

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -1,3 +1,5 @@
+import Observation
+import Synchronization
 import Testing
 import WebInspectorTransport
 @testable import WebInspectorCore
@@ -98,7 +100,10 @@ func selectedNodeStylesResolvesSelectedDOMNodeThroughCSSSession() throws {
     session.selectNode(bodyID)
     let identity = try #require(session.selectedCSSNodeStyleIdentity().successValue)
 
-    #expect(session.selectedNodeStyles == nil)
+    let pendingStyles = try #require(session.selectedNodeStyles)
+    #expect(pendingStyles.identity == identity)
+    #expect(pendingStyles.state == .needsRefresh)
+    #expect(pendingStyles.sections.isEmpty)
 
     let token = try #require(css.beginRefresh(identity: identity))
     let loadingStyles = try #require(session.selectedNodeStyles)
@@ -1199,6 +1204,49 @@ func cssSessionCancelsActiveRefreshBackToNeedsRefresh() throws {
 
     #expect(css.selectedState == .needsRefresh)
     #expect(css.refreshState(forSelected: identity) == .needsRefresh)
+}
+
+@Test
+@MainActor
+func cssSessionRefreshDoesNotRepublishCurrentSelectedNodeStyles() throws {
+    let css = CSSSession()
+    let identity = cssIdentity()
+    css.selectNodeStyles(identity: identity)
+    let selectedStyles = try #require(css.selectedNodeStyles)
+
+    let selectedNodeStylesInvalidations = Mutex(0)
+    withObservationTracking {
+        _ = css.selectedNodeStyles
+    } onChange: {
+        selectedNodeStylesInvalidations.withLock { $0 += 1 }
+    }
+
+    let token = try #require(css.beginRefresh(identity: identity))
+
+    #expect(css.selectedNodeStyles === selectedStyles)
+    #expect(css.selectedState == .loading)
+    #expect(selectedNodeStylesInvalidations.withLock { $0 } == 0)
+
+    css.applyRefresh(
+        token: token,
+        matched: CSSMatchedStylesPayload(matchedRules: [
+            CSSRuleMatchPayload(
+                rule: rule(
+                    selector: "body",
+                    properties: [
+                        CSSPropertyPayload(name: "margin", value: "0", text: "margin: 0;"),
+                    ]
+                ),
+                matchingSelectors: [0]
+            ),
+        ]),
+        inline: .init(),
+        computed: []
+    )
+
+    #expect(css.selectedNodeStyles === selectedStyles)
+    #expect(css.selectedState == .loaded)
+    #expect(selectedNodeStylesInvalidations.withLock { $0 } == 0)
 }
 
 private func cssIdentity(

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -216,7 +216,7 @@ func cssRuleSourceLocationPrefersSelectorRangeOverSourceLine() throws {
             CSSRuleMatchPayload(
                 rule: rule(
                     selector: ".result-card",
-                    sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+                    sourceURL: "https://styles.example/assets/result-card.css",
                     sourceLine: 4,
                     selectorRange: CSSSourceRange(startLine: 27, startColumn: 22164, endLine: 27, endColumn: 22176),
                     properties: [
@@ -233,9 +233,9 @@ func cssRuleSourceLocationPrefersSelectorRangeOverSourceLine() throws {
     let section = try #require(css.selectedNodeStyles?.sections.first)
     let rule = try #require(section.rule)
     #expect(section.title == ".result-card")
-    #expect(rule.sourceURL == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87")
+    #expect(rule.sourceURL == "https://styles.example/assets/result-card.css")
     #expect(rule.sourceLocation == CSSRuleSourceLocation(
-        sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+        sourceURL: "https://styles.example/assets/result-card.css",
         line: 27,
         column: 22164
     ))

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -857,6 +857,58 @@ func setChildNodesUpdatesExistingNodeObjectForSameNodeID() throws {
 }
 
 @Test
+@MainActor
+func setChildNodesPrunesOmittedDescendantsWhenReusingChildNode() throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = DOMSession()
+
+    session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    let before = session.snapshot()
+    let bodyID = try #require(before.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(4))])
+
+    session.applySetChildNodes(
+        parent: bodyID,
+        children: [
+            .element(
+                nodeID: 5,
+                name: "div",
+                children: [
+                    .element(nodeID: 6, name: "span"),
+                    .element(nodeID: 7, name: "em"),
+                ]
+            ),
+        ]
+    )
+    let loaded = session.snapshot()
+    let divID = try #require(loaded.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(5))])
+    let spanID = try #require(loaded.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(6))])
+    let emID = try #require(loaded.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(7))])
+    let div = try #require(session.node(for: divID))
+
+    session.applySetChildNodes(
+        parent: bodyID,
+        children: [
+            DOMNodePayload(
+                nodeID: .init(5),
+                nodeType: .element,
+                nodeName: "div",
+                localName: "div",
+                regularChildren: .unrequested(count: 0)
+            ),
+        ]
+    )
+
+    let refreshed = session.snapshot()
+    #expect(session.node(for: divID) === div)
+    #expect(refreshed.nodesByID[spanID] == nil)
+    #expect(refreshed.nodesByID[emID] == nil)
+    #expect(refreshed.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(6))] == nil)
+    #expect(refreshed.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(7))] == nil)
+    #expect(refreshed.nodesByID[divID]?.regularChildren.loadedChildren.isEmpty == true)
+}
+
+@Test
 func childNodeInsertedUsesWebKitPreviousSiblingSemantics() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let session = await DOMSession()

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -828,6 +828,35 @@ func detachedRootCannotOverwriteConnectedPageDocumentNodes() async throws {
 }
 
 @Test
+@MainActor
+func setChildNodesUpdatesExistingNodeObjectForSameNodeID() throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = DOMSession()
+
+    session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
+    let before = session.snapshot()
+    let bodyID = try #require(before.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(4))])
+
+    session.applySetChildNodes(
+        parent: bodyID,
+        children: [.element(nodeID: 5, name: "div", attributes: [.init(name: "class", value: "before")])]
+    )
+    let childID = try #require(session.snapshot().currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(5))])
+    let child = try #require(session.node(for: childID))
+
+    session.applySetChildNodes(
+        parent: bodyID,
+        children: [.element(nodeID: 5, name: "span", attributes: [.init(name: "class", value: "after")])]
+    )
+
+    let updatedChild = try #require(session.node(for: childID))
+    #expect(updatedChild === child)
+    #expect(updatedChild.nodeName == "span")
+    #expect(updatedChild.attributes == [.init(name: "class", value: "after")])
+}
+
+@Test
 func childNodeInsertedUsesWebKitPreviousSiblingSemantics() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let session = await DOMSession()

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -567,11 +567,13 @@ func selectedNodeStylesTracksNewSelectionWhileElementStylesLoad() async throws {
     }
 
     dom.selectNode(inputID)
-    _ = try await waitUntil {
-        await session.attachment.dom.selectedNodeStyles == nil ? true : nil
-    }
-
     let inputIdentity = try #require(dom.selectedCSSNodeStyleIdentity().successValue)
+    _ = try await waitUntil {
+        await MainActor.run {
+            let styles = session.attachment.dom.selectedNodeStyles
+            return styles?.identity == inputIdentity && styles?.state == .needsRefresh ? true : nil
+        }
+    }
     let inputToken = try #require(css.beginRefresh(identity: inputIdentity))
     let loadingInputStyles = try #require(session.attachment.dom.selectedNodeStyles)
     #expect(loadingInputStyles.identity == inputIdentity)

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -104,25 +104,25 @@ struct DOMContainerTests {
     }
 
     @Test
-    func elementStyleHeaderConfigurationFormatsRuleOriginText() {
-        let googleLocation = CSSRuleSourceLocation(
-            sourceURL: "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87",
+    func elementStyleSectionHeaderTextFormatsRuleOriginText() {
+        let stylesheetLocation = CSSRuleSourceLocation(
+            sourceURL: "https://styles.example/assets/result-card.css",
             line: 27,
             column: 22164
         )
-        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(for: googleLocation) == "search:28:22165")
-        #expect(DOMElementStyleSectionHeaderConfiguration.fullDisplayText(for: googleLocation) == "https://www.google.com/search?q=%E5%9C%B0%E9%9C%87:28:22165")
+        #expect(DOMElementStyleSectionHeaderText.displayText(for: stylesheetLocation) == "result-card.css:28:22165")
+        #expect(DOMElementStyleSectionHeaderText.fullDisplayText(for: stylesheetLocation) == "https://styles.example/assets/result-card.css:28:22165")
 
-        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
+        #expect(DOMElementStyleSectionHeaderText.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 1)
         ) == "styles.css:2")
-        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
+        #expect(DOMElementStyleSectionHeaderText.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 80)
         ) == "styles.css:1")
-        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(
+        #expect(DOMElementStyleSectionHeaderText.displayText(
             for: CSSRuleSourceLocation(sourceURL: "styles.css", line: 0, column: 81)
         ) == "styles.css:1:82")
-        #expect(DOMElementStyleSectionHeaderConfiguration.displayText(for: .userAgent) == "User Agent Style Sheet")
+        #expect(DOMElementStyleSectionHeaderText.displayText(for: .userAgent) == "User Agent Style Sheet")
     }
 
     @Test
@@ -170,6 +170,52 @@ struct DOMContainerTests {
         #expect(didUpdateVisibleRow)
         #expect(viewController.collectionView.isHidden == false)
         #expect(visibleCellIDs(in: viewController) == cellIDsBeforeUpdate)
+    }
+
+    @Test
+    func elementViewControllerUpdatesVisibleSectionHeaderDuringSameNodeStyleRefresh() async throws {
+        let dom = makeDOMSession(capabilities: .pageDefault)
+        let body = try #require(firstElement(named: "body", in: dom))
+        dom.selectNode(body.id)
+
+        let css = dom.elementStyles
+        try applyBodyStyles(to: css, in: dom)
+
+        let viewController = makeElementViewController(dom: dom)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderHeader = await waitUntil {
+            styleSectionHeaderViews(in: viewController).first?.titleTextForTesting == "body"
+                && styleSectionHeaderViews(in: viewController).first?.originTextForTesting == "styles.css:2"
+        }
+        window.layoutIfNeeded()
+
+        #expect(didRenderHeader)
+        let headerBeforeUpdate = try #require(styleSectionHeaderViews(in: viewController).first)
+        let headerIDBeforeUpdate = ObjectIdentifier(headerBeforeUpdate)
+
+        let identity = try dom.selectedCSSNodeStyleIdentity().get()
+        let refreshToken = try #require(css.beginRefresh(identity: identity))
+        try applyBodyStyles(
+            to: css,
+            in: dom,
+            token: refreshToken,
+            selector: ".content",
+            sourceURL: "updated.css",
+            sourceLine: 5
+        )
+
+        let didUpdateHeader = await waitUntil {
+            guard let header = styleSectionHeaderViews(in: viewController).first else {
+                return false
+            }
+            return ObjectIdentifier(header) == headerIDBeforeUpdate
+                && header.titleTextForTesting == ".content"
+                && header.originTextForTesting == "updated.css:6"
+        }
+
+        #expect(didUpdateHeader)
     }
 
     @Test
@@ -900,6 +946,8 @@ struct DOMContainerTests {
         in dom: DOMSession,
         token: CSSStyleRefreshToken? = nil,
         selector: String = "body",
+        sourceURL: String = "styles.css",
+        sourceLine: Int = 1,
         marginValue: String = "0",
         marginText: String = "margin: 0;"
     ) throws -> BodyStyleIDs {
@@ -918,8 +966,8 @@ struct DOMContainerTests {
                                 selectors: [CSSSelector(text: selector)],
                                 text: selector
                             ),
-                            sourceURL: "styles.css",
-                            sourceLine: 1,
+                            sourceURL: sourceURL,
+                            sourceLine: sourceLine,
                             origin: .author,
                             style: CSSStylePayload(
                                 id: styleID,
@@ -1137,6 +1185,13 @@ struct DOMContainerTests {
     private func hiddenVariableCells(in viewController: DOMElementViewController) -> [DOMElementStyleHiddenVariablesCollectionCell] {
         viewController.collectionView.visibleCells
             .compactMap { $0 as? DOMElementStyleHiddenVariablesCollectionCell }
+    }
+
+    private func styleSectionHeaderViews(in viewController: DOMElementViewController) -> [DOMElementStyleSectionHeaderView] {
+        viewController.collectionView.visibleSupplementaryViews(
+            ofKind: UICollectionView.elementKindSectionHeader
+        )
+        .compactMap { $0 as? DOMElementStyleSectionHeaderView }
     }
 
     private func visibleCellIDs(in viewController: DOMElementViewController) -> [ObjectIdentifier] {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -9,16 +9,16 @@ import UIKit
 @Suite(.serialized)
 struct DOMContainerTests {
     @Test
-    func elementViewControllerLoadsEmptyContent() {
+    func elementViewControllerShowsUnavailableStateWithoutSelectedStyles() {
         let dom = makeDOMSession()
         let viewController = makeElementViewController(dom: dom)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
         #expect(viewController.view.backgroundColor == .systemBackground)
-        #expect(viewController.contentUnavailableConfiguration == nil)
-        #expect(viewController.collectionViewForTesting.isHidden == false)
-        #expect(viewController.collectionViewForTesting.numberOfSections == 0)
+        #expect(viewController.contentUnavailableConfiguration != nil)
+        #expect(viewController.collectionView.isHidden == false)
+        #expect(viewController.collectionView.numberOfSections == 0)
     }
 
     @Test
@@ -34,11 +34,11 @@ struct DOMContainerTests {
         viewController.loadViewIfNeeded()
 
         #expect(viewController.view.backgroundColor == .clear)
-        #expect(viewController.collectionViewForTesting.backgroundColor == .clear)
+        #expect(viewController.collectionView.backgroundColor == .clear)
     }
 
     @Test
-    func elementViewControllerShowsBlankCollectionWhenDocumentRootArrivesAfterViewLoad() async throws {
+    func elementViewControllerKeepsUnavailableStateWhenDocumentRootArrivesWithoutSelection() async throws {
         let targetID = ProtocolTargetIdentifier("page-main")
         let dom = DOMSession()
         dom.applyTargetCreated(
@@ -54,18 +54,18 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        #expect(viewController.contentUnavailableConfiguration == nil)
-        #expect(viewController.collectionViewForTesting.isHidden == false)
-        #expect(viewController.collectionViewForTesting.numberOfSections == 0)
+        #expect(viewController.contentUnavailableConfiguration != nil)
+        #expect(viewController.collectionView.isHidden == false)
+        #expect(viewController.collectionView.numberOfSections == 0)
 
         _ = dom.replaceDocumentRoot(documentNode(), targetID: targetID)
 
-        let didRenderCurrentRoot = await waitUntil {
-            viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+        let didKeepUnavailableState = await waitUntil {
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 0
         }
-        #expect(didRenderCurrentRoot)
+        #expect(didKeepUnavailableState)
     }
 
     @Test
@@ -82,14 +82,14 @@ struct DOMContainerTests {
         defer { window.isHidden = true }
 
         let didRenderRows = await waitUntil {
-            viewController.collectionViewForTesting.numberOfSections == 1
-                && viewController.collectionViewForTesting.numberOfItems(inSection: 0) == 3
+            viewController.collectionView.numberOfSections == 1
+                && viewController.collectionView.numberOfItems(inSection: 0) == 3
         }
         window.layoutIfNeeded()
 
         #expect(didRenderRows)
         #expect(viewController.contentUnavailableConfiguration == nil)
-        #expect(viewController.collectionViewForTesting.isHidden == false)
+        #expect(viewController.collectionView.isHidden == false)
 
         let propertyViews = stylePropertyViews(in: viewController)
         let declarations = propertyViews.map(\.declarationTextForTesting)
@@ -139,8 +139,8 @@ struct DOMContainerTests {
         defer { window.isHidden = true }
 
         let didRenderRows = await waitUntil {
-            viewController.collectionViewForTesting.numberOfSections == 1
-                && viewController.collectionViewForTesting.numberOfItems(inSection: 0) == 3
+            viewController.collectionView.numberOfSections == 1
+                && viewController.collectionView.numberOfItems(inSection: 0) == 3
         }
         window.layoutIfNeeded()
 
@@ -150,7 +150,7 @@ struct DOMContainerTests {
         let identity = try dom.selectedCSSNodeStyleIdentity().get()
         let refreshToken = try #require(css.beginRefresh(identity: identity))
         window.layoutIfNeeded()
-        #expect(viewController.collectionViewForTesting.isHidden == false)
+        #expect(viewController.collectionView.isHidden == false)
         #expect(visibleCellIDs(in: viewController) == cellIDsBeforeUpdate)
 
         try applyBodyStyles(
@@ -168,12 +168,12 @@ struct DOMContainerTests {
         }
 
         #expect(didUpdateVisibleRow)
-        #expect(viewController.collectionViewForTesting.isHidden == false)
+        #expect(viewController.collectionView.isHidden == false)
         #expect(visibleCellIDs(in: viewController) == cellIDsBeforeUpdate)
     }
 
     @Test
-    func elementViewControllerShowsBlankCollectionWhileNewSelectionStylesAreHydrating() async throws {
+    func elementViewControllerKeepsCurrentRowsWhileNewSelectionStylesAreHydrating() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let body = try #require(firstElement(named: "body", in: dom))
         dom.selectNode(body.id)
@@ -204,12 +204,15 @@ struct DOMContainerTests {
         #expect(css.selectedNodeStyles?.identity == inputIdentity)
         #expect(css.selectedState == .loading)
         #expect(css.refreshState(forSelected: inputIdentity) == .loading)
-        let didRenderBlankCollection = await waitUntil {
+        let didKeepBodyRowsWhileInputLoads = await waitUntil {
             viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 1
+                && stylePropertyViews(in: viewController)
+                    .map(\.declarationTextForTesting)
+                    .contains("margin: 0;")
         }
-        #expect(didRenderBlankCollection)
+        #expect(didKeepBodyRowsWhileInputLoads)
 
         try applyBodyStyles(
             to: css,
@@ -227,11 +230,11 @@ struct DOMContainerTests {
         }
 
         #expect(didRenderInputRows)
-        #expect(viewController.collectionViewForTesting.isHidden == false)
+        #expect(viewController.collectionView.isHidden == false)
     }
 
     @Test
-    func elementViewControllerShowsBlankCollectionForInitialElementSelectionWhileStylesHydrate() async throws {
+    func elementViewControllerShowsPlaceholderForInitialElementSelectionWhileStylesHydrate() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let css = dom.elementStyles
         let viewController = makeElementViewController(dom: dom)
@@ -243,13 +246,13 @@ struct DOMContainerTests {
         let identity = try dom.selectedCSSNodeStyleIdentity().get()
         #expect(css.beginRefresh(identity: identity) != nil)
 
-        let didRenderBlankCollection = await waitUntil {
-            viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+        let didRenderPlaceholder = await waitUntil {
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 0
         }
 
-        #expect(didRenderBlankCollection)
+        #expect(didRenderPlaceholder)
     }
 
     @Test
@@ -281,9 +284,9 @@ struct DOMContainerTests {
         dom.selectNode(nil)
 
         let didClearRows = await waitUntil {
-            viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 0
         }
 
         #expect(didClearRows)
@@ -312,9 +315,9 @@ struct DOMContainerTests {
         dom.applyNodeRemoved(body.id)
 
         let didClearRows = await waitUntil {
-            viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 0
         }
 
         #expect(didClearRows)
@@ -344,9 +347,9 @@ struct DOMContainerTests {
         css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(body.id))
 
         let didClearRows = await waitUntil {
-            viewController.contentUnavailableConfiguration == nil
-                && viewController.collectionViewForTesting.isHidden == false
-                && viewController.collectionViewForTesting.numberOfSections == 0
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.collectionView.isHidden == false
+                && viewController.collectionView.numberOfSections == 0
         }
 
         #expect(didClearRows)
@@ -366,8 +369,8 @@ struct DOMContainerTests {
         defer { window.isHidden = true }
 
         let didCollapseUnusedVariables = await waitUntil {
-            viewController.collectionViewForTesting.numberOfSections == 2
-                && viewController.collectionViewForTesting.numberOfItems(inSection: 1) == 3
+            viewController.collectionView.numberOfSections == 2
+                && viewController.collectionView.numberOfItems(inSection: 1) == 3
                 && hiddenVariableCells(in: viewController).count == 1
         }
         window.layoutIfNeeded()
@@ -387,7 +390,7 @@ struct DOMContainerTests {
 
         let didRevealUnusedVariables = await waitUntil {
             let declarations = stylePropertyViews(in: viewController).map(\.declarationTextForTesting)
-            return viewController.collectionViewForTesting.numberOfItems(inSection: 1) == 4
+            return viewController.collectionView.numberOfItems(inSection: 1) == 4
                 && hiddenVariableCells(in: viewController).isEmpty
                 && declarations.contains("--unused-a: red;")
                 && declarations.contains("--unused-b: blue;")
@@ -1127,17 +1130,17 @@ struct DOMContainerTests {
     }
 
     private func stylePropertyViews(in viewController: DOMElementViewController) -> [DOMElementStylePropertyView] {
-        viewController.collectionViewForTesting.visibleCells
+        viewController.collectionView.visibleCells
             .compactMap { ($0 as? DOMElementStylePropertyCollectionCell)?.propertyViewForTesting }
     }
 
     private func hiddenVariableCells(in viewController: DOMElementViewController) -> [DOMElementStyleHiddenVariablesCollectionCell] {
-        viewController.collectionViewForTesting.visibleCells
+        viewController.collectionView.visibleCells
             .compactMap { $0 as? DOMElementStyleHiddenVariablesCollectionCell }
     }
 
     private func visibleCellIDs(in viewController: DOMElementViewController) -> [ObjectIdentifier] {
-        viewController.collectionViewForTesting.visibleCells.map(ObjectIdentifier.init)
+        viewController.collectionView.visibleCells.map(ObjectIdentifier.init)
     }
 
     private func propertyView(

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "198cb2870c416b366c53a409efd24d57e3559fd6627ec1ae29bb1172dfb08ae0",
+  "originHash" : "0cce760e05c3819e343e8ec90fd0499fe97255ee4227cffe0d343cdfb45110ed",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "1ee629798da1913416216f2f7b46acf2723327e3",
-        "version" : "0.10.1"
+        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
+        "version" : "0.11.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2e7ff31516ae22d1cebd8580364e6e0acfc1c1ff",
-        "version" : "0.10.0"
+        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
+        "version" : "0.10.1"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Stabilize DOM element style rendering, CSS refresh behavior, and Xcode previews for the DOM element surface.

## Changes
- Update DOM/CSS model handling for stable selected-style refreshes and reused DOM node subtree pruning.
- Simplify DOM element style observation and section header binding.
- Move UIKit previews into dedicated preview files and add a preview transport mock for DOM element CSS toggles.
- Refresh SyntaxEditorUI and ObservationBridge pins across package resolution surfaces.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review --base main` clean, `findingCount: 0`
