### PR TITLE
Stabilize time-dependent test waits

### DIFF
--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -338,16 +338,12 @@ struct MonoclyLifecycleTests {
 
             #expect(mainSceneDelegate.window == nil)
             #expect(mainSceneDelegate.rootViewController == nil)
-            #expect(waitForCondition {
-                BrowserInspectorCoordinator.hasInspectorWindow(for: rootViewController.inspectorSession)
-            })
+            #expect(BrowserInspectorCoordinator.hasInspectorWindow(for: rootViewController.inspectorSession))
 
             inspectorSceneDelegate.disconnect(windowScene: windowScene)
             await rootViewController.waitForInspectorSessionTransitions()
 
-            #expect(waitForCondition {
-                BrowserInspectorCoordinator.hasInspectorWindow(for: rootViewController.inspectorSession) == false
-            })
+            #expect(BrowserInspectorCoordinator.hasInspectorWindow(for: rootViewController.inspectorSession) == false)
         }
     }
 
@@ -612,7 +608,9 @@ private extension MonoclyLifecycleTests {
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()
         context.retain(window)
-        drainMainQueue()
+        rootViewController.loadViewIfNeeded()
+        rootViewController.view.layoutIfNeeded()
+        window.layoutIfNeeded()
         return HostedRootFixture(windowScene: windowScene, rootViewController: rootViewController)
     }
 
@@ -622,21 +620,6 @@ private extension MonoclyLifecycleTests {
                 .compactMap { $0 as? UIWindowScene }
                 .first
         )
-    }
-
-    func drainMainQueue() {
-        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
-    }
-
-    func waitForCondition(timeout: TimeInterval = 2, condition: () -> Bool) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if condition() {
-                return true
-            }
-            drainMainQueue()
-        }
-        return condition()
     }
 
     func makeSavedStateFixture(

--- a/Sources/WebInspectorTransport/TransportBackend.swift
+++ b/Sources/WebInspectorTransport/TransportBackend.swift
@@ -18,9 +18,16 @@ package struct SentTargetMessage: Equatable, Sendable {
 }
 
 package actor FakeTransportBackend: TransportBackend {
+    private struct MessageWaiter: Sendable {
+        var id: UInt64
+        var ordinal: Int
+        var after: Int
+        var continuation: CheckedContinuation<String, Error>
+    }
+
     private struct TargetMessageWaiter: Sendable {
         var id: UInt64
-        var method: String
+        var method: String?
         var ordinal: Int
         var after: Int
         var continuation: CheckedContinuation<SentTargetMessage, Error>
@@ -29,6 +36,9 @@ package actor FakeTransportBackend: TransportBackend {
     private var messages: [String]
     private var sendError: (any Error)?
     private var detached: Bool
+    private var messageWaiters: [MessageWaiter]
+    private var nextMessageWaiterID: UInt64
+    private var cancelledMessageWaiterIDs: Set<UInt64>
     private var targetMessageWaiters: [TargetMessageWaiter]
     private var nextTargetMessageWaiterID: UInt64
     private var cancelledTargetMessageWaiterIDs: Set<UInt64>
@@ -36,6 +46,9 @@ package actor FakeTransportBackend: TransportBackend {
     package init() {
         messages = []
         detached = false
+        messageWaiters = []
+        nextMessageWaiterID = 0
+        cancelledMessageWaiterIDs = []
         targetMessageWaiters = []
         nextTargetMessageWaiterID = 0
         cancelledTargetMessageWaiterIDs = []
@@ -46,6 +59,7 @@ package actor FakeTransportBackend: TransportBackend {
             throw sendError
         }
         messages.append(message)
+        resumeMessageWaiters()
         resumeTargetMessageWaiters()
     }
 
@@ -65,7 +79,41 @@ package actor FakeTransportBackend: TransportBackend {
         messages.compactMap { Self.sentTargetMessage(from: $0) }
     }
 
+    package func waitForMessage(ordinal: Int = 0, after count: Int = 0) async throws -> String {
+        try Task.checkCancellation()
+        if let message = message(ordinal: ordinal, after: count) {
+            return message
+        }
+
+        nextMessageWaiterID &+= 1
+        let waiterID = nextMessageWaiterID
+        let message = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                registerMessageWaiter(
+                    id: waiterID,
+                    ordinal: ordinal,
+                    after: count,
+                    continuation: continuation
+                )
+            }
+        } onCancel: {
+            Task {
+                await self.cancelMessageWaiter(waiterID)
+            }
+        }
+        try Task.checkCancellation()
+        return message
+    }
+
+    package func waitForTargetMessage(ordinal: Int = 0, after count: Int = 0) async throws -> SentTargetMessage {
+        try await waitForTargetMessage(method: nil, ordinal: ordinal, after: count)
+    }
+
     package func waitForTargetMessage(method: String, ordinal: Int = 0, after count: Int = 0) async throws -> SentTargetMessage {
+        try await waitForTargetMessage(method: method as String?, ordinal: ordinal, after: count)
+    }
+
+    private func waitForTargetMessage(method: String?, ordinal: Int, after count: Int) async throws -> SentTargetMessage {
         try Task.checkCancellation()
         if let message = targetMessage(method: method, ordinal: ordinal, after: count) {
             return message
@@ -96,6 +144,20 @@ package actor FakeTransportBackend: TransportBackend {
         detached
     }
 
+    private func resumeMessageWaiters() {
+        var remainingWaiters: [MessageWaiter] = []
+        for waiter in messageWaiters {
+            if cancelledMessageWaiterIDs.remove(waiter.id) != nil {
+                waiter.continuation.resume(throwing: CancellationError())
+            } else if let message = message(ordinal: waiter.ordinal, after: waiter.after) {
+                waiter.continuation.resume(returning: message)
+            } else {
+                remainingWaiters.append(waiter)
+            }
+        }
+        messageWaiters = remainingWaiters
+    }
+
     private func resumeTargetMessageWaiters() {
         var remainingWaiters: [TargetMessageWaiter] = []
         for waiter in targetMessageWaiters {
@@ -110,9 +172,33 @@ package actor FakeTransportBackend: TransportBackend {
         targetMessageWaiters = remainingWaiters
     }
 
+    private func registerMessageWaiter(
+        id: UInt64,
+        ordinal: Int,
+        after count: Int,
+        continuation: CheckedContinuation<String, Error>
+    ) {
+        guard cancelledMessageWaiterIDs.remove(id) == nil else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        if let message = message(ordinal: ordinal, after: count) {
+            continuation.resume(returning: message)
+            return
+        }
+        messageWaiters.append(
+            MessageWaiter(
+                id: id,
+                ordinal: ordinal,
+                after: count,
+                continuation: continuation
+            )
+        )
+    }
+
     private func registerTargetMessageWaiter(
         id: UInt64,
-        method: String,
+        method: String?,
         ordinal: Int,
         after count: Int,
         continuation: CheckedContinuation<SentTargetMessage, Error>
@@ -136,6 +222,15 @@ package actor FakeTransportBackend: TransportBackend {
         )
     }
 
+    private func cancelMessageWaiter(_ id: UInt64) {
+        guard let index = messageWaiters.firstIndex(where: { $0.id == id }) else {
+            cancelledMessageWaiterIDs.insert(id)
+            return
+        }
+        let waiter = messageWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
     private func cancelTargetMessageWaiter(_ id: UInt64) {
         guard let index = targetMessageWaiters.firstIndex(where: { $0.id == id }) else {
             cancelledTargetMessageWaiterIDs.insert(id)
@@ -145,9 +240,20 @@ package actor FakeTransportBackend: TransportBackend {
         waiter.continuation.resume(throwing: CancellationError())
     }
 
-    private func targetMessage(method: String, ordinal: Int, after count: Int) -> SentTargetMessage? {
+    private func message(ordinal: Int, after count: Int) -> String? {
+        let matches = Array(messages.dropFirst(count))
+        guard matches.indices.contains(ordinal) else {
+            return nil
+        }
+        return matches[ordinal]
+    }
+
+    private func targetMessage(method: String?, ordinal: Int, after count: Int) -> SentTargetMessage? {
         let matches = sentTargetMessages().dropFirst(count).filter { sentMessage in
-            Self.messageMethod(from: sentMessage.message) == method
+            guard let method else {
+                return true
+            }
+            return Self.messageMethod(from: sentMessage.message) == method
         }
         guard matches.indices.contains(ordinal) else {
             return nil

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -24,6 +24,8 @@ package final class DOMElementViewController: UICollectionViewController {
 
 #if DEBUG
     package private(set) var lastSnapshotAnimatedForTesting = false
+    private var elementStylesObservationDelivery: ObservationDelivery?
+    private var selectedNodeStyleObservationDelivery: ObservationDelivery?
 #endif
 
     private lazy var dataSource = makeDataSource()
@@ -166,7 +168,7 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func startObservingState() {
-        observationScope.observe(inspection.dom.elementStyles, tracking: { elementStyles in
+        let delivery = observationScope.observe(inspection.dom.elementStyles, tracking: { elementStyles in
             _ = elementStyles.selectedNodeStyles
         }) { [weak self] _, elementStyles in
             self?.bindSelectedNodeStyles(
@@ -174,12 +176,18 @@ package final class DOMElementViewController: UICollectionViewController {
                 unavailableState: elementStyles.selectedState
             )
         }
+#if DEBUG
+        elementStylesObservationDelivery = delivery
+#endif
     }
 
     private func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?, unavailableState: CSSNodeStylesState) {
         guard let nodeStyles else {
             observedNodeStyles = nil
             selectedNodeStyleObservationScope.cancelAll()
+#if DEBUG
+            selectedNodeStyleObservationDelivery = nil
+#endif
             render(unavailableState)
             return
         }
@@ -189,12 +197,15 @@ package final class DOMElementViewController: UICollectionViewController {
         }
         observedNodeStyles = nodeStyles
         selectedNodeStyleObservationScope.cancelAll()
-        selectedNodeStyleObservationScope.observe(nodeStyles) { [weak self] _, nodeStyles in
+        let delivery = selectedNodeStyleObservationScope.observe(nodeStyles) { [weak self] _, nodeStyles in
             guard self?.observedNodeStyles === nodeStyles else {
                 return
             }
             self?.render(nodeStyles)
         }
+#if DEBUG
+        selectedNodeStyleObservationDelivery = delivery
+#endif
     }
 
     private func render(_ nodeStyles: CSSNodeStyles) {
@@ -335,5 +346,15 @@ package final class DOMElementViewController: UICollectionViewController {
             inspection?.dom.requestSetCSSProperty(propertyID, enabled: enabled) ?? false
         }
     }
+
+#if DEBUG
+    package var elementStylesObservationDeliveryForTesting: ObservationDelivery? {
+        elementStylesObservationDelivery
+    }
+
+    package var selectedNodeStyleObservationDeliveryForTesting: ObservationDelivery? {
+        selectedNodeStyleObservationDelivery
+    }
+#endif
 }
 #endif

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4922,9 +4922,27 @@ private func waitForBackendTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
     ordinal: Int,
-    after count: Int
+    after count: Int,
+    timeout: Duration = .seconds(5)
 ) async throws -> SentTargetMessage {
-    try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
+    try await withThrowingTaskGroup(of: SentTargetMessage.self) { group in
+        defer {
+            group.cancelAll()
+        }
+
+        group.addTask {
+            try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
+        }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw TransportError.replyTimeout(method: method, targetID: nil)
+        }
+
+        guard let message = try await group.next() else {
+            throw TransportError.replyTimeout(method: method, targetID: nil)
+        }
+        return message
+    }
 }
 
 private struct CSSRefreshMessages {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -120,7 +120,7 @@ func domainPumpsApplyNetworkEventsToNetworkSession() async throws {
         targetID: .pageMain,
         message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-1","frameId":"main-frame","request":{"url":"https://example.com/app.js"},"timestamp":1}}"#
     )
-    let request = try await waitUntil {
+    let request = try await awaitValueAfterActorTurns {
         await session.attachment.network.requestSnapshot(for: .init(targetID: .pageMain, requestID: .init("request-1")))
     }
 
@@ -141,7 +141,7 @@ func domainPumpsApplyConsoleEventsToConsoleSession() async throws {
         message: #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"warning","text":"hello","type":"log","networkRequestId":"request-1"}}}"#
     )
 
-    let snapshot: ConsoleSessionSnapshot = try await waitUntil {
+    let snapshot: ConsoleSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.console.snapshot()
         guard snapshot.orderedMessageIDs.isEmpty == false else {
             return nil
@@ -170,7 +170,7 @@ func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
         runtimeAgentTargetID: .pageMain,
         objectID: RuntimeRemoteObjectIdentifier("console-object")
     )
-    let _: Bool = try await waitUntil {
+    let _: Bool = try await awaitValueAfterActorTurns {
         let runtimeSnapshot = await session.attachment.runtime.snapshot()
         let consoleSnapshot = await session.attachment.console.snapshot()
         let linkedParameter = await MainActor.run {
@@ -194,7 +194,7 @@ func domainPumpsReleaseConsoleRuntimeObjectsOnConsoleClear() async throws {
         message: #"{"method":"Console.messagesCleared","params":{"reason":"console-api"}}"#
     )
 
-    let _: Bool = try await waitUntil {
+    let _: Bool = try await awaitValueAfterActorTurns {
         let runtimeSnapshot = await session.attachment.runtime.snapshot()
         let consoleSnapshot = await session.attachment.console.snapshot()
         guard runtimeSnapshot.remoteObjectsByID[objectKey] == nil,
@@ -217,7 +217,7 @@ func domainPumpsApplyRootScopedConsoleEventsToMainPageConsoleSession() async thr
         #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"error","text":"root hello","type":"log","networkRequestId":"request-root"}}}"#
     )
 
-    let snapshot: ConsoleSessionSnapshot = try await waitUntil {
+    let snapshot: ConsoleSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.console.snapshot()
         guard snapshot.orderedMessageIDs.isEmpty == false else {
             return nil
@@ -241,10 +241,10 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":81,"type":"normal","frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
     }
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
     }
 
@@ -253,7 +253,7 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextDestroyed","params":{"executionContextId":81}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         let runtimeContext = await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
         let domContext = await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 81)]
         return runtimeContext == nil && domContext == nil ? true : nil
@@ -264,7 +264,7 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":82,"type":"normal","frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
     }
     await receiveTargetDispatch(
@@ -272,7 +272,7 @@ func domainPumpsApplyRuntimeContextTeardownToRuntimeAndDOMSessions() async throw
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextsCleared","params":{}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         let runtimeContext = await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
         let domContext = await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 82)]
         return runtimeContext == nil && domContext == nil ? true : nil
@@ -289,7 +289,7 @@ func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime"],"isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     await receiveTargetDispatch(
@@ -298,14 +298,14 @@ func runtimeContextDispatchedOnPageResolvesToFrameTargetByFrameID() async throws
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":77,"frameId":"ad-frame"}}}"#
     )
 
-    let runtimeSnapshot: RuntimeStateSnapshot = try await waitUntil {
+    let runtimeSnapshot: RuntimeStateSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.runtime.snapshot()
         guard snapshot.executionContextsByKey[contextKey(.pageMain, 77)]?.targetID == .frameAd else {
             return nil
         }
         return snapshot
     }
-    let domSnapshot: DOMSessionSnapshot = try await waitUntil {
+    let domSnapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.executionContextsByKey[contextKey(.pageMain, 77)]?.targetID == .frameAd else {
             return nil
@@ -326,14 +326,14 @@ func rootRuntimeClearRemovesFrameContextOwnedByPageRuntimeAgent() async throws {
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["Runtime"],"isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     await transport.receiveRootMessage(
         #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":78,"frameId":"ad-frame"}}}"#
     )
 
-    let _: Bool = try await waitUntil {
+    let _: Bool = try await awaitValueAfterActorTurns {
         let runtimeContext = await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         let domContext = await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         guard runtimeContext?.targetID == .frameAd,
@@ -346,7 +346,7 @@ func rootRuntimeClearRemovesFrameContextOwnedByPageRuntimeAgent() async throws {
     }
 
     await transport.receiveRootMessage(#"{"method":"Runtime.executionContextsCleared","params":{}}"#)
-    let _: Bool = try await waitUntil {
+    let _: Bool = try await awaitValueAfterActorTurns {
         let runtimeContext = await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         let domContext = await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 78)]
         return runtimeContext == nil && domContext == nil ? true : nil
@@ -407,7 +407,7 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
         targetID: .pageMain,
         message: #"{"method":"Network.responseReceived","params":{"requestId":"request-2","timestamp":2,"type":"XHR","response":{"url":"https://example.com/api.json","status":200,"mimeType":"application/json","headers":{"content-type":"application/json"}}}}"#
     )
-    let request = try await waitUntil {
+    let request = try await awaitValueAfterActorTurns {
         await session.attachment.network.request(for: .init(targetID: .pageMain, requestID: .init("request-2")))
     }
     let responseBody = await request.responseBody
@@ -464,7 +464,7 @@ func networkResponseBodyFetchErrorDoesNotRetry() async throws {
         targetID: .pageMain,
         message: #"{"method":"Network.loadingFinished","params":{"requestId":"request-error","timestamp":3}}"#
     )
-    let request = try await waitUntil {
+    let request = try await awaitValueAfterActorTurns {
         await session.attachment.network.request(for: .init(targetID: .pageMain, requestID: .init("request-error")))
     }
     let responseBody = await request.responseBody
@@ -562,13 +562,13 @@ func selectedNodeStylesTracksNewSelectionWhileElementStylesLoad() async throws {
         marginValue: "0",
         marginText: "margin: 0;"
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNodeStyles === bodyStyles ? true : nil
     }
 
     dom.selectNode(inputID)
     let inputIdentity = try #require(dom.selectedCSSNodeStyleIdentity().successValue)
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await MainActor.run {
             let styles = session.attachment.dom.selectedNodeStyles
             return styles?.identity == inputIdentity && styles?.state == .needsRefresh ? true : nil
@@ -588,12 +588,12 @@ func selectedNodeStylesTracksNewSelectionWhileElementStylesLoad() async throws {
         marginValue: "8px",
         marginText: "margin: 8px;"
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNodeStyles === inputStyles ? true : nil
     }
 
     dom.selectNode(nil)
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNodeStyles == nil ? true : nil
     }
 }
@@ -619,7 +619,7 @@ func selectedElementStyleHydrationLoadsCSSSessionWhenActive() async throws {
         styleSheetID: "sheet-body"
     )
 
-    let didLoadStyles = try await waitUntil {
+    let didLoadStyles = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
     }
     #expect(didLoadStyles)
@@ -654,7 +654,7 @@ func selectedElementStyleHydrationCancellationDoesNotPublishFailure() async thro
         styleSheetID: "sheet-html"
     )
 
-    let didLoadReplacementStyles = try await waitUntil {
+    let didLoadReplacementStyles = try await awaitValueAfterActorTurns {
         let selectedNodeID = await session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID
         let selectedState = await session.attachment.dom.elementStyles.selectedState
         return selectedNodeID == htmlID && selectedState == .loaded ? true : nil
@@ -677,7 +677,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
     let firstSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
     _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .loading ? true : nil
     }
 
@@ -694,7 +694,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
         styleSheetID: "sheet-body"
     )
 
-    let didLoadStyles = try await waitUntil {
+    let didLoadStyles = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
     }
     #expect(didLoadStyles)
@@ -721,7 +721,7 @@ func selectedElementStyleHydrationClearsStylesAfterSelectionDisappears() async t
         selector: "body",
         styleSheetID: "sheet-body"
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
     }
 
@@ -730,10 +730,10 @@ func selectedElementStyleHydrationClearsStylesAfterSelectionDisappears() async t
         targetID: .pageMain,
         message: #"{"method":"DOM.childNodeRemoved","params":{"nodeId":4}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNodeID == nil ? true : nil
     }
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedNodeStyles == nil ? true : nil
     }
 
@@ -897,7 +897,7 @@ func cssPropertyToggleSendsSetStyleTextAndRefreshesStyles() async throws {
         marginStatus: "disabled",
         marginText: "/* margin: 0; */"
     )
-    _ = try await waitUntil { @MainActor in
+    _ = try await awaitValueAfterActorTurns { @MainActor in
         session.attachment.dom.elementStyles.selectedNodeStyles?.sections[1].style.cssProperties[0].isEnabled == false ? true : nil
     }
 
@@ -931,7 +931,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
     await transport.receiveRootMessage(
         #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-body"}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .needsRefresh ? true : nil
     }
 
@@ -949,7 +949,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         targetID: .pageMain,
         message: #"{"method":"DOM.attributeModified","params":{"nodeId":4,"name":"class","value":"featured"}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .needsRefresh ? true : nil
     }
 
@@ -967,7 +967,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         targetID: .pageMain,
         message: #"{"method":"DOM.attributeModified","params":{"nodeId":5,"name":"class","value":"child-only"}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .needsRefresh ? true : nil
     }
 
@@ -993,7 +993,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         targetID: .pageMain,
         message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"ASIDE","localName":"aside"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .needsRefresh ? true : nil
     }
 
@@ -1016,7 +1016,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         targetID: .pageMain,
         message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":4,"childNodeCount":3}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedState == .needsRefresh ? true : nil
     }
 }
@@ -1045,7 +1045,7 @@ func documentUpdatedClearsSelectedCSSNodeStylesForInvalidatedDocument() async th
         targetID: .pageMain,
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.elementStyles.selectedNodeStyles == nil ? true : nil
     }
     #expect(await session.attachment.dom.elementStyles.selectedNodeStyles == nil)
@@ -1110,7 +1110,7 @@ func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
         targetID: .pageMain,
         message: #"{"method":"DOM.childNodeRemoved","params":{"nodeId":4}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNodeID == nil ? true : nil
     }
 
@@ -1165,7 +1165,7 @@ func frameDocumentRefreshUpdatesOnlyFrameDocument() async throws {
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":["DOM"],"isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
 
@@ -1176,7 +1176,7 @@ func frameDocumentRefreshUpdatesOnlyFrameDocument() async throws {
         messageID: try messageID(sent.message),
         result: ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html"}]}}"##
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID
     }
 
@@ -1197,7 +1197,7 @@ func frameTargetWithoutDOMCapabilityDoesNotHydrateOnCreationOrDocumentUpdated() 
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","domains":[],"isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     await receiveTargetDispatch(
@@ -1221,7 +1221,7 @@ func frameTargetWithoutAdvertisedDomainsUsesWebKitFrameDefaultAndDoesNotHydrateO
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
 
@@ -1389,7 +1389,7 @@ func consoleEnableTargetNotFoundDoesNotMarkCommandUnsupported() async throws {
         message: "Target not found"
     )
 
-    let didPublishFailure = try await waitUntil {
+    let didPublishFailure = try await awaitValueAfterActorTurns {
         await session.lastError != nil ? true : nil
     }
     #expect(didPublishFailure)
@@ -1603,7 +1603,7 @@ func provisionalFrameDocumentReplyBeforeCommitRehydratesCommittedFrame() async t
         result: secondLazyFrameDocumentResult
     )
 
-    let snapshot: DOMSessionSnapshot = try await waitUntil {
+    let snapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.targetsByID[ProtocolTargetIdentifier.frameAd]?.currentDocumentID != nil else {
             return nil
@@ -1749,7 +1749,7 @@ func subframeCommitDoesNotRetargetPageRuntimeOrConsoleState() async throws {
         targetID: .pageMain,
         message: #"{"method":"Console.messageAdded","params":{"message":{"source":"console-api","level":"log","text":"page message","type":"log"}}}"#
     )
-    let _: Bool = try await waitUntil {
+    let _: Bool = try await awaitValueAfterActorTurns {
         let runtimeSnapshot = await session.attachment.runtime.snapshot()
         let consoleSnapshot = await session.attachment.console.snapshot()
         guard runtimeSnapshot.executionContextsByKey[contextKey(.pageMain, 7)]?.targetID == .pageMain,
@@ -1811,7 +1811,7 @@ func provisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydrating() asy
         messageID: try messageID(committedRequest.message),
         result: secondLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))]
     }
 
@@ -1868,7 +1868,7 @@ func oldlessProvisionalFrameCommitCancelsInFlightDocumentRequestBeforeRehydratin
         messageID: try messageID(committedRequest.message),
         result: secondLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))]
     }
 
@@ -1927,7 +1927,7 @@ func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
         messageID: try messageID(frameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    let finalSnapshot: DOMSessionSnapshot = try await waitUntil {
+    let finalSnapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.targetsByID[.frameAd]?.currentDocumentID != nil else {
             return nil
@@ -1951,7 +1951,7 @@ func pageDocumentUpdatedInvalidatesCurrentPageDocumentWithoutReloading() async t
         targetID: .pageMain,
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
-    let snapshot: DOMSessionSnapshot = try await waitUntil {
+    let snapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageDocumentID == nil else {
             return nil
@@ -1977,7 +1977,7 @@ func ensureDOMDocumentLoadedReloadsInvalidatedPageDocument() async throws {
         targetID: .pageMain,
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
-    let invalidatedSnapshot: DOMSessionSnapshot = try await waitUntil {
+    let invalidatedSnapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageDocumentID == nil else {
             return nil
@@ -2021,7 +2021,7 @@ func documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending() asyn
         targetID: .pageMain,
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
-    let _: DOMSessionSnapshot = try await waitUntil {
+    let _: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageDocumentID == nil else {
             return nil
@@ -2138,7 +2138,7 @@ func staleSetChildNodesAfterPageNavigationDoesNotMoveHeadChildrenIntoNewBody() a
         targetID: .pageMain,
         message: #"{"method":"DOM.setChildNodes","params":{"parentId":4,"nodes":[{"nodeId":8,"nodeType":1,"nodeName":"STYLE","localName":"style"}]}}"#
     )
-    let _: DOMSessionSnapshot = try await waitUntil {
+    let _: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageDocumentID == nil else {
             return nil
@@ -2205,7 +2205,7 @@ func rootScopedDocumentUpdatedInvalidatesCurrentPageDocument() async throws {
         messageID: try messageID(frameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
 
@@ -2234,7 +2234,7 @@ func rootScopedDocumentUpdatedInvalidatesCurrentPageDocument() async throws {
     let sentCountBeforeTargetlessUpdate = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
 
-    let afterUpdate: DOMSessionSnapshot = try await waitUntil {
+    let afterUpdate: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageDocumentID == nil else {
             return nil
@@ -2278,7 +2278,7 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
         messageID: try messageID(firstFrameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
 
@@ -2352,7 +2352,7 @@ func lazyIframeInsertionAndFrameDocumentUpdateKeepParentPageTree() async throws 
         result: secondLazyFrameDocumentResult
     )
 
-    let afterUpdate: DOMSessionSnapshot = try await waitUntil {
+    let afterUpdate: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard let currentDocumentID = snapshot.targetsByID[.frameAd]?.currentDocumentID,
               currentDocumentID != firstFrameDocumentID else {
@@ -2397,7 +2397,7 @@ func repeatedFrameDocumentUpdatedReissuesInFlightFrameReload() async throws {
         messageID: try messageID(initialFrameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]?.currentDocumentID
     }
 
@@ -2448,7 +2448,7 @@ func repeatedFrameDocumentUpdatedReissuesInFlightFrameReload() async throws {
         result: secondLazyFrameDocumentResult
     )
 
-    let snapshot: DOMSessionSnapshot = try await waitUntil {
+    let snapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(201))] != nil else {
             return nil
@@ -2556,7 +2556,7 @@ func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
 
@@ -2626,7 +2626,7 @@ func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
         messageID: try messageID(disable.message),
         result: "{}"
     )
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "CANVAS")
@@ -2756,7 +2756,7 @@ func linkNavigationBuffersProvisionalDOMEventsUntilCommit() async throws {
         documentResult: newDocumentWithHeadChildCountResult
     )
 
-    let snapshot: DOMSessionSnapshot = try await waitUntil {
+    let snapshot: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
         let snapshot = await session.attachment.dom.snapshot()
         guard snapshot.currentPageTargetID == .pageNext,
               snapshot.currentNodeIDByKey[.init(targetID: .pageNext, nodeID: .init(3))] != nil else {
@@ -2782,10 +2782,10 @@ func requestNodeWaitsForPathPushBeforeSelectingNode() async throws {
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     #expect(await session.attachment.runtime.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]?.targetID == .pageMain)
@@ -2935,7 +2935,7 @@ func detachedFrameSetChildNodesRootKeepsRequestNodeSelectable() async throws {
         messageID: try messageID(frameDocumentRequest.message),
         result: firstLazyFrameDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[ProtocolTargetIdentifier.frameAd]?.currentDocumentID
     }
 
@@ -2986,7 +2986,7 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     let intent = await session.attachment.dom.beginInspectSelectionRequest(
@@ -3032,7 +3032,7 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
         message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-path"]}]}}"#
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3097,7 +3097,7 @@ func targetDestroyedClearsActiveElementPicker() async throws {
     await transport.receiveRootMessage(
         #"{"method":"Target.targetDestroyed","params":{"targetId":"page-main"}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.isSelectingElement == false ? true : nil
     }
 }
@@ -3119,7 +3119,7 @@ func targetCommitClearsElementPickerForOldTarget() async throws {
         #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#
     )
 
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.isSelectingElement == false ? true : nil
     }
 
@@ -3205,7 +3205,7 @@ func elementPickerIgnoresInspectEventBeforeInspectModeReply() async throws {
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
 
@@ -3270,7 +3270,7 @@ func elementPickerIgnoresInspectEventBeforeInspectModeReply() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3288,7 +3288,7 @@ func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() asyn
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
 
@@ -3391,7 +3391,7 @@ func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() asyn
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3409,7 +3409,7 @@ func staleInspectEventCompletionDoesNotCancelRestartedPicker() async throws {
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
@@ -3489,7 +3489,7 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
@@ -3526,7 +3526,7 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3549,7 +3549,7 @@ func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
         targetID: .pageMain,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7,"frameId":"main-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.pageMain, 7)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
@@ -3586,7 +3586,7 @@ func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.attributes == [DOMAttribute(name: "id", value: "selected-after-path-push")])
@@ -3602,7 +3602,7 @@ func inspectorInspectRecordedExecutionContextOverridesEventTargetHint() async th
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     _ = await session.attachment.dom.replaceDocumentRoot(
@@ -3621,7 +3621,7 @@ func inspectorInspectRecordedExecutionContextOverridesEventTargetHint() async th
         targetID: .frameAd,
         message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":77,"frameId":"ad-frame"}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().executionContextsByKey[contextKey(.frameAd, 77)]
     }
     try await beginPicker(session: session, transport: transport, backend: backend)
@@ -3663,7 +3663,7 @@ func inspectorInspectRecordedExecutionContextOverridesEventTargetHint() async th
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3712,7 +3712,7 @@ func inspectorInspectOpaqueObjectIDFallsBackToPickerTarget() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3728,7 +3728,7 @@ func targetScopedInspectorInspectUsesEventTargetAsFallback() async throws {
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     _ = await session.attachment.dom.replaceDocumentRoot(
@@ -3781,7 +3781,7 @@ func targetScopedInspectorInspectUsesEventTargetAsFallback() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3797,7 +3797,7 @@ func targetScopedInspectorInspectFallsBackToEventTargetWhenContextIsUnrecorded()
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     _ = await session.attachment.dom.replaceDocumentRoot(
@@ -3851,7 +3851,7 @@ func targetScopedInspectorInspectFallsBackToEventTargetWhenContextIsUnrecorded()
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -3928,7 +3928,7 @@ func domInspectReloadsDocumentBeforeFailingUnknownProtocolNode() async throws {
         result: "{}"
     )
 
-    let selectedNode = try await waitUntil {
+    let selectedNode = try await awaitValueAfterActorTurns {
         await session.attachment.dom.selectedNode
     }
     #expect(await selectedNode.nodeName == "DIV")
@@ -4103,7 +4103,7 @@ func frameDOMNodeCopyDeleteRouteThroughPageTargetWithScopedNodeID() async throws
     await transport.receiveRootMessage(
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().targetsByID[.frameAd]
     }
     _ = await session.attachment.dom.replaceDocumentRoot(
@@ -4378,7 +4378,7 @@ func deleteUndoReloadCancellationClearsUndoHistory() async throws {
         message: #"{"method":"DOM.documentUpdated","params":{}}"#
     )
 
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await MainActor.run {
             undoManager.canRedo == false ? session.lastError : nil
         }
@@ -4508,7 +4508,7 @@ func deleteUndoKeepsOlderUndoStatesCurrentAfterReload() async throws {
         messageID: try messageID(documentAfterFirstUndo.message),
         result: nestedDocumentResult
     )
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(4))]
     }
 
@@ -4691,7 +4691,7 @@ func domActionAvailabilityWaitsForActiveAttachment() async throws {
         result: mainDocumentResult
     )
 
-    _ = try await waitUntil {
+    _ = try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().currentPageDocumentID != nil ? true : nil
     }
     #expect(await session.hasActiveConnection == false)
@@ -4894,15 +4894,13 @@ private func targetMessageMethods(_ backend: FakeTransportBackend) async -> [Str
 private func waitForTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
-    after count: Int = 0,
-    timeout: Duration = .seconds(5)
+    after count: Int = 0
 ) async throws -> SentTargetMessage {
     try await waitForBackendTargetMessage(
         backend,
         method: method,
         ordinal: 0,
-        after: count,
-        timeout: timeout
+        after: count
     )
 }
 
@@ -4910,15 +4908,13 @@ private func waitForTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
     ordinal: Int,
-    after count: Int = 0,
-    timeout: Duration = .seconds(5)
+    after count: Int = 0
 ) async throws -> SentTargetMessage {
     try await waitForBackendTargetMessage(
         backend,
         method: method,
         ordinal: ordinal,
-        after: count,
-        timeout: timeout
+        after: count
     )
 }
 
@@ -4926,25 +4922,9 @@ private func waitForBackendTargetMessage(
     _ backend: FakeTransportBackend,
     method: String,
     ordinal: Int,
-    after count: Int,
-    timeout: Duration
+    after count: Int
 ) async throws -> SentTargetMessage {
-    try await withThrowingTaskGroup(of: SentTargetMessage.self) { group in
-        defer { group.cancelAll() }
-
-        group.addTask {
-            try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
-        }
-        group.addTask {
-            try await Task.sleep(for: timeout)
-            throw TransportError.replyTimeout(method: method, targetID: nil)
-        }
-
-        guard let message = try await group.next() else {
-            throw TransportError.replyTimeout(method: method, targetID: nil)
-        }
-        return message
-    }
+    try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
 }
 
 private struct CSSRefreshMessages {
@@ -5050,19 +5030,17 @@ private func applySingleRuleStyles(
     return try #require(css.nodeStyles(for: identity))
 }
 
-private func waitUntil<Value: Sendable>(
-    timeout: Duration = .seconds(1),
-    timeoutError: any Error = TransportError.replyTimeout(method: "test wait", targetID: nil),
+private func awaitValueAfterActorTurns<Value: Sendable>(
+    maxTicks: Int = 256,
     _ body: @escaping @Sendable () async -> Value?
 ) async throws -> Value {
-    let deadline = ContinuousClock.now + timeout
-    while ContinuousClock.now < deadline {
+    for _ in 0..<maxTicks {
         if let value = await body() {
             return value
         }
-        try await Task.sleep(for: .milliseconds(5))
+        await Task.yield()
     }
-    throw timeoutError
+    throw TransportError.replyTimeout(method: "test wait", targetID: nil)
 }
 
 private func waitForCurrentNode(
@@ -5070,7 +5048,7 @@ private func waitForCurrentNode(
     targetID: ProtocolTargetIdentifier,
     protocolNodeID: DOMProtocolNodeID
 ) async throws -> DOMNodeIdentifier {
-    try await waitUntil {
+    try await awaitValueAfterActorTurns {
         await session.attachment.dom.snapshot().currentNodeIDByKey[
             .init(targetID: targetID, nodeID: protocolNodeID)
         ]

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -68,10 +68,7 @@ func domEnableIsTransportLocalWhileCSSEnableRoutesToTargetBackend() async throws
             ProtocolCommand(domain: .css, method: "CSS.enable", routing: .octopus(pageTarget: .init("page-main")))
         )
     }
-    let cssSent = try await waitUntil {
-        let messages = await backend.sentTargetMessages()
-        return messages.last
-    }
+    let cssSent = try await waitForTargetMessage(backend)
     await receiveTargetDispatch(
         session,
         targetID: .init("page-main"),
@@ -577,8 +574,8 @@ func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws
 
     let targetStream = await session.events(for: .target)
     let domStream = await session.events(for: .dom)
-    let targetTask = firstEvent(from: targetStream)
-    let domTask = firstEvent(from: domStream)
+    let targetEvents = ProtocolEventRecorder(stream: targetStream)
+    let domEvents = ProtocolEventRecorder(stream: domStream)
 
     await receiveTargetDispatch(
         session,
@@ -587,8 +584,8 @@ func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws
     )
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#)
 
-    let targetEvent = try #require(await targetTask.value)
-    let domEvent = try #require(await domTask.value)
+    let targetEvent = try #require(await targetEvents.event())
+    let domEvent = try #require(await domEvents.event())
 
     #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
     #expect(domEvent.method == "DOM.childNodeCountUpdated")
@@ -606,8 +603,8 @@ func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async thr
 
     let targetStream = await session.events(for: .target)
     let domStream = await session.events(for: .dom)
-    let targetTask = firstEvent(from: targetStream)
-    let domTask = firstEvent(from: domStream)
+    let targetEvents = ProtocolEventRecorder(stream: targetStream)
+    let domEvents = ProtocolEventRecorder(stream: domStream)
 
     await receiveTargetDispatch(
         session,
@@ -616,8 +613,8 @@ func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async thr
     )
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
 
-    let targetEvent = try #require(await targetTask.value)
-    let domEvent = try #require(await domTask.value)
+    let targetEvent = try #require(await targetEvents.event())
+    let domEvent = try #require(await domEvents.event())
 
     #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
     #expect(domEvent.method == "DOM.childNodeCountUpdated")
@@ -669,9 +666,9 @@ func rootScopedRuntimeDOMAndConsoleEventsResolveToCurrentPageTarget() async thro
     let runtimeStream = await session.events(for: .runtime)
     let domStream = await session.events(for: .dom)
     let consoleStream = await session.events(for: .console)
-    let runtimeTask = firstEvent(from: runtimeStream)
-    let domTask = firstEvent(from: domStream)
-    let consoleTask = firstEvent(from: consoleStream)
+    let runtimeEvents = ProtocolEventRecorder(stream: runtimeStream)
+    let domEvents = ProtocolEventRecorder(stream: domStream)
+    let consoleEvents = ProtocolEventRecorder(stream: consoleStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Runtime.executionContextCreated","params":{"context":{"id":11,"frameId":"main-frame"}}}"#)
@@ -680,9 +677,9 @@ func rootScopedRuntimeDOMAndConsoleEventsResolveToCurrentPageTarget() async thro
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByKey[contextKey("page-main", 11)]?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await runtimeTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await domTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await consoleTask.value?.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(await runtimeEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(await domEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(await consoleEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
 }
 
 @Test
@@ -690,12 +687,12 @@ func rootScopedDocumentUpdatedRemainsTargetless() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let domStream = await session.events(for: .dom)
-    let domTask = firstEvent(from: domStream)
+    let domEvents = ProtocolEventRecorder(stream: domStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
 
-    #expect(await domTask.value?.targetID == nil)
+    #expect(await domEvents.event()?.targetID == nil)
 }
 
 @Test
@@ -703,12 +700,12 @@ func rootScopedInspectorEventsRemainTargetless() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let inspectorStream = await session.events(for: .inspector)
-    let inspectorTask = firstEvent(from: inspectorStream)
+    let inspectorEvents = ProtocolEventRecorder(stream: inspectorStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"type":"object","subtype":"node","objectId":"node-1"}}}"#)
 
-    #expect(await inspectorTask.value?.targetID == nil)
+    #expect(await inspectorEvents.event()?.targetID == nil)
 }
 
 @Test
@@ -868,20 +865,20 @@ func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
     let consoleStream = await session.events(for: .console)
     let networkStream = await session.events(for: .network)
 
-    let domTask = firstEvent(from: domStream)
-    let cssTask = firstEvent(from: cssStream)
-    let consoleTask = firstEvent(from: consoleStream)
-    let networkTask = firstEvent(from: networkStream)
+    let domEvents = ProtocolEventRecorder(stream: domStream)
+    let cssEvents = ProtocolEventRecorder(stream: cssStream)
+    let consoleEvents = ProtocolEventRecorder(stream: consoleStream)
+    let networkEvents = ProtocolEventRecorder(stream: networkStream)
 
     await receiveTargetDispatch(session, targetID: .init("frame-A"), message: #"{"method":"DOM.setChildNodes","params":{"parentId":1,"nodes":[]}}"#)
     await receiveTargetDispatch(session, targetID: .init("frame-A"), message: #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"s1"}}"#)
     await receiveTargetDispatch(session, targetID: .init("frame-A"), message: #"{"method":"Console.messageAdded","params":{"message":{"text":"hello"}}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"r1","request":{"url":"https://example.com"},"timestamp":1}}"#)
 
-    #expect(await domTask.value?.method == "DOM.setChildNodes")
-    #expect(await cssTask.value?.method == "CSS.styleSheetChanged")
-    #expect(await consoleTask.value?.method == "Console.messageAdded")
-    #expect(await networkTask.value?.method == "Network.requestWillBeSent")
+    #expect(await domEvents.event()?.method == "DOM.setChildNodes")
+    #expect(await cssEvents.event()?.method == "CSS.styleSheetChanged")
+    #expect(await consoleEvents.event()?.method == "Console.messageAdded")
+    #expect(await networkEvents.event()?.method == "Network.requestWillBeSent")
 }
 
 @Test
@@ -889,7 +886,7 @@ func rootCSSStyleSheetEventsResolveFrameTargetFromFrameIDAndStyleSheetOwnership(
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let cssStream = await session.events(for: .css)
-    let eventsTask = firstEvents(4, from: cssStream)
+    let cssEvents = ProtocolEventRecorder(stream: cssStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","parentFrameId":"main-frame","isProvisional":false}}}"#)
@@ -898,7 +895,7 @@ func rootCSSStyleSheetEventsResolveFrameTargetFromFrameIDAndStyleSheetOwnership(
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetRemoved","params":{"styleSheetId":"sheet-frame"}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-frame"}}"#)
 
-    let events = await eventsTask.value
+    let events = await cssEvents.events(prefix: 4)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged", "CSS.styleSheetRemoved", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         ProtocolTargetIdentifier("frame-A"),
@@ -913,14 +910,14 @@ func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let cssStream = await session.events(for: .css)
-    let eventsTask = firstEvents(3, from: cssStream)
+    let cssEvents = ProtocolEventRecorder(stream: cssStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-late-frame","frameId":"late-frame"}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-late","type":"frame","frameId":"late-frame","parentFrameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-late-frame"}}"#)
 
-    let events = await eventsTask.value
+    let events = await cssEvents.events(prefix: 3)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         nil,
@@ -934,14 +931,14 @@ func rootCSSStyleSheetAddedBeforeProvisionalFrameTargetReplaysAfterCommit() asyn
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let cssStream = await session.events(for: .css)
-    let eventsTask = firstEvents(2, from: cssStream)
+    let cssEvents = ProtocolEventRecorder(stream: cssStream)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetAdded","params":{"header":{"styleSheetId":"sheet-provisional-frame","frameId":"ad-frame"}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
 
-    let events = await eventsTask.value
+    let events = await cssEvents.events(prefix: 2)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded"])
     #expect(events.map(\.targetID) == [
         nil,
@@ -954,21 +951,21 @@ func orderedStreamReceivesTargetEventsAcrossDomainsInTransportOrder() async thro
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend)
     let stream = await session.orderedEvents()
-    let eventsTask = firstEvents(4, from: stream)
+    let events = ProtocolEventRecorder(stream: stream)
 
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"DOM.documentUpdated","params":{}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"r1","request":{"url":"https://example.com"},"timestamp":1}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7}}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":2}}"#)
 
-    let events = await eventsTask.value
-    #expect(events.map(\.method) == [
+    let recordedEvents = await events.events(prefix: 4)
+    #expect(recordedEvents.map(\.method) == [
         "DOM.documentUpdated",
         "Network.requestWillBeSent",
         "Runtime.executionContextCreated",
         "DOM.childNodeCountUpdated",
     ])
-    #expect(events.map(\.sequence) == [1, 2, 3, 4])
+    #expect(recordedEvents.map(\.sequence) == [1, 2, 3, 4])
 }
 
 @Test
@@ -1693,79 +1690,93 @@ func domProtocolDispatchingDecodesOuterHTMLResultAndInspectEvents() throws {
     ))
 }
 
-private func firstEvent(
-    from stream: AsyncStream<ProtocolEventEnvelope>,
-    timeout: Duration = .seconds(1)
-) -> Task<ProtocolEventEnvelope?, Never> {
-    Task {
-        await withTaskGroup(of: ProtocolEventEnvelope?.self) { group in
-            group.addTask {
-                var iterator = stream.makeAsyncIterator()
-                return await iterator.next()
-            }
-            group.addTask {
-                try? await Task.sleep(for: timeout)
-                return nil
-            }
+private final class ProtocolEventRecorder: Sendable {
+    private let storage = ProtocolEventRecorderStorage()
+    private let task: Task<Void, Never>
 
-            let result = await group.next() ?? nil
-            group.cancelAll()
-            return result
+    init(stream: AsyncStream<ProtocolEventEnvelope>) {
+        let storage = self.storage
+        task = Task {
+            for await event in stream {
+                await storage.record(event)
+            }
+            await storage.finish()
         }
+    }
+
+    deinit {
+        task.cancel()
+    }
+
+    func event(at index: Int = 0) async -> ProtocolEventEnvelope? {
+        await storage.event(at: index)
+    }
+
+    func events(prefix count: Int) async -> [ProtocolEventEnvelope] {
+        await storage.events(prefix: count)
     }
 }
 
-private func firstEvents(
-    _ count: Int,
-    from stream: AsyncStream<ProtocolEventEnvelope>,
-    timeout: Duration = .seconds(1)
-) -> Task<[ProtocolEventEnvelope], Never> {
-    Task {
-        await withTaskGroup(of: [ProtocolEventEnvelope].self) { group in
-            group.addTask {
-                var iterator = stream.makeAsyncIterator()
-                var events: [ProtocolEventEnvelope] = []
-                while events.count < count {
-                    guard let event = await iterator.next() else {
-                        break
-                    }
-                    events.append(event)
-                }
-                return events
-            }
-            group.addTask {
-                try? await Task.sleep(for: timeout)
-                return []
-            }
+private actor ProtocolEventRecorderStorage {
+    private var events: [ProtocolEventEnvelope] = []
+    private var waiters: [Int: [CheckedContinuation<Bool, Never>]] = [:]
+    private var isFinished = false
 
-            let result = await group.next() ?? []
-            group.cancelAll()
-            return result
+    func record(_ event: ProtocolEventEnvelope) {
+        events.append(event)
+        resumeReadyWaiters()
+    }
+
+    func finish() {
+        isFinished = true
+        resumeReadyWaiters()
+    }
+
+    func event(at index: Int) async -> ProtocolEventEnvelope? {
+        guard await waitUntilCount(index + 1) else {
+            return nil
+        }
+        return events[index]
+    }
+
+    func events(prefix count: Int) async -> [ProtocolEventEnvelope] {
+        guard await waitUntilCount(count) else {
+            return events
+        }
+        return Array(events.prefix(count))
+    }
+
+    private func waitUntilCount(_ count: Int) async -> Bool {
+        if events.count >= count {
+            return true
+        }
+        if isFinished {
+            return false
+        }
+        return await withCheckedContinuation { continuation in
+            waiters[count, default: []].append(continuation)
+        }
+    }
+
+    private func resumeReadyWaiters() {
+        for (count, continuations) in waiters {
+            guard events.count >= count || isFinished else {
+                continue
+            }
+            waiters[count] = nil
+            for continuation in continuations {
+                continuation.resume(returning: events.count >= count)
+            }
         }
     }
 }
 
 private func waitForRootMessage(_ backend: FakeTransportBackend) async throws -> String {
-    try await waitUntil {
-        await backend.sentMessages().last
-    }
+    try await backend.waitForMessage()
 }
 
 private func waitForTargetMessage(_ backend: FakeTransportBackend) async throws -> SentTargetMessage {
-    try await waitUntil {
-        await backend.sentTargetMessages().last
-    }
-}
-
-private func waitUntil<Value: Sendable>(_ body: @escaping @Sendable () async -> Value?) async throws -> Value {
-    let deadline = ContinuousClock.now + .seconds(1)
-    while ContinuousClock.now < deadline {
-        if let value = await body() {
-            return value
-        }
-        try await Task.sleep(for: .milliseconds(5))
-    }
-    throw TransportError.replyTimeout(method: "test wait", targetID: nil)
+    try await backend.waitForTargetMessage()
 }
 
 private actor ManualResponseTimeout {

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -1708,18 +1708,25 @@ private final class ProtocolEventRecorder: Sendable {
         task.cancel()
     }
 
-    func event(at index: Int = 0) async -> ProtocolEventEnvelope? {
-        await storage.event(at: index)
+    func event(at index: Int = 0, timeout: Duration = .seconds(1)) async -> ProtocolEventEnvelope? {
+        await storage.event(at: index, timeout: timeout)
     }
 
-    func events(prefix count: Int) async -> [ProtocolEventEnvelope] {
-        await storage.events(prefix: count)
+    func events(prefix count: Int, timeout: Duration = .seconds(1)) async -> [ProtocolEventEnvelope] {
+        await storage.events(prefix: count, timeout: timeout)
     }
 }
 
 private actor ProtocolEventRecorderStorage {
+    private struct CountWaiter: Sendable {
+        var count: Int
+        var continuation: CheckedContinuation<Bool, Never>
+        var timeoutTask: Task<Void, Never>?
+    }
+
     private var events: [ProtocolEventEnvelope] = []
-    private var waiters: [Int: [CheckedContinuation<Bool, Never>]] = [:]
+    private var waiters: [UInt64: CountWaiter] = [:]
+    private var nextWaiterID: UInt64 = 0
     private var isFinished = false
 
     func record(_ event: ProtocolEventEnvelope) {
@@ -1732,51 +1739,135 @@ private actor ProtocolEventRecorderStorage {
         resumeReadyWaiters()
     }
 
-    func event(at index: Int) async -> ProtocolEventEnvelope? {
-        guard await waitUntilCount(index + 1) else {
+    func event(at index: Int, timeout: Duration) async -> ProtocolEventEnvelope? {
+        guard await waitUntilCount(index + 1, timeout: timeout) else {
             return nil
         }
         return events[index]
     }
 
-    func events(prefix count: Int) async -> [ProtocolEventEnvelope] {
-        guard await waitUntilCount(count) else {
+    func events(prefix count: Int, timeout: Duration) async -> [ProtocolEventEnvelope] {
+        guard await waitUntilCount(count, timeout: timeout) else {
             return events
         }
         return Array(events.prefix(count))
     }
 
-    private func waitUntilCount(_ count: Int) async -> Bool {
+    private func waitUntilCount(_ count: Int, timeout: Duration) async -> Bool {
         if events.count >= count {
             return true
         }
         if isFinished {
             return false
         }
-        return await withCheckedContinuation { continuation in
-            waiters[count, default: []].append(continuation)
+
+        nextWaiterID &+= 1
+        let waiterID = nextWaiterID
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                registerWaiter(
+                    id: waiterID,
+                    count: count,
+                    timeout: timeout,
+                    continuation: continuation
+                )
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(waiterID)
+            }
         }
+    }
+
+    private func registerWaiter(
+        id: UInt64,
+        count: Int,
+        timeout: Duration,
+        continuation: CheckedContinuation<Bool, Never>
+    ) {
+        if events.count >= count {
+            continuation.resume(returning: true)
+            return
+        }
+        if isFinished {
+            continuation.resume(returning: false)
+            return
+        }
+
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            timeoutWaiter(id)
+        }
+        waiters[id] = CountWaiter(
+            count: count,
+            continuation: continuation,
+            timeoutTask: timeoutTask
+        )
     }
 
     private func resumeReadyWaiters() {
-        for (count, continuations) in waiters {
-            guard events.count >= count || isFinished else {
+        let readyWaiterIDs = waiters.compactMap { id, waiter in
+            events.count >= waiter.count || isFinished ? id : nil
+        }
+        for waiterID in readyWaiterIDs {
+            guard let waiter = waiters[waiterID] else {
                 continue
             }
-            waiters[count] = nil
-            for continuation in continuations {
-                continuation.resume(returning: events.count >= count)
-            }
+            resolveWaiter(waiterID, returning: events.count >= waiter.count)
         }
+    }
+
+    private func timeoutWaiter(_ id: UInt64) {
+        resolveWaiter(id, returning: false)
+    }
+
+    private func cancelWaiter(_ id: UInt64) {
+        resolveWaiter(id, returning: false)
+    }
+
+    private func resolveWaiter(_ id: UInt64, returning value: Bool) {
+        guard let waiter = waiters.removeValue(forKey: id) else {
+            return
+        }
+        waiter.timeoutTask?.cancel()
+        waiter.continuation.resume(returning: value)
     }
 }
 
-private func waitForRootMessage(_ backend: FakeTransportBackend) async throws -> String {
-    try await backend.waitForMessage()
+private func waitForRootMessage(_ backend: FakeTransportBackend, timeout: Duration = .seconds(1)) async throws -> String {
+    try await waitForBackendValue(timeout: timeout) {
+        try await backend.waitForMessage()
+    }
 }
 
-private func waitForTargetMessage(_ backend: FakeTransportBackend) async throws -> SentTargetMessage {
-    try await backend.waitForTargetMessage()
+private func waitForTargetMessage(_ backend: FakeTransportBackend, timeout: Duration = .seconds(1)) async throws -> SentTargetMessage {
+    try await waitForBackendValue(timeout: timeout) {
+        try await backend.waitForTargetMessage()
+    }
+}
+
+private func waitForBackendValue<Value: Sendable>(
+    timeout: Duration,
+    _ operation: @escaping @Sendable () async throws -> Value
+) async throws -> Value {
+    try await withThrowingTaskGroup(of: Value.self) { group in
+        defer {
+            group.cancelAll()
+        }
+
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw TransportError.replyTimeout(method: "test wait", targetID: nil)
+        }
+
+        guard let value = try await group.next() else {
+            throw TransportError.replyTimeout(method: "test wait", targetID: nil)
+        }
+        return value
+    }
 }
 
 private actor ManualResponseTimeout {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import ObservationBridge
 import Testing
 import WebInspectorTransport
 import UIKit
@@ -60,7 +61,7 @@ struct DOMContainerTests {
 
         _ = dom.replaceDocumentRoot(documentNode(), targetID: targetID)
 
-        let didKeepUnavailableState = await waitUntil {
+        let didKeepUnavailableState = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
@@ -81,7 +82,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderRows = await waitUntil {
+        let didRenderRows = await waitUntilRendered(in: viewController) {
             viewController.collectionView.numberOfSections == 1
                 && viewController.collectionView.numberOfItems(inSection: 0) == 3
         }
@@ -138,7 +139,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderRows = await waitUntil {
+        let didRenderRows = await waitUntilRendered(in: viewController) {
             viewController.collectionView.numberOfSections == 1
                 && viewController.collectionView.numberOfItems(inSection: 0) == 3
         }
@@ -161,7 +162,7 @@ struct DOMContainerTests {
             marginText: "margin: 4px;"
         )
 
-        let didUpdateVisibleRow = await waitUntil {
+        let didUpdateVisibleRow = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 4px;")
@@ -185,7 +186,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderHeader = await waitUntil {
+        let didRenderHeader = await waitUntilRendered(in: viewController) {
             styleSectionHeaderViews(in: viewController).first?.titleTextForTesting == "body"
                 && styleSectionHeaderViews(in: viewController).first?.originTextForTesting == "styles.css:2"
         }
@@ -206,7 +207,7 @@ struct DOMContainerTests {
             sourceLine: 5
         )
 
-        let didUpdateHeader = await waitUntil {
+        let didUpdateHeader = await waitUntilRendered(in: viewController) {
             guard let header = styleSectionHeaderViews(in: viewController).first else {
                 return false
             }
@@ -231,7 +232,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderBodyRows = await waitUntil {
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 0;")
@@ -250,7 +251,7 @@ struct DOMContainerTests {
         #expect(css.selectedNodeStyles?.identity == inputIdentity)
         #expect(css.selectedState == .loading)
         #expect(css.refreshState(forSelected: inputIdentity) == .loading)
-        let didKeepBodyRowsWhileInputLoads = await waitUntil {
+        let didKeepBodyRowsWhileInputLoads = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration == nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 1
@@ -269,7 +270,7 @@ struct DOMContainerTests {
             marginText: "margin: 8px;"
         )
 
-        let didRenderInputRows = await waitUntil {
+        let didRenderInputRows = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 8px;")
@@ -292,7 +293,7 @@ struct DOMContainerTests {
         let identity = try dom.selectedCSSNodeStyleIdentity().get()
         #expect(css.beginRefresh(identity: identity) != nil)
 
-        let didRenderPlaceholder = await waitUntil {
+        let didRenderPlaceholder = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
@@ -314,7 +315,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderBodyRows = await waitUntil {
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 0;")
@@ -329,7 +330,7 @@ struct DOMContainerTests {
 
         dom.selectNode(nil)
 
-        let didClearRows = await waitUntil {
+        let didClearRows = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
@@ -351,7 +352,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderBodyRows = await waitUntil {
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 0;")
@@ -360,7 +361,7 @@ struct DOMContainerTests {
 
         dom.applyNodeRemoved(body.id)
 
-        let didClearRows = await waitUntil {
+        let didClearRows = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
@@ -382,7 +383,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderBodyRows = await waitUntil {
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
             stylePropertyViews(in: viewController)
                 .map(\.declarationTextForTesting)
                 .contains("margin: 0;")
@@ -392,7 +393,7 @@ struct DOMContainerTests {
         let identity = try dom.selectedCSSNodeStyleIdentity().get()
         css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(body.id))
 
-        let didClearRows = await waitUntil {
+        let didClearRows = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
@@ -414,7 +415,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             viewController.collectionView.numberOfSections == 2
                 && viewController.collectionView.numberOfItems(inSection: 1) == 3
                 && hiddenVariableCells(in: viewController).count == 1
@@ -434,7 +435,7 @@ struct DOMContainerTests {
 
         revealCell.tapRevealForTesting()
 
-        let didRevealUnusedVariables = await waitUntil {
+        let didRevealUnusedVariables = await waitUntilRendered(in: viewController) {
             let declarations = stylePropertyViews(in: viewController).map(\.declarationTextForTesting)
             return viewController.collectionView.numberOfItems(inSection: 1) == 4
                 && hiddenVariableCells(in: viewController).isEmpty
@@ -476,7 +477,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         window.layoutIfNeeded()
@@ -511,7 +512,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         window.layoutIfNeeded()
@@ -539,7 +540,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseOnlyUnusedVariables = await waitUntil {
+        let didCollapseOnlyUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         window.layoutIfNeeded()
@@ -577,7 +578,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         window.layoutIfNeeded()
@@ -611,7 +612,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         window.layoutIfNeeded()
@@ -651,7 +652,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseOnlyUnusedVariable = await waitUntil {
+        let didCollapseOnlyUnusedVariable = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 1 unused CSS variable"
         }
         window.layoutIfNeeded()
@@ -675,7 +676,7 @@ struct DOMContainerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didCollapseUnusedVariables = await waitUntil {
+        let didCollapseUnusedVariables = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 2 unused CSS variables"
         }
         #expect(didCollapseUnusedVariables)
@@ -693,7 +694,7 @@ struct DOMContainerTests {
             ]
         )
 
-        let didUpdateHiddenVariableCount = await waitUntil {
+        let didUpdateHiddenVariableCount = await waitUntilRendered(in: viewController) {
             hiddenVariableCells(in: viewController).first?.revealTitleForTesting == "Show 3 unused CSS variables"
         }
         #expect(didUpdateHiddenVariableCount)
@@ -1207,19 +1208,21 @@ struct DOMContainerTests {
         }
     }
 
-    private func waitUntil(
-        timeoutNanoseconds: UInt64 = 1_000_000_000,
-        condition: @escaping @MainActor () -> Bool
+    private func waitUntilRendered(
+        in viewController: DOMElementViewController,
+        condition: @escaping @MainActor @Sendable () -> Bool
     ) async -> Bool {
-        let interval: UInt64 = 10_000_000
-        let attempts = Int(timeoutNanoseconds / interval)
-        for _ in 0..<attempts {
-            if condition() {
-                return true
-            }
-            try? await Task.sleep(nanoseconds: interval)
+        guard let delivery = viewController.selectedNodeStyleObservationDeliveryForTesting
+            ?? viewController.elementStylesObservationDeliveryForTesting else {
+            viewController.collectionView.layoutIfNeeded()
+            return condition()
         }
-        return condition()
+        let renderedValues = await delivery.values {
+            viewController.collectionView.layoutIfNeeded()
+            viewController.view.layoutIfNeeded()
+            return condition()
+        }
+        return await renderedValues.waitUntil { $0 } != nil
     }
 
     private func action(titled title: String, in menu: UIMenu) -> UIAction? {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -1212,17 +1212,42 @@ struct DOMContainerTests {
         in viewController: DOMElementViewController,
         condition: @escaping @MainActor @Sendable () -> Bool
     ) async -> Bool {
-        guard let delivery = viewController.selectedNodeStyleObservationDeliveryForTesting
-            ?? viewController.elementStylesObservationDeliveryForTesting else {
-            viewController.collectionView.layoutIfNeeded()
-            return condition()
+        if sampleRenderedCondition(in: viewController, condition: condition) {
+            return true
         }
-        let renderedValues = await delivery.values {
-            viewController.collectionView.layoutIfNeeded()
-            viewController.view.layoutIfNeeded()
-            return condition()
+
+        let deliveries = [
+            viewController.selectedNodeStyleObservationDeliveryForTesting,
+            viewController.elementStylesObservationDeliveryForTesting,
+        ].compactMap { $0 }
+        guard deliveries.isEmpty == false else {
+            return sampleRenderedCondition(in: viewController, condition: condition)
         }
-        return await renderedValues.waitUntil { $0 } != nil
+
+        var renderedValues: [ObservedValues<Bool>] = []
+        for delivery in deliveries {
+            renderedValues.append(
+                await delivery.values {
+                    sampleRenderedCondition(in: viewController, condition: condition)
+                }
+            )
+        }
+        for _ in 0..<256 {
+            if renderedValues.contains(where: { $0.latestValue == true }) {
+                return true
+            }
+            await Task.yield()
+        }
+        return sampleRenderedCondition(in: viewController, condition: condition)
+    }
+
+    private func sampleRenderedCondition(
+        in viewController: DOMElementViewController,
+        condition: @MainActor @Sendable () -> Bool
+    ) -> Bool {
+        viewController.collectionView.layoutIfNeeded()
+        viewController.view.layoutIfNeeded()
+        return condition()
     }
 
     private func action(titled title: String, in menu: UIMenu) -> UIAction? {

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -396,12 +396,13 @@ struct NetworkDetailViewControllerTests {
             navigationController.viewControllers.last === detailViewController
         }
         #expect(didPush)
+        await waitForNavigationTransitionToFinish(in: navigationController)
 
-        let didPop = await withUIKitAnimationsDisabled {
+        withUIKitAnimationsDisabled {
             model.selectRequest(nil)
-            return await waitUntil {
-                navigationController.viewControllers == [listViewController]
-            }
+        }
+        let didPop = await waitUntil {
+            navigationController.viewControllers == [listViewController]
         }
         #expect(didPop)
     }
@@ -426,14 +427,16 @@ struct NetworkDetailViewControllerTests {
             navigationController.viewControllers.last === detailViewController
         }
         #expect(didPush)
+        await waitForNavigationTransitionToFinish(in: navigationController)
 
-        let didPop = await withUIKitAnimationsDisabled {
+        withUIKitAnimationsDisabled {
             network.reset()
-            #expect(model.selectedRequestID == request.id)
-            #expect(model.selectedRequest == nil)
-            return await waitUntil {
-                navigationController.viewControllers == [listViewController]
-            }
+        }
+        #expect(model.selectedRequestID == request.id)
+        #expect(model.selectedRequest == nil)
+
+        let didPop = await waitUntil {
+            navigationController.viewControllers == [listViewController]
         }
         #expect(didPop)
     }
@@ -574,11 +577,25 @@ struct NetworkDetailViewControllerTests {
         return false
     }
 
-    private func withUIKitAnimationsDisabled<T>(_ body: () async -> T) async -> T {
+    private func waitForNavigationTransitionToFinish(in navigationController: UINavigationController) async {
+        guard let transitionCoordinator = navigationController.transitionCoordinator else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            let didRegister = transitionCoordinator.animate(alongsideTransition: nil) { _ in
+                continuation.resume()
+            }
+            if didRegister == false {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func withUIKitAnimationsDisabled<T>(_ body: () -> T) -> T {
         let wereAnimationsEnabled = UIView.areAnimationsEnabled
         UIView.setAnimationsEnabled(false)
         defer { UIView.setAnimationsEnabled(wereAnimationsEnabled) }
-        return await body()
+        return body()
     }
 }
 #endif

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -397,9 +397,11 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didPush)
 
-        model.selectRequest(nil)
-        let didPop = await waitUntilAllowingAnimations {
-            navigationController.viewControllers == [listViewController]
+        let didPop = await withUIKitAnimationsDisabled {
+            model.selectRequest(nil)
+            return await waitUntil {
+                navigationController.viewControllers == [listViewController]
+            }
         }
         #expect(didPop)
     }
@@ -425,12 +427,13 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didPush)
 
-        network.reset()
-        #expect(model.selectedRequestID == request.id)
-        #expect(model.selectedRequest == nil)
-
-        let didPop = await waitUntilAllowingAnimations {
-            navigationController.viewControllers == [listViewController]
+        let didPop = await withUIKitAnimationsDisabled {
+            network.reset()
+            #expect(model.selectedRequestID == request.id)
+            #expect(model.selectedRequest == nil)
+            return await waitUntil {
+                navigationController.viewControllers == [listViewController]
+            }
         }
         #expect(didPop)
     }
@@ -571,18 +574,11 @@ struct NetworkDetailViewControllerTests {
         return false
     }
 
-    private func waitUntilAllowingAnimations(
-        maxTicks: Int = 256,
-        _ condition: @MainActor () -> Bool
-    ) async -> Bool {
-        for _ in 0..<maxTicks {
-            if condition() {
-                return true
-            }
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-        return false
+    private func withUIKitAnimationsDisabled<T>(_ body: () async -> T) async -> T {
+        let wereAnimationsEnabled = UIView.areAnimationsEnabled
+        UIView.setAnimationsEnabled(false)
+        defer { UIView.setAnimationsEnabled(wereAnimationsEnabled) }
+        return await body()
     }
 }
 #endif


### PR DESCRIPTION
## Purpose
Stabilize WebInspectorKit tests that depended on short sleeps, wall-clock polling, or animation delays.

## Changes
- Add deterministic raw-message wait support to `FakeTransportBackend` and use it from transport tests.
- Replace transport event sleep races with a local protocol event recorder plus bounded failure guards.
- Remove wall-clock polling from inspector session helpers while keeping bounded failure guards for missing backend messages.
- Expose DEBUG-only `ObservationDelivery` hooks for DOM style rendering tests and wait on rendered state after production observation delivery.
- Replace UIKit animation sleep waits with transition-coordinator synchronization plus scoped disabled animations, and remove Monocly run-loop/date polling.

## Testing
- `swift test --filter WebInspectorTransportTests`
- `swift test --filter InspectorSessionTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMContainerTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/NetworkDetailViewControllerTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `rg -n "Task\\.sleep|ContinuousClock|Date\\(|RunLoop\\.main\\.run|timeoutNanoseconds|waitUntilAllowingAnimations" Tests Monocly/MonoclyTests --glob '*.swift'`
- `git diff --check`
- `codex-review --base refs/codex/pr-fix-base/140/957b77e409ac6aaee88f6c71c3f5bea6629ddb26`