### PR TITLE
Replace network image filter with media

### DIFF
--- a/Sources/WebInspectorCore/Network/NetworkProtocol.swift
+++ b/Sources/WebInspectorCore/Network/NetworkProtocol.swift
@@ -245,6 +245,7 @@ package struct NetworkResourceType: RawRepresentable, Hashable, Sendable {
     package static let document = Self("Document")
     package static let styleSheet = Self("StyleSheet")
     package static let image = Self("Image")
+    package static let media = Self("Media")
     package static let font = Self("Font")
     package static let script = Self("Script")
     package static let xhr = Self("XHR")

--- a/Sources/WebInspectorUI/Localizable.xcstrings
+++ b/Sources/WebInspectorUI/Localizable.xcstrings
@@ -4011,144 +4011,144 @@
         }
       }
     },
-    "network.filter.image" : {
+    "network.filter.media" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "صورة"
+            "value" : "وسائط"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bild"
+            "value" : "Medien"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image"
+            "value" : "Media"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image"
+            "value" : "Media"
           }
         },
         "en-IN" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image"
+            "value" : "Media"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imagen"
+            "value" : "Medios"
           }
         },
         "es-419" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imagen"
+            "value" : "Medios"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image"
+            "value" : "Médias"
           }
         },
         "fr-CA" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image"
+            "value" : "Médias"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "छवि"
+            "value" : "मीडिया"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gambar"
+            "value" : "Media"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Immagine"
+            "value" : "Media"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "画像"
+            "value" : "メディア"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이미지"
+            "value" : "미디어"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afbeelding"
+            "value" : "Media"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imagem"
+            "value" : "Mídia"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imagem"
+            "value" : "Multimédia"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imagine"
+            "value" : "Media"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Изображение"
+            "value" : "Медиа"
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "รูปภาพ"
+            "value" : "สื่อ"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Görsel"
+            "value" : "Medya"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "图像"
+            "value" : "媒体"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "影像"
+            "value" : "媒體"
           }
         }
       }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -53,6 +53,7 @@ final class NetworkBodyViewController: UIViewController {
     private var imageWidthConstraint: NSLayoutConstraint?
     private var imageHeightConstraint: NSLayoutConstraint?
     private var shouldResetImageZoomOnNextLayout = false
+    private var imagePreviewLayoutBoundsSize: CGSize?
 #if DEBUG
     private var bodyObservationDelivery: ObservationDelivery?
 #endif
@@ -237,13 +238,14 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func mediaPayload(for body: NetworkBody) -> NetworkBodyMediaPayload? {
-        let mimeType = normalizedMIMEType(metadata?.mimeType)
-        guard isMediaMIMEType(mimeType) || isMediaURL(metadata?.url) else {
+        guard let previewKind = NetworkMediaPreviewSupport.previewKind(
+            mimeType: metadata?.mimeType,
+            url: metadata?.url
+        ) else {
             return nil
         }
 
-        if isHLSMIMEType(mimeType) || isHLSURL(metadata?.url),
-           let remoteURL = playableRemoteMediaURL(metadata?.url) {
+        if previewKind == .hlsPlaylist, let remoteURL = playableRemoteMediaURL(metadata?.url) {
             return .movie(remoteURL)
         }
 
@@ -260,13 +262,12 @@ final class NetworkBodyViewController: UIViewController {
             return nil
         }
 
-        if isImageMIMEType(mimeType) || isImageURL(metadata?.url),
-           let image = UIImage(data: data) {
+        if previewKind == .image, let image = UIImage(data: data) {
             return .image(image)
         }
 
-        if isPlayableMIMEType(mimeType) || isPlayableURL(metadata?.url) {
-            guard let fileURL = writeMediaData(data, mimeType: mimeType, url: metadata?.url) else {
+        if previewKind == .movie || previewKind == .hlsPlaylist {
+            guard let fileURL = writeMediaData(data, mimeType: metadata?.mimeType, url: metadata?.url) else {
                 return nil
             }
             return .movie(fileURL)
@@ -288,6 +289,7 @@ final class NetworkBodyViewController: UIViewController {
         syntaxView.isHidden = true
         imageScrollView.isHidden = false
         shouldResetImageZoomOnNextLayout = true
+        imagePreviewLayoutBoundsSize = nil
         imageView.image = image
         imageWidthConstraint?.constant = max(image.size.width, 1)
         imageHeightConstraint?.constant = max(image.size.height, 1)
@@ -338,6 +340,7 @@ final class NetworkBodyViewController: UIViewController {
         imageWidthConstraint?.constant = 0
         imageHeightConstraint?.constant = 0
         shouldResetImageZoomOnNextLayout = false
+        imagePreviewLayoutBoundsSize = nil
         imageScrollView.contentInset = .zero
         imageScrollView.contentOffset = .zero
         imageScrollView.minimumZoomScale = 1
@@ -346,9 +349,12 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func updateImagePreviewLayoutIfNeeded() {
-        let didUpdate = updateImagePreviewLayout(resetZoom: shouldResetImageZoomOnNextLayout)
+        let boundsSize = imageScrollView.bounds.size
+        let shouldResetZoom = shouldResetImageZoomOnNextLayout || imagePreviewLayoutBoundsSize != boundsSize
+        let didUpdate = updateImagePreviewLayout(resetZoom: shouldResetZoom)
         if didUpdate {
             shouldResetImageZoomOnNextLayout = false
+            imagePreviewLayoutBoundsSize = boundsSize
         }
     }
 
@@ -377,7 +383,7 @@ final class NetworkBodyViewController: UIViewController {
 
         imageScrollView.maximumZoomScale = maximumZoomScale
         imageScrollView.minimumZoomScale = minimumZoomScale
-        imageScrollView.setZoomScale(targetZoomScale, animated: false)
+        imageScrollView.zoomScale = targetZoomScale
         updateImageContentInset()
         return true
     }
@@ -450,67 +456,6 @@ private enum NetworkBodyMediaPayload {
     case movie(URL)
 }
 
-private func normalizedMIMEType(_ mimeType: String?) -> String? {
-    mimeType?
-        .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-        .first
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-}
-
-private func isMediaMIMEType(_ mimeType: String?) -> Bool {
-    isImageMIMEType(mimeType) || isPlayableMIMEType(mimeType)
-}
-
-private func isImageMIMEType(_ mimeType: String?) -> Bool {
-    guard let mimeType else {
-        return false
-    }
-    return mimeType.hasPrefix("image/") && mimeType != "image/svg+xml"
-}
-
-private func isPlayableMIMEType(_ mimeType: String?) -> Bool {
-    guard let mimeType else {
-        return false
-    }
-    return mimeType.hasPrefix("video/") || mimeType.hasPrefix("audio/") || isHLSMIMEType(mimeType)
-}
-
-private func isHLSMIMEType(_ mimeType: String?) -> Bool {
-    switch mimeType {
-    case "application/vnd.apple.mpegurl", "application/x-mpegurl", "application/mpegurl",
-         "audio/mpegurl", "audio/x-mpegurl":
-        true
-    default:
-        false
-    }
-}
-
-private func isMediaURL(_ url: String?) -> Bool {
-    isImageURL(url) || isPlayableURL(url)
-}
-
-private func isImageURL(_ url: String?) -> Bool {
-    switch pathExtension(url) {
-    case "apng", "gif", "heic", "heif", "jpg", "jpeg", "png", "tif", "tiff", "webp":
-        return true
-    default:
-        return false
-    }
-}
-
-private func isPlayableURL(_ url: String?) -> Bool {
-    switch pathExtension(url) {
-    case "aac", "aif", "aiff", "m4a", "m4v", "m3u8", "mov", "mp3", "mp4", "wav":
-        return true
-    default:
-        return false
-    }
-}
-
-private func isHLSURL(_ url: String?) -> Bool {
-    pathExtension(url) == "m3u8"
-}
-
 private func playableRemoteMediaURL(_ url: String?) -> URL? {
     guard let url = url.flatMap(URL.init(string:)) else {
         return nil
@@ -523,38 +468,8 @@ private func playableRemoteMediaURL(_ url: String?) -> URL? {
     }
 }
 
-private func pathExtension(_ url: String?) -> String? {
-    guard let url else {
-        return nil
-    }
-    return URL(string: url)?.pathExtension.lowercased()
-}
-
 private func mediaFileExtension(mimeType: String?, url: String?) -> String {
-    if let pathExtension = pathExtension(url), pathExtension.isEmpty == false {
-        return pathExtension
-    }
-    switch mimeType {
-    case "application/vnd.apple.mpegurl", "application/x-mpegurl", "application/mpegurl",
-         "audio/mpegurl", "audio/x-mpegurl":
-        return "m3u8"
-    case "audio/aac":
-        return "aac"
-    case "audio/aiff":
-        return "aiff"
-    case "audio/mpeg":
-        return "mp3"
-    case "audio/mp4":
-        return "m4a"
-    case "audio/wav", "audio/x-wav":
-        return "wav"
-    case "video/quicktime":
-        return "mov"
-    case "video/x-m4v":
-        return "m4v"
-    default:
-        return "mp4"
-    }
+    NetworkMediaPreviewSupport.temporaryFileExtension(mimeType: mimeType, url: url)
 }
 
 private func removeTemporaryMediaFile(at url: URL?) {

--- a/Sources/WebInspectorUI/Network/List/NetworkResourceFilter.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkResourceFilter.swift
@@ -5,7 +5,7 @@ package enum NetworkResourceFilter: String, CaseIterable, Hashable, Sendable, Id
     case all
     case document
     case stylesheet
-    case image
+    case media
     case font
     case script
     case xhrFetch
@@ -17,7 +17,7 @@ package enum NetworkResourceFilter: String, CaseIterable, Hashable, Sendable, Id
         [
             .document,
             .stylesheet,
-            .image,
+            .media,
             .font,
             .script,
             .xhrFetch,
@@ -53,8 +53,8 @@ package enum NetworkResourceFilter: String, CaseIterable, Hashable, Sendable, Id
             String(localized: "network.filter.document", bundle: .module)
         case .stylesheet:
             "CSS"
-        case .image:
-            String(localized: "network.filter.image", bundle: .module)
+        case .media:
+            String(localized: "network.filter.media", bundle: .module)
         case .font:
             String(localized: "network.filter.font", bundle: .module)
         case .script:
@@ -72,8 +72,8 @@ package enum NetworkResourceFilter: String, CaseIterable, Hashable, Sendable, Id
             self = .document
         case .styleSheet:
             self = .stylesheet
-        case .image:
-            self = .image
+        case .image, .media:
+            self = .media
         case .font:
             self = .font
         case .script:
@@ -92,10 +92,10 @@ package enum NetworkResourceFilter: String, CaseIterable, Hashable, Sendable, Id
             .lowercased() ?? ""
         let pathExtension = URL(string: url)?.pathExtension.lowercased() ?? ""
 
-        if normalizedMimeType == "text/css" || pathExtension == "css" {
+        if case .previewable = NetworkMediaPreviewSupport.classification(mimeType: mimeType, url: url) {
+            self = .media
+        } else if normalizedMimeType == "text/css" || pathExtension == "css" {
             self = .stylesheet
-        } else if normalizedMimeType.hasPrefix("image/") {
-            self = .image
         } else if normalizedMimeType.hasPrefix("font/") || ["woff", "woff2", "ttf", "otf"].contains(pathExtension) {
             self = .font
         } else if normalizedMimeType.contains("javascript") || ["js", "mjs"].contains(pathExtension) {

--- a/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
+++ b/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
@@ -1,0 +1,234 @@
+import AVFoundation
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+package enum NetworkMediaPreviewKind: Equatable, Sendable {
+    case image
+    case movie
+    case hlsPlaylist
+}
+
+package enum NetworkMediaPreviewClassification: Equatable, Sendable {
+    case previewable(NetworkMediaPreviewKind)
+    case notPreviewable
+    case unknown
+}
+
+package enum NetworkMediaPreviewSupport {
+    package static func previewKind(mimeType: String?, url: String?) -> NetworkMediaPreviewKind? {
+        guard case .previewable(let kind) = classification(mimeType: mimeType, url: url) else {
+            return nil
+        }
+        return kind
+    }
+
+    package static func classification(
+        mimeType: String?,
+        url: String?
+    ) -> NetworkMediaPreviewClassification {
+        let normalizedMIMEType = normalizedMIMEType(mimeType)
+
+        if isHLSMIMEType(normalizedMIMEType) {
+            return .previewable(.hlsPlaylist)
+        }
+
+        if let normalizedMIMEType {
+            if isSVGMIMEType(normalizedMIMEType) {
+                return .notPreviewable
+            }
+            if isSupportedImageMIMEType(normalizedMIMEType) {
+                return .previewable(.image)
+            }
+            if isPlayableMIMEType(normalizedMIMEType) {
+                return .previewable(.movie)
+            }
+            if let type = contentType(mimeType: normalizedMIMEType) {
+                let classification = classification(for: type)
+                switch classification {
+                case .previewable, .notPreviewable:
+                    return classification
+                case .unknown:
+                    break
+                }
+            }
+            if normalizedMIMEType.hasPrefix("image/")
+                || normalizedMIMEType.hasPrefix("audio/")
+                || normalizedMIMEType.hasPrefix("video/") {
+                return .notPreviewable
+            }
+        }
+
+        guard shouldInferFromURL(mimeType: normalizedMIMEType) else {
+            return .unknown
+        }
+
+        if isHLSURL(url) {
+            return .previewable(.hlsPlaylist)
+        }
+
+        if isSupportedImageURL(url) {
+            return .previewable(.image)
+        }
+
+        if let type = contentType(url: url) {
+            let classification = classification(for: type)
+            switch classification {
+            case .previewable, .notPreviewable:
+                return classification
+            case .unknown:
+                break
+            }
+        }
+
+        return .unknown
+    }
+
+    package static func temporaryFileExtension(mimeType: String?, url: String?) -> String {
+        if let pathExtension = pathExtension(url), pathExtension.isEmpty == false {
+            return pathExtension
+        }
+
+        let normalizedMIMEType = normalizedMIMEType(mimeType)
+        if isHLSMIMEType(normalizedMIMEType) {
+            return "m3u8"
+        }
+        if let normalizedMIMEType,
+           let preferredExtension = contentType(mimeType: normalizedMIMEType)?.preferredFilenameExtension {
+            return preferredExtension
+        }
+
+        switch normalizedMIMEType {
+        case "audio/aiff":
+            return "aiff"
+        case "audio/mp4":
+            return "m4a"
+        case "audio/wav", "audio/x-wav":
+            return "wav"
+        case "video/x-m4v":
+            return "m4v"
+        default:
+            return "mp4"
+        }
+    }
+
+    private static func classification(for type: UTType) -> NetworkMediaPreviewClassification {
+        if type.conforms(to: .svg) {
+            return .notPreviewable
+        }
+        if type.conforms(to: .image) {
+            return isSupportedImageType(type) ? .previewable(.image) : .notPreviewable
+        }
+        if isSupportedAudiovisualType(type) {
+            return .previewable(.movie)
+        }
+        if type.conforms(to: .audio)
+            || type.conforms(to: .movie)
+            || type.conforms(to: .video)
+            || type.conforms(to: .audiovisualContent) {
+            return .notPreviewable
+        }
+        return .unknown
+    }
+
+    private static func contentType(mimeType: String) -> UTType? {
+        UTType(mimeType: mimeType, conformingTo: .data)
+    }
+
+    private static func contentType(url: String?) -> UTType? {
+        guard let pathExtension = pathExtension(url), pathExtension.isEmpty == false else {
+            return nil
+        }
+        return UTType(filenameExtension: pathExtension, conformingTo: .data)
+    }
+
+    private static func isSupportedImageType(_ type: UTType) -> Bool {
+        supportedImageTypes.contains { supportedType in
+            type.conforms(to: supportedType)
+        }
+    }
+
+    private static func isSupportedAudiovisualType(_ type: UTType) -> Bool {
+        supportedAudiovisualContentTypes.contains { supportedType in
+            type.conforms(to: supportedType)
+        }
+    }
+
+    private static func isPlayableMIMEType(_ mimeType: String) -> Bool {
+        supportedAudiovisualMIMETypes.contains(mimeType) || AVURLAsset.isPlayableExtendedMIMEType(mimeType)
+    }
+
+    private static func isSupportedImageMIMEType(_ mimeType: String) -> Bool {
+        switch mimeType {
+        case "image/apng":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isSVGMIMEType(_ mimeType: String) -> Bool {
+        mimeType == "image/svg+xml"
+    }
+
+    private static func isHLSMIMEType(_ mimeType: String?) -> Bool {
+        switch mimeType {
+        case "application/vnd.apple.mpegurl", "application/x-mpegurl", "application/mpegurl",
+             "audio/mpegurl", "audio/x-mpegurl":
+            true
+        default:
+            false
+        }
+    }
+
+    private static func isHLSURL(_ url: String?) -> Bool {
+        pathExtension(url) == "m3u8"
+    }
+
+    private static func isSupportedImageURL(_ url: String?) -> Bool {
+        switch pathExtension(url) {
+        case "apng":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func normalizedMIMEType(_ mimeType: String?) -> String? {
+        mimeType?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+    }
+
+    private static func pathExtension(_ url: String?) -> String? {
+        guard let url else {
+            return nil
+        }
+        return URL(string: url)?.pathExtension.lowercased()
+    }
+
+    private static func shouldInferFromURL(mimeType: String?) -> Bool {
+        guard let mimeType else {
+            return true
+        }
+        switch mimeType {
+        case "application/octet-stream", "binary/octet-stream":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static let supportedImageTypes: [UTType] = {
+        (CGImageSourceCopyTypeIdentifiers() as? [String] ?? []).compactMap(UTType.init)
+    }()
+
+    private static let supportedAudiovisualContentTypes = AVURLAsset.audiovisualTypes().compactMap { fileType in
+        UTType(fileType.rawValue)
+    }
+
+    private static let supportedAudiovisualMIMETypes = Set(
+        AVURLAsset.audiovisualMIMETypes().map { $0.lowercased() }
+    )
+}

--- a/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
+++ b/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
@@ -52,8 +52,13 @@ package enum NetworkMediaPreviewSupport {
                     break
                 }
             }
-            if normalizedMIMEType.hasPrefix("image/")
-                || normalizedMIMEType.hasPrefix("audio/")
+            if normalizedMIMEType.hasPrefix("image/") {
+                if case .previewable(.image) = imageClassification(url: url) {
+                    return .previewable(.image)
+                }
+                return .notPreviewable
+            }
+            if normalizedMIMEType.hasPrefix("audio/")
                 || normalizedMIMEType.hasPrefix("video/") {
                 return .notPreviewable
             }
@@ -160,7 +165,7 @@ package enum NetworkMediaPreviewSupport {
 
     private static func isSupportedImageMIMEType(_ mimeType: String) -> Bool {
         switch mimeType {
-        case "image/apng":
+        case "image/apng", "image/pjpeg", "image/x-png":
             return true
         default:
             return false
@@ -192,6 +197,16 @@ package enum NetworkMediaPreviewSupport {
         default:
             return false
         }
+    }
+
+    private static func imageClassification(url: String?) -> NetworkMediaPreviewClassification {
+        if isSupportedImageURL(url) {
+            return .previewable(.image)
+        }
+        if let type = contentType(url: url) {
+            return classification(for: type)
+        }
+        return .unknown
     }
 
     private static func normalizedMIMEType(_ mimeType: String?) -> String? {

--- a/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
@@ -78,12 +78,24 @@ extension NetworkRequest {
     }
 
     package var resourceFilter: NetworkResourceFilter {
+        let responseURL = response?.url ?? request.url
+        switch NetworkMediaPreviewSupport.classification(mimeType: response?.mimeType, url: responseURL) {
+        case .previewable:
+            return .media
+        case .notPreviewable:
+            if resourceType == .media {
+                return .media
+            }
+            return NetworkResourceFilter(mimeType: response?.mimeType, url: responseURL)
+        case .unknown:
+            break
+        }
         if let resourceType {
             return NetworkResourceFilter(resourceType: resourceType)
         }
         return NetworkResourceFilter(
             mimeType: response?.mimeType,
-            url: request.url
+            url: responseURL
         )
     }
 
@@ -139,6 +151,8 @@ extension NetworkResourceType {
             "stylesheet"
         case .image:
             "image"
+        case .media:
+            "media"
         case .font:
             "font"
         case .script:

--- a/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
@@ -78,15 +78,29 @@ extension NetworkRequest {
     }
 
     package var resourceFilter: NetworkResourceFilter {
-        let responseURL = response?.url ?? request.url
-        switch NetworkMediaPreviewSupport.classification(mimeType: response?.mimeType, url: responseURL) {
+        guard let response else {
+            if let resourceType {
+                return NetworkResourceFilter(resourceType: resourceType)
+            }
+            return NetworkResourceFilter(mimeType: nil, url: request.url)
+        }
+
+        if let resourceType, shouldKeepResourceTypeForURLInferredMedia(resourceType) {
+            if case .previewable = NetworkMediaPreviewSupport.classification(mimeType: response.mimeType, url: nil) {
+                return .media
+            }
+            return NetworkResourceFilter(resourceType: resourceType)
+        }
+
+        let responseURL = response.url
+        switch NetworkMediaPreviewSupport.classification(mimeType: response.mimeType, url: responseURL) {
         case .previewable:
             return .media
         case .notPreviewable:
             if resourceType == .media {
                 return .media
             }
-            return NetworkResourceFilter(mimeType: response?.mimeType, url: responseURL)
+            return NetworkResourceFilter(mimeType: response.mimeType, url: responseURL)
         case .unknown:
             break
         }
@@ -94,7 +108,7 @@ extension NetworkRequest {
             return NetworkResourceFilter(resourceType: resourceType)
         }
         return NetworkResourceFilter(
-            mimeType: response?.mimeType,
+            mimeType: response.mimeType,
             url: responseURL
         )
     }
@@ -139,6 +153,15 @@ extension NetworkRequest {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .binary
         return formatter.string(fromByteCount: Int64(length))
+    }
+}
+
+private func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkResourceType) -> Bool {
+    switch resourceType {
+    case .image, .media, .xhr, .fetch, .other:
+        return false
+    default:
+        return true
     }
 }
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -12,6 +12,8 @@ struct NetworkDetailViewControllerTests {
     @Test
     func resourceFilterSpecialistTitlesFollowWebInspectorLabels() {
         #expect(NetworkResourceFilter.stylesheet.localizedTitle == "CSS")
+        #expect(NetworkResourceFilter.media.localizedTitle == String(localized: "network.filter.media", bundle: .module))
+        #expect(localizedResourceString("network.filter.media", locale: "en") == "Media")
         #expect(NetworkResourceFilter.script.localizedTitle == "JS")
         #expect(NetworkResourceFilter.xhrFetch.localizedTitle == "XHR / Fetch")
     }
@@ -1085,6 +1087,14 @@ struct NetworkDetailViewControllerTests {
         UIView.setAnimationsEnabled(false)
         defer { UIView.setAnimationsEnabled(wereAnimationsEnabled) }
         return body()
+    }
+
+    private func localizedResourceString(_ key: String, locale: String) -> String? {
+        guard let bundleURL = Bundle.module.url(forResource: locale, withExtension: "lproj"),
+              let bundle = Bundle(url: bundleURL) else {
+            return nil
+        }
+        return bundle.localizedString(forKey: key, value: nil, table: nil)
     }
 }
 #endif

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -42,6 +42,159 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
 
 @Test
 @MainActor
+func mediaFilterIncludesPreviewableMediaResponses() async throws {
+    let network = NetworkSession()
+    applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://cdn.example.com/photo.png",
+        resourceType: .image,
+        mimeType: "image/png",
+        timestamp: 1
+    )
+    applyRequest(
+        to: network,
+        requestID: "2",
+        url: "https://cdn.example.com/movie.mp4",
+        resourceType: .media,
+        mimeType: "video/mp4",
+        timestamp: 2
+    )
+    applyRequest(
+        to: network,
+        requestID: "3",
+        url: "https://api.example.com/avatar",
+        resourceType: .xhr,
+        mimeType: "image/avif",
+        timestamp: 3
+    )
+    applyRequest(
+        to: network,
+        requestID: "4",
+        url: "https://api.example.com/avatar.avif",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 4
+    )
+    applyRequest(
+        to: network,
+        requestID: "5",
+        url: "https://media.example.com/live/master.m3u8",
+        resourceType: .xhr,
+        mimeType: "application/vnd.apple.mpegurl",
+        timestamp: 5
+    )
+    applyRequest(
+        to: network,
+        requestID: "6",
+        url: "https://media.example.com/clip.mp4",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 6
+    )
+    applyRequest(
+        to: network,
+        requestID: "7",
+        url: "https://media.example.com/song.mp3",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 7
+    )
+    applyRequest(
+        to: network,
+        requestID: "8",
+        url: "https://cdn.example.com/animated.apng",
+        resourceType: .xhr,
+        mimeType: "image/apng",
+        timestamp: 8
+    )
+    applyRequest(
+        to: network,
+        requestID: "9",
+        url: "https://cdn.example.com/icon.svg",
+        resourceType: .image,
+        mimeType: "image/svg+xml",
+        timestamp: 9
+    )
+    applyRequest(
+        to: network,
+        requestID: "10",
+        url: "https://cdn.example.com/font.woff2",
+        resourceType: .font,
+        mimeType: "font/woff2",
+        timestamp: 10
+    )
+    applyRequest(
+        to: network,
+        requestID: "11",
+        url: "https://api.example.com/data.json",
+        resourceType: .xhr,
+        mimeType: "application/json",
+        timestamp: 11
+    )
+    applyRequest(
+        to: network,
+        requestID: "12",
+        url: "https://cdn.example.com/app.js",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 12
+    )
+    applyRequest(
+        to: network,
+        requestID: "13",
+        url: "https://cdn.example.com/player.mp4",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 13
+    )
+    applyRequest(
+        to: network,
+        requestID: "14",
+        url: "https://cdn.example.com/theme.png",
+        resourceType: .styleSheet,
+        mimeType: "text/css",
+        timestamp: 14
+    )
+    applyRequest(
+        to: network,
+        requestID: "15",
+        url: "https://api.example.com/download",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 15
+    )
+    applyRequest(
+        to: network,
+        requestID: "16",
+        url: "https://cdn.example.com/animated.apng",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 16
+    )
+
+    let model = NetworkPanelModel(network: network)
+    model.setResourceFilter(.media, enabled: true)
+
+    #expect(model.displayRequests.map(\.id.requestID.rawValue) == ["16", "8", "7", "6", "5", "4", "3", "2", "1"])
+}
+
+@Test
+func mediaPreviewSupportClassifiesAVIFAndExcludesSVG() {
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/avif", url: nil) == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: nil, url: "https://cdn.example.com/photo.avif") == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/apng", url: nil) == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: nil, url: "https://cdn.example.com/animated.apng") == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "application/octet-stream", url: "https://cdn.example.com/animated.apng") == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == nil)
+    #expect(NetworkMediaPreviewSupport.classification(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == .notPreviewable)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "text/javascript", url: "https://cdn.example.com/player.mp4") == nil)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "text/css", url: "https://cdn.example.com/theme.png") == nil)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "application/octet-stream", url: "https://api.example.com/download") == nil)
+}
+
+@Test
+@MainActor
 func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
     let network = NetworkSession()
     let requestID = applyRequest(

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -172,6 +172,21 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 16
     )
+    applyRequest(
+        to: network,
+        requestID: "17",
+        url: "https://cdn.example.com/player.mp4",
+        resourceType: .script,
+        mimeType: "application/octet-stream",
+        timestamp: 17
+    )
+    applyPendingRequest(
+        to: network,
+        requestID: "18",
+        url: "https://api.example.com/pending-avatar.png",
+        resourceType: .xhr,
+        timestamp: 18
+    )
 
     let model = NetworkPanelModel(network: network)
     model.setResourceFilter(.media, enabled: true)
@@ -186,6 +201,9 @@ func mediaPreviewSupportClassifiesAVIFAndExcludesSVG() {
     #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/apng", url: nil) == .image)
     #expect(NetworkMediaPreviewSupport.previewKind(mimeType: nil, url: "https://cdn.example.com/animated.apng") == .image)
     #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "application/octet-stream", url: "https://cdn.example.com/animated.apng") == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/x-png", url: nil) == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/pjpeg", url: nil) == .image)
+    #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/x-unknown", url: "https://cdn.example.com/photo.png") == .image)
     #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == nil)
     #expect(NetworkMediaPreviewSupport.classification(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == .notPreviewable)
     #expect(NetworkMediaPreviewSupport.previewKind(mimeType: "text/javascript", url: "https://cdn.example.com/player.mp4") == nil)
@@ -258,4 +276,25 @@ private func applyRequest(
         timestamp: timestamp + 0.2
     )
     return key
+}
+
+@MainActor
+@discardableResult
+private func applyPendingRequest(
+    to network: NetworkSession,
+    requestID rawRequestID: String,
+    url: String,
+    resourceType: NetworkResourceType,
+    timestamp: Double
+) -> NetworkRequest.ID {
+    network.applyRequestWillBeSent(
+        targetID: ProtocolTargetIdentifier("page"),
+        requestID: NetworkRequestIdentifier(rawRequestID),
+        frameID: DOMFrameIdentifier("main"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: NetworkRequestPayload(url: url),
+        resourceType: resourceType,
+        timestamp: timestamp
+    )
 }


### PR DESCRIPTION
## Purpose
Replace the Network tab's Image filter with a broader Media filter that matches media-previewable responses.

## Changes
- Rename the UI filter from Image to Media and add `NetworkResourceType.media`.
- Share media preview classification between request filtering and body preview rendering.
- Classify ImageIO-supported images, AV media, and HLS while excluding SVG from Media.
- Preserve explicit resource-type filtering until response metadata is available.
- Add regression coverage for AVIF, APNG, legacy image MIME aliases, generic octet-stream handling, and non-media resources.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` against `origin/codex/network-detail-mode-palette` passed with no findings.