### PR TITLE
Fix CSS hydration ownership

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSProtocolDispatching.swift
+++ b/Sources/WebInspectorCore/CSS/CSSProtocolDispatching.swift
@@ -148,6 +148,33 @@ extension CSSSession: CSSProtocolEventHandler {
     }
 }
 
+extension DOMSession: CSSProtocolEventHandler {
+    package func cssStyleSheetChanged(targetID: ProtocolTargetIdentifier) {
+        elementStyles.cssStyleSheetChanged(targetID: targetID)
+        reconcileSelectedNodeStyleHydrationIfNeeded()
+    }
+
+    package func cssStyleSheetRemoved(styleSheetID: CSSStyleSheetIdentifier, targetID: ProtocolTargetIdentifier) {
+        elementStyles.cssStyleSheetRemoved(styleSheetID: styleSheetID, targetID: targetID)
+        reconcileSelectedNodeStyleHydrationIfNeeded()
+    }
+
+    package func cssStyleSheetAdded(_ header: CSSStyleSheetHeaderPayload, targetID: ProtocolTargetIdentifier) {
+        elementStyles.cssStyleSheetAdded(header, targetID: targetID)
+        reconcileSelectedNodeStyleHydrationIfNeeded()
+    }
+
+    package func cssMediaQueryResultChanged(targetID: ProtocolTargetIdentifier) {
+        elementStyles.cssMediaQueryResultChanged(targetID: targetID)
+        reconcileSelectedNodeStyleHydrationIfNeeded()
+    }
+
+    package func cssNodeLayoutFlagsChanged(targetID: ProtocolTargetIdentifier, nodeID: DOMProtocolNodeID) {
+        elementStyles.cssNodeLayoutFlagsChanged(targetID: targetID, nodeID: nodeID)
+        reconcileSelectedNodeStyleHydrationIfNeeded()
+    }
+}
+
 private struct StyleSheetIdentifierParams: Decodable {
     var styleSheetId: CSSStyleSheetIdentifier
 }

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -2426,12 +2426,13 @@ package final class DOMSession {
         return .failed(failure)
     }
 
-    private func syncSelectedElementStyles() {
+    package func syncSelectedElementStyles() {
         switch selectedCSSNodeStyleIdentity() {
         case let .success(identity):
             elementStyles.selectNodeStyles(identity: identity)
         case let .failure(reason):
             elementStyles.markSelectedNodeUnavailable(reason)
         }
+        reconcileSelectedNodeStyleHydrationIfNeeded()
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -1,5 +1,4 @@
 import Foundation
-import ObservationBridge
 import WebInspectorTransport
 
 @MainActor
@@ -127,16 +126,8 @@ final class DOMSessionElementStyleHydrationController {
     }
 
     private(set) var isActive = false
-    private let observationScope = ObservationScope()
     private var activeRefresh: Refresh?
     private var propertyUpdateRequests: [CSSPropertyIdentifier: PropertyUpdateRequest] = [:]
-
-    func observeSelection(in session: DOMSession, onChange: @escaping @MainActor () -> Void) {
-        observationScope.cancelAll()
-        observationScope.observe(session) { _, _ in
-            onChange()
-        }
-    }
 
     @discardableResult
     func setActive(_ isActive: Bool) -> Bool {
@@ -145,10 +136,6 @@ final class DOMSessionElementStyleHydrationController {
         }
         self.isActive = isActive
         return true
-    }
-
-    func cancelObservation() {
-        observationScope.cancelAll()
     }
 
     func isRefreshing(identity: CSSNodeStyleIdentity) -> Bool {
@@ -358,13 +345,11 @@ extension DOMSession {
         self.commandChannel = commandChannel
         self.recordError = recordError
         elementStyles.bindProtocolChannel(commandChannel)
-        if styleHydration.isActive {
-            startSelectedNodeStyleHydration()
-        }
+        reconcileSelectedNodeStyleHydrationIfNeeded()
     }
 
     package func unbindProtocolChannel() {
-        stopSelectedNodeStyleHydration()
+        cancelSelectedNodeStyleHydrationRefresh()
         cancelDocumentRequests()
         cancelCSSActionRequests()
         commandChannel = nil
@@ -685,9 +670,9 @@ extension DOMSession {
             return
         }
         if isActive, commandChannel != nil {
-            startSelectedNodeStyleHydration()
+            reconcileSelectedNodeStyleHydrationIfNeeded()
         } else {
-            stopSelectedNodeStyleHydration()
+            cancelSelectedNodeStyleHydrationRefresh()
         }
     }
 
@@ -729,18 +714,10 @@ extension DOMSession {
         recordError?(nil)
     }
 
-    private func startSelectedNodeStyleHydration() {
-        styleHydration.observeSelection(in: self) { [weak self] in
-            self?.reconcileSelectedNodeStyleHydration()
+    package func reconcileSelectedNodeStyleHydrationIfNeeded() {
+        guard styleHydration.isActive else {
+            return
         }
-    }
-
-    private func stopSelectedNodeStyleHydration() {
-        styleHydration.cancelObservation()
-        cancelSelectedNodeStyleHydrationRefresh()
-    }
-
-    private func reconcileSelectedNodeStyleHydration() {
         guard commandChannel != nil else {
             return
         }
@@ -850,11 +827,11 @@ extension DOMSession {
         let targetCommit = result.targetCommit
         if let destroyedTargetID {
             cancelDocumentRequest(targetID: destroyedTargetID, reason: "targetDestroyed")
-            elementStyles.removeStyles(targetID: destroyedTargetID)
+            removeElementStyles(targetID: destroyedTargetID)
         }
         if let oldTargetID = targetCommit?.consumedOldTargetID {
             cancelDocumentRequest(targetID: oldTargetID, reason: "targetCommit")
-            elementStyles.removeStyles(targetID: oldTargetID)
+            removeElementStyles(targetID: oldTargetID)
         }
         applyElementPickerTargetLifecycle(event, targetCommit: targetCommit)
         return result
@@ -870,6 +847,7 @@ extension DOMSession {
                 elementStyles.removeStyles(targetID: targetID)
             }
             refreshDocumentAfterBackendUpdate(event)
+            syncSelectedElementStyles()
             return
         }
         let selectedStyleIdentity = try? selectedCSSNodeStyleIdentity().get()
@@ -878,9 +856,10 @@ extension DOMSession {
            let targetID = event.targetID,
            selectedStyleIdentity.targetID == targetID {
             if selectedNodeID != selectedStyleIdentity.nodeID {
-                elementStyles.removeStyles(targetID: targetID)
+                removeElementStyles(targetID: targetID)
             } else if selectedStylesShouldRefresh(after: event) {
                 elementStyles.markNeedsRefresh(targetID: targetID, nodeID: selectedStyleIdentity.protocolNodeID)
+                reconcileSelectedNodeStyleHydrationIfNeeded()
             }
         }
         if event.method == "DOM.setChildNodes" {
@@ -1178,9 +1157,14 @@ extension DOMSession {
             return
         }
         try protocolCommands.applyGetDocumentResult(result, to: self)
-        elementStyles.removeStyles(targetID: targetID)
+        removeElementStyles(targetID: targetID)
         startPendingFrameOwnerHydration()
         recordError?(nil)
+    }
+
+    private func removeElementStyles(targetID: ProtocolTargetIdentifier) {
+        elementStyles.removeStyles(targetID: targetID)
+        syncSelectedElementStyles()
     }
 
     private var currentAppliedDOMSequence: UInt64 {
@@ -1308,7 +1292,7 @@ extension DOMSession {
         try await perform(intent)
         applyNodeRemoved(nodeID)
         selectNode(nil)
-        elementStyles.removeStyles(targetID: documentID.targetID)
+        removeElementStyles(targetID: documentID.targetID)
         recordError?(nil)
 
         return DOMSessionDeleteUndoState(

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -353,7 +353,7 @@ package final class InspectorSession {
             ConsoleProtocolEventDispatcher(handler: attachment.console, runtime: attachment.runtime),
             DOMProtocolEventDispatcher(session: attachment.dom),
             InspectorProtocolEventDispatcher(session: attachment.dom),
-            CSSProtocolEventDispatcher(handler: attachment.dom.elementStyles),
+            CSSProtocolEventDispatcher(handler: attachment.dom),
             NetworkProtocolEventDispatcher(session: attachment.network),
         ])
     }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -680,9 +680,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
     let firstSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
     _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
-    _ = try await awaitValueAfterActorTurns {
-        await session.attachment.dom.elementStyles.selectedState == .loading ? true : nil
-    }
+    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
 
     session.attachment.dom.setSelectedNodeStyleHydrationActive(false)
     #expect(session.attachment.dom.elementStyles.selectedState == .needsRefresh)
@@ -701,6 +699,33 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
         await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
     }
     #expect(didLoadStyles)
+    #expect(session.lastError == nil)
+}
+
+@Test
+@MainActor
+func selectedElementStyleHydrationSelectionChangeStartsReplacementRefresh() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
+    let firstSentCount = await backend.sentTargetMessages().count
+    session.attachment.dom.selectNode(bodyID)
+
+    let firstMessages = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
+    #expect(try messageParameters(firstMessages.matched.message)["nodeId"] as? Int == 4)
+    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
+
+    let secondSentCount = await backend.sentTargetMessages().count
+    session.attachment.dom.selectNode(htmlID)
+    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+    #expect(try messageParameters(secondMessages.matched.message)["nodeId"] as? Int == 2)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == htmlID)
+    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
     #expect(session.lastError == nil)
 }
 
@@ -741,6 +766,118 @@ func selectedElementStyleHydrationClearsStylesAfterSelectionDisappears() async t
     }
 
     #expect(session.attachment.dom.elementStyles.selectedNodeStyles == nil)
+}
+
+@Test
+@MainActor
+func selectedElementStyleHydrationRefreshesAfterCSSEvents() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let bodyID = try await hydrateSelectedBodyStyles(
+        session: session,
+        transport: transport,
+        backend: backend
+    )
+
+    let sheetChangedCount = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-body"}}"#
+    )
+    let sheetChangedMessages = try await waitForCSSRefreshMessages(backend, after: sheetChangedCount)
+    #expect(try messageParameters(sheetChangedMessages.matched.message)["nodeId"] as? Int == 4)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: sheetChangedMessages,
+        selector: "body",
+        styleSheetID: "sheet-body-refresh"
+    )
+    let didLoadAfterSheetChange = try await awaitValueAfterActorTurns {
+        await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadAfterSheetChange)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == bodyID)
+    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+
+    let layoutChangedCount = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"CSS.nodeLayoutFlagsChanged","params":{"nodeId":4}}"#
+    )
+    let layoutChangedMessages = try await waitForCSSRefreshMessages(backend, after: layoutChangedCount)
+    #expect(try messageParameters(layoutChangedMessages.matched.message)["nodeId"] as? Int == 4)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: layoutChangedMessages,
+        selector: "body",
+        styleSheetID: "sheet-body-layout"
+    )
+    let didLoadAfterLayoutChange = try await awaitValueAfterActorTurns {
+        await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadAfterLayoutChange)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == bodyID)
+    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.lastError == nil)
+}
+
+@Test
+@MainActor
+func selectedElementStyleHydrationCancelsAfterDocumentUpdateInvalidatesRoot() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    _ = try await hydrateSelectedBodyStyles(
+        session: session,
+        transport: transport,
+        backend: backend
+    )
+
+    let sentCount = await backend.sentTargetMessages().count
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#
+    )
+
+    let didInvalidateRoot = try await awaitValueAfterActorTurns {
+        await session.attachment.dom.currentPageRootNode == nil ? true : nil
+    }
+    #expect(didInvalidateRoot)
+    #expect(session.attachment.dom.currentPageRootNode == nil)
+    #expect(session.attachment.dom.elementStyles.selectedState == .unavailable(.noSelection))
+    #expect(await backend.sentTargetMessages().count == sentCount)
+}
+
+@Test
+@MainActor
+func selectedElementStyleHydrationClearsAfterSelectedTargetDestroyed() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    _ = try await hydrateSelectedBodyStyles(
+        session: session,
+        transport: transport,
+        backend: backend
+    )
+
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetDestroyed","params":{"targetId":"page-main"}}"#
+    )
+
+    let didClearSelection = try await awaitValueAfterActorTurns {
+        await session.attachment.dom.selectedNodeID == nil ? true : nil
+    }
+    #expect(didClearSelection)
+    #expect(session.attachment.dom.selectedNodeID == nil)
+    #expect(session.attachment.dom.elementStyles.selectedState == .unavailable(.noSelection))
+    #expect(session.lastError == nil)
 }
 
 @Test
@@ -5010,6 +5147,32 @@ private func waitForBackendTargetMessage(
         }
         return message
     }
+}
+
+@MainActor
+private func hydrateSelectedBodyStyles(
+    session: InspectorSession,
+    transport: TransportSession,
+    backend: FakeTransportBackend
+) async throws -> DOMNodeIdentifier {
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+    session.attachment.dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: messages,
+        selector: "body",
+        styleSheetID: "sheet-body"
+    )
+    let didLoadStyles = try await awaitValueAfterActorTurns {
+        await session.attachment.dom.elementStyles.selectedState == .loaded ? true : nil
+    }
+    #expect(didLoadStyles)
+    return bodyID
 }
 
 private struct CSSRefreshMessages {


### PR DESCRIPTION
## Purpose

Fix selected-node CSS hydration so protocol refreshes are owned by DOM session state changes instead of observation delivery. This removes the source of flaky command reissue behavior around selection, document, target, and CSS invalidation.

## Changes

- Move selected style hydration reconciliation into DOMSession owner mutations.
- Route production CSS protocol events through DOMSession so cache invalidation and active hydration reconcile together.
- Keep CSSSession as the low-level cache unit for existing tests.
- Add regression coverage for active toggle, selection changes, CSS events, document invalidation, and target destruction.

## Testing

- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -derivedDataPath /tmp/WebInspectorKit-DD-core -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorCoreTests
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- git diff --check
- codex-review --base main: no findings