### PR TITLE
Keep DOM element picker available after navigation

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -124,6 +124,10 @@ extension DOMSession {
         hasActiveCommandChannel && currentPageTargetID != nil
     }
 
+    package var canBeginElementPicker: Bool {
+        hasActiveCommandChannel && currentPageTargetID != nil
+    }
+
     package var canSelectElement: Bool {
         hasActiveCommandChannel && currentPageRootNode != nil
     }

--- a/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
+++ b/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
@@ -154,7 +154,7 @@ package final class DOMNavigationItems: NSObject {
 
     private func renderPickItem() {
         let dom = inspector.attachment.dom
-        let isEnabled = dom.canSelectElement
+        let isEnabled = dom.canBeginElementPicker
         if pickItem.isEnabled != isEnabled {
             pickItem.isEnabled = isEnabled
         }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2079,6 +2079,70 @@ func documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending() asyn
     #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(50))] == nil)
 }
 
+@Test("Regression: element picker begins after page documentUpdated invalidates loaded document")
+func elementPickerBeginsAfterDocumentUpdatedInvalidatesLoadedDocument() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+    let _: DOMSessionSnapshot = try await awaitValueAfterActorTurns {
+        let snapshot = await session.attachment.dom.snapshot()
+        guard snapshot.currentPageDocumentID == nil else {
+            return nil
+        }
+        return snapshot
+    }
+    #expect(await session.attachment.dom.canSelectElement == false)
+    #expect(await session.attachment.dom.canBeginElementPicker)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let beginTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let documentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCount
+    )
+    #expect(documentRequest.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(
+        await backend.sentTargetMessages().dropFirst(sentCount).compactMap { try? messageMethod($0.message) } == [
+            "DOM.getDocument",
+        ]
+    )
+
+    let afterDocumentRequest = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: documentRequest.targetIdentifier,
+        messageID: try messageID(documentRequest.message),
+        result: manualReloadDocumentResult
+    )
+
+    let enableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: afterDocumentRequest
+    )
+    #expect(enableMessage.targetIdentifier == ProtocolTargetIdentifier.pageMain)
+    #expect(try boolParameter("enabled", in: enableMessage.message) == true)
+    await receiveTargetReply(
+        transport,
+        targetID: enableMessage.targetIdentifier,
+        messageID: try messageID(enableMessage.message),
+        result: "{}"
+    )
+
+    try await beginTask.value
+    #expect(await session.attachment.dom.isSelectingElement)
+}
+
 @Test("Regression: stale setChildNodes from previous page does not move head children into new body")
 func staleSetChildNodesAfterPageNavigationDoesNotMoveHeadChildrenIntoNewBody() async throws {
     let backend = FakeTransportBackend()


### PR DESCRIPTION
## Purpose
Fix the compact Element picker button staying disabled after page navigation invalidates the current DOM document.

## Changes
- Add a `canBeginElementPicker` DOM session availability contract that only requires an active page target.
- Use that contract for the DOM picker navigation item instead of requiring an already-loaded root node.
- Add a Core regression test covering `DOM.documentUpdated` invalidation followed by lazy document reload and inspect-mode enable.

## Testing
- `swift test --filter elementPickerBeginsAfterDocumentUpdatedInvalidatesLoadedDocument`
- `swift test --filter WebInspectorCoreTests`
- `git diff --check`
- Xcode Issue Navigator and changed-file diagnostics: 0 issues
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review --base main` clean (`findingCount: 0`)
