### PR TITLE
Adopt SyntaxEditorUI 0.11.0

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
-        "version" : "0.10.1"
+        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
+        "version" : "0.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "58da797e284649ea79f2a604ab188bde3869272ec8ff6aaa79e8e12015eb85df",
+  "originHash" : "48746d64be97337bcd1493ed21516df2fa896eeed8c291d9af75a734fa2330ae",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
-        "version" : "0.10.1"
+        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
+        "version" : "0.11.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.10.1"
+            exact: "0.11.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -383,6 +383,66 @@ package final class CSSSession {
         var propertyIDs: [PropertyMembership]
     }
 
+    private enum RefreshCommandResult: Sendable {
+        case success(ProtocolCommandResult)
+        case failure(RefreshCommandFailure)
+
+        var failure: RefreshCommandFailure? {
+            guard case let .failure(failure) = self else {
+                return nil
+            }
+            return failure
+        }
+
+        func requireSuccess() throws -> ProtocolCommandResult {
+            switch self {
+            case let .success(result):
+                return result
+            case let .failure(failure):
+                throw failure.error
+            }
+        }
+    }
+
+    private enum RefreshCommandFailure: Error, Sendable {
+        case cancellation
+        case transport(TransportError)
+        case inspector(InspectorSessionError)
+        case other(String)
+
+        init(_ error: any Error) {
+            if error is CancellationError {
+                self = .cancellation
+            } else if let error = error as? TransportError {
+                self = .transport(error)
+            } else if let error = error as? InspectorSessionError {
+                self = .inspector(error)
+            } else {
+                self = .other(String(describing: error))
+            }
+        }
+
+        var error: any Error {
+            switch self {
+            case .cancellation:
+                CancellationError()
+            case let .transport(error):
+                error
+            case let .inspector(error):
+                error
+            case let .other(message):
+                InspectorSessionError(message)
+            }
+        }
+
+        var isCancellation: Bool {
+            guard case .cancellation = self else {
+                return false
+            }
+            return true
+        }
+    }
+
     private enum PropertyMembership: Equatable {
         case identified(CSSPropertyIdentifier)
         case anonymous(index: Int)
@@ -1498,15 +1558,36 @@ package final class CSSSession {
     }
 
     private func fetchRefreshResultsWithoutCompatibilityRetry(for identity: CSSNodeStyleIdentity) async throws -> RefreshResults {
-        async let matched = perform(.getMatchedStyles(identity: identity))
-        async let inline = perform(.getInlineStyles(identity: identity))
-        async let computed = perform(.getComputedStyle(identity: identity))
-        let results = try await (matched, inline, computed)
+        async let matched = performRefreshCommand(.getMatchedStyles(identity: identity))
+        async let inline = performRefreshCommand(.getInlineStyles(identity: identity))
+        async let computed = performRefreshCommand(.getComputedStyle(identity: identity))
+        let results = await (matched, inline, computed)
+        let failures = [results.0, results.1, results.2].compactMap(\.failure)
+        if failures.contains(where: \.isCancellation) {
+            throw CancellationError()
+        }
+        if let retryFailure = failures.first(where: { shouldRetryAfterEnablingCSSAgent($0.error) }) {
+            throw retryFailure.error
+        }
+        if let failure = failures.first {
+            throw failure.error
+        }
+        let matchedResult = try results.0.requireSuccess()
+        let inlineResult = try results.1.requireSuccess()
+        let computedResult = try results.2.requireSuccess()
         return RefreshResults(
-            matched: try protocolCommands.matchedStyles(from: results.0),
-            inline: try protocolCommands.inlineStyles(from: results.1),
-            computed: try protocolCommands.computedStyles(from: results.2)
+            matched: try protocolCommands.matchedStyles(from: matchedResult),
+            inline: try protocolCommands.inlineStyles(from: inlineResult),
+            computed: try protocolCommands.computedStyles(from: computedResult)
         )
+    }
+
+    private func performRefreshCommand(_ intent: CSSCommandIntent) async -> RefreshCommandResult {
+        do {
+            return .success(try await perform(intent))
+        } catch {
+            return .failure(RefreshCommandFailure(error))
+        }
     }
 
     private func enableAgentForCompatibility(targetID: ProtocolTargetIdentifier) async throws {

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -183,6 +183,13 @@ private final class InspectorTargetRegistry {
 }
 
 @MainActor
+package protocol InspectorInspectableWebView: AnyObject {
+    var isInspectable: Bool { get set }
+}
+
+extension WKWebView: InspectorInspectableWebView {}
+
+@MainActor
 private final class InspectorConnection {
     let transport: TransportSession
     weak var webView: WKWebView?
@@ -843,13 +850,16 @@ package final class InspectorSession {
         connection === candidate || pendingConnection === candidate
     }
 
-    package static func prepareInspectability(for webView: WKWebView) -> Bool {
+    package static func prepareInspectability<WebView: InspectorInspectableWebView>(for webView: WebView) -> Bool {
         let originalValue = webView.isInspectable
         webView.isInspectable = true
         return originalValue
     }
 
-    package static func restoreInspectabilityIfNeeded(on webView: WKWebView, originalValue: Bool?) {
+    package static func restoreInspectabilityIfNeeded<WebView: InspectorInspectableWebView>(
+        on webView: WebView,
+        originalValue: Bool?
+    ) {
         guard let originalValue else {
             return
         }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -6,8 +6,8 @@ import UIKit
 
 @MainActor
 final class NetworkBodyViewController: UIViewController {
-    private let syntaxDocument = SyntaxEditorDocument(text: "")
-    private let syntaxConfiguration = SyntaxEditorConfiguration(
+    private let syntaxModel = SyntaxEditorModel(
+        text: "",
         language: .json,
         isEditable: false,
         lineWrappingEnabled: true,
@@ -15,8 +15,7 @@ final class NetworkBodyViewController: UIViewController {
         drawsBackground: false
     )
     private lazy var syntaxView = SyntaxEditorView(
-        document: syntaxDocument,
-        configuration: syntaxConfiguration
+        model: syntaxModel
     )
     private let observationScope = ObservationScope()
     private weak var body: NetworkBody?
@@ -128,15 +127,15 @@ final class NetworkBodyViewController: UIViewController {
         syntaxKind: NetworkBodySyntaxKind
     ) {
         let syntax = syntaxKind.syntax
-        if syntaxConfiguration.language != syntax.language {
-            syntaxConfiguration.language = syntax.language
+        if syntaxModel.language != syntax.language {
+            syntaxModel.language = syntax.language
         }
         let colorTheme: SyntaxEditorColorTheme = syntax.usesPlainTextTheme ? .v2WebInspectorPlainText : .default
-        if syntaxConfiguration.colorTheme != colorTheme {
-            syntaxConfiguration.colorTheme = colorTheme
+        if syntaxModel.colorTheme != colorTheme {
+            syntaxModel.colorTheme = colorTheme
         }
-        if syntaxDocument.textSnapshot() != text {
-            syntaxDocument.replaceText(text)
+        if syntaxModel.text != text {
+            syntaxModel.replaceText(text)
         }
     }
 }
@@ -162,7 +161,7 @@ private extension NetworkBodySyntaxKind {
     var syntax: (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
         switch self {
         case .plainText:
-            (.json, true)
+            (.plainText, true)
         case .json:
             (.json, false)
         case .html:

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3179,9 +3179,7 @@ func detachedFrameSetChildNodesRootKeepsRequestNodeSelectable() async throws {
 func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
-    let session = await InspectorSession(
-        configuration: .init(responseTimeout: .seconds(1), bootstrapTimeout: .seconds(1))
-    )
+    let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
     let snapshotBeforeSelection = await session.attachment.dom.snapshot()
 
@@ -3741,12 +3739,7 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
 func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
-    let session = await InspectorSession(
-        configuration: .init(
-            responseTimeout: .seconds(1),
-            bootstrapTimeout: .seconds(1)
-        )
-    )
+    let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
     await receiveTargetDispatch(
         transport,
@@ -4821,7 +4814,7 @@ func bootstrapFailureClearsSeededModelState() async throws {
     let session = await InspectorSession(
         configuration: .init(
             responseTimeout: .milliseconds(20),
-            bootstrapTimeout: .seconds(1)
+            bootstrapTimeout: testBootstrapTimeout
         )
     )
     await transport.receiveRootMessage(
@@ -4928,8 +4921,7 @@ func domActionAvailabilityWaitsForActiveAttachment() async throws {
 @MainActor
 @Test
 func attachInspectabilityPreparationRestoresOriginalValue() throws {
-    let webView = WKWebView(frame: .zero)
-    let initialValue = webView.isInspectable
+    let webView = TestInspectableWebView(isInspectable: false)
     webView.isInspectable = false
 
     let originalValue = InspectorSession.prepareInspectability(for: webView)
@@ -4940,7 +4932,6 @@ func attachInspectabilityPreparationRestoresOriginalValue() throws {
     InspectorSession.restoreInspectabilityIfNeeded(on: webView, originalValue: originalValue)
 
     #expect(webView.isInspectable == false)
-    webView.isInspectable = initialValue
 }
 
 private func connect(
@@ -4957,11 +4948,8 @@ private func connect(
     do {
         try await completeBootstrap(transport: transport, backend: backend)
     } catch {
-        do {
-            try await connectTask.value
-        } catch {
-            throw error
-        }
+        connectTask.cancel()
+        _ = try? await connectTask.value
         throw error
     }
     try await connectTask.value
@@ -5091,6 +5079,14 @@ private let newDocumentWithHeadChildCountResult = ##"{"root":{"nodeId":1,"nodeTy
 private let firstLazyFrameDocumentResult = ##"{"root":{"nodeId":101,"nodeType":9,"nodeName":"#document","documentURL":"https://frame.example/ad","baseURL":"https://frame.example/ad","children":[{"nodeId":102,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":103,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":104,"nodeType":1,"nodeName":"CANVAS","localName":"canvas"}]}]}]}}"##
 private let secondLazyFrameDocumentResult = ##"{"root":{"nodeId":201,"nodeType":9,"nodeName":"#document","documentURL":"https://frame.example/ad","baseURL":"https://frame.example/ad","children":[{"nodeId":202,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":203,"nodeType":1,"nodeName":"BODY","localName":"body","children":[{"nodeId":204,"nodeType":1,"nodeName":"VIDEO","localName":"video"}]}]}]}}"##
 
+private final class TestInspectableWebView: InspectorInspectableWebView {
+    var isInspectable: Bool
+
+    init(isInspectable: Bool) {
+        self.isInspectable = isInspectable
+    }
+}
+
 private func targetMessageMethods(_ backend: FakeTransportBackend) async -> [String?] {
     await backend.sentTargetMessages().map { try? messageMethod($0.message) }
 }
@@ -5127,7 +5123,7 @@ private func waitForBackendTargetMessage(
     method: String,
     ordinal: Int,
     after count: Int,
-    timeout: Duration = .seconds(5)
+    timeout: Duration = .milliseconds(750)
 ) async throws -> SentTargetMessage {
     try await withThrowingTaskGroup(of: SentTargetMessage.self) { group in
         defer {
@@ -5185,10 +5181,10 @@ private func waitForCSSRefreshMessages(
     _ backend: FakeTransportBackend,
     after count: Int
 ) async throws -> CSSRefreshMessages {
-    async let matched = waitForTargetMessage(backend, method: "CSS.getMatchedStylesForNode", after: count)
-    async let inline = waitForTargetMessage(backend, method: "CSS.getInlineStylesForNode", after: count)
-    async let computed = waitForTargetMessage(backend, method: "CSS.getComputedStyleForNode", after: count)
-    return try await CSSRefreshMessages(matched: matched, inline: inline, computed: computed)
+    let matched = try await waitForTargetMessage(backend, method: "CSS.getMatchedStylesForNode", after: count)
+    let inline = try await waitForTargetMessage(backend, method: "CSS.getInlineStylesForNode", after: count)
+    let computed = try await waitForTargetMessage(backend, method: "CSS.getComputedStyleForNode", after: count)
+    return CSSRefreshMessages(matched: matched, inline: inline, computed: computed)
 }
 
 private func replyCSSRefresh(
@@ -5454,10 +5450,13 @@ private extension ProtocolTargetIdentifier {
 
 private extension InspectorSessionConfiguration {
     static let test = InspectorSessionConfiguration(
-        responseTimeout: .seconds(1),
-        bootstrapTimeout: .seconds(1)
+        responseTimeout: testResponseTimeout,
+        bootstrapTimeout: testBootstrapTimeout
     )
 }
+
+private let testResponseTimeout: Duration = .milliseconds(750)
+private let testBootstrapTimeout: Duration = .milliseconds(750)
 
 private extension DOMSessionSnapshot {
     var currentPageDocumentID: DOMDocumentIdentifier? {

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -3,10 +3,13 @@ import Testing
 @testable import WebInspectorCore
 @testable import WebInspectorTransport
 
+private let testResponseTimeout: Duration = .milliseconds(750)
+private let testWaitTimeout: Duration = .milliseconds(750)
+
 @Test
 func rootCommandResolvesFromRootReply() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
 
     let sendTask = Task {
         try await session.send(
@@ -27,7 +30,7 @@ func rootCommandResolvesFromRootReply() async throws {
 @Test
 func targetCommandUsesNestedReplyKey() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","isProvisional":false}}}"#)
 
     let sendTask = Task {
@@ -55,7 +58,7 @@ func targetCommandUsesNestedReplyKey() async throws {
 @Test
 func domEnableIsTransportLocalWhileCSSEnableRoutesToTargetBackend() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
 
     let domResult = try await session.send(
@@ -86,7 +89,7 @@ func domEnableIsTransportLocalWhileCSSEnableRoutesToTargetBackend() async throws
 @Test
 func pageTargetDefaultsExposeCSSCapabilityEvenWithoutDomainMetadata() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"web-page","frameId":"main-frame","isProvisional":false}}}"#)
 
     let target = try #require(await session.snapshot().targetsByID[ProtocolTargetIdentifier("page-main")])
@@ -97,7 +100,7 @@ func pageTargetDefaultsExposeCSSCapabilityEvenWithoutDomainMetadata() async thro
 @Test
 func pageTargetDomainMetadataKeepsPageDefaultCSSCapability() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","domains":["DOM"],"isProvisional":false}}}"#)
 
     let target = try #require(await session.snapshot().targetsByID[ProtocolTargetIdentifier("page-main")])
@@ -108,7 +111,7 @@ func pageTargetDomainMetadataKeepsPageDefaultCSSCapability() async throws {
 @Test
 func targetReplyCarriesPerDomainSequenceWatermarks() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
 
     let sendTask = Task {
@@ -144,7 +147,7 @@ func targetReplyCarriesPerDomainSequenceWatermarks() async throws {
 @Test
 func targetCommandWrapperErrorFailsPendingReplyImmediately() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","isProvisional":false}}}"#)
 
     let sendTask = Task {
@@ -165,7 +168,7 @@ func targetCommandWrapperErrorFailsPendingReplyImmediately() async throws {
 @Test
 func targetDestroyFailsPendingTargetReplies() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-A","type":"frame","frameId":"frame-A","isProvisional":false}}}"#)
 
     let sendTask = Task {
@@ -225,7 +228,7 @@ func remoteErrorAndTimeoutFailPendingReplies() async throws {
 @Test
 func cancellationFailsPendingReplyImmediately() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
 
     let sendTask = Task {
         try await session.send(
@@ -303,7 +306,7 @@ func fakeBackendTargetMessageWaiterCancellationDoesNotResumeWithLaterMessage() a
 @Test
 func detachFailsPendingRepliesAndClosesStreams() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     let stream = await session.events(for: .dom)
     let streamTask = Task {
         var iterator = stream.makeAsyncIterator()
@@ -329,7 +332,7 @@ func detachFailsPendingRepliesAndClosesStreams() async throws {
 @Test
 func waitForCurrentMainPageTargetFailsAfterDetach() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
 
     let target = try await session.waitForCurrentMainPageTarget()
@@ -438,7 +441,7 @@ func subframeCommitDoesNotConsumeCurrentMainPageTarget() async throws {
 @Test
 func targetCommitRetargetsPendingRepliesToCommittedTarget() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
 
     let sendTask = Task {
@@ -464,7 +467,7 @@ func targetCommitRetargetsPendingRepliesToCommittedTarget() async throws {
 @Test
 func provisionalTargetReplyIsBufferedUntilCommit() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
 
     let sendTask = Task {
@@ -538,7 +541,7 @@ func bufferedProvisionalTargetReplySurvivesResponseTimeoutBeforeCommit() async t
 @Test
 func oldlessTargetCommitInfersSoleProvisionalTarget() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
 
     let sendTask = Task {
@@ -567,7 +570,7 @@ func oldlessTargetCommitInfersSoleProvisionalTarget() async throws {
 @Test
 func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-next","type":"page","frameId":"main-frame","isProvisional":true}}}"#)
@@ -584,8 +587,8 @@ func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws
     )
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#)
 
-    let targetEvent = try #require(await targetEvents.event())
-    let domEvent = try #require(await domEvents.event())
+    let targetEvent = try await targetEvents.event()
+    let domEvent = try await domEvents.event()
 
     #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
     #expect(domEvent.method == "DOM.childNodeCountUpdated")
@@ -597,7 +600,7 @@ func provisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws
 @Test
 func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .seconds(1))
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
 
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
 
@@ -613,8 +616,8 @@ func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async thr
     )
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
 
-    let targetEvent = try #require(await targetEvents.event())
-    let domEvent = try #require(await domEvents.event())
+    let targetEvent = try await targetEvents.event()
+    let domEvent = try await domEvents.event()
 
     #expect(targetEvent.method == "Target.didCommitProvisionalTarget")
     #expect(domEvent.method == "DOM.childNodeCountUpdated")
@@ -677,9 +680,12 @@ func rootScopedRuntimeDOMAndConsoleEventsResolveToCurrentPageTarget() async thro
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByKey[contextKey("page-main", 11)]?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await runtimeEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await domEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
-    #expect(await consoleEvents.event()?.targetID == ProtocolTargetIdentifier("page-main"))
+    let runtimeEvent = try await runtimeEvents.event()
+    let domEvent = try await domEvents.event()
+    let consoleEvent = try await consoleEvents.event()
+    #expect(runtimeEvent.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(domEvent.targetID == ProtocolTargetIdentifier("page-main"))
+    #expect(consoleEvent.targetID == ProtocolTargetIdentifier("page-main"))
 }
 
 @Test
@@ -692,7 +698,8 @@ func rootScopedDocumentUpdatedRemainsTargetless() async throws {
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"DOM.documentUpdated","params":{}}"#)
 
-    #expect(await domEvents.event()?.targetID == nil)
+    let event = try await domEvents.event()
+    #expect(event.targetID == nil)
 }
 
 @Test
@@ -705,7 +712,8 @@ func rootScopedInspectorEventsRemainTargetless() async throws {
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"type":"object","subtype":"node","objectId":"node-1"}}}"#)
 
-    #expect(await inspectorEvents.event()?.targetID == nil)
+    let event = try await inspectorEvents.event()
+    #expect(event.targetID == nil)
 }
 
 @Test
@@ -875,10 +883,14 @@ func domainStreamsReceiveIndependentTargetEventsInOrder() async throws {
     await receiveTargetDispatch(session, targetID: .init("frame-A"), message: #"{"method":"Console.messageAdded","params":{"message":{"text":"hello"}}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"r1","request":{"url":"https://example.com"},"timestamp":1}}"#)
 
-    #expect(await domEvents.event()?.method == "DOM.setChildNodes")
-    #expect(await cssEvents.event()?.method == "CSS.styleSheetChanged")
-    #expect(await consoleEvents.event()?.method == "Console.messageAdded")
-    #expect(await networkEvents.event()?.method == "Network.requestWillBeSent")
+    let domEvent = try await domEvents.event()
+    let cssEvent = try await cssEvents.event()
+    let consoleEvent = try await consoleEvents.event()
+    let networkEvent = try await networkEvents.event()
+    #expect(domEvent.method == "DOM.setChildNodes")
+    #expect(cssEvent.method == "CSS.styleSheetChanged")
+    #expect(consoleEvent.method == "Console.messageAdded")
+    #expect(networkEvent.method == "Network.requestWillBeSent")
 }
 
 @Test
@@ -895,7 +907,7 @@ func rootCSSStyleSheetEventsResolveFrameTargetFromFrameIDAndStyleSheetOwnership(
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetRemoved","params":{"styleSheetId":"sheet-frame"}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-frame"}}"#)
 
-    let events = await cssEvents.events(prefix: 4)
+    let events = try await cssEvents.events(prefix: 4)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetChanged", "CSS.styleSheetRemoved", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         ProtocolTargetIdentifier("frame-A"),
@@ -917,7 +929,7 @@ func rootCSSStyleSheetAddedBeforeFrameTargetDoesNotPinSheetToPage() async throws
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-late","type":"frame","frameId":"late-frame","parentFrameId":"main-frame","isProvisional":false}}}"#)
     await session.receiveRootMessage(#"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-late-frame"}}"#)
 
-    let events = await cssEvents.events(prefix: 3)
+    let events = try await cssEvents.events(prefix: 3)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded", "CSS.styleSheetChanged"])
     #expect(events.map(\.targetID) == [
         nil,
@@ -938,7 +950,7 @@ func rootCSSStyleSheetAddedBeforeProvisionalFrameTargetReplaysAfterCommit() asyn
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":true}}}"#)
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
 
-    let events = await cssEvents.events(prefix: 2)
+    let events = try await cssEvents.events(prefix: 2)
     #expect(events.map(\.method) == ["CSS.styleSheetAdded", "CSS.styleSheetAdded"])
     #expect(events.map(\.targetID) == [
         nil,
@@ -958,7 +970,7 @@ func orderedStreamReceivesTargetEventsAcrossDomainsInTransportOrder() async thro
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"Runtime.executionContextCreated","params":{"context":{"id":7}}}"#)
     await receiveTargetDispatch(session, targetID: .init("page-main"), message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":3,"childNodeCount":2}}"#)
 
-    let recordedEvents = await events.events(prefix: 4)
+    let recordedEvents = try await events.events(prefix: 4)
     #expect(recordedEvents.map(\.method) == [
         "DOM.documentUpdated",
         "Network.requestWillBeSent",
@@ -1708,12 +1720,12 @@ private final class ProtocolEventRecorder: Sendable {
         task.cancel()
     }
 
-    func event(at index: Int = 0, timeout: Duration = .seconds(1)) async -> ProtocolEventEnvelope? {
-        await storage.event(at: index, timeout: timeout)
+    func event(at index: Int = 0, timeout: Duration = testWaitTimeout) async throws -> ProtocolEventEnvelope {
+        try await storage.event(at: index, timeout: timeout)
     }
 
-    func events(prefix count: Int, timeout: Duration = .seconds(1)) async -> [ProtocolEventEnvelope] {
-        await storage.events(prefix: count, timeout: timeout)
+    func events(prefix count: Int, timeout: Duration = testWaitTimeout) async throws -> [ProtocolEventEnvelope] {
+        try await storage.events(prefix: count, timeout: timeout)
     }
 }
 
@@ -1739,16 +1751,16 @@ private actor ProtocolEventRecorderStorage {
         resumeReadyWaiters()
     }
 
-    func event(at index: Int, timeout: Duration) async -> ProtocolEventEnvelope? {
+    func event(at index: Int, timeout: Duration) async throws -> ProtocolEventEnvelope {
         guard await waitUntilCount(index + 1, timeout: timeout) else {
-            return nil
+            throw TransportError.replyTimeout(method: "test event", targetID: nil)
         }
         return events[index]
     }
 
-    func events(prefix count: Int, timeout: Duration) async -> [ProtocolEventEnvelope] {
+    func events(prefix count: Int, timeout: Duration) async throws -> [ProtocolEventEnvelope] {
         guard await waitUntilCount(count, timeout: timeout) else {
-            return events
+            throw TransportError.replyTimeout(method: "test events", targetID: nil)
         }
         return Array(events.prefix(count))
     }
@@ -1834,13 +1846,13 @@ private actor ProtocolEventRecorderStorage {
     }
 }
 
-private func waitForRootMessage(_ backend: FakeTransportBackend, timeout: Duration = .seconds(1)) async throws -> String {
+private func waitForRootMessage(_ backend: FakeTransportBackend, timeout: Duration = testWaitTimeout) async throws -> String {
     try await waitForBackendValue(timeout: timeout) {
         try await backend.waitForMessage()
     }
 }
 
-private func waitForTargetMessage(_ backend: FakeTransportBackend, timeout: Duration = .seconds(1)) async throws -> SentTargetMessage {
+private func waitForTargetMessage(_ backend: FakeTransportBackend, timeout: Duration = testWaitTimeout) async throws -> SentTargetMessage {
     try await waitForBackendValue(timeout: timeout) {
         try await backend.waitForTargetMessage()
     }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -203,7 +203,8 @@ struct NetworkDetailViewControllerTests {
         let didSwitch = await waitUntil {
             viewController.currentModeForTesting == .requestBody
                 && viewController.bodyTextViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
-                && viewController.bodyTextViewForTesting.configuration.drawsBackground == false
+                && viewController.bodyTextViewForTesting.model.language == .plainText
+                && viewController.bodyTextViewForTesting.model.drawsBackground == false
         }
         #expect(didSwitch)
     }
@@ -302,7 +303,7 @@ struct NetworkDetailViewControllerTests {
             return fetchedIDs == [request.id]
                 && viewController.currentModeForTesting == .responseBody
                 && viewController.bodyTextViewForTesting.text.isEmpty
-                && viewController.bodyTextViewForTesting.configuration.language == .json
+                && viewController.bodyTextViewForTesting.model.language == .json
                 && indicatorItem.isHidden == false
                 && activityIndicator.isAnimating
         }

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0cce760e05c3819e343e8ec90fd0499fe97255ee4227cffe0d343cdfb45110ed",
+  "originHash" : "8fb32aec0366af0e0148d352ccc26a8e4a09bcf6fe5c9ed518e9425b4910e809",
   "pins" : [
     {
       "identity" : "machokit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "4ca1dce884589f35bfd20a31135354c178bbba08",
-        "version" : "0.10.1"
+        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
+        "version" : "0.11.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Adopt SyntaxEditorUI v0.11.0 and migrate WebInspectorKit's Network body editor to the new model-based API.

## Changes
- Update the SyntaxEditorUI package pin and all SwiftPM resolver surfaces to v0.11.0.
- Replace Network body editor usage of `SyntaxEditorDocument` and `SyntaxEditorConfiguration` with a single `SyntaxEditorModel`.
- Route plain Network body content through `SyntaxLanguage.plainText` and update UI assertions to inspect `SyntaxEditorView.model`.

## Testing
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `xcodebuild -resolvePackageDependencies -project Monocly/Monocly.xcodeproj -scheme Monocly`
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -derivedDataPath /Users/kn/Dev/WebInspectorKit/.derivedData/SyntaxEditorUI-0.11-validation`
- `codex-review` on uncommitted changes: `findingCount: 0`

Note: The first test run without a custom DerivedData path hit an existing Xcode build database lock; the rerun above used a dedicated DerivedData path and passed.