### PR TITLE
fix(network): defer JSON body pretty printing

### DIFF
--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -60,29 +60,34 @@ package final class NetworkBody {
     package let role: NetworkBodyRole
     package var kind: NetworkBodyKind {
         didSet {
-            refreshTextRepresentation()
+            invalidatePreparedTextRepresentation()
         }
     }
     package private(set) var full: String? {
         didSet {
-            refreshTextRepresentation()
+            invalidatePreparedTextRepresentation()
         }
     }
     package private(set) var size: Int?
     package private(set) var isBase64Encoded: Bool {
         didSet {
-            refreshTextRepresentation()
+            invalidatePreparedTextRepresentation()
         }
     }
     package private(set) var isTruncated: Bool
     package var fetchState: NetworkBodyFetchState
     package private(set) var sourceSyntaxKind: NetworkBodySyntaxKind {
         didSet {
-            refreshTextRepresentation()
+            invalidatePreparedTextRepresentation()
         }
     }
     package private(set) var textRepresentation: String?
     package private(set) var textRepresentationSyntaxKind: NetworkBodySyntaxKind
+    @ObservationIgnored private var textRepresentationGeneration = 0
+    @ObservationIgnored private var preparedTextRepresentationGeneration: Int?
+    @ObservationIgnored private var textRepresentationTask: Task<Void, Never>?
+    @ObservationIgnored private var isBatchingTextRepresentationInvalidation = false
+    @ObservationIgnored private var needsTextRepresentationInvalidation = false
 
     package init(
         role: NetworkBodyRole,
@@ -107,6 +112,10 @@ package final class NetworkBody {
         refreshTextRepresentation()
     }
 
+    isolated deinit {
+        textRepresentationTask?.cancel()
+    }
+
     package var needsFetch: Bool {
         switch fetchState {
         case .available:
@@ -117,8 +126,10 @@ package final class NetworkBody {
     }
 
     package func updateHints(kind: NetworkBodyKind, sourceSyntaxKind: NetworkBodySyntaxKind) {
-        self.kind = kind
-        self.sourceSyntaxKind = sourceSyntaxKind
+        withTextRepresentationInvalidationBatch {
+            self.kind = kind
+            self.sourceSyntaxKind = sourceSyntaxKind
+        }
     }
 
     package func markFetching() {
@@ -130,11 +141,38 @@ package final class NetworkBody {
     }
 
     package func apply(_ payload: NetworkBodyPayload) {
-        full = payload.body
-        isBase64Encoded = payload.base64Encoded
-        isTruncated = payload.isTruncated
+        withTextRepresentationInvalidationBatch {
+            full = payload.body
+            isBase64Encoded = payload.base64Encoded
+            isTruncated = payload.isTruncated
+        }
         size = payload.size ?? payload.body.utf8.count
         fetchState = .loaded
+    }
+
+    package func prepareTextRepresentation() {
+        guard case .loaded = fetchState else {
+            return
+        }
+        guard preparedTextRepresentationGeneration != textRepresentationGeneration else {
+            return
+        }
+        guard textRepresentationTask == nil else {
+            return
+        }
+        guard let input = preparedTextRepresentationInput() else {
+            preparedTextRepresentationGeneration = textRepresentationGeneration
+            return
+        }
+
+        let generation = textRepresentationGeneration
+        textRepresentationTask = Task.detached(priority: .utility) { [weak self] in
+            let result = NetworkBodyPreparedTextRepresentation.make(from: input)
+            guard Task.isCancelled == false else {
+                return
+            }
+            await self?.applyPreparedTextRepresentation(result, generation: generation)
+        }
     }
 
     package static func makeRequestBody(for request: NetworkRequestPayload) -> NetworkBody? {
@@ -228,16 +266,36 @@ package final class NetworkBody {
         }
     }
 
+    private func withTextRepresentationInvalidationBatch(_ updates: () -> Void) {
+        isBatchingTextRepresentationInvalidation = true
+        updates()
+        isBatchingTextRepresentationInvalidation = false
+
+        if needsTextRepresentationInvalidation {
+            needsTextRepresentationInvalidation = false
+            invalidatePreparedTextRepresentation()
+        }
+    }
+
+    private func invalidatePreparedTextRepresentation() {
+        guard isBatchingTextRepresentationInvalidation == false else {
+            needsTextRepresentationInvalidation = true
+            return
+        }
+        textRepresentationGeneration += 1
+        preparedTextRepresentationGeneration = nil
+        textRepresentationTask?.cancel()
+        textRepresentationTask = nil
+        refreshTextRepresentation()
+    }
+
     private func refreshTextRepresentation() {
         let contentText = decodedContentText()
         let formText = kind == .form ? formattedURLEncodedFormText(from: contentText) : nil
-        let prettyJSON = formText == nil ? prettyPrintedJSON(from: contentText) : nil
-        let displayText = formText ?? prettyJSON ?? (kind == .binary ? nil : contentText)
+        let displayText = formText ?? (kind == .binary ? nil : contentText)
         let syntaxKind: NetworkBodySyntaxKind
         if kind == .binary || kind == .form {
             syntaxKind = .plainText
-        } else if prettyJSON != nil {
-            syntaxKind = .json
         } else {
             syntaxKind = sourceSyntaxKind
         }
@@ -248,6 +306,39 @@ package final class NetworkBody {
         if textRepresentationSyntaxKind != syntaxKind {
             textRepresentationSyntaxKind = syntaxKind
         }
+    }
+
+    private func preparedTextRepresentationInput() -> NetworkBodyPreparedTextRepresentation.Input? {
+        guard kind != .binary, kind != .form else {
+            return nil
+        }
+        guard let contentText = decodedContentText() else {
+            return nil
+        }
+        let isJSONCandidate = sourceSyntaxKind == .json || Self.looksLikeJSON(contentText)
+        guard isJSONCandidate else {
+            return nil
+        }
+        return NetworkBodyPreparedTextRepresentation.Input(text: contentText)
+    }
+
+    private func applyPreparedTextRepresentation(
+        _ result: NetworkBodyPreparedTextRepresentation.Result?,
+        generation: Int
+    ) {
+        guard generation == textRepresentationGeneration else {
+            return
+        }
+        if let result {
+            if textRepresentation != result.text {
+                textRepresentation = result.text
+            }
+            if textRepresentationSyntaxKind != result.syntaxKind {
+                textRepresentationSyntaxKind = result.syntaxKind
+            }
+        }
+        preparedTextRepresentationGeneration = generation
+        textRepresentationTask = nil
     }
 
     private func decodedContentText() -> String? {
@@ -303,8 +394,33 @@ package final class NetworkBody {
             .removingPercentEncoding
     }
 
-    private func prettyPrintedJSON(from text: String?) -> String? {
-        guard let text, let data = text.data(using: .utf8) else {
+    private static func looksLikeJSON(_ text: String?) -> Bool {
+        guard let firstNonWhitespace = text?.first(where: { $0.isWhitespace == false }) else {
+            return false
+        }
+        return firstNonWhitespace == "{" || firstNonWhitespace == "["
+    }
+}
+
+private enum NetworkBodyPreparedTextRepresentation {
+    struct Input: Sendable {
+        let text: String
+    }
+
+    struct Result: Sendable {
+        let text: String
+        let syntaxKind: NetworkBodySyntaxKind
+    }
+
+    static func make(from input: Input) -> Result? {
+        guard let prettyJSON = prettyPrintedJSON(from: input.text) else {
+            return nil
+        }
+        return Result(text: prettyJSON, syntaxKind: .json)
+    }
+
+    private static func prettyPrintedJSON(from text: String) -> String? {
+        guard let data = text.data(using: .utf8) else {
             return nil
         }
         guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -54,6 +54,18 @@ package struct NetworkBodyPayload: Equatable, Sendable {
     }
 }
 
+package struct NetworkBodyTextPreparation: Sendable {
+    private let task: Task<Void, Never>
+
+    fileprivate init(task: Task<Void, Never>) {
+        self.task = task
+    }
+
+    package func wait() async {
+        await task.value
+    }
+}
+
 @MainActor
 @Observable
 package final class NetworkBody {
@@ -150,29 +162,32 @@ package final class NetworkBody {
         fetchState = .loaded
     }
 
-    package func prepareTextRepresentation() {
+    @discardableResult
+    package func prepareTextRepresentation() -> NetworkBodyTextPreparation? {
         guard case .loaded = fetchState else {
-            return
+            return nil
         }
         guard preparedTextRepresentationGeneration != textRepresentationGeneration else {
-            return
+            return nil
         }
-        guard textRepresentationTask == nil else {
-            return
+        if let textRepresentationTask {
+            return NetworkBodyTextPreparation(task: textRepresentationTask)
         }
         guard let input = preparedTextRepresentationInput() else {
             preparedTextRepresentationGeneration = textRepresentationGeneration
-            return
+            return nil
         }
 
         let generation = textRepresentationGeneration
-        textRepresentationTask = Task.detached(priority: .utility) { [weak self] in
+        let task = Task.detached(priority: .utility) { [weak self] in
             let result = NetworkBodyPreparedTextRepresentation.make(from: input)
             guard Task.isCancelled == false else {
                 return
             }
             await self?.applyPreparedTextRepresentation(result, generation: generation)
         }
+        textRepresentationTask = task
+        return NetworkBodyTextPreparation(task: task)
     }
 
     package static func makeRequestBody(for request: NetworkRequestPayload) -> NetworkBody? {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -98,6 +98,7 @@ final class NetworkBodyViewController: UIViewController {
             displayText = ""
             syntaxKind = body.textRepresentationSyntaxKind
         case .loaded:
+            body.prepareTextRepresentation()
             displayText = body.textRepresentation
                 ?? String(localized: "network.body.unavailable", bundle: .module)
             syntaxKind = body.textRepresentationSyntaxKind

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -438,6 +438,12 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
     await fetchTask.value
 
     #expect(await body.fetchState == .loaded)
+    #expect(await body.textRepresentation == #"{"ok":true}"#)
+    await body.prepareTextRepresentation()
+    let didPrepareJSON: Bool = try await awaitValueAfterActorTurns {
+        await body.textRepresentation?.contains("\n") == true ? true : nil
+    }
+    #expect(didPrepareJSON)
     #expect(await body.textRepresentation?.contains("\n") == true)
     #expect(await body.textRepresentation?.contains(#""ok""#) == true)
 }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -439,11 +439,8 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
 
     #expect(await body.fetchState == .loaded)
     #expect(await body.textRepresentation == #"{"ok":true}"#)
-    await body.prepareTextRepresentation()
-    let didPrepareJSON: Bool = try await awaitValueAfterActorTurns {
-        await body.textRepresentation?.contains("\n") == true ? true : nil
-    }
-    #expect(didPrepareJSON)
+    let preparation = try #require(await body.prepareTextRepresentation())
+    await preparation.wait()
     #expect(await body.textRepresentation?.contains("\n") == true)
     #expect(await body.textRepresentation?.contains(#""ok""#) == true)
 }

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -205,12 +205,9 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() asyn
     #expect(body.textRepresentation == #"{"name":"codex","value":42}"#)
     #expect(body.textRepresentationSyntaxKind == .json)
 
-    body.prepareTextRepresentation()
+    let preparation = try #require(body.prepareTextRepresentation())
+    await preparation.wait()
 
-    let didPrepareJSON = await waitUntil {
-        body.textRepresentation?.contains("\n") == true
-    }
-    #expect(didPrepareJSON)
     #expect(body.textRepresentation?.contains("\n") == true)
     #expect(body.textRepresentation?.contains(#""name""#) == true)
     #expect(body.textRepresentationSyntaxKind == .json)
@@ -227,13 +224,11 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
         fetchState: .loaded
     )
 
-    body.prepareTextRepresentation()
+    let firstPreparation = try #require(body.prepareTextRepresentation())
+    await firstPreparation.wait()
 
-    let didPrepareFirstBody = await waitUntil {
-        body.textRepresentation?.contains("\n") == true
-            && body.textRepresentation?.contains(#""first""#) == true
-    }
-    #expect(didPrepareFirstBody)
+    #expect(body.textRepresentation?.contains("\n") == true)
+    #expect(body.textRepresentation?.contains(#""first""#) == true)
 
     body.apply(
         NetworkBodyPayload(
@@ -245,13 +240,11 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
     #expect(body.textRepresentation == #"{"second":true}"#)
     #expect(body.textRepresentation?.contains(#""first""#) == false)
 
-    body.prepareTextRepresentation()
+    let secondPreparation = try #require(body.prepareTextRepresentation())
+    await secondPreparation.wait()
 
-    let didPrepareSecondBody = await waitUntil {
-        body.textRepresentation?.contains("\n") == true
-            && body.textRepresentation?.contains(#""second""#) == true
-    }
-    #expect(didPrepareSecondBody)
+    #expect(body.textRepresentation?.contains("\n") == true)
+    #expect(body.textRepresentation?.contains(#""second""#) == true)
     #expect(body.textRepresentation?.contains(#""first""#) == false)
 }
 
@@ -269,8 +262,9 @@ func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
     #expect(body.textRepresentation == "[INFO] started")
     #expect(body.textRepresentationSyntaxKind == .plainText)
 
-    body.prepareTextRepresentation()
-    await yieldForTextRepresentationPreparation()
+    if let preparation = body.prepareTextRepresentation() {
+        await preparation.wait()
+    }
 
     #expect(body.textRepresentation == "[INFO] started")
     #expect(body.textRepresentationSyntaxKind == .plainText)
@@ -730,24 +724,4 @@ func loadingFailureOnlyUpdatesMatchingTargetScopedRequest() async throws {
 
     #expect(page.state == .pending)
     #expect(frame.state == .failed(errorText: "cancelled", canceled: true))
-}
-
-@MainActor
-private func waitUntil(
-    maxTicks: Int = 256,
-    _ condition: @MainActor () -> Bool
-) async -> Bool {
-    for _ in 0..<maxTicks {
-        if condition() {
-            return true
-        }
-        await Task.yield()
-    }
-    return false
-}
-
-private func yieldForTextRepresentationPreparation(maxTicks: Int = 16) async {
-    for _ in 0..<maxTicks {
-        await Task.yield()
-    }
 }

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -163,7 +163,7 @@ func requestPostDataCreatesObservableRequestBody() throws {
 
 @Test
 @MainActor
-func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() throws {
+func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() async throws {
     let session = NetworkSession()
     let targetID = ProtocolTargetIdentifier("page")
     let requestID = NetworkRequestIdentifier("0.response-body")
@@ -202,9 +202,78 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() thro
     )
 
     #expect(body.fetchState == .loaded)
+    #expect(body.textRepresentation == #"{"name":"codex","value":42}"#)
+    #expect(body.textRepresentationSyntaxKind == .json)
+
+    body.prepareTextRepresentation()
+
+    let didPrepareJSON = await waitUntil {
+        body.textRepresentation?.contains("\n") == true
+    }
+    #expect(didPrepareJSON)
     #expect(body.textRepresentation?.contains("\n") == true)
     #expect(body.textRepresentation?.contains(#""name""#) == true)
     #expect(body.textRepresentationSyntaxKind == .json)
+}
+
+@Test
+@MainActor
+func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws {
+    let body = NetworkBody(
+        role: .response,
+        kind: .text,
+        full: #"{"first":true}"#,
+        sourceSyntaxKind: .json,
+        fetchState: .loaded
+    )
+
+    body.prepareTextRepresentation()
+
+    let didPrepareFirstBody = await waitUntil {
+        body.textRepresentation?.contains("\n") == true
+            && body.textRepresentation?.contains(#""first""#) == true
+    }
+    #expect(didPrepareFirstBody)
+
+    body.apply(
+        NetworkBodyPayload(
+            body: #"{"second":true}"#,
+            base64Encoded: false
+        )
+    )
+
+    #expect(body.textRepresentation == #"{"second":true}"#)
+    #expect(body.textRepresentation?.contains(#""first""#) == false)
+
+    body.prepareTextRepresentation()
+
+    let didPrepareSecondBody = await waitUntil {
+        body.textRepresentation?.contains("\n") == true
+            && body.textRepresentation?.contains(#""second""#) == true
+    }
+    #expect(didPrepareSecondBody)
+    #expect(body.textRepresentation?.contains(#""first""#) == false)
+}
+
+@Test
+@MainActor
+func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
+    let body = NetworkBody(
+        role: .response,
+        kind: .text,
+        full: "[INFO] started",
+        sourceSyntaxKind: .plainText,
+        fetchState: .loaded
+    )
+
+    #expect(body.textRepresentation == "[INFO] started")
+    #expect(body.textRepresentationSyntaxKind == .plainText)
+
+    body.prepareTextRepresentation()
+    await yieldForTextRepresentationPreparation()
+
+    #expect(body.textRepresentation == "[INFO] started")
+    #expect(body.textRepresentationSyntaxKind == .plainText)
 }
 
 @Test
@@ -661,4 +730,24 @@ func loadingFailureOnlyUpdatesMatchingTargetScopedRequest() async throws {
 
     #expect(page.state == .pending)
     #expect(frame.state == .failed(errorText: "cancelled", canceled: true))
+}
+
+@MainActor
+private func waitUntil(
+    maxTicks: Int = 256,
+    _ condition: @MainActor () -> Bool
+) async -> Bool {
+    for _ in 0..<maxTicks {
+        if condition() {
+            return true
+        }
+        await Task.yield()
+    }
+    return false
+}
+
+private func yieldForTextRepresentationPreparation(maxTicks: Int = 16) async {
+    for _ in 0..<maxTicks {
+        await Task.yield()
+    }
 }


### PR DESCRIPTION
## Purpose
Defer expensive JSON body pretty printing until the body view actually needs it, avoiding synchronous JSONSerialization work on the main actor during network body updates.

Fixes #39

## Changes
- Keep raw network body text available synchronously while moving JSON pretty printing to a generation-guarded background task.
- Start body text preparation from the loaded body view path.
- Replace yield-based asynchronous formatting assertions with a deterministic preparation handle that tests can await without exposing the internal cancellable task.
- Cover on-demand formatting, invalidation after fetched content changes, and invalid JSON-looking plain text.

## Testing
- `swift test --filter NetworkModelTests`
- `swift test --filter networkResponseBodyFetchAppliesResultToCoreRequest`
- `git diff --check`
- `codex-review` (uncommitted changes)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,id=0DEF74CE-37FF-4DCD-B50D-DD552276BE23' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`