### PR TITLE
Restore Monocly browser sessions

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -53,6 +53,7 @@ final class BrowserPageViewController: UIViewController {
     private var didAutoPresentInspector = false
     private var progressHeightConstraint: NSLayoutConstraint?
     private var currentChromePlacement: ChromePlacement?
+    var onSelectedWebViewInstalled: ((WKWebView) -> Void)?
 
     init(
         store: BrowserStore,
@@ -184,6 +185,7 @@ final class BrowserPageViewController: UIViewController {
         if view.window != nil {
             viewportCoordinator.hostViewDidAppear()
         }
+        onSelectedWebViewInstalled?(webView)
     }
 
     private func configureChrome() {

--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit)
 import ObservationBridge
 import UIKit
+import WebKit
 import WebInspectorKit
 #if os(iOS)
 import WKViewportCoordinator
@@ -45,6 +46,8 @@ final class BrowserPageViewController: UIViewController {
     private lazy var forwardNavigationAction = UIAction { [weak self] _ in
         self?.store.goForward()
     }
+    private var hostedWebView: WKWebView?
+    private var hostedWebViewConstraints: [NSLayoutConstraint] = []
     private var viewportCoordinator: BrowserViewportCoordinator?
     private var inspectorWindowObserverID: UUID?
     private var didAutoPresentInspector = false
@@ -82,11 +85,8 @@ final class BrowserPageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureViewHierarchy()
+        installSelectedWebViewIfNeeded()
         configureChrome()
-        viewportCoordinator = BrowserViewportCoordinator(webView: store.webView)
-        viewportCoordinator?.hostViewController = self
-        (store.webView as? BrowserViewportWebView)?.viewportCoordinator = viewportCoordinator
-        viewportCoordinator?.webViewHierarchyDidChange()
 
         startObservingStore()
         inspectorWindowObserverID = BrowserInspectorCoordinator.observeInspectorWindowPresentation { [weak self] _ in
@@ -133,21 +133,12 @@ final class BrowserPageViewController: UIViewController {
     private func configureViewHierarchy() {
         view.backgroundColor = store.underPageBackgroundColor ?? .clear
 
-        let webView = store.webView
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(webView)
-
         progressView.translatesAutoresizingMaskIntoConstraints = false
         progressView.trackTintColor = .clear
         view.addSubview(progressView)
         progressHeightConstraint = progressView.heightAnchor.constraint(equalToConstant: 0)
 
         var constraints = [
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
             progressView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             progressView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             progressView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -158,6 +149,41 @@ final class BrowserPageViewController: UIViewController {
         }
 
         NSLayoutConstraint.activate(constraints)
+    }
+
+    private func installSelectedWebViewIfNeeded() {
+        let webView = store.webView
+        guard hostedWebView !== webView else {
+            return
+        }
+
+        if let hostedWebView {
+            (hostedWebView as? BrowserViewportWebView)?.viewportCoordinator = nil
+            viewportCoordinator?.invalidate()
+            NSLayoutConstraint.deactivate(hostedWebViewConstraints)
+            hostedWebView.removeFromSuperview()
+        }
+
+        hostedWebView = webView
+        hostedWebViewConstraints = [
+            webView.topAnchor.constraint(equalTo: view.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ]
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        view.insertSubview(webView, at: 0)
+        NSLayoutConstraint.activate(hostedWebViewConstraints)
+
+        let viewportCoordinator = BrowserViewportCoordinator(webView: webView)
+        viewportCoordinator.hostViewController = self
+        self.viewportCoordinator = viewportCoordinator
+        (webView as? BrowserViewportWebView)?.viewportCoordinator = viewportCoordinator
+        viewportCoordinator.webViewHierarchyDidChange()
+        if view.window != nil {
+            viewportCoordinator.hostViewDidAppear()
+        }
     }
 
     private func configureChrome() {
@@ -420,6 +446,7 @@ final class BrowserPageViewController: UIViewController {
             return
         }
 
+        installSelectedWebViewIfNeeded()
         navigationItem.title = store.displayTitle
         syncNavigationButtonStates(store: store)
 

--- a/Monocly/Monocly/Controllers/BrowserRootViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserRootViewController+UIKit.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import UIKit
+import WebKit
 import WebInspectorKit
 
 @MainActor
@@ -12,11 +13,14 @@ final class BrowserRootViewController: UINavigationController {
     let store: BrowserStore
     let inspectorSession: WebInspectorSession
     let launchConfiguration: BrowserLaunchConfiguration
+    private var desiredInspectorSessionAttachment: InspectorSessionAttachment = .detached
     private var resolvedInspectorSessionAttachment: InspectorSessionAttachment = .detached
     private var pendingInspectorSessionAttachment: InspectorSessionAttachment?
     private var inspectorLifecycleTask: Task<Void, Never>?
     private var isFinalizingInspectorSession = false
     private var isPreservingInspectorSessionForSceneDisconnection = false
+    private weak var attachedWebView: WKWebView?
+    var onAttachInspectorSessionForTesting: ((WKWebView) -> Void)?
 
     init(
         store: BrowserStore? = nil,
@@ -40,6 +44,10 @@ final class BrowserRootViewController: UINavigationController {
         )
 
         super.init(rootViewController: pageViewController)
+
+        pageViewController.onSelectedWebViewInstalled = { [weak self] webView in
+            self?.selectedWebViewDidChange(to: webView)
+        }
     }
 
     @available(*, unavailable)
@@ -106,14 +114,38 @@ final class BrowserRootViewController: UINavigationController {
         viewControllers.first as? BrowserPageViewController
     }
 
+    func setInspectorSessionAttachedForTesting(to webView: WKWebView) {
+        desiredInspectorSessionAttachment = .attached
+        resolvedInspectorSessionAttachment = .attached
+        attachedWebView = webView
+    }
+
 }
 
 private extension BrowserRootViewController {
+    private func selectedWebViewDidChange(to webView: WKWebView) {
+        guard desiredInspectorSessionAttachment == .attached else {
+            return
+        }
+        guard attachedWebView !== webView || inspectorLifecycleTask != nil else {
+            return
+        }
+        requestInspectorSessionAttachment(.attached)
+    }
+
     private func requestInspectorSessionAttachment(_ attachment: InspectorSessionAttachment) {
         if isFinalizingInspectorSession, attachment != .detached {
             return
         }
-        guard resolvedInspectorSessionAttachment != attachment
+        desiredInspectorSessionAttachment = attachment
+
+        let attachmentIsResolved = switch attachment {
+        case .attached:
+            resolvedInspectorSessionAttachment == .attached && attachedWebView === store.webView
+        case .detached:
+            resolvedInspectorSessionAttachment == .detached
+        }
+        guard attachmentIsResolved == false
             || pendingInspectorSessionAttachment != nil
             || inspectorLifecycleTask != nil else {
             return
@@ -138,13 +170,19 @@ private extension BrowserRootViewController {
 
                 switch desiredAttachment {
                 case .attached:
-                    guard self.resolvedInspectorSessionAttachment != .attached else {
+                    let webView = store.webView
+                    guard self.resolvedInspectorSessionAttachment != .attached
+                        || self.attachedWebView !== webView else {
                         continue
                     }
                     do {
-                        try await inspectorSession.attach(to: store.webView)
+                        self.onAttachInspectorSessionForTesting?(webView)
+                        try await inspectorSession.attach(to: webView)
                         self.resolvedInspectorSessionAttachment = .attached
+                        self.attachedWebView = webView
                     } catch {
+                        self.resolvedInspectorSessionAttachment = .detached
+                        self.attachedWebView = nil
                         continue
                     }
                 case .detached:
@@ -153,6 +191,7 @@ private extension BrowserRootViewController {
                     }
                     await inspectorSession.detach()
                     self.resolvedInspectorSessionAttachment = .detached
+                    self.attachedWebView = nil
                 }
             }
         }

--- a/Monocly/Monocly/Models/BrowserSessionStore.swift
+++ b/Monocly/Monocly/Models/BrowserSessionStore.swift
@@ -40,6 +40,7 @@ struct BrowserSessionStore {
     private enum Path {
         static let rootDirectory = "Monocly"
         static let sessionDirectory = "BrowserSession"
+        static let sceneSessionsDirectory = "scene-sessions"
         static let tabsDirectory = "tabs"
         static let sessionFile = "session.json"
     }
@@ -60,6 +61,22 @@ struct BrowserSessionStore {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         self.encoder = encoder
         self.decoder = JSONDecoder()
+    }
+
+    init(
+        sceneSessionPersistentIdentifier: String,
+        browserSessionDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        let browserSessionDirectoryURL = browserSessionDirectoryURL
+            ?? Self.defaultRootDirectoryURL(fileManager: fileManager)
+        let sceneDirectoryURL = browserSessionDirectoryURL
+            .appendingPathComponent(Path.sceneSessionsDirectory, isDirectory: true)
+            .appendingPathComponent(
+                Self.sceneSessionDirectoryName(for: sceneSessionPersistentIdentifier),
+                isDirectory: true
+            )
+        self.init(rootDirectoryURL: sceneDirectoryURL, fileManager: fileManager)
     }
 
     func load() -> BrowserRestoredSession? {
@@ -127,5 +144,13 @@ struct BrowserSessionStore {
         return applicationSupportURL
             .appendingPathComponent(Path.rootDirectory, isDirectory: true)
             .appendingPathComponent(Path.sessionDirectory, isDirectory: true)
+    }
+
+    private static func sceneSessionDirectoryName(for persistentIdentifier: String) -> String {
+        let encodedIdentifier = persistentIdentifier.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+        guard let encodedIdentifier, encodedIdentifier.isEmpty == false else {
+            return "default"
+        }
+        return encodedIdentifier
     }
 }

--- a/Monocly/Monocly/Models/BrowserSessionStore.swift
+++ b/Monocly/Monocly/Models/BrowserSessionStore.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+struct BrowserSessionSnapshot: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let selectedTabID: UUID
+    let tabs: [BrowserTabSnapshot]
+
+    init(
+        schemaVersion: Int = BrowserSessionSnapshot.currentSchemaVersion,
+        selectedTabID: UUID,
+        tabs: [BrowserTabSnapshot]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.selectedTabID = selectedTabID
+        self.tabs = tabs
+    }
+}
+
+struct BrowserTabSnapshot: Codable, Equatable, Identifiable {
+    let id: UUID
+    let url: URL
+    let title: String?
+    let createdAt: Date
+    let lastUsedAt: Date
+    let stateFileName: String
+
+    static func stateFileName(for id: UUID) -> String {
+        "\(id.uuidString).state"
+    }
+}
+
+struct BrowserRestoredSession {
+    let snapshot: BrowserSessionSnapshot
+    let tabStateDataByID: [UUID: Data]
+}
+
+struct BrowserSessionStore {
+    private enum Path {
+        static let rootDirectory = "Monocly"
+        static let sessionDirectory = "BrowserSession"
+        static let tabsDirectory = "tabs"
+        static let sessionFile = "session.json"
+    }
+
+    let rootDirectoryURL: URL
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        rootDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.fileManager = fileManager
+        self.rootDirectoryURL = rootDirectoryURL ?? Self.defaultRootDirectoryURL(fileManager: fileManager)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.encoder = encoder
+        self.decoder = JSONDecoder()
+    }
+
+    func load() -> BrowserRestoredSession? {
+        guard let data = try? Data(contentsOf: sessionFileURL),
+              let snapshot = try? decoder.decode(BrowserSessionSnapshot.self, from: data),
+              snapshot.schemaVersion == BrowserSessionSnapshot.currentSchemaVersion,
+              snapshot.tabs.isEmpty == false else {
+            return nil
+        }
+
+        let tabStateDataByID = snapshot.tabs.reduce(into: [UUID: Data]()) { result, tab in
+            let stateURL = tabsDirectoryURL.appendingPathComponent(tab.stateFileName)
+            if let data = try? Data(contentsOf: stateURL) {
+                result[tab.id] = data
+            }
+        }
+
+        return BrowserRestoredSession(snapshot: snapshot, tabStateDataByID: tabStateDataByID)
+    }
+
+    func save(snapshot: BrowserSessionSnapshot, tabStateDataByID: [UUID: Data]) throws {
+        try fileManager.createDirectory(at: tabsDirectoryURL, withIntermediateDirectories: true)
+
+        let validStateFileNames = Set(snapshot.tabs.map(\.stateFileName))
+        for tab in snapshot.tabs {
+            let stateURL = tabsDirectoryURL.appendingPathComponent(tab.stateFileName)
+            guard let stateData = tabStateDataByID[tab.id] else {
+                try? fileManager.removeItem(at: stateURL)
+                continue
+            }
+            try stateData.write(to: stateURL, options: .atomic)
+        }
+
+        try removeStaleStateFiles(retaining: validStateFileNames)
+
+        let sessionData = try encoder.encode(snapshot)
+        try sessionData.write(to: sessionFileURL, options: .atomic)
+    }
+
+    private var sessionFileURL: URL {
+        rootDirectoryURL.appendingPathComponent(Path.sessionFile)
+    }
+
+    private var tabsDirectoryURL: URL {
+        rootDirectoryURL.appendingPathComponent(Path.tabsDirectory, isDirectory: true)
+    }
+
+    private func removeStaleStateFiles(retaining validStateFileNames: Set<String>) throws {
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: tabsDirectoryURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for fileURL in contents where validStateFileNames.contains(fileURL.lastPathComponent) == false {
+            try? fileManager.removeItem(at: fileURL)
+        }
+    }
+
+    private static func defaultRootDirectoryURL(fileManager: FileManager) -> URL {
+        let applicationSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return applicationSupportURL
+            .appendingPathComponent(Path.rootDirectory, isDirectory: true)
+            .appendingPathComponent(Path.sessionDirectory, isDirectory: true)
+    }
+}

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -335,6 +335,7 @@ private enum BrowserTabStoreSPI {
 
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private var hasLoadedInitialRequest = false
+    @ObservationIgnored private var isHoldingRestoredTitle: Bool
     @ObservationIgnored private var restoredInteractionState: Data?
     @ObservationIgnored var onStateChanged: (() -> Void)?
 
@@ -363,7 +364,7 @@ private enum BrowserTabStoreSPI {
     }
 
     var interactionStateData: Data? {
-        webView.interactionState as? Data
+        restoredInteractionState ?? (webView.interactionState as? Data)
     }
 
     init(
@@ -381,6 +382,7 @@ private enum BrowserTabStoreSPI {
         pageTitle = title
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
+        isHoldingRestoredTitle = title?.isEmpty == false
         self.restoredInteractionState = restoredInteractionState
 
         let configuration = WKWebViewConfiguration()
@@ -444,6 +446,8 @@ private enum BrowserTabStoreSPI {
 
     func load(url: URL) {
         restoredInteractionState = nil
+        isHoldingRestoredTitle = false
+        pageTitle = nil
         currentURL = url
         hasLoadedInitialRequest = true
         webView.load(URLRequest(url: url))
@@ -520,7 +524,15 @@ private enum BrowserTabStoreSPI {
                 guard let self else {
                     return
                 }
+                guard let title else {
+                    if self.isHoldingRestoredTitle == false {
+                        self.pageTitle = nil
+                    }
+                    self.notifyStateChanged()
+                    return
+                }
                 self.pageTitle = title
+                self.isHoldingRestoredTitle = false
                 self.notifyStateChanged()
             }
             .store(in: &cancellables)
@@ -770,6 +782,10 @@ extension BrowserTabStore: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         didFinishNavigationCount += 1
+        if webView.title == nil {
+            isHoldingRestoredTitle = false
+            pageTitle = nil
+        }
 #if canImport(UIKit)
         endRefreshingIfNeeded()
 #endif

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -335,6 +335,7 @@ private enum BrowserTabStoreSPI {
 
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private var hasLoadedInitialRequest = false
+    @ObservationIgnored private(set) var initialRequestLoadCount = 0
     @ObservationIgnored private var isHoldingRestoredTitle: Bool
     @ObservationIgnored private var restoredInteractionState: Data?
     @ObservationIgnored var onStateChanged: (() -> Void)?
@@ -468,10 +469,12 @@ private enum BrowserTabStoreSPI {
         }
 
         hasLoadedInitialRequest = true
-        webView.load(URLRequest(url: initialURL))
         if let restoredInteractionState {
             webView.interactionState = restoredInteractionState
             self.restoredInteractionState = nil
+        } else {
+            initialRequestLoadCount += 1
+            webView.load(URLRequest(url: initialURL))
         }
         notifyStateChanged()
     }

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -268,7 +268,7 @@ typealias BrowserPlatformColor = NSColor
 
 private let logger = Logger(
     subsystem: "Monocly",
-    category: "BrowserStore"
+    category: "BrowserTabStore"
 )
 
 enum BrowserHistoryDirection {
@@ -283,7 +283,7 @@ struct BrowserHistoryMenuItem {
     let direction: BrowserHistoryDirection
 }
 
-private enum BrowserStoreSPI {
+private enum BrowserTabStoreSPI {
     private static func deobfuscate(_ reverseTokens: [String]) -> String {
         reverseTokens.reversed().joined()
     }
@@ -308,7 +308,8 @@ private enum BrowserStoreSPI {
 }
 
 @MainActor
-@Observable final class BrowserStore: NSObject {
+@Observable final class BrowserTabStore: NSObject {
+    let id: UUID
     let webView: WKWebView
     private let initialURL: URL
 
@@ -324,6 +325,9 @@ private enum BrowserStoreSPI {
     var lastNavigationErrorDescription: String?
     var didCommitNavigationCount = 0
     var didFinishNavigationCount = 0
+    var pageTitle: String?
+    var createdAt: Date
+    var lastUsedAt: Date
 
 #if canImport(UIKit)
     private var refreshControl: UIRefreshControl?
@@ -331,12 +335,17 @@ private enum BrowserStoreSPI {
 
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored private var hasLoadedInitialRequest = false
+    @ObservationIgnored private var restoredInteractionState: Data?
+    @ObservationIgnored var onStateChanged: (() -> Void)?
 
     var isShowingProgress: Bool {
         isLoading && estimatedProgress < 1.0
     }
 
     var displayTitle: String {
+        if let pageTitle, pageTitle.isEmpty == false {
+            return pageTitle
+        }
         if let host = currentURL?.host(), host.isEmpty == false {
             return host
         }
@@ -349,9 +358,30 @@ private enum BrowserStoreSPI {
         return "Monocly"
     }
 
-    init(url: URL, automaticallyLoadsInitialRequest: Bool = true) {
+    var persistedURL: URL {
+        currentURL ?? webView.url ?? initialURL
+    }
+
+    var interactionStateData: Data? {
+        webView.interactionState as? Data
+    }
+
+    init(
+        id: UUID = UUID(),
+        url: URL,
+        title: String? = nil,
+        createdAt: Date = Date(),
+        lastUsedAt: Date = Date(),
+        restoredInteractionState: Data? = nil,
+        automaticallyLoadsInitialRequest: Bool = true
+    ) {
+        self.id = id
         initialURL = url
         currentURL = url
+        pageTitle = title
+        self.createdAt = createdAt
+        self.lastUsedAt = lastUsedAt
+        self.restoredInteractionState = restoredInteractionState
 
         let configuration = WKWebViewConfiguration()
 #if canImport(UIKit)
@@ -413,14 +443,18 @@ private enum BrowserStoreSPI {
     }
 
     func load(url: URL) {
+        restoredInteractionState = nil
+        currentURL = url
+        hasLoadedInitialRequest = true
         webView.load(URLRequest(url: url))
+        notifyStateChanged()
     }
 
-    func backHistoryItems(limit: Int = BrowserStoreSPI.maximumHistoryMenuItemCount) -> [BrowserHistoryMenuItem] {
+    func backHistoryItems(limit: Int = BrowserTabStoreSPI.maximumHistoryMenuItemCount) -> [BrowserHistoryMenuItem] {
         historyItems(direction: .back, limit: limit)
     }
 
-    func forwardHistoryItems(limit: Int = BrowserStoreSPI.maximumHistoryMenuItemCount) -> [BrowserHistoryMenuItem] {
+    func forwardHistoryItems(limit: Int = BrowserTabStoreSPI.maximumHistoryMenuItemCount) -> [BrowserHistoryMenuItem] {
         historyItems(direction: .forward, limit: limit)
     }
 
@@ -431,6 +465,28 @@ private enum BrowserStoreSPI {
 
         hasLoadedInitialRequest = true
         webView.load(URLRequest(url: initialURL))
+        if let restoredInteractionState {
+            webView.interactionState = restoredInteractionState
+            self.restoredInteractionState = nil
+        }
+        notifyStateChanged()
+    }
+
+    func markSelected(at date: Date = Date()) {
+        lastUsedAt = date
+        loadInitialRequestIfNeeded()
+        notifyStateChanged()
+    }
+
+    func snapshot(stateFileName: String) -> BrowserTabSnapshot {
+        BrowserTabSnapshot(
+            id: id,
+            url: persistedURL,
+            title: pageTitle,
+            createdAt: createdAt,
+            lastUsedAt: lastUsedAt,
+            stateFileName: stateFileName
+        )
     }
 
     private func setObservers() {
@@ -443,6 +499,7 @@ private enum BrowserStoreSPI {
                     return
                 }
                 self.estimatedProgress = progress
+                self.notifyStateChanged()
             }
             .store(in: &cancellables)
 
@@ -453,6 +510,18 @@ private enum BrowserStoreSPI {
                     return
                 }
                 self.syncCurrentURL(url)
+                self.notifyStateChanged()
+            }
+            .store(in: &cancellables)
+
+        webView.publisher(for: \.title, options: [.initial, .new])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] title in
+                guard let self else {
+                    return
+                }
+                self.pageTitle = title
+                self.notifyStateChanged()
             }
             .store(in: &cancellables)
 
@@ -463,6 +532,7 @@ private enum BrowserStoreSPI {
                     return
                 }
                 self.canGoForward = canGoForward
+                self.notifyStateChanged()
             }
             .store(in: &cancellables)
 
@@ -473,6 +543,7 @@ private enum BrowserStoreSPI {
                     return
                 }
                 self.canGoBack = canGoBack
+                self.notifyStateChanged()
             }
             .store(in: &cancellables)
 
@@ -483,6 +554,7 @@ private enum BrowserStoreSPI {
                     return
                 }
                 self.underPageBackgroundColor = underPageBackgroundColor
+                self.notifyStateChanged()
             }
             .store(in: &cancellables)
     }
@@ -493,11 +565,13 @@ private enum BrowserStoreSPI {
     ) {
         isLoading = webView.isLoading
         estimatedProgress = webView.estimatedProgress
+        lastUsedAt = Date()
         syncCurrentURL(webView.url)
         if clearsNavigationError {
             lastNavigationErrorDescription = nil
         }
         invalidateHistoryIfNeeded()
+        notifyStateChanged()
     }
 
     private func syncCurrentURL(_ url: URL?) {
@@ -512,6 +586,10 @@ private enum BrowserStoreSPI {
     private func invalidateHistoryIfNeeded() {
         canGoBack = webView.canGoBack
         canGoForward = webView.canGoForward
+    }
+
+    private func notifyStateChanged() {
+        onStateChanged?()
     }
 
     private func historyItems(direction: BrowserHistoryDirection, limit: Int) -> [BrowserHistoryMenuItem] {
@@ -536,7 +614,7 @@ private enum BrowserStoreSPI {
     }
 
     private func spiHistoryItems(direction: BrowserHistoryDirection, limit: Int) -> [WKBackForwardListItem] {
-        let clampedLimit = max(0, min(limit, BrowserStoreSPI.maximumHistoryMenuItemCount))
+        let clampedLimit = max(0, min(limit, BrowserTabStoreSPI.maximumHistoryMenuItemCount))
         guard clampedLimit > 0 else {
             return []
         }
@@ -554,8 +632,8 @@ private enum BrowserStoreSPI {
     }
 
     private func spiBrowsingContextController() -> NSObject? {
-        guard webView.responds(to: BrowserStoreSPI.browsingContextControllerSelector),
-              let browsingContextController = webView.perform(BrowserStoreSPI.browsingContextControllerSelector)?
+        guard webView.responds(to: BrowserTabStoreSPI.browsingContextControllerSelector),
+              let browsingContextController = webView.perform(BrowserTabStoreSPI.browsingContextControllerSelector)?
                 .takeUnretainedValue() as? NSObject else {
             return nil
         }
@@ -564,8 +642,8 @@ private enum BrowserStoreSPI {
 
     private func spiBackForwardList() -> WKBackForwardList? {
         guard let browsingContextController = spiBrowsingContextController(),
-              browsingContextController.responds(to: BrowserStoreSPI.backForwardListSelector),
-              let backForwardList = browsingContextController.perform(BrowserStoreSPI.backForwardListSelector)?
+              browsingContextController.responds(to: BrowserTabStoreSPI.backForwardListSelector),
+              let backForwardList = browsingContextController.perform(BrowserTabStoreSPI.backForwardListSelector)?
                 .takeUnretainedValue() as? WKBackForwardList else {
             return nil
         }
@@ -574,18 +652,18 @@ private enum BrowserStoreSPI {
 
     private func spiGoToHistoryItem(_ item: WKBackForwardListItem) -> Bool {
         guard let browsingContextController = spiBrowsingContextController(),
-              browsingContextController.responds(to: BrowserStoreSPI.goToBackForwardListItemSelector) else {
+              browsingContextController.responds(to: BrowserTabStoreSPI.goToBackForwardListItemSelector) else {
             return false
         }
-        browsingContextController.perform(BrowserStoreSPI.goToBackForwardListItemSelector, with: item)
+        browsingContextController.perform(BrowserTabStoreSPI.goToBackForwardListItemSelector, with: item)
         return true
     }
 
     private func configureHistoryDelegateIfAvailable() {
-        guard webView.responds(to: BrowserStoreSPI.setHistoryDelegateSelector) else {
+        guard webView.responds(to: BrowserTabStoreSPI.setHistoryDelegateSelector) else {
             return
         }
-        webView.perform(BrowserStoreSPI.setHistoryDelegateSelector, with: self)
+        webView.perform(BrowserTabStoreSPI.setHistoryDelegateSelector, with: self)
     }
 
 #if canImport(UIKit)
@@ -609,7 +687,7 @@ private enum BrowserStoreSPI {
 #endif
 }
 
-extension BrowserStore: WKNavigationDelegate {
+extension BrowserTabStore: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
 #if canImport(AppKit)
         if navigationAction.navigationType == .linkActivated,
@@ -628,6 +706,7 @@ extension BrowserStore: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         isLoading = true
         estimatedProgress = .zero
+        notifyStateChanged()
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
@@ -686,6 +765,7 @@ extension BrowserStore: WKNavigationDelegate {
         lastWebContentTerminationDate = Date()
         lastWebContentTerminationURL = webView.url
         invalidateHistoryIfNeeded()
+        notifyStateChanged()
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -697,7 +777,7 @@ extension BrowserStore: WKNavigationDelegate {
     }
 }
 
-extension BrowserStore {
+extension BrowserTabStore {
     @objc(_webView:backForwardListItemAdded:removed:)
     func _webView(
         _ webView: WKWebView!,
@@ -705,20 +785,23 @@ extension BrowserStore {
         removed itemsRemoved: [WKBackForwardListItem]!
     ) {
         invalidateHistoryIfNeeded()
+        notifyStateChanged()
     }
 
     @objc(_webView:didNavigateWithNavigationData:)
     func _webView(_ webView: WKWebView!, didNavigateWith navigationData: NSObject!) {
         invalidateHistoryIfNeeded()
+        notifyStateChanged()
     }
 
     @objc(_webView:didUpdateHistoryTitle:forURL:)
     func _webView(_ webView: WKWebView!, didUpdateHistoryTitle title: String!, forURL url: URL!) {
         invalidateHistoryIfNeeded()
+        notifyStateChanged()
     }
 }
 
-extension BrowserStore: WKUIDelegate {
+extension BrowserTabStore: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard navigationAction.targetFrame == nil, let url = navigationAction.request.url else {
             return nil
@@ -777,7 +860,7 @@ extension BrowserStore: WKUIDelegate {
     }
 }
 
-private extension BrowserStore {
+private extension BrowserTabStore {
 #if canImport(UIKit)
     @MainActor
     func presentJavaScriptAlert(message: String, webView: WKWebView) async {

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -338,6 +338,7 @@ private enum BrowserTabStoreSPI {
     @ObservationIgnored private(set) var initialRequestLoadCount = 0
     @ObservationIgnored private var isHoldingRestoredTitle: Bool
     @ObservationIgnored private var restoredInteractionState: Data?
+    @ObservationIgnored private var canSaveWebViewInteractionState = true
     @ObservationIgnored var onStateChanged: (() -> Void)?
 
     var isShowingProgress: Bool {
@@ -365,7 +366,13 @@ private enum BrowserTabStoreSPI {
     }
 
     var interactionStateData: Data? {
-        restoredInteractionState ?? (webView.interactionState as? Data)
+        if let restoredInteractionState {
+            return restoredInteractionState
+        }
+        guard canSaveWebViewInteractionState else {
+            return nil
+        }
+        return webView.interactionState as? Data
     }
 
     init(
@@ -428,25 +435,33 @@ private enum BrowserTabStoreSPI {
         guard webView.canGoBack else {
             return
         }
-        webView.goBack()
+        if webView.goBack() != nil {
+            markWebViewInteractionStatePendingNavigation()
+        }
     }
 
     func goForward() {
         guard webView.canGoForward else {
             return
         }
-        webView.goForward()
+        if webView.goForward() != nil {
+            markWebViewInteractionStatePendingNavigation()
+        }
     }
 
     func go(to item: WKBackForwardListItem) {
-        guard spiGoToHistoryItem(item) == false else {
+        if spiGoToHistoryItem(item) {
+            markWebViewInteractionStatePendingNavigation()
             return
         }
-        webView.go(to: item)
+        if webView.go(to: item) != nil {
+            markWebViewInteractionStatePendingNavigation()
+        }
     }
 
     func load(url: URL) {
         restoredInteractionState = nil
+        markWebViewInteractionStatePendingNavigation()
         isHoldingRestoredTitle = false
         pageTitle = nil
         currentURL = url
@@ -472,8 +487,10 @@ private enum BrowserTabStoreSPI {
         if let restoredInteractionState {
             webView.interactionState = restoredInteractionState
             self.restoredInteractionState = nil
+            canSaveWebViewInteractionState = true
         } else {
             initialRequestLoadCount += 1
+            markWebViewInteractionStatePendingNavigation()
             webView.load(URLRequest(url: initialURL))
         }
         notifyStateChanged()
@@ -593,6 +610,14 @@ private enum BrowserTabStoreSPI {
         currentURL = url
     }
 
+    private func markWebViewInteractionStatePendingNavigation() {
+        canSaveWebViewInteractionState = false
+    }
+
+    private func markWebViewInteractionStateSynchronized() {
+        canSaveWebViewInteractionState = true
+    }
+
     private func isBenignNavigationCancellation(_ error: any Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
@@ -690,6 +715,7 @@ private enum BrowserTabStoreSPI {
     }
 
     @objc private func handleRefreshControl() {
+        markWebViewInteractionStatePendingNavigation()
         webView.reload()
     }
 
@@ -719,6 +745,7 @@ extension BrowserTabStore: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        markWebViewInteractionStatePendingNavigation()
         isLoading = true
         estimatedProgress = .zero
         notifyStateChanged()
@@ -776,6 +803,7 @@ extension BrowserTabStore: WKNavigationDelegate {
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         logger.debug("\(#function) web content process terminated")
         isLoading = false
+        markWebViewInteractionStatePendingNavigation()
         webContentTerminationCount += 1
         lastWebContentTerminationDate = Date()
         lastWebContentTerminationURL = webView.url
@@ -785,6 +813,7 @@ extension BrowserTabStore: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         didFinishNavigationCount += 1
+        markWebViewInteractionStateSynchronized()
         if webView.title == nil {
             isHoldingRestoredTitle = false
             pageTitle = nil

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -618,6 +618,13 @@ private enum BrowserTabStoreSPI {
         canSaveWebViewInteractionState = true
     }
 
+    private func markWebViewInteractionStateSynchronizedIfNavigationSettled() {
+        guard webView.isLoading == false else {
+            return
+        }
+        markWebViewInteractionStateSynchronized()
+    }
+
     private func isBenignNavigationCancellation(_ error: any Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
@@ -771,6 +778,7 @@ extension BrowserTabStore: WKNavigationDelegate {
             endRefreshingIfNeeded()
 #endif
             syncNavigationState(from: webView)
+            markWebViewInteractionStateSynchronizedIfNavigationSettled()
             return
         }
         lastNavigationErrorDescription = navigationError.localizedDescription
@@ -778,6 +786,7 @@ extension BrowserTabStore: WKNavigationDelegate {
         endRefreshingIfNeeded()
 #endif
         syncNavigationState(from: webView)
+        markWebViewInteractionStateSynchronizedIfNavigationSettled()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError navigationError: Error) {
@@ -787,6 +796,7 @@ extension BrowserTabStore: WKNavigationDelegate {
             endRefreshingIfNeeded()
 #endif
             syncNavigationState(from: webView)
+            markWebViewInteractionStateSynchronizedIfNavigationSettled()
             return
         }
         lastNavigationErrorDescription = navigationError.localizedDescription
@@ -794,6 +804,7 @@ extension BrowserTabStore: WKNavigationDelegate {
         endRefreshingIfNeeded()
 #endif
         syncNavigationState(from: webView)
+        markWebViewInteractionStateSynchronizedIfNavigationSettled()
     }
 
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {

--- a/Monocly/Monocly/Models/BrowserWindowStore.swift
+++ b/Monocly/Monocly/Models/BrowserWindowStore.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Observation
+import WebKit
+
+@MainActor
+@Observable
+final class BrowserStore {
+    private let fallbackURL: URL
+    private let sessionStore: BrowserSessionStore?
+    private let saveDebounceDuration: UInt64
+
+    private(set) var tabs: [BrowserTabStore]
+    var selectedTabID: UUID
+    private(set) var stateRevision = 0
+
+    @ObservationIgnored private var restorationComplete = false
+    @ObservationIgnored private var saveTask: Task<Void, Never>?
+
+    var selectedTab: BrowserTabStore? {
+        _ = stateRevision
+        return tabs.first { $0.id == selectedTabID } ?? tabs.first
+    }
+
+    var webView: WKWebView {
+        resolvedSelectedTab.webView
+    }
+
+    var canGoBack: Bool {
+        selectedTab?.canGoBack ?? false
+    }
+
+    var canGoForward: Bool {
+        selectedTab?.canGoForward ?? false
+    }
+
+    var estimatedProgress: Double {
+        selectedTab?.estimatedProgress ?? .zero
+    }
+
+    var isLoading: Bool {
+        selectedTab?.isLoading ?? false
+    }
+
+    var currentURL: URL? {
+        selectedTab?.currentURL
+    }
+
+    var underPageBackgroundColor: BrowserPlatformColor? {
+        selectedTab?.underPageBackgroundColor
+    }
+
+    var webContentTerminationCount: Int {
+        selectedTab?.webContentTerminationCount ?? 0
+    }
+
+    var lastWebContentTerminationDate: Date? {
+        selectedTab?.lastWebContentTerminationDate
+    }
+
+    var lastWebContentTerminationURL: URL? {
+        selectedTab?.lastWebContentTerminationURL
+    }
+
+    var lastNavigationErrorDescription: String? {
+        selectedTab?.lastNavigationErrorDescription
+    }
+
+    var didCommitNavigationCount: Int {
+        selectedTab?.didCommitNavigationCount ?? 0
+    }
+
+    var didFinishNavigationCount: Int {
+        selectedTab?.didFinishNavigationCount ?? 0
+    }
+
+    var isShowingProgress: Bool {
+        selectedTab?.isShowingProgress ?? false
+    }
+
+    var displayTitle: String {
+        selectedTab?.displayTitle ?? "Monocly"
+    }
+
+    init(
+        url: URL,
+        automaticallyLoadsInitialRequest: Bool = true,
+        sessionStore: BrowserSessionStore? = BrowserSessionStore(),
+        saveDebounceDuration: UInt64 = 500_000_000
+    ) {
+        fallbackURL = url
+        self.sessionStore = sessionStore
+        self.saveDebounceDuration = saveDebounceDuration
+
+        let tab = BrowserTabStore(url: url, automaticallyLoadsInitialRequest: automaticallyLoadsInitialRequest)
+        tabs = [tab]
+        selectedTabID = tab.id
+
+        configureTabCallbacks()
+        restorationComplete = true
+    }
+
+    init(
+        restoring restoredSession: BrowserRestoredSession?,
+        fallbackURL: URL,
+        sessionStore: BrowserSessionStore? = BrowserSessionStore(),
+        saveDebounceDuration: UInt64 = 500_000_000
+    ) {
+        self.fallbackURL = fallbackURL
+        self.sessionStore = sessionStore
+        self.saveDebounceDuration = saveDebounceDuration
+
+        if let restoredSession,
+           restoredSession.snapshot.tabs.isEmpty == false {
+            let restoredTabs = restoredSession.snapshot.tabs.map { tabSnapshot in
+                BrowserTabStore(
+                    id: tabSnapshot.id,
+                    url: tabSnapshot.url,
+                    title: tabSnapshot.title,
+                    createdAt: tabSnapshot.createdAt,
+                    lastUsedAt: tabSnapshot.lastUsedAt,
+                    restoredInteractionState: restoredSession.tabStateDataByID[tabSnapshot.id],
+                    automaticallyLoadsInitialRequest: false
+                )
+            }
+            tabs = restoredTabs
+            selectedTabID = restoredTabs.contains(where: { $0.id == restoredSession.snapshot.selectedTabID })
+                ? restoredSession.snapshot.selectedTabID
+                : restoredTabs[0].id
+        } else {
+            let tab = BrowserTabStore(url: fallbackURL, automaticallyLoadsInitialRequest: false)
+            tabs = [tab]
+            selectedTabID = tab.id
+        }
+
+        configureTabCallbacks()
+    }
+
+    deinit {
+        saveTask?.cancel()
+    }
+
+    func selectTab(id: UUID) {
+        guard let tab = tabs.first(where: { $0.id == id }) else {
+            return
+        }
+        selectedTabID = tab.id
+        tab.markSelected()
+        noteStateChanged()
+    }
+
+    func goBack() {
+        selectedTab?.goBack()
+    }
+
+    func goForward() {
+        selectedTab?.goForward()
+    }
+
+    func go(to item: WKBackForwardListItem) {
+        selectedTab?.go(to: item)
+    }
+
+    func load(url: URL) {
+        selectedTab?.load(url: url)
+    }
+
+    func backHistoryItems(limit: Int = 20) -> [BrowserHistoryMenuItem] {
+        selectedTab?.backHistoryItems(limit: limit) ?? []
+    }
+
+    func forwardHistoryItems(limit: Int = 20) -> [BrowserHistoryMenuItem] {
+        selectedTab?.forwardHistoryItems(limit: limit) ?? []
+    }
+
+    func loadInitialRequestIfNeeded() {
+        resolvedSelectedTab.markSelected()
+        restorationComplete = true
+        preserveSession(immediate: false)
+    }
+
+    func preserveSession(immediate: Bool) {
+        guard restorationComplete else {
+            return
+        }
+        guard sessionStore != nil else {
+            return
+        }
+
+        saveTask?.cancel()
+        saveTask = nil
+
+        if immediate {
+            saveCurrentSession()
+            return
+        }
+
+        saveTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            try? await Task.sleep(nanoseconds: self.saveDebounceDuration)
+            guard Task.isCancelled == false else {
+                return
+            }
+            self.saveTask = nil
+            self.saveCurrentSession()
+        }
+    }
+
+    private var resolvedSelectedTab: BrowserTabStore {
+        if let selectedTab {
+            return selectedTab
+        }
+
+        let tab = BrowserTabStore(url: fallbackURL, automaticallyLoadsInitialRequest: false)
+        tabs = [tab]
+        selectedTabID = tab.id
+        configureTabCallbacks()
+        noteStateChanged()
+        return tab
+    }
+
+    private func configureTabCallbacks() {
+        for tab in tabs {
+            tab.onStateChanged = { [weak self] in
+                self?.noteStateChanged()
+            }
+        }
+    }
+
+    private func noteStateChanged() {
+        stateRevision += 1
+        preserveSession(immediate: false)
+    }
+
+    private func saveCurrentSession() {
+        guard let sessionStore else {
+            return
+        }
+        if tabs.isEmpty {
+            let tab = BrowserTabStore(url: fallbackURL, automaticallyLoadsInitialRequest: false)
+            tabs = [tab]
+            selectedTabID = tab.id
+            configureTabCallbacks()
+            stateRevision += 1
+        }
+
+        let selectedID = tabs.contains(where: { $0.id == selectedTabID }) ? selectedTabID : tabs[0].id
+        selectedTabID = selectedID
+
+        var tabStateDataByID: [UUID: Data] = [:]
+        let tabSnapshots = tabs.map { tab in
+            if let stateData = tab.interactionStateData {
+                tabStateDataByID[tab.id] = stateData
+            }
+            return tab.snapshot(stateFileName: BrowserTabSnapshot.stateFileName(for: tab.id))
+        }
+
+        let snapshot = BrowserSessionSnapshot(selectedTabID: selectedID, tabs: tabSnapshots)
+        try? sessionStore.save(snapshot: snapshot, tabStateDataByID: tabStateDataByID)
+    }
+}

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -272,6 +272,7 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else {
             return
         }
+        rootViewController?.store.preserveSession(immediate: true)
         MonoclyWindowContextStore.shared.sceneWillResignActive(windowScene)
     }
 
@@ -284,16 +285,27 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
 
     func connect(
         windowScene: UIWindowScene,
-        launchConfiguration: BrowserLaunchConfiguration = .current()
+        launchConfiguration: BrowserLaunchConfiguration = .current(),
+        sessionStore: BrowserSessionStore = BrowserSessionStore()
     ) {
-        let rootViewController = preservedRootViewController
-            ?? BrowserRootViewController(launchConfiguration: launchConfiguration)
-        if preservedRootViewController === rootViewController {
+        let rootViewController: BrowserRootViewController
+        if let preservedRoot = preservedRootViewController {
+            rootViewController = preservedRoot
             BrowserInspectorCoordinator.setInspectorWindowReleaseHandler(
                 for: rootViewController.inspectorSession,
                 nil
             )
             preservedRootViewController = nil
+        } else {
+            let store = BrowserStore(
+                restoring: sessionStore.load(),
+                fallbackURL: launchConfiguration.initialURL,
+                sessionStore: sessionStore
+            )
+            rootViewController = BrowserRootViewController(
+                store: store,
+                launchConfiguration: launchConfiguration
+            )
         }
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController
@@ -311,6 +323,7 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
 
     func disconnect(windowScene: UIWindowScene) {
         if let rootViewController {
+            rootViewController.store.preserveSession(immediate: true)
             if BrowserInspectorCoordinator.hasInspectorWindow(for: rootViewController.inspectorSession) {
                 preservedRootViewController = rootViewController
                 rootViewController.prepareForSceneDisconnectionPreservingInspectorSession()

--- a/Monocly/Monocly/MonoclyApp.swift
+++ b/Monocly/Monocly/MonoclyApp.swift
@@ -286,7 +286,7 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
     func connect(
         windowScene: UIWindowScene,
         launchConfiguration: BrowserLaunchConfiguration = .current(),
-        sessionStore: BrowserSessionStore = BrowserSessionStore()
+        sessionStore: BrowserSessionStore? = nil
     ) {
         let rootViewController: BrowserRootViewController
         if let preservedRoot = preservedRootViewController {
@@ -297,6 +297,9 @@ final class MonoclyMainSceneDelegate: NSObject, UIWindowSceneDelegate {
             )
             preservedRootViewController = nil
         } else {
+            let sessionStore = sessionStore ?? BrowserSessionStore(
+                sceneSessionPersistentIdentifier: windowScene.session.persistentIdentifier
+            )
             let store = BrowserStore(
                 restoring: sessionStore.load(),
                 fallbackURL: launchConfiguration.initialURL,

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -209,6 +209,80 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func autosavePreservesPendingRestoredStateForUnselectedTabs() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let selectedID = UUID()
+            let backgroundID = UUID()
+            let backgroundState = Data("background-state".utf8)
+            let restoredSession = BrowserRestoredSession(
+                snapshot: BrowserSessionSnapshot(
+                    selectedTabID: selectedID,
+                    tabs: [
+                        BrowserTabSnapshot(
+                            id: selectedID,
+                            url: try #require(URL(string: "https://example.com/selected")),
+                            title: "Selected",
+                            createdAt: Date(timeIntervalSince1970: 100),
+                            lastUsedAt: Date(timeIntervalSince1970: 200),
+                            stateFileName: BrowserTabSnapshot.stateFileName(for: selectedID)
+                        ),
+                        BrowserTabSnapshot(
+                            id: backgroundID,
+                            url: try #require(URL(string: "https://example.com/background")),
+                            title: "Background",
+                            createdAt: Date(timeIntervalSince1970: 100),
+                            lastUsedAt: Date(timeIntervalSince1970: 100),
+                            stateFileName: BrowserTabSnapshot.stateFileName(for: backgroundID)
+                        )
+                    ]
+                ),
+                tabStateDataByID: [backgroundID: backgroundState]
+            )
+            let store = BrowserStore(
+                restoring: restoredSession,
+                fallbackURL: try #require(URL(string: "https://fallback.example/")),
+                sessionStore: sessionStore
+            )
+
+            store.loadInitialRequestIfNeeded()
+            store.preserveSession(immediate: true)
+
+            let savedSession = try #require(sessionStore.load())
+            #expect(savedSession.tabStateDataByID[backgroundID] == backgroundState)
+        }
+    }
+
+    @Test
+    func restoredTitleSurvivesInitialNilWebViewTitleObservation() throws {
+        let tabID = UUID()
+        let store = BrowserStore(
+            restoring: BrowserRestoredSession(
+                snapshot: BrowserSessionSnapshot(
+                    selectedTabID: tabID,
+                    tabs: [
+                        BrowserTabSnapshot(
+                            id: tabID,
+                            url: try #require(URL(string: "https://example.com/restored-title")),
+                            title: "Restored Title",
+                            createdAt: Date(timeIntervalSince1970: 100),
+                            lastUsedAt: Date(timeIntervalSince1970: 100),
+                            stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                        )
+                    ]
+                ),
+                tabStateDataByID: [:]
+            ),
+            fallbackURL: try #require(URL(string: "https://fallback.example/")),
+            sessionStore: nil
+        )
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        #expect(store.tabs[0].snapshot(stateFileName: "tab.state").title == "Restored Title")
+        #expect(store.displayTitle == "Restored Title")
+    }
+
+    @Test
     func mainSceneDelegateConnectsWithRestoredBrowserStore() throws {
         try withTemporarySessionStore { sessionStore, _ in
             let windowScene = try makeWindowScene()

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -293,6 +293,44 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func explicitNavigationDoesNotSaveStaleRestoredInteractionStateForNewURL() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let tabID = UUID()
+            let restoredState = Data("restored-state".utf8)
+            let newURL = try #require(URL(string: "https://example.com/new-page"))
+            let restoredSession = BrowserRestoredSession(
+                snapshot: BrowserSessionSnapshot(
+                    selectedTabID: tabID,
+                    tabs: [
+                        BrowserTabSnapshot(
+                            id: tabID,
+                            url: try #require(URL(string: "https://example.com/restored-state")),
+                            title: "Restored State",
+                            createdAt: Date(timeIntervalSince1970: 100),
+                            lastUsedAt: Date(timeIntervalSince1970: 100),
+                            stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                        )
+                    ]
+                ),
+                tabStateDataByID: [tabID: restoredState]
+            )
+            let store = BrowserStore(
+                restoring: restoredSession,
+                fallbackURL: try #require(URL(string: "https://fallback.example/")),
+                sessionStore: sessionStore
+            )
+
+            store.loadInitialRequestIfNeeded()
+            store.load(url: newURL)
+            store.preserveSession(immediate: true)
+
+            let savedSession = try #require(sessionStore.load())
+            #expect(savedSession.snapshot.tabs.first?.url == newURL)
+            #expect(savedSession.tabStateDataByID[tabID] == nil)
+        }
+    }
+
+    @Test
     func autosavePreservesPendingRestoredStateForUnselectedTabs() throws {
         try withTemporarySessionStore { sessionStore, _ in
             let selectedID = UUID()

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -331,6 +331,50 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func failedNavigationKeepsSynchronizedInteractionStateSaveable() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let tabID = UUID()
+            let restoredURL = try #require(URL(string: "https://example.com/restored-state"))
+            let restoredState = Data("restored-state".utf8)
+            let restoredSession = BrowserRestoredSession(
+                snapshot: BrowserSessionSnapshot(
+                    selectedTabID: tabID,
+                    tabs: [
+                        BrowserTabSnapshot(
+                            id: tabID,
+                            url: restoredURL,
+                            title: "Restored State",
+                            createdAt: Date(timeIntervalSince1970: 100),
+                            lastUsedAt: Date(timeIntervalSince1970: 100),
+                            stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                        )
+                    ]
+                ),
+                tabStateDataByID: [tabID: restoredState]
+            )
+            let store = BrowserStore(
+                restoring: restoredSession,
+                fallbackURL: try #require(URL(string: "https://fallback.example/")),
+                sessionStore: sessionStore
+            )
+            let tab = try #require(store.selectedTab)
+
+            store.loadInitialRequestIfNeeded()
+            tab.webView(tab.webView, didStartProvisionalNavigation: nil)
+            tab.webView(
+                tab.webView,
+                didFailProvisionalNavigation: nil,
+                withError: URLError(.notConnectedToInternet)
+            )
+            store.preserveSession(immediate: true)
+
+            let savedSession = try #require(sessionStore.load())
+            #expect(savedSession.snapshot.tabs.first?.url == restoredURL)
+            #expect(savedSession.tabStateDataByID[tabID] != nil)
+        }
+    }
+
+    @Test
     func autosavePreservesPendingRestoredStateForUnselectedTabs() throws {
         try withTemporarySessionStore { sessionStore, _ in
             let selectedID = UUID()

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 #if os(iOS)
 import UIKit
+import WebKit
 
 @Suite(.serialized)
 @MainActor
@@ -258,6 +259,40 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func restoredInteractionStateDoesNotTriggerInitialURLLoad() throws {
+        let tabID = UUID()
+        let restoredURL = try #require(URL(string: "https://example.com/restored-state"))
+        let restoredState = Data("restored-state".utf8)
+        let restoredSession = BrowserRestoredSession(
+            snapshot: BrowserSessionSnapshot(
+                selectedTabID: tabID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: tabID,
+                        url: restoredURL,
+                        title: "Restored State",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                    )
+                ]
+            ),
+            tabStateDataByID: [tabID: restoredState]
+        )
+        let store = BrowserStore(
+            restoring: restoredSession,
+            fallbackURL: try #require(URL(string: "https://fallback.example/")),
+            sessionStore: nil
+        )
+        let tab = try #require(store.selectedTab)
+
+        store.loadInitialRequestIfNeeded()
+
+        #expect(tab.initialRequestLoadCount == 0)
+        #expect(store.currentURL == restoredURL)
+    }
+
+    @Test
     func autosavePreservesPendingRestoredStateForUnselectedTabs() throws {
         try withTemporarySessionStore { sessionStore, _ in
             let selectedID = UUID()
@@ -329,6 +364,60 @@ struct BrowserSessionRestoreTests {
 
         #expect(store.tabs[0].snapshot(stateFileName: "tab.state").title == "Restored Title")
         #expect(store.displayTitle == "Restored Title")
+    }
+
+    @Test
+    func rootReattachesInspectorSessionAfterSelectedTabWebViewChanges() async throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let restoredSession = BrowserRestoredSession(
+            snapshot: BrowserSessionSnapshot(
+                selectedTabID: firstID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: firstID,
+                        url: try #require(URL(string: "about:blank#first")),
+                        title: "First",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: firstID)
+                    ),
+                    BrowserTabSnapshot(
+                        id: secondID,
+                        url: try #require(URL(string: "about:blank#second")),
+                        title: "Second",
+                        createdAt: Date(timeIntervalSince1970: 200),
+                        lastUsedAt: Date(timeIntervalSince1970: 200),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: secondID)
+                    )
+                ]
+            ),
+            tabStateDataByID: [:]
+        )
+        let store = BrowserStore(
+            restoring: restoredSession,
+            fallbackURL: try #require(URL(string: "about:blank")),
+            sessionStore: nil
+        )
+        let rootViewController = BrowserRootViewController(
+            store: store,
+            launchConfiguration: BrowserLaunchConfiguration(initialURL: try #require(URL(string: "about:blank")))
+        )
+        rootViewController.loadViewIfNeeded()
+        rootViewController.viewControllers.first?.loadViewIfNeeded()
+        let firstWebView = store.tabs[0].webView
+        let secondWebView = store.tabs[1].webView
+        var attachTargets: [WKWebView] = []
+        rootViewController.setInspectorSessionAttachedForTesting(to: firstWebView)
+        rootViewController.onAttachInspectorSessionForTesting = { webView in
+            attachTargets.append(webView)
+        }
+
+        store.selectTab(id: secondID)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await rootViewController.waitForInspectorSessionTransitions()
+
+        #expect(attachTargets.contains { $0 === secondWebView })
     }
 
     @Test

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Testing
+@testable import Monocly
+
+#if os(iOS)
+import UIKit
+
+@Suite(.serialized)
+@MainActor
+struct BrowserSessionRestoreTests {
+    @Test
+    func sessionStoreSavesAndLoadsMultipleTabsAndStateBlobs() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let firstID = UUID()
+            let secondID = UUID()
+            let firstDate = Date(timeIntervalSince1970: 100)
+            let secondDate = Date(timeIntervalSince1970: 200)
+            let snapshot = BrowserSessionSnapshot(
+                selectedTabID: secondID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: firstID,
+                        url: try #require(URL(string: "https://example.com/first")),
+                        title: "First",
+                        createdAt: firstDate,
+                        lastUsedAt: firstDate,
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: firstID)
+                    ),
+                    BrowserTabSnapshot(
+                        id: secondID,
+                        url: try #require(URL(string: "https://example.com/second")),
+                        title: "Second",
+                        createdAt: secondDate,
+                        lastUsedAt: secondDate,
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: secondID)
+                    )
+                ]
+            )
+            let tabStateDataByID = [
+                firstID: Data("first-state".utf8),
+                secondID: Data("second-state".utf8)
+            ]
+
+            try sessionStore.save(snapshot: snapshot, tabStateDataByID: tabStateDataByID)
+
+            let restoredSession = try #require(sessionStore.load())
+            #expect(restoredSession.snapshot == snapshot)
+            #expect(restoredSession.tabStateDataByID == tabStateDataByID)
+        }
+    }
+
+    @Test
+    func sessionStoreIgnoresCorruptJSON() throws {
+        try withTemporarySessionStore { sessionStore, rootDirectoryURL in
+            try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+            try Data("{".utf8).write(to: rootDirectoryURL.appendingPathComponent("session.json"))
+
+            #expect(sessionStore.load() == nil)
+        }
+    }
+
+    @Test
+    func sessionStoreLoadsSnapshotWhenStateBlobIsMissing() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let tabID = UUID()
+            let snapshot = BrowserSessionSnapshot(
+                selectedTabID: tabID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: tabID,
+                        url: try #require(URL(string: "https://example.com/missing-state")),
+                        title: "Missing State",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 200),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                    )
+                ]
+            )
+
+            try sessionStore.save(snapshot: snapshot, tabStateDataByID: [:])
+
+            let restoredSession = try #require(sessionStore.load())
+            #expect(restoredSession.snapshot == snapshot)
+            #expect(restoredSession.tabStateDataByID.isEmpty)
+        }
+    }
+
+    @Test
+    func browserStoreCreatesFallbackTabWithoutSnapshot() throws {
+        let fallbackURL = try #require(URL(string: "https://fallback.example/"))
+        let store = BrowserStore(
+            restoring: nil,
+            fallbackURL: fallbackURL,
+            sessionStore: nil
+        )
+
+        #expect(store.tabs.count == 1)
+        #expect(store.selectedTabID == store.tabs[0].id)
+        #expect(store.currentURL == fallbackURL)
+        #expect(store.webView === store.tabs[0].webView)
+    }
+
+    @Test
+    func browserStoreRestoresTabsAndSelectedWebViewFromSnapshot() throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let fallbackURL = try #require(URL(string: "https://fallback.example/"))
+        let selectedURL = try #require(URL(string: "https://example.com/selected"))
+        let restoredSession = BrowserRestoredSession(
+            snapshot: BrowserSessionSnapshot(
+                selectedTabID: secondID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: firstID,
+                        url: try #require(URL(string: "https://example.com/first")),
+                        title: "First",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: firstID)
+                    ),
+                    BrowserTabSnapshot(
+                        id: secondID,
+                        url: selectedURL,
+                        title: "Selected",
+                        createdAt: Date(timeIntervalSince1970: 200),
+                        lastUsedAt: Date(timeIntervalSince1970: 300),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: secondID)
+                    )
+                ]
+            ),
+            tabStateDataByID: [:]
+        )
+
+        let store = BrowserStore(
+            restoring: restoredSession,
+            fallbackURL: fallbackURL,
+            sessionStore: nil
+        )
+
+        #expect(store.tabs.map(\.id) == [firstID, secondID])
+        #expect(store.selectedTabID == secondID)
+        #expect(store.currentURL == selectedURL)
+        #expect(store.displayTitle == "Selected")
+        #expect(store.webView === store.tabs[1].webView)
+    }
+
+    @Test
+    func browserStoreNormalizesInvalidSelectedTabToFirstRestoredTab() throws {
+        let tabID = UUID()
+        let restoredURL = try #require(URL(string: "https://example.com/restored"))
+        let restoredSession = BrowserRestoredSession(
+            snapshot: BrowserSessionSnapshot(
+                selectedTabID: UUID(),
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: tabID,
+                        url: restoredURL,
+                        title: "Restored",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                    )
+                ]
+            ),
+            tabStateDataByID: [:]
+        )
+
+        let store = BrowserStore(
+            restoring: restoredSession,
+            fallbackURL: try #require(URL(string: "https://fallback.example/")),
+            sessionStore: nil
+        )
+
+        #expect(store.selectedTabID == tabID)
+        #expect(store.currentURL == restoredURL)
+    }
+
+    @Test
+    func restoredStoreDoesNotReplaceSelectedTabURLWithFallbackInitialURL() throws {
+        let tabID = UUID()
+        let restoredURL = try #require(URL(string: "https://example.com/restored"))
+        let fallbackURL = try #require(URL(string: "https://fallback.example/"))
+        let restoredSession = BrowserRestoredSession(
+            snapshot: BrowserSessionSnapshot(
+                selectedTabID: tabID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: tabID,
+                        url: restoredURL,
+                        title: "Restored",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: tabID)
+                    )
+                ]
+            ),
+            tabStateDataByID: [:]
+        )
+        let store = BrowserStore(
+            restoring: restoredSession,
+            fallbackURL: fallbackURL,
+            sessionStore: nil
+        )
+
+        store.loadInitialRequestIfNeeded()
+
+        #expect(store.currentURL == restoredURL)
+        #expect(store.currentURL != fallbackURL)
+    }
+
+    @Test
+    func mainSceneDelegateConnectsWithRestoredBrowserStore() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let windowScene = try makeWindowScene()
+            let selectedTabID = UUID()
+            let restoredURL = try #require(URL(string: "https://example.com/restored"))
+            let launchConfiguration = BrowserLaunchConfiguration(
+                initialURL: try #require(URL(string: "https://fallback.example/"))
+            )
+            let snapshot = BrowserSessionSnapshot(
+                selectedTabID: selectedTabID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: selectedTabID,
+                        url: restoredURL,
+                        title: "Restored",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: selectedTabID)
+                    )
+                ]
+            )
+            try sessionStore.save(snapshot: snapshot, tabStateDataByID: [:])
+            let sceneDelegate = MonoclyMainSceneDelegate()
+            defer {
+                sceneDelegate.disconnect(windowScene: windowScene)
+            }
+
+            sceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: sessionStore
+            )
+
+            let rootViewController = try #require(sceneDelegate.rootViewController)
+            #expect(rootViewController.store.selectedTabID == selectedTabID)
+            #expect(rootViewController.store.currentURL == restoredURL)
+        }
+    }
+
+    @Test
+    func mainSceneDelegateForcesSaveWhenSceneResignsActive() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let windowScene = try makeWindowScene()
+            let launchConfiguration = BrowserLaunchConfiguration(
+                initialURL: try #require(URL(string: "https://initial.example/"))
+            )
+            let sceneDelegate = MonoclyMainSceneDelegate()
+            defer {
+                sceneDelegate.disconnect(windowScene: windowScene)
+            }
+            sceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: sessionStore
+            )
+            let rootViewController = try #require(sceneDelegate.rootViewController)
+            let navigatedURL = try #require(URL(string: "https://example.com/navigated"))
+
+            rootViewController.store.loadInitialRequestIfNeeded()
+            rootViewController.store.load(url: navigatedURL)
+            sceneDelegate.sceneWillResignActive(windowScene)
+
+            let restoredSession = try #require(sessionStore.load())
+            #expect(restoredSession.snapshot.selectedTabID == rootViewController.store.selectedTabID)
+            #expect(restoredSession.snapshot.tabs.first?.url == navigatedURL)
+        }
+    }
+
+    @Test
+    func mainSceneDelegateForcesSaveWhenSceneDisconnects() throws {
+        try withTemporarySessionStore { sessionStore, _ in
+            let windowScene = try makeWindowScene()
+            let launchConfiguration = BrowserLaunchConfiguration(
+                initialURL: try #require(URL(string: "https://initial.example/"))
+            )
+            let sceneDelegate = MonoclyMainSceneDelegate()
+            sceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: sessionStore
+            )
+            let rootViewController = try #require(sceneDelegate.rootViewController)
+            let navigatedURL = try #require(URL(string: "https://example.com/disconnect"))
+
+            rootViewController.store.loadInitialRequestIfNeeded()
+            rootViewController.store.load(url: navigatedURL)
+            sceneDelegate.disconnect(windowScene: windowScene)
+
+            let restoredSession = try #require(sessionStore.load())
+            #expect(restoredSession.snapshot.selectedTabID == rootViewController.store.selectedTabID)
+            #expect(restoredSession.snapshot.tabs.first?.url == navigatedURL)
+        }
+    }
+
+    private func withTemporarySessionStore<T>(
+        _ body: (BrowserSessionStore, URL) throws -> T
+    ) throws -> T {
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MonoclyBrowserSession-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: rootDirectoryURL)
+        }
+        return try body(BrowserSessionStore(rootDirectoryURL: rootDirectoryURL), rootDirectoryURL)
+    }
+
+    private func makeWindowScene() throws -> UIWindowScene {
+        try #require(
+            UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first
+        )
+    }
+}
+#endif

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -86,6 +86,55 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func sessionStoreScopesSnapshotsBySceneSessionIdentifier() throws {
+        try withTemporaryBrowserSessionDirectory { browserSessionDirectoryURL in
+            let firstStore = BrowserSessionStore(
+                sceneSessionPersistentIdentifier: "scene/a",
+                browserSessionDirectoryURL: browserSessionDirectoryURL
+            )
+            let secondStore = BrowserSessionStore(
+                sceneSessionPersistentIdentifier: "scene/b",
+                browserSessionDirectoryURL: browserSessionDirectoryURL
+            )
+            let firstID = UUID()
+            let secondID = UUID()
+            let firstSnapshot = BrowserSessionSnapshot(
+                selectedTabID: firstID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: firstID,
+                        url: try #require(URL(string: "https://example.com/first-scene")),
+                        title: "First Scene",
+                        createdAt: Date(timeIntervalSince1970: 100),
+                        lastUsedAt: Date(timeIntervalSince1970: 100),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: firstID)
+                    )
+                ]
+            )
+            let secondSnapshot = BrowserSessionSnapshot(
+                selectedTabID: secondID,
+                tabs: [
+                    BrowserTabSnapshot(
+                        id: secondID,
+                        url: try #require(URL(string: "https://example.com/second-scene")),
+                        title: "Second Scene",
+                        createdAt: Date(timeIntervalSince1970: 200),
+                        lastUsedAt: Date(timeIntervalSince1970: 200),
+                        stateFileName: BrowserTabSnapshot.stateFileName(for: secondID)
+                    )
+                ]
+            )
+
+            try firstStore.save(snapshot: firstSnapshot, tabStateDataByID: [:])
+            try secondStore.save(snapshot: secondSnapshot, tabStateDataByID: [:])
+
+            #expect(firstStore.rootDirectoryURL != secondStore.rootDirectoryURL)
+            #expect(firstStore.load()?.snapshot == firstSnapshot)
+            #expect(secondStore.load()?.snapshot == secondSnapshot)
+        }
+    }
+
+    @Test
     func browserStoreCreatesFallbackTabWithoutSnapshot() throws {
         let fallbackURL = try #require(URL(string: "https://fallback.example/"))
         let store = BrowserStore(
@@ -380,12 +429,20 @@ struct BrowserSessionRestoreTests {
     private func withTemporarySessionStore<T>(
         _ body: (BrowserSessionStore, URL) throws -> T
     ) throws -> T {
+        try withTemporaryBrowserSessionDirectory { rootDirectoryURL in
+            try body(BrowserSessionStore(rootDirectoryURL: rootDirectoryURL), rootDirectoryURL)
+        }
+    }
+
+    private func withTemporaryBrowserSessionDirectory<T>(
+        _ body: (URL) throws -> T
+    ) throws -> T {
         let rootDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MonoclyBrowserSession-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: rootDirectoryURL)
         }
-        return try body(BrowserSessionStore(rootDirectoryURL: rootDirectoryURL), rootDirectoryURL)
+        return try body(rootDirectoryURL)
     }
 
     private func makeWindowScene() throws -> UIWindowScene {

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -258,7 +258,11 @@ struct MonoclyLifecycleTests {
             let windowScene = try makeWindowScene()
             let launchConfiguration = BrowserLaunchConfiguration(initialURL: URL(string: "about:blank")!)
 
-            sceneDelegate.connect(windowScene: windowScene, launchConfiguration: launchConfiguration)
+            sceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: makeTemporarySessionStore(context: context)
+            )
 
             let hostWindow = try #require(sceneDelegate.window)
             context.retain(hostWindow)
@@ -286,7 +290,11 @@ struct MonoclyLifecycleTests {
             let windowScene = try makeWindowScene()
             let launchConfiguration = BrowserLaunchConfiguration(initialURL: URL(string: "about:blank")!)
 
-            sceneDelegate.connect(windowScene: windowScene, launchConfiguration: launchConfiguration)
+            sceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: makeTemporarySessionStore(context: context)
+            )
 
             let hostWindow = try #require(sceneDelegate.window)
             context.retain(hostWindow)
@@ -316,7 +324,11 @@ struct MonoclyLifecycleTests {
                 )
             )
 
-            mainSceneDelegate.connect(windowScene: windowScene, launchConfiguration: launchConfiguration)
+            mainSceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: makeTemporarySessionStore(context: context)
+            )
 
             let mainWindow = try #require(mainSceneDelegate.window)
             context.retain(mainWindow)
@@ -363,7 +375,11 @@ struct MonoclyLifecycleTests {
                 )
             )
 
-            mainSceneDelegate.connect(windowScene: windowScene, launchConfiguration: launchConfiguration)
+            mainSceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: makeTemporarySessionStore(context: context)
+            )
 
             let firstWindow = try #require(mainSceneDelegate.window)
             context.retain(firstWindow)
@@ -379,7 +395,11 @@ struct MonoclyLifecycleTests {
             context.retain(try #require(inspectorSceneDelegate.window))
 
             mainSceneDelegate.disconnect(windowScene: windowScene)
-            mainSceneDelegate.connect(windowScene: windowScene, launchConfiguration: launchConfiguration)
+            mainSceneDelegate.connect(
+                windowScene: windowScene,
+                launchConfiguration: launchConfiguration,
+                sessionStore: makeTemporarySessionStore(context: context)
+            )
 
             let reconnectedWindow = try #require(mainSceneDelegate.window)
             context.retain(reconnectedWindow)
@@ -600,10 +620,27 @@ private extension MonoclyLifecycleTests {
         return try await body(context)
     }
 
+    func makeTemporarySessionStore(context: TestContext) -> BrowserSessionStore {
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MonoclyBrowserSession-\(UUID().uuidString)", isDirectory: true)
+        context.addCleanup {
+            try? FileManager.default.removeItem(at: rootDirectoryURL)
+        }
+        return BrowserSessionStore(rootDirectoryURL: rootDirectoryURL)
+    }
+
     func makeHostedRootViewController(context: TestContext) throws -> HostedRootFixture {
         let windowScene = try makeWindowScene()
         let launchConfiguration = BrowserLaunchConfiguration(initialURL: URL(string: "about:blank")!)
-        let rootViewController = BrowserRootViewController(launchConfiguration: launchConfiguration)
+        let store = BrowserStore(
+            url: launchConfiguration.initialURL,
+            automaticallyLoadsInitialRequest: false,
+            sessionStore: nil
+        )
+        let rootViewController = BrowserRootViewController(
+            store: store,
+            launchConfiguration: launchConfiguration
+        )
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()


### PR DESCRIPTION
## Purpose
Restore Monocly's browser session after app relaunch while reshaping the internal browser owner model so it can grow into multiple tabs later.

## Changes
- Split the previous one-web-view browser owner into a window-level `BrowserStore` and per-tab `BrowserTabStore`.
- Add `BrowserSessionSnapshot`, `BrowserTabSnapshot`, and `BrowserSessionStore` for JSON metadata plus per-tab `WKWebView.interactionState` blobs under Application Support.
- Restore the main browser session during scene connection and force-save it when scenes resign active or disconnect.
- Reinstall the selected tab web view in `BrowserPageViewController` so future tab switching can swap the hosted `WKWebView`.
- Add Monocly session restore coverage and keep existing inspector scene preservation tests isolated from persistent session state.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`