### PR TITLE
Follow page background appearance

### DIFF
--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -266,6 +266,7 @@ final class BrowserInspectorCoordinator {
 
         let anchor = resolvePresentationAnchor(from: presenter)
         let sheetController = WebInspectorViewController(session: inspectorSession)
+        sheetController.followsInspectedPageAppearance = true
         if #available(iOS 26.0, *) {
             sheetController.drawsBackground = false
         }

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -215,6 +215,7 @@ struct MonoclyLifecycleTests {
                 coordinator.presentedSheetControllerForTesting as? WebInspectorViewController
             )
             #expect(didPresent)
+            #expect(sheetController.followsInspectedPageAppearance)
             if #available(iOS 26.0, *) {
                 #expect(sheetController.drawsBackground == false)
             }
@@ -415,6 +416,7 @@ struct MonoclyLifecycleTests {
             let inspectorWindow = try #require(sceneDelegate.window)
             context.retain(inspectorWindow)
             #expect(inspectorWindow.rootViewController === sceneDelegate.inspectorViewController)
+            #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.followsInspectedPageAppearance == false)
             if #available(iOS 26.0, *) {
                 #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.drawsBackground == true)
             }

--- a/Sources/WebInspectorUI/Containers/WebInspectorPageAppearanceObserver.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorPageAppearanceObserver.swift
@@ -1,0 +1,102 @@
+#if canImport(UIKit)
+import UIKit
+import WebKit
+
+@MainActor
+package enum WebInspectorPageAppearance {
+    package static func interfaceStyle(
+        for color: UIColor?,
+        in traitCollection: UITraitCollection
+    ) -> UIUserInterfaceStyle {
+        guard let color else {
+            return .unspecified
+        }
+
+        let resolvedColor = color.resolvedColor(with: traitCollection)
+        guard let sRGBColorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let convertedColor = resolvedColor.cgColor.converted(
+                to: sRGBColorSpace,
+                intent: .defaultIntent,
+                options: nil
+              ),
+              let components = convertedColor.components,
+              components.count >= 3,
+              convertedColor.alpha > 0.01 else {
+            return .unspecified
+        }
+
+        let red = components[0]
+        let green = components[1]
+        let blue = components[2]
+        let lightness = 0.5 * (max(red, green, blue) + min(red, green, blue))
+        return lightness <= 0.5 ? .dark : .light
+    }
+}
+
+@MainActor
+package final class WebInspectorPageAppearanceObserver {
+    private weak var webView: WKWebView?
+    private let apply: @MainActor (UIUserInterfaceStyle) -> Void
+    private var backgroundObservation: NSKeyValueObservation?
+    private var traitRegistration: (any UITraitChangeRegistration)?
+
+    package init(
+        webView: WKWebView,
+        apply: @escaping @MainActor (UIUserInterfaceStyle) -> Void
+    ) {
+        self.webView = webView
+        self.apply = apply
+    }
+
+    isolated deinit {
+        invalidate()
+    }
+
+    package func start() {
+        guard let webView else {
+            apply(.unspecified)
+            return
+        }
+
+        backgroundObservation = webView.observe(
+            \.underPageBackgroundColor,
+            options: [.initial, .new]
+        ) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.publishCurrentStyle()
+            }
+        }
+
+        traitRegistration = webView.registerForTraitChanges(
+            UITraitCollection.systemTraitsAffectingColorAppearance
+        ) { [weak self] (_: WKWebView, _: UITraitCollection) in
+            self?.publishCurrentStyle()
+        }
+    }
+
+    package func invalidate() {
+        backgroundObservation?.invalidate()
+        backgroundObservation = nil
+
+        if let traitRegistration,
+           let webView {
+            webView.unregisterForTraitChanges(traitRegistration)
+        }
+        traitRegistration = nil
+    }
+
+    private func publishCurrentStyle() {
+        guard let webView else {
+            apply(.unspecified)
+            return
+        }
+
+        apply(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: webView.underPageBackgroundColor,
+                in: webView.traitCollection
+            )
+        )
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -9,6 +9,9 @@ import WebInspectorCore
 public final class WebInspectorSession {
     package let inspector: InspectorSession
     package let interface: InterfaceModel
+    @ObservationIgnored private let attachAction: @MainActor (InspectorSession, WKWebView) async throws -> Void
+    @ObservationIgnored private let detachAction: @MainActor (InspectorSession) async -> Void
+    @ObservationIgnored private var pageAppearanceObserver: WebInspectorPageAppearanceObserver?
 
     public convenience init(tabs: [WebInspectorTab] = [.dom, .network]) {
         self.init(inspector: InspectorSession(), tabs: tabs)
@@ -16,13 +19,22 @@ public final class WebInspectorSession {
 
     package init(
         inspector: InspectorSession,
-        tabs: [WebInspectorTab] = [.dom, .network]
+        tabs: [WebInspectorTab] = [.dom, .network],
+        attachAction: @escaping @MainActor (InspectorSession, WKWebView) async throws -> Void = { inspector, webView in
+            try await inspector.attach(to: webView)
+        },
+        detachAction: @escaping @MainActor (InspectorSession) async -> Void = { inspector in
+            await inspector.detach()
+        }
     ) {
         self.inspector = inspector
         self.interface = InterfaceModel(tabs: tabs)
+        self.attachAction = attachAction
+        self.detachAction = detachAction
     }
 
     isolated deinit {
+        stopPageAppearanceObservation()
         interface.removeContentCache()
     }
 
@@ -31,11 +43,38 @@ public final class WebInspectorSession {
     }
 
     public func attach(to webView: WKWebView) async throws {
-        try await inspector.attach(to: webView)
+        stopPageAppearanceObservation()
+        do {
+            try await attachAction(inspector, webView)
+            startPageAppearanceObservation(for: webView)
+        } catch {
+            stopPageAppearanceObservation()
+            throw error
+        }
     }
 
     public func detach() async {
-        await inspector.detach()
+        stopPageAppearanceObservation()
+        await detachAction(inspector)
+    }
+
+    private func startPageAppearanceObservation(for webView: WKWebView) {
+        let observer = WebInspectorPageAppearanceObserver(webView: webView) { [weak interface] style in
+            interface?.setPreferredInterfaceStyle(style)
+        }
+        pageAppearanceObserver = observer
+        observer.start()
+    }
+
+    private func stopPageAppearanceObservation() {
+        pageAppearanceObserver?.invalidate()
+        pageAppearanceObserver = nil
+        interface.setPreferredInterfaceStyle(.unspecified)
+    }
+
+    package func startPageAppearanceObservationForTesting(webView: WKWebView) {
+        stopPageAppearanceObservation()
+        startPageAppearanceObservation(for: webView)
     }
 }
 
@@ -44,13 +83,16 @@ public final class WebInspectorSession {
 package final class InterfaceModel {
     package private(set) var tabs: [WebInspectorTab]
     package private(set) var selectedItemID: TabDisplayItem.ID?
+    package private(set) var preferredInterfaceStyle: UIUserInterfaceStyle
     @ObservationIgnored private let projection = TabDisplayProjection()
     @ObservationIgnored private let contentCache = TabContentCache()
     @ObservationIgnored private var networkPanelModel: NetworkPanelModel?
 
     package init(tabs: [WebInspectorTab] = [.dom, .network]) {
-        self.tabs = Self.uniqueTabs(tabs)
-        selectedItemID = self.tabs.first?.id
+        let uniqueTabs = Self.uniqueTabs(tabs)
+        self.tabs = uniqueTabs
+        preferredInterfaceStyle = .unspecified
+        selectedItemID = uniqueTabs.first?.id
     }
 
     package func displayItems(for hostLayout: WebInspectorTabHostLayout) -> [TabDisplayItem] {
@@ -105,6 +147,13 @@ package final class InterfaceModel {
             self.selectedItemID = uniqueTabs.first?.id
             return
         }
+    }
+
+    package func setPreferredInterfaceStyle(_ style: UIUserInterfaceStyle) {
+        guard preferredInterfaceStyle != style else {
+            return
+        }
+        preferredInterfaceStyle = style
     }
 
     package func viewController<Content: UIViewController>(

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import ObservationBridge
 import WebInspectorCore
 import UIKit
 import WebKit
@@ -12,6 +13,7 @@ public final class WebInspectorViewController: UIViewController {
 
     public let session: WebInspectorSession
     private var drawsBackgroundStorage = true
+    private let observationScope = ObservationScope()
 
     @available(iOS 26.0, *)
     public var drawsBackground: Bool {
@@ -31,6 +33,7 @@ public final class WebInspectorViewController: UIViewController {
         self.session = session
         super.init(nibName: nil, bundle: nil)
         webInspectorSetDrawsBackgroundTraitOverride(drawsBackgroundStorage)
+        bindInterfaceAppearance()
     }
 
     public convenience init(tabs: [WebInspectorTab]) {
@@ -40,6 +43,10 @@ public final class WebInspectorViewController: UIViewController {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
+    }
+
+    isolated deinit {
+        observationScope.cancelAll()
     }
 
     public override func viewDidLoad() {
@@ -74,6 +81,19 @@ public final class WebInspectorViewController: UIViewController {
 
     private func applyBackgroundFromTraits() {
         view.backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+    }
+
+    private func bindInterfaceAppearance() {
+        observationScope.observe(session.interface) { [weak self] _, interface in
+            self?.applyPreferredInterfaceStyle(interface.preferredInterfaceStyle)
+        }
+    }
+
+    private func applyPreferredInterfaceStyle(_ style: UIUserInterfaceStyle) {
+        guard overrideUserInterfaceStyle != style else {
+            return
+        }
+        overrideUserInterfaceStyle = style
     }
 
     private func setDrawsBackground(_ drawsBackground: Bool) {

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -14,6 +14,7 @@ public final class WebInspectorViewController: UIViewController {
     public let session: WebInspectorSession
     private var drawsBackgroundStorage = true
     private var followsInspectedPageAppearanceStorage = false
+    private var appliedInspectedPageInterfaceStyle: UIUserInterfaceStyle?
     private let observationScope = ObservationScope()
 
     public var followsInspectedPageAppearance: Bool {
@@ -96,11 +97,16 @@ public final class WebInspectorViewController: UIViewController {
     }
 
     private func applyPreferredInterfaceStyle(_ style: UIUserInterfaceStyle) {
-        let resolvedStyle = followsInspectedPageAppearanceStorage ? style : .unspecified
-        guard overrideUserInterfaceStyle != resolvedStyle else {
+        guard followsInspectedPageAppearanceStorage else {
             return
         }
-        overrideUserInterfaceStyle = resolvedStyle
+
+        if overrideUserInterfaceStyle != style {
+            overrideUserInterfaceStyle = style
+            appliedInspectedPageInterfaceStyle = style
+        } else if appliedInspectedPageInterfaceStyle != nil {
+            appliedInspectedPageInterfaceStyle = style
+        }
     }
 
     private func setFollowsInspectedPageAppearance(_ followsInspectedPageAppearance: Bool) {
@@ -108,7 +114,22 @@ public final class WebInspectorViewController: UIViewController {
             return
         }
         followsInspectedPageAppearanceStorage = followsInspectedPageAppearance
+        guard followsInspectedPageAppearance else {
+            clearAppliedInspectedPageInterfaceStyle()
+            return
+        }
         applyPreferredInterfaceStyle(session.interface.preferredInterfaceStyle)
+    }
+
+    private func clearAppliedInspectedPageInterfaceStyle() {
+        defer {
+            appliedInspectedPageInterfaceStyle = nil
+        }
+        guard let appliedInspectedPageInterfaceStyle,
+              overrideUserInterfaceStyle == appliedInspectedPageInterfaceStyle else {
+            return
+        }
+        overrideUserInterfaceStyle = .unspecified
     }
 
     private func setDrawsBackground(_ drawsBackground: Bool) {

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -13,7 +13,13 @@ public final class WebInspectorViewController: UIViewController {
 
     public let session: WebInspectorSession
     private var drawsBackgroundStorage = true
+    private var followsInspectedPageAppearanceStorage = false
     private let observationScope = ObservationScope()
+
+    public var followsInspectedPageAppearance: Bool {
+        get { followsInspectedPageAppearanceStorage }
+        set { setFollowsInspectedPageAppearance(newValue) }
+    }
 
     @available(iOS 26.0, *)
     public var drawsBackground: Bool {
@@ -90,10 +96,19 @@ public final class WebInspectorViewController: UIViewController {
     }
 
     private func applyPreferredInterfaceStyle(_ style: UIUserInterfaceStyle) {
-        guard overrideUserInterfaceStyle != style else {
+        let resolvedStyle = followsInspectedPageAppearanceStorage ? style : .unspecified
+        guard overrideUserInterfaceStyle != resolvedStyle else {
             return
         }
-        overrideUserInterfaceStyle = style
+        overrideUserInterfaceStyle = resolvedStyle
+    }
+
+    private func setFollowsInspectedPageAppearance(_ followsInspectedPageAppearance: Bool) {
+        guard followsInspectedPageAppearanceStorage != followsInspectedPageAppearance else {
+            return
+        }
+        followsInspectedPageAppearanceStorage = followsInspectedPageAppearance
+        applyPreferredInterfaceStyle(session.interface.preferredInterfaceStyle)
     }
 
     private func setDrawsBackground(_ drawsBackground: Bool) {

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -2,12 +2,17 @@
 import Testing
 import WebInspectorTransport
 import UIKit
+import WebKit
 @testable import WebInspectorCore
 @testable import WebInspectorUI
 
 @MainActor
 @Suite(.serialized)
 struct ParentContainerTests {
+    private enum TestAttachError: Error, Equatable {
+        case failed
+    }
+
     @Test
     func sessionAndViewControllerUseDOMAndNetworkTabsByDefault() {
         let session = WebInspectorSession()
@@ -30,6 +35,143 @@ struct ParentContainerTests {
             #expect(viewController.drawsBackground)
         }
         #expect(viewController.view.backgroundColor == .systemBackground)
+    }
+
+    @Test
+    func pageAppearanceStyleUsesWebKitLightnessThreshold() {
+        let traits = UITraitCollection(userInterfaceStyle: .light)
+
+        #expect(WebInspectorPageAppearance.interfaceStyle(for: .white, in: traits) == .light)
+        #expect(WebInspectorPageAppearance.interfaceStyle(for: .black, in: traits) == .dark)
+        #expect(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1),
+                in: traits
+            ) == .dark
+        )
+        #expect(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: UIColor(red: 0.51, green: 0.51, blue: 0.51, alpha: 1),
+                in: traits
+            ) == .light
+        )
+        #expect(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: UIColor(red: 0, green: 0, blue: 0, alpha: 0.01),
+                in: traits
+            ) == .unspecified
+        )
+    }
+
+    @Test
+    func pageAppearanceStyleResolvesDynamicColorsWithWebViewTraits() {
+        let dynamicColor = UIColor { traits in
+            traits.userInterfaceStyle == .dark ? .black : .white
+        }
+
+        #expect(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: dynamicColor,
+                in: UITraitCollection(userInterfaceStyle: .light)
+            ) == .light
+        )
+        #expect(
+            WebInspectorPageAppearance.interfaceStyle(
+                for: dynamicColor,
+                in: UITraitCollection(userInterfaceStyle: .dark)
+            ) == .dark
+        )
+    }
+
+    @Test
+    func sessionUpdatesPreferredInterfaceStyleFromUnderPageBackgroundColor() async {
+        let session = WebInspectorSession()
+        let webView = WKWebView(frame: .zero)
+
+        session.startPageAppearanceObservationForTesting(webView: webView)
+        webView.underPageBackgroundColor = .black
+
+        let didApplyDarkStyle = await waitUntil {
+            session.interface.preferredInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        webView.underPageBackgroundColor = .white
+        let didApplyLightStyle = await waitUntil {
+            session.interface.preferredInterfaceStyle == .light
+        }
+        #expect(didApplyLightStyle)
+    }
+
+    @Test
+    func sessionDetachClearsPageAppearanceObservation() async {
+        let session = WebInspectorSession()
+        let webView = WKWebView(frame: .zero)
+
+        session.startPageAppearanceObservationForTesting(webView: webView)
+        webView.underPageBackgroundColor = .black
+        let didApplyDarkStyle = await waitUntil {
+            session.interface.preferredInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        await session.detach()
+
+        #expect(session.interface.preferredInterfaceStyle == .unspecified)
+        webView.underPageBackgroundColor = .white
+        await Task.yield()
+        #expect(session.interface.preferredInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func attachFailureClearsPreviousPageAppearanceObservation() async {
+        let session = WebInspectorSession(
+            inspector: InspectorSession(),
+            attachAction: { _, _ in throw TestAttachError.failed }
+        )
+        let observedWebView = WKWebView(frame: .zero)
+        session.startPageAppearanceObservationForTesting(webView: observedWebView)
+        observedWebView.underPageBackgroundColor = .black
+        let didApplyDarkStyle = await waitUntil {
+            session.interface.preferredInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        await #expect(throws: TestAttachError.failed) {
+            try await session.attach(to: WKWebView(frame: .zero))
+        }
+
+        #expect(session.interface.preferredInterfaceStyle == .unspecified)
+        observedWebView.underPageBackgroundColor = .white
+        await Task.yield()
+        #expect(session.interface.preferredInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func viewControllerAppliesSessionPreferredInterfaceStyle() async throws {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        session.interface.setPreferredInterfaceStyle(.dark)
+        let didApplyDarkStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .dark
+                && viewController.traitCollection.userInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        viewController.horizontalSizeClassOverrideForTesting = .compact
+        let compactHost = try #require(viewController.activeHostViewControllerForTesting as? CompactTabBarController)
+        compactHost.loadViewIfNeeded()
+        #expect(compactHost.overrideUserInterfaceStyle == .unspecified)
+        #expect(compactHost.traitCollection.userInterfaceStyle == .dark)
+
+        session.interface.setPreferredInterfaceStyle(.unspecified)
+        let didClearStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .unspecified
+        }
+        #expect(didClearStyle)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -148,9 +148,45 @@ struct ParentContainerTests {
     }
 
     @Test
-    func viewControllerAppliesSessionPreferredInterfaceStyle() async throws {
+    func viewControllerIgnoresSessionPreferredInterfaceStyleByDefault() async {
         let session = WebInspectorSession()
         let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(viewController.followsInspectedPageAppearance == false)
+
+        session.interface.setPreferredInterfaceStyle(.dark)
+        await Task.yield()
+        #expect(viewController.overrideUserInterfaceStyle == .unspecified)
+
+        session.interface.setPreferredInterfaceStyle(.light)
+        await Task.yield()
+        #expect(viewController.overrideUserInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func viewControllerAppliesCurrentSessionPreferredInterfaceStyleWhenOptingIn() async {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        session.interface.setPreferredInterfaceStyle(.dark)
+        viewController.followsInspectedPageAppearance = true
+
+        let didApplyDarkStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .dark
+                && viewController.traitCollection.userInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+    }
+
+    @Test
+    func viewControllerFollowsSessionPreferredInterfaceStyleWhileOptedIn() async throws {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        viewController.followsInspectedPageAppearance = true
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
@@ -165,13 +201,63 @@ struct ParentContainerTests {
         let compactHost = try #require(viewController.activeHostViewControllerForTesting as? CompactTabBarController)
         compactHost.loadViewIfNeeded()
         #expect(compactHost.overrideUserInterfaceStyle == .unspecified)
-        #expect(compactHost.traitCollection.userInterfaceStyle == .dark)
+        let didInheritDarkStyle = await waitUntil {
+            compactHost.traitCollection.userInterfaceStyle == .dark
+        }
+        #expect(didInheritDarkStyle)
 
-        session.interface.setPreferredInterfaceStyle(.unspecified)
+        session.interface.setPreferredInterfaceStyle(.light)
+        let didApplyLightStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .light
+                && viewController.traitCollection.userInterfaceStyle == .light
+        }
+        #expect(didApplyLightStyle)
+    }
+
+    @Test
+    func viewControllerClearsAndIgnoresSessionPreferredInterfaceStyleWhenOptingOut() async {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        viewController.followsInspectedPageAppearance = true
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        session.interface.setPreferredInterfaceStyle(.dark)
+        let didApplyDarkStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        viewController.followsInspectedPageAppearance = false
         let didClearStyle = await waitUntil {
             viewController.overrideUserInterfaceStyle == .unspecified
         }
         #expect(didClearStyle)
+
+        session.interface.setPreferredInterfaceStyle(.light)
+        await Task.yield()
+        #expect(viewController.overrideUserInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func viewControllerClearsPreferredInterfaceStyleWhenSessionStyleBecomesUnspecified() async {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        viewController.followsInspectedPageAppearance = true
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        session.interface.setPreferredInterfaceStyle(.dark)
+        let didApplyDarkStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        session.interface.setPreferredInterfaceStyle(.unspecified)
+        let didApplyUnspecifiedStyle = await waitUntil {
+            viewController.overrideUserInterfaceStyle == .unspecified
+        }
+        #expect(didApplyUnspecifiedStyle)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -166,6 +166,23 @@ struct ParentContainerTests {
     }
 
     @Test
+    func viewControllerPreservesManualInterfaceStyleOverrideWhenPageFollowingIsDisabled() async {
+        let session = WebInspectorSession()
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.overrideUserInterfaceStyle = .dark
+        session.interface.setPreferredInterfaceStyle(.light)
+        await Task.yield()
+        #expect(viewController.overrideUserInterfaceStyle == .dark)
+
+        session.interface.setPreferredInterfaceStyle(.unspecified)
+        await Task.yield()
+        #expect(viewController.overrideUserInterfaceStyle == .dark)
+    }
+
+    @Test
     func viewControllerAppliesCurrentSessionPreferredInterfaceStyleWhenOptingIn() async {
         let session = WebInspectorSession()
         let viewController = WebInspectorViewController(session: session)


### PR DESCRIPTION
## Purpose

Automatically align the inspector UI appearance with the inspected page background when the page reports a light or dark under-page background color.

## Changes

- Observe `WKWebView.underPageBackgroundColor` from `WebInspectorSession` during attach/detach lifecycle.
- Add package-internal page appearance classification using resolved sRGB color lightness.
- Store the preferred inspector interface style in `InterfaceModel` and apply it at the root `WebInspectorViewController`.
- Add UI tests for color classification, session observation cleanup, attach failure cleanup, and root style propagation.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- `codex-review --base main`