### PR TITLE
Cache network list display projections

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -35,7 +35,7 @@ final class NetworkBodyViewController: UIViewController {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.backgroundColor = .clear
-        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.contentInsetAdjustmentBehavior = .automatic
         scrollView.delegate = self
         scrollView.isHidden = true
         scrollView.maximumZoomScale = 1
@@ -45,7 +45,7 @@ final class NetworkBodyViewController: UIViewController {
         return scrollView
     }()
     private let observationScope = ObservationScope()
-    private let scrollEdgeState: NetworkPreviewRoleScrollEdgeState?
+    private let scrollEdgeState: NetworkDetailScrollEdgeState?
     private weak var body: NetworkBody?
     private var metadata: NetworkBodyPreviewMetadata?
     private var hasDisplayedBody = false
@@ -59,7 +59,7 @@ final class NetworkBodyViewController: UIViewController {
     private var bodyObservationDelivery: ObservationDelivery?
 #endif
 
-    init(scrollEdgeState: NetworkPreviewRoleScrollEdgeState? = nil) {
+    init(scrollEdgeState: NetworkDetailScrollEdgeState? = nil) {
         self.scrollEdgeState = scrollEdgeState
         super.init(nibName: nil, bundle: nil)
     }
@@ -116,6 +116,7 @@ final class NetworkBodyViewController: UIViewController {
         metadata = nil
         startObserving(body: nil)
         hideMediaPreview()
+        scrollEdgeState?.contentScrollView = nil
     }
 
     private func configureSyntaxView() {
@@ -140,10 +141,10 @@ final class NetworkBodyViewController: UIViewController {
             syntaxView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             syntaxView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             syntaxView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            imageScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            imageScrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            imageScrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            imageScrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            imageScrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            imageScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             imageView.topAnchor.constraint(equalTo: imageScrollView.contentLayoutGuide.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: imageScrollView.contentLayoutGuide.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: imageScrollView.contentLayoutGuide.trailingAnchor),
@@ -311,7 +312,7 @@ final class NetworkBodyViewController: UIViewController {
         hideImagePreview()
         removeMediaPlayerViewController()
         syntaxView.isHidden = false
-        scrollEdgeState?.scrollView = syntaxView
+        scrollEdgeState?.contentScrollView = syntaxView
     }
 
     private func showImagePreview(_ image: UIImage) {
@@ -319,7 +320,7 @@ final class NetworkBodyViewController: UIViewController {
         removeCachedTemporaryMediaFile()
         syntaxView.isHidden = true
         imageScrollView.isHidden = false
-        scrollEdgeState?.scrollView = imageScrollView
+        scrollEdgeState?.contentScrollView = imageScrollView
         shouldResetImageZoomOnNextLayout = true
         imagePreviewLayoutState = nil
         imageView.image = image
@@ -333,7 +334,7 @@ final class NetworkBodyViewController: UIViewController {
     private func showMoviePreview(_ url: URL) {
         hideImagePreview()
         syntaxView.isHidden = true
-        scrollEdgeState?.scrollView = nil
+        scrollEdgeState?.contentScrollView = nil
         if let temporaryFileURL = mediaTemporaryFile?.fileURL, temporaryFileURL != url {
             removeCachedTemporaryMediaFile()
         }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -45,6 +45,7 @@ final class NetworkBodyViewController: UIViewController {
         return scrollView
     }()
     private let observationScope = ObservationScope()
+    private let scrollEdgeState: NetworkPreviewRoleScrollEdgeState?
     private weak var body: NetworkBody?
     private var metadata: NetworkBodyPreviewMetadata?
     private var hasDisplayedBody = false
@@ -57,6 +58,16 @@ final class NetworkBodyViewController: UIViewController {
 #if DEBUG
     private var bodyObservationDelivery: ObservationDelivery?
 #endif
+
+    init(scrollEdgeState: NetworkPreviewRoleScrollEdgeState? = nil) {
+        self.scrollEdgeState = scrollEdgeState
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -300,6 +311,7 @@ final class NetworkBodyViewController: UIViewController {
         hideImagePreview()
         removeMediaPlayerViewController()
         syntaxView.isHidden = false
+        scrollEdgeState?.scrollView = syntaxView
     }
 
     private func showImagePreview(_ image: UIImage) {
@@ -307,6 +319,7 @@ final class NetworkBodyViewController: UIViewController {
         removeCachedTemporaryMediaFile()
         syntaxView.isHidden = true
         imageScrollView.isHidden = false
+        scrollEdgeState?.scrollView = imageScrollView
         shouldResetImageZoomOnNextLayout = true
         imagePreviewLayoutState = nil
         imageView.image = image
@@ -320,6 +333,7 @@ final class NetworkBodyViewController: UIViewController {
     private func showMoviePreview(_ url: URL) {
         hideImagePreview()
         syntaxView.isHidden = true
+        scrollEdgeState?.scrollView = nil
         if let temporaryFileURL = mediaTemporaryFile?.fileURL, temporaryFileURL != url {
             removeCachedTemporaryMediaFile()
         }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -36,6 +36,7 @@ final class NetworkBodyViewController: UIViewController {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.backgroundColor = .clear
         scrollView.contentInsetAdjustmentBehavior = .automatic
+        scrollView.contentAlignmentPoint = CGPoint(x: 0.5, y: 0.5)
         scrollView.delegate = self
         scrollView.isHidden = true
         scrollView.maximumZoomScale = 1
@@ -403,17 +404,21 @@ final class NetworkBodyViewController: UIViewController {
         }
 
         imageScrollView.layoutIfNeeded()
+        imageScrollView.contentInset = .zero
         let imageSize = image.size
-        let boundsSize = imageScrollView.bounds.size
+        let visibleBoundsSize = imagePreviewVisibleBoundsSize()
+        guard visibleBoundsSize.width > 0, visibleBoundsSize.height > 0 else {
+            return false
+        }
         let fitScale = min(
-            boundsSize.width / imageSize.width,
-            boundsSize.height / imageSize.height
+            visibleBoundsSize.width / imageSize.width,
+            visibleBoundsSize.height / imageSize.height
         )
         let minimumZoomScale = min(1, fitScale)
         let maximumZoomScale = max(4, 1 / minimumZoomScale)
         let isKeepingAutoFit = imagePreviewLayoutState.map { state in
             state.imageSize == imageSize
-                && state.boundsSize != boundsSize
+                && state.visibleBoundsSize != visibleBoundsSize
                 && abs(imageScrollView.zoomScale - state.minimumZoomScale) < Self.imageZoomScaleTolerance
         } ?? false
         let targetZoomScale = resetZoom || isKeepingAutoFit
@@ -423,32 +428,19 @@ final class NetworkBodyViewController: UIViewController {
         imageScrollView.maximumZoomScale = maximumZoomScale
         imageScrollView.minimumZoomScale = minimumZoomScale
         imageScrollView.zoomScale = targetZoomScale
-        updateImageContentInset()
         imagePreviewLayoutState = ImagePreviewLayoutState(
             imageSize: imageSize,
-            boundsSize: boundsSize,
+            visibleBoundsSize: visibleBoundsSize,
             minimumZoomScale: minimumZoomScale
         )
         return true
     }
 
-    private func updateImageContentInset() {
-        guard let image = imageView.image else {
-            imageScrollView.contentInset = .zero
-            return
-        }
-
-        let scaledImageSize = CGSize(
-            width: image.size.width * imageScrollView.zoomScale,
-            height: image.size.height * imageScrollView.zoomScale
-        )
-        let horizontalInset = max((imageScrollView.bounds.width - scaledImageSize.width) / 2, 0)
-        let verticalInset = max((imageScrollView.bounds.height - scaledImageSize.height) / 2, 0)
-        imageScrollView.contentInset = UIEdgeInsets(
-            top: verticalInset,
-            left: horizontalInset,
-            bottom: verticalInset,
-            right: horizontalInset
+    private func imagePreviewVisibleBoundsSize() -> CGSize {
+        let adjustedInset = imageScrollView.adjustedContentInset
+        return CGSize(
+            width: max(imageScrollView.bounds.width - adjustedInset.left - adjustedInset.right, 0),
+            height: max(imageScrollView.bounds.height - adjustedInset.top - adjustedInset.bottom, 0)
         )
     }
 
@@ -516,13 +508,16 @@ final class NetworkBodyViewController: UIViewController {
 extension NetworkBodyViewController: UIScrollViewDelegate {
     nonisolated func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         MainActor.assumeIsolated {
-            imageView
+            scrollView === imageScrollView ? imageView : nil
         }
     }
 
-    nonisolated func scrollViewDidZoom(_ scrollView: UIScrollView) {
+    nonisolated func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
         MainActor.assumeIsolated {
-            updateImageContentInset()
+            guard scrollView === imageScrollView else {
+                return
+            }
+            updateImagePreviewLayoutIfNeeded()
         }
     }
 }
@@ -534,7 +529,7 @@ private enum NetworkBodyMediaPayload {
 
 private struct ImagePreviewLayoutState {
     var imageSize: CGSize
-    var boundsSize: CGSize
+    var visibleBoundsSize: CGSize
     var minimumZoomScale: CGFloat
 }
 

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailScrollEdgeController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailScrollEdgeController.swift
@@ -5,26 +5,36 @@ import UIKit
 
 @MainActor
 @Observable
-final class NetworkPreviewRoleScrollEdgeState {
-    var isControlVisible = false
-    var scrollView: UIScrollView?
+final class NetworkDetailScrollEdgeState {
+    var isPreviewRoleControlVisible = false
+    var contentScrollView: UIScrollView?
 }
 
 @MainActor
-final class NetworkPreviewRoleScrollEdgeController {
-    let scrollEdgeState = NetworkPreviewRoleScrollEdgeState()
+final class NetworkDetailScrollEdgeController {
+    let scrollEdgeState = NetworkDetailScrollEdgeState()
     private let observationScope = ObservationScope()
     private var interaction: UIInteraction?
+    private weak var registeredInteractionScrollView: UIScrollView?
 #if DEBUG
     private var observationDelivery: ObservationDelivery?
 #endif
 
-    var isControlVisible: Bool {
+    var isPreviewRoleControlVisible: Bool {
         get {
-            scrollEdgeState.isControlVisible
+            scrollEdgeState.isPreviewRoleControlVisible
         }
         set {
-            scrollEdgeState.isControlVisible = newValue
+            scrollEdgeState.isPreviewRoleControlVisible = newValue
+        }
+    }
+
+    var contentScrollView: UIScrollView? {
+        get {
+            scrollEdgeState.contentScrollView
+        }
+        set {
+            scrollEdgeState.contentScrollView = newValue
         }
     }
 
@@ -32,36 +42,43 @@ final class NetworkPreviewRoleScrollEdgeController {
         observationScope.cancelAll()
     }
 
-    func install(in containerView: UIView) {
+    func install(previewRoleControlContainerView: UIView) {
         guard interaction == nil else {
             return
         }
         if #available(iOS 26.0, *) {
             let interaction = UIScrollEdgeElementContainerInteraction()
             interaction.edge = .top
-            containerView.addInteraction(interaction)
+            previewRoleControlContainerView.addInteraction(interaction)
             self.interaction = interaction
             let delivery = observationScope.observe(scrollEdgeState) { [weak self] _, state in
                 self?.render(state)
             }
+            render(scrollEdgeState)
 #if DEBUG
             observationDelivery = delivery
 #endif
         }
     }
 
-    private func render(_ state: NetworkPreviewRoleScrollEdgeState) {
+    private func render(_ state: NetworkDetailScrollEdgeState) {
         if #available(iOS 26.0, *) {
+            let contentScrollView = state.contentScrollView
             guard let interaction = interaction as? UIScrollEdgeElementContainerInteraction else {
                 return
             }
-            interaction.scrollView = state.isControlVisible ? state.scrollView : nil
+            let interactionScrollView = state.isPreviewRoleControlVisible ? contentScrollView : nil
+            guard registeredInteractionScrollView !== interactionScrollView else {
+                return
+            }
+            interaction.scrollView = interactionScrollView
+            registeredInteractionScrollView = interactionScrollView
         }
     }
 }
 
 #if DEBUG
-extension NetworkPreviewRoleScrollEdgeController {
+extension NetworkDetailScrollEdgeController {
     @available(iOS 26.0, *)
     var interactionForTesting: UIScrollEdgeElementContainerInteraction? {
         interaction as? UIScrollEdgeElementContainerInteraction

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailSegmentedControlControllers.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailSegmentedControlControllers.swift
@@ -1,0 +1,189 @@
+#if canImport(UIKit)
+import WebInspectorCore
+import UIKit
+
+@MainActor
+final class NetworkDetailModeControlController {
+    let view: UISegmentedControl
+    var selectionHandler: ((NetworkDetailMode) -> Void)?
+    private var mode: NetworkDetailMode
+    private var isEnabled = false
+
+    init(initialMode: NetworkDetailMode) {
+        mode = initialMode
+        view = UISegmentedControl(items: NetworkDetailMode.allCases.map(\.title))
+        view.selectedSegmentIndex = Self.index(for: initialMode)
+        view.accessibilityIdentifier = "WebInspector.Network.DetailModeSegmentedControl"
+        view.addTarget(self, action: #selector(valueChanged(_:)), for: .valueChanged)
+    }
+
+    func render(mode: NetworkDetailMode, isEnabled: Bool) {
+        self.mode = mode
+        self.isEnabled = isEnabled
+        view.isEnabled = isEnabled
+        view.selectedSegmentIndex = Self.index(for: mode)
+        view.accessibilityLabel = mode.title
+        for index in NetworkDetailMode.allCases.indices {
+            view.setEnabled(isEnabled, forSegmentAt: index)
+        }
+    }
+
+    @objc private func valueChanged(_ sender: UISegmentedControl) {
+        guard NetworkDetailMode.allCases.indices.contains(sender.selectedSegmentIndex) else {
+            render(mode: mode, isEnabled: isEnabled)
+            return
+        }
+        selectionHandler?(NetworkDetailMode.allCases[sender.selectedSegmentIndex])
+    }
+
+    private static func index(for mode: NetworkDetailMode) -> Int {
+        NetworkDetailMode.allCases.firstIndex(of: mode) ?? UISegmentedControl.noSegment
+    }
+}
+
+@MainActor
+final class NetworkPreviewRoleControlController {
+    let containerView: NetworkDetailSegmentedControlContentView
+    var selectionHandler: ((NetworkBodyRole) -> Void)?
+    private let segmentedControl: UISegmentedControl
+    private var roles: [NetworkBodyRole] = []
+    private var selectedRole: NetworkBodyRole?
+    private var isVisible = false
+
+    init() {
+        let segmentedControl = UISegmentedControl()
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        segmentedControl.accessibilityIdentifier = "WebInspector.Network.DetailPreviewRoleSegmentedControl"
+        self.segmentedControl = segmentedControl
+        containerView = NetworkDetailSegmentedControlContentView(segmentedControl: segmentedControl)
+        segmentedControl.addTarget(self, action: #selector(valueChanged(_:)), for: .valueChanged)
+    }
+
+    @discardableResult
+    func render(
+        roles: [NetworkBodyRole],
+        selectedRole: NetworkBodyRole?,
+        isVisible: Bool
+    ) -> Bool {
+        self.selectedRole = selectedRole
+        self.isVisible = isVisible
+        if self.roles != roles {
+            self.roles = roles
+            segmentedControl.removeAllSegments()
+            for (index, role) in roles.enumerated() {
+                segmentedControl.insertSegment(
+                    withTitle: Self.title(for: role),
+                    at: index,
+                    animated: false
+                )
+            }
+        }
+        containerView.isHidden = isVisible == false
+        segmentedControl.selectedSegmentIndex = selectedRole.flatMap(roles.firstIndex(of:))
+            ?? UISegmentedControl.noSegment
+        segmentedControl.accessibilityLabel = selectedRole.map(Self.title(for:))
+        return isVisible
+    }
+
+    @objc private func valueChanged(_ sender: UISegmentedControl) {
+        guard roles.indices.contains(sender.selectedSegmentIndex) else {
+            render(roles: roles, selectedRole: selectedRole, isVisible: isVisible)
+            return
+        }
+        selectionHandler?(roles[sender.selectedSegmentIndex])
+    }
+
+    private static func title(for role: NetworkBodyRole) -> String {
+        switch role {
+        case .request:
+            String(localized: "network.section.request", bundle: .module)
+        case .response:
+            String(localized: "network.section.response", bundle: .module)
+        }
+    }
+}
+
+@MainActor
+final class NetworkDetailSegmentedControlContentView: UIView {
+    private let segmentedControl: UISegmentedControl
+
+    init(segmentedControl: UISegmentedControl) {
+        self.segmentedControl = segmentedControl
+        let height = Self.preferredHeight(for: segmentedControl)
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: height))
+        preservesSuperviewLayoutMargins = true
+        addSubview(segmentedControl)
+        NSLayoutConstraint.activate([
+            segmentedControl.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            segmentedControl.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            segmentedControl.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: Self.preferredHeight(for: segmentedControl))
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        CGSize(width: size.width, height: Self.preferredHeight(for: segmentedControl))
+    }
+
+    override func systemLayoutSizeFitting(_ targetSize: CGSize) -> CGSize {
+        fittingSize(for: targetSize)
+    }
+
+    override func systemLayoutSizeFitting(
+        _ targetSize: CGSize,
+        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
+        verticalFittingPriority: UILayoutPriority
+    ) -> CGSize {
+        fittingSize(for: targetSize)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    private func fittingSize(for targetSize: CGSize) -> CGSize {
+        let width = targetSize.width == 0 ? UIView.noIntrinsicMetric : targetSize.width
+        return CGSize(width: width, height: Self.preferredHeight(for: segmentedControl))
+    }
+
+    private static func preferredHeight(for segmentedControl: UISegmentedControl) -> CGFloat {
+        let navigationBarHeight = UINavigationBar(frame: .zero)
+            .sizeThatFits(CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+            .height
+        return max(segmentedControl.intrinsicContentSize.height, navigationBarHeight)
+    }
+}
+
+#if DEBUG
+extension NetworkDetailModeControlController {
+    var isEnabledForTesting: Bool {
+        view.isEnabled
+    }
+
+    func isModeEnabledForTesting(_ mode: NetworkDetailMode) -> Bool {
+        view.isEnabledForSegment(at: Self.index(for: mode))
+    }
+
+    func selectModeForTesting(_ mode: NetworkDetailMode) {
+        view.selectedSegmentIndex = Self.index(for: mode)
+        valueChanged(view)
+    }
+}
+
+extension NetworkPreviewRoleControlController {
+    var isHiddenForTesting: Bool {
+        containerView.isHidden
+    }
+
+    func selectRoleForTesting(_ role: NetworkBodyRole) {
+        segmentedControl.selectedSegmentIndex = roles.firstIndex(of: role)
+            ?? UISegmentedControl.noSegment
+        valueChanged(segmentedControl)
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -9,7 +9,24 @@ package final class NetworkDetailViewController: UIViewController {
     private let modelObservationScope = ObservationScope()
     private let selectedRequestRenderObservationScope = ObservationScope()
     private let responseBodyFetchObservationScope = ObservationScope()
-    private let bodyViewController = NetworkBodyViewController()
+    private let previewRoleScrollEdgeController = NetworkPreviewRoleScrollEdgeController()
+    private lazy var bodyViewController = NetworkBodyViewController(
+        scrollEdgeState: previewRoleScrollEdgeController.scrollEdgeState
+    )
+    private lazy var modeControlController: NetworkDetailModeControlController = {
+        let controller = NetworkDetailModeControlController(initialMode: mode)
+        controller.selectionHandler = { [weak self] mode in
+            self?.setMode(mode)
+        }
+        return controller
+    }()
+    private lazy var previewRoleControlController: NetworkPreviewRoleControlController = {
+        let controller = NetworkPreviewRoleControlController()
+        controller.selectionHandler = { [weak self] role in
+            self?.setPreviewRole(role)
+        }
+        return controller
+    }()
     private var previewRoles: [NetworkBodyRole] = []
     private var hasBoundSelectedRequest = false
     private weak var observedRequest: NetworkRequest?
@@ -19,26 +36,9 @@ package final class NetworkDetailViewController: UIViewController {
     private var selectedRequestRenderObservationDelivery: ObservationDelivery?
     private var responseBodyFetchObservationDelivery: ObservationDelivery?
 #endif
-    private lazy var modeSegmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: NetworkDetailMode.allCases.map(\.title))
-        control.selectedSegmentIndex = modeIndex(for: mode)
-        control.accessibilityIdentifier = "WebInspector.Network.DetailModeSegmentedControl"
-        control.addTarget(self, action: #selector(modeSegmentedControlValueChanged(_:)), for: .valueChanged)
-        return control
-    }()
-    private lazy var previewRoleSegmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl()
-        control.translatesAutoresizingMaskIntoConstraints = false
-        control.accessibilityIdentifier = "WebInspector.Network.DetailPreviewRoleSegmentedControl"
-        control.addTarget(self, action: #selector(previewRoleSegmentedControlValueChanged(_:)), for: .valueChanged)
-        return control
-    }()
-    private lazy var previewRoleControlContainer = NetworkDetailSegmentedControlContentView(
-        segmentedControl: previewRoleSegmentedControl
-    )
     private lazy var previewStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
-            previewRoleControlContainer,
+            previewRoleControlController.containerView,
             bodyViewController.view,
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -87,6 +87,7 @@ package final class NetworkDetailViewController: UIViewController {
         }
         installContentViews()
         installModeTitleView()
+        previewRoleScrollEdgeController.install(in: previewRoleControlController.containerView)
         startObservingModel()
     }
 
@@ -102,7 +103,6 @@ package final class NetworkDetailViewController: UIViewController {
     private func applyBackgroundFromTraits() {
         let backgroundColor = webInspectorBackgroundPolicy.backgroundColor
         view.backgroundColor = backgroundColor
-        previewRoleControlContainer.backgroundColor = backgroundColor
         bodyViewController.view.backgroundColor = backgroundColor
         headersTextView.backgroundColor = backgroundColor
     }
@@ -126,7 +126,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func installModeTitleView() {
-        navigationItem.titleView = modeSegmentedControl
+        navigationItem.titleView = modeControlController.view
         renderModeControl()
     }
 
@@ -203,25 +203,6 @@ package final class NetworkDetailViewController: UIViewController {
         headersTextView.render(request: request)
     }
 
-    @objc private func modeSegmentedControlValueChanged(_ sender: UISegmentedControl) {
-        guard NetworkDetailMode.allCases.indices.contains(sender.selectedSegmentIndex) else {
-            renderModeControl()
-            return
-        }
-        setMode(NetworkDetailMode.allCases[sender.selectedSegmentIndex])
-    }
-
-    @objc private func previewRoleSegmentedControlValueChanged(_ sender: UISegmentedControl) {
-        guard previewRoles.indices.contains(sender.selectedSegmentIndex) else {
-            renderPreviewRoleControl(
-                roles: previewRoles,
-                selectedRole: selectedPreviewRole(from: previewRoles)
-            )
-            return
-        }
-        setPreviewRole(previewRoles[sender.selectedSegmentIndex])
-    }
-
     private func setMode(_ nextMode: NetworkDetailMode) {
         guard mode != nextMode else {
             renderModeControl()
@@ -246,16 +227,7 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func renderModeControl(selectedRequest request: NetworkRequest? = nil) {
         let request = request ?? observedRequest
-        modeSegmentedControl.isEnabled = request != nil
-        modeSegmentedControl.selectedSegmentIndex = modeIndex(for: mode)
-        modeSegmentedControl.accessibilityLabel = mode.title
-        for index in NetworkDetailMode.allCases.indices {
-            modeSegmentedControl.setEnabled(request != nil, forSegmentAt: index)
-        }
-    }
-
-    private func modeIndex(for mode: NetworkDetailMode) -> Int {
-        NetworkDetailMode.allCases.firstIndex(of: mode) ?? UISegmentedControl.noSegment
+        modeControlController.render(mode: mode, isEnabled: request != nil)
     }
 
     private func showEmptySelection() {
@@ -282,6 +254,7 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func showHeaders() {
         previewStackView.isHidden = true
+        previewRoleScrollEdgeController.isControlVisible = false
         bodyViewController.releasePreviewResources()
         headersTextView.isHidden = false
     }
@@ -329,21 +302,15 @@ package final class NetworkDetailViewController: UIViewController {
         roles: [NetworkBodyRole],
         selectedRole: NetworkBodyRole?
     ) {
-        if previewRoles != roles {
-            previewRoles = roles
-            previewRoleSegmentedControl.removeAllSegments()
-            for (index, role) in roles.enumerated() {
-                previewRoleSegmentedControl.insertSegment(
-                    withTitle: title(for: role),
-                    at: index,
-                    animated: false
-                )
-            }
-        }
-        previewRoleControlContainer.isHidden = roles.count < 2
-        previewRoleSegmentedControl.selectedSegmentIndex = selectedRole.flatMap(roles.firstIndex(of:))
-            ?? UISegmentedControl.noSegment
-        previewRoleSegmentedControl.accessibilityLabel = selectedRole.map(title(for:))
+        previewRoles = roles
+        let isControlVisible = roles.count >= 2
+        let isVisibleInPreview = isControlVisible && previewStackView.isHidden == false
+        previewRoleControlController.render(
+            roles: roles,
+            selectedRole: selectedRole,
+            isVisible: isVisibleInPreview
+        )
+        previewRoleScrollEdgeController.isControlVisible = isVisibleInPreview
     }
 
     private func bindResponseBodyFetchObservationIfNeeded(
@@ -436,69 +403,6 @@ package final class NetworkDetailViewController: UIViewController {
         headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
     }
 
-    private func title(for role: NetworkBodyRole) -> String {
-        switch role {
-        case .request:
-            String(localized: "network.section.request", bundle: .module)
-        case .response:
-            String(localized: "network.section.response", bundle: .module)
-        }
-    }
-}
-
-@MainActor
-private final class NetworkDetailSegmentedControlContentView: UIView {
-    private let segmentedControl: UISegmentedControl
-
-    init(segmentedControl: UISegmentedControl) {
-        self.segmentedControl = segmentedControl
-        let height = Self.preferredHeight(for: segmentedControl)
-        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: height))
-        preservesSuperviewLayoutMargins = true
-        addSubview(segmentedControl)
-        NSLayoutConstraint.activate([
-            segmentedControl.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            segmentedControl.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
-            segmentedControl.centerYAnchor.constraint(equalTo: centerYAnchor),
-        ])
-    }
-
-    override var intrinsicContentSize: CGSize {
-        CGSize(width: UIView.noIntrinsicMetric, height: Self.preferredHeight(for: segmentedControl))
-    }
-
-    override func sizeThatFits(_ size: CGSize) -> CGSize {
-        CGSize(width: size.width, height: Self.preferredHeight(for: segmentedControl))
-    }
-
-    override func systemLayoutSizeFitting(_ targetSize: CGSize) -> CGSize {
-        fittingSize(for: targetSize)
-    }
-
-    override func systemLayoutSizeFitting(
-        _ targetSize: CGSize,
-        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
-        verticalFittingPriority: UILayoutPriority
-    ) -> CGSize {
-        fittingSize(for: targetSize)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        nil
-    }
-
-    private func fittingSize(for targetSize: CGSize) -> CGSize {
-        let width = targetSize.width == 0 ? UIView.noIntrinsicMetric : targetSize.width
-        return CGSize(width: width, height: Self.preferredHeight(for: segmentedControl))
-    }
-
-    private static func preferredHeight(for segmentedControl: UISegmentedControl) -> CGFloat {
-        let navigationBarHeight = UINavigationBar(frame: .zero)
-            .sizeThatFits(CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
-            .height
-        return max(segmentedControl.intrinsicContentSize.height, navigationBarHeight)
-    }
 }
 
 #if DEBUG
@@ -524,11 +428,20 @@ extension NetworkDetailViewController {
     }
 
     var isDetailModeControlEnabledForTesting: Bool {
-        modeSegmentedControl.isEnabled
+        modeControlController.isEnabledForTesting
     }
 
     var isPreviewRoleControlHiddenForTesting: Bool {
-        previewRoleControlContainer.isHidden
+        previewRoleControlController.isHiddenForTesting
+    }
+
+    @available(iOS 26.0, *)
+    var previewRoleScrollEdgeInteractionForTesting: UIScrollEdgeElementContainerInteraction? {
+        previewRoleScrollEdgeController.interactionForTesting
+    }
+
+    var previewRoleScrollEdgeObservationDeliveryForTesting: ObservationDelivery? {
+        previewRoleScrollEdgeController.observationDeliveryForTesting
     }
 
     var modelObservationDeliveryForTesting: ObservationDelivery? {
@@ -544,12 +457,11 @@ extension NetworkDetailViewController {
     }
 
     func isDetailModeEnabledForTesting(_ mode: NetworkDetailMode) -> Bool {
-        modeSegmentedControl.isEnabledForSegment(at: modeIndex(for: mode))
+        modeControlController.isModeEnabledForTesting(mode)
     }
 
     func selectModeForTesting(_ mode: NetworkDetailMode) {
-        modeSegmentedControl.selectedSegmentIndex = modeIndex(for: mode)
-        modeSegmentedControlValueChanged(modeSegmentedControl)
+        modeControlController.selectModeForTesting(mode)
     }
 
     func setModeForTesting(_ mode: NetworkDetailMode) {
@@ -557,9 +469,7 @@ extension NetworkDetailViewController {
     }
 
     func selectPreviewRoleForTesting(_ role: NetworkBodyRole) {
-        previewRoleSegmentedControl.selectedSegmentIndex = previewRoles.firstIndex(of: role)
-            ?? UISegmentedControl.noSegment
-        previewRoleSegmentedControlValueChanged(previewRoleSegmentedControl)
+        previewRoleControlController.selectRoleForTesting(role)
     }
 }
 #endif

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -31,6 +31,8 @@ package final class NetworkDetailViewController: UIViewController {
     private var hasBoundSelectedRequest = false
     private weak var observedRequest: NetworkRequest?
     private weak var responseBodyFetchRequest: NetworkRequest?
+    private var bodyTopToPreviewContainerConstraint: NSLayoutConstraint?
+    private var bodyTopToPreviewRoleControlConstraint: NSLayoutConstraint?
 #if DEBUG
     private var modelObservationDelivery: ObservationDelivery?
     private var selectedRequestRenderObservationDelivery: ObservationDelivery?
@@ -119,12 +121,21 @@ package final class NetworkDetailViewController: UIViewController {
         previewContainerView.addSubview(previewRoleControlController.containerView)
         bodyViewController.didMove(toParent: self)
 
+        let bodyTopToPreviewContainerConstraint = bodyViewController.view.topAnchor.constraint(
+            equalTo: previewContainerView.topAnchor
+        )
+        let bodyTopToPreviewRoleControlConstraint = bodyViewController.view.topAnchor.constraint(
+            equalTo: previewRoleControlController.containerView.bottomAnchor
+        )
+        self.bodyTopToPreviewContainerConstraint = bodyTopToPreviewContainerConstraint
+        self.bodyTopToPreviewRoleControlConstraint = bodyTopToPreviewRoleControlConstraint
+        bodyTopToPreviewContainerConstraint.isActive = true
+
         NSLayoutConstraint.activate([
             previewContainerView.topAnchor.constraint(equalTo: view.topAnchor),
             previewContainerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             previewContainerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             previewContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            bodyViewController.view.topAnchor.constraint(equalTo: previewContainerView.topAnchor),
             bodyViewController.view.leadingAnchor.constraint(equalTo: previewContainerView.leadingAnchor),
             bodyViewController.view.trailingAnchor.constraint(equalTo: previewContainerView.trailingAnchor),
             bodyViewController.view.bottomAnchor.constraint(equalTo: previewContainerView.bottomAnchor),
@@ -136,6 +147,16 @@ package final class NetworkDetailViewController: UIViewController {
             headersTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             headersTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+
+    private func updatePreviewRoleControlLayout(isVisible: Bool) {
+        if #available(iOS 26.0, *) {
+            bodyTopToPreviewRoleControlConstraint?.isActive = false
+            bodyTopToPreviewContainerConstraint?.isActive = true
+        } else {
+            bodyTopToPreviewContainerConstraint?.isActive = isVisible == false
+            bodyTopToPreviewRoleControlConstraint?.isActive = isVisible
+        }
     }
 
     private func installModeTitleView() {
@@ -325,6 +346,7 @@ package final class NetworkDetailViewController: UIViewController {
             selectedRole: selectedRole,
             isVisible: isVisibleInPreview
         )
+        updatePreviewRoleControlLayout(isVisible: isVisibleInPreview)
         scrollEdgeController.isPreviewRoleControlVisible = isVisibleInPreview
     }
 

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -9,9 +9,9 @@ package final class NetworkDetailViewController: UIViewController {
     private let modelObservationScope = ObservationScope()
     private let selectedRequestRenderObservationScope = ObservationScope()
     private let responseBodyFetchObservationScope = ObservationScope()
-    private let previewRoleScrollEdgeController = NetworkPreviewRoleScrollEdgeController()
+    private let scrollEdgeController = NetworkDetailScrollEdgeController()
     private lazy var bodyViewController = NetworkBodyViewController(
-        scrollEdgeState: previewRoleScrollEdgeController.scrollEdgeState
+        scrollEdgeState: scrollEdgeController.scrollEdgeState
     )
     private lazy var modeControlController: NetworkDetailModeControlController = {
         let controller = NetworkDetailModeControlController(initialMode: mode)
@@ -36,17 +36,12 @@ package final class NetworkDetailViewController: UIViewController {
     private var selectedRequestRenderObservationDelivery: ObservationDelivery?
     private var responseBodyFetchObservationDelivery: ObservationDelivery?
 #endif
-    private lazy var previewStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [
-            previewRoleControlController.containerView,
-            bodyViewController.view,
-        ])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.spacing = 0
-        stackView.isHidden = true
-        stackView.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
-        return stackView
+    private lazy var previewContainerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
+        return view
     }()
     private lazy var headersTextView: NetworkHeadersTextView = {
         let view = NetworkHeadersTextView()
@@ -87,8 +82,15 @@ package final class NetworkDetailViewController: UIViewController {
         }
         installContentViews()
         installModeTitleView()
-        previewRoleScrollEdgeController.install(in: previewRoleControlController.containerView)
+        scrollEdgeController.install(previewRoleControlContainerView: previewRoleControlController.containerView)
         startObservingModel()
+    }
+
+    override package func contentScrollView(for edge: NSDirectionalRectEdge) -> UIScrollView? {
+        if edge == .top || edge == .bottom {
+            return scrollEdgeController.contentScrollView ?? super.contentScrollView(for: edge)
+        }
+        return super.contentScrollView(for: edge)
     }
 
     private func startObservingModel() {
@@ -109,15 +111,26 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func installContentViews() {
         addChild(bodyViewController)
-        view.addSubview(previewStackView)
+        view.addSubview(previewContainerView)
         view.addSubview(headersTextView)
+        bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        previewRoleControlController.containerView.translatesAutoresizingMaskIntoConstraints = false
+        previewContainerView.addSubview(bodyViewController.view)
+        previewContainerView.addSubview(previewRoleControlController.containerView)
         bodyViewController.didMove(toParent: self)
 
         NSLayoutConstraint.activate([
-            previewStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            previewStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            previewStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            previewStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            previewContainerView.topAnchor.constraint(equalTo: view.topAnchor),
+            previewContainerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            previewContainerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            previewContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            bodyViewController.view.topAnchor.constraint(equalTo: previewContainerView.topAnchor),
+            bodyViewController.view.leadingAnchor.constraint(equalTo: previewContainerView.leadingAnchor),
+            bodyViewController.view.trailingAnchor.constraint(equalTo: previewContainerView.trailingAnchor),
+            bodyViewController.view.bottomAnchor.constraint(equalTo: previewContainerView.bottomAnchor),
+            previewRoleControlController.containerView.topAnchor.constraint(equalTo: previewContainerView.safeAreaLayoutGuide.topAnchor),
+            previewRoleControlController.containerView.leadingAnchor.constraint(equalTo: previewContainerView.leadingAnchor),
+            previewRoleControlController.containerView.trailingAnchor.constraint(equalTo: previewContainerView.trailingAnchor),
             headersTextView.topAnchor.constraint(equalTo: view.topAnchor),
             headersTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             headersTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
@@ -231,11 +244,12 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showEmptySelection() {
-        previewStackView.isHidden = true
+        previewContainerView.isHidden = true
         headersTextView.isHidden = true
         bodyViewController.display(body: nil)
         headersTextView.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
+        scrollEdgeController.contentScrollView = nil
 
         if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
            configuration.text == String(localized: "network.empty.selection.title", bundle: .module) {
@@ -249,14 +263,15 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func showPreview() {
         headersTextView.isHidden = true
-        previewStackView.isHidden = false
+        previewContainerView.isHidden = false
     }
 
     private func showHeaders() {
-        previewStackView.isHidden = true
-        previewRoleScrollEdgeController.isControlVisible = false
+        previewContainerView.isHidden = true
+        scrollEdgeController.isPreviewRoleControlVisible = false
         bodyViewController.releasePreviewResources()
         headersTextView.isHidden = false
+        scrollEdgeController.contentScrollView = headersTextView.contentScrollView
     }
 
     private func renderPreview(selectedRequest request: NetworkRequest) {
@@ -304,13 +319,13 @@ package final class NetworkDetailViewController: UIViewController {
     ) {
         previewRoles = roles
         let isControlVisible = roles.count >= 2
-        let isVisibleInPreview = isControlVisible && previewStackView.isHidden == false
+        let isVisibleInPreview = isControlVisible && previewContainerView.isHidden == false
         previewRoleControlController.render(
             roles: roles,
             selectedRole: selectedRole,
             isVisible: isVisibleInPreview
         )
-        previewRoleScrollEdgeController.isControlVisible = isVisibleInPreview
+        scrollEdgeController.isPreviewRoleControlVisible = isVisibleInPreview
     }
 
     private func bindResponseBodyFetchObservationIfNeeded(
@@ -408,7 +423,11 @@ package final class NetworkDetailViewController: UIViewController {
 #if DEBUG
 extension NetworkDetailViewController {
     var previewViewForTesting: UIView {
-        previewStackView
+        previewContainerView
+    }
+
+    var previewRoleControlContainerViewForTesting: UIView {
+        previewRoleControlController.containerView
     }
 
     var headersTextViewForTesting: NetworkHeadersTextView {
@@ -437,11 +456,11 @@ extension NetworkDetailViewController {
 
     @available(iOS 26.0, *)
     var previewRoleScrollEdgeInteractionForTesting: UIScrollEdgeElementContainerInteraction? {
-        previewRoleScrollEdgeController.interactionForTesting
+        scrollEdgeController.interactionForTesting
     }
 
     var previewRoleScrollEdgeObservationDeliveryForTesting: ObservationDelivery? {
-        previewRoleScrollEdgeController.observationDeliveryForTesting
+        scrollEdgeController.observationDeliveryForTesting
     }
 
     var modelObservationDeliveryForTesting: ObservationDelivery? {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -10,7 +10,6 @@ package final class NetworkDetailViewController: UIViewController {
     private let selectedRequestRenderObservationScope = ObservationScope()
     private let responseBodyFetchObservationScope = ObservationScope()
     private let bodyViewController = NetworkBodyViewController()
-    private var modePalette: UIView?
     private var previewRoles: [NetworkBodyRole] = []
     private var hasBoundSelectedRequest = false
     private weak var observedRequest: NetworkRequest?
@@ -22,15 +21,11 @@ package final class NetworkDetailViewController: UIViewController {
 #endif
     private lazy var modeSegmentedControl: UISegmentedControl = {
         let control = UISegmentedControl(items: NetworkDetailMode.allCases.map(\.title))
-        control.translatesAutoresizingMaskIntoConstraints = false
         control.selectedSegmentIndex = modeIndex(for: mode)
         control.accessibilityIdentifier = "WebInspector.Network.DetailModeSegmentedControl"
         control.addTarget(self, action: #selector(modeSegmentedControlValueChanged(_:)), for: .valueChanged)
         return control
     }()
-    private lazy var modePaletteContentView = NetworkDetailModePaletteContentView(
-        segmentedControl: modeSegmentedControl
-    )
     private lazy var previewRoleSegmentedControl: UISegmentedControl = {
         let control = UISegmentedControl()
         control.translatesAutoresizingMaskIntoConstraints = false
@@ -38,19 +33,9 @@ package final class NetworkDetailViewController: UIViewController {
         control.addTarget(self, action: #selector(previewRoleSegmentedControlValueChanged(_:)), for: .valueChanged)
         return control
     }()
-    private lazy var previewRoleControlContainer: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.preservesSuperviewLayoutMargins = true
-        view.addSubview(previewRoleSegmentedControl)
-        NSLayoutConstraint.activate([
-            previewRoleSegmentedControl.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
-            previewRoleSegmentedControl.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            previewRoleSegmentedControl.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            previewRoleSegmentedControl.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
-        ])
-        return view
-    }()
+    private lazy var previewRoleControlContainer = NetworkDetailSegmentedControlContentView(
+        segmentedControl: previewRoleSegmentedControl
+    )
     private lazy var previewStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
             previewRoleControlContainer,
@@ -101,7 +86,7 @@ package final class NetworkDetailViewController: UIViewController {
             }
         }
         installContentViews()
-        installModePalette()
+        installModeTitleView()
         startObservingModel()
     }
 
@@ -140,21 +125,9 @@ package final class NetworkDetailViewController: UIViewController {
         ])
     }
 
-    private func installModePalette() {
-        let palette = unsafe Self.makeNavigationBarPalette(contentView: modePaletteContentView)
-        _ = unsafe navigationItem.perform(NetworkDetailModePaletteRuntime.attachSelector, with: palette)
-        modePalette = palette
+    private func installModeTitleView() {
+        navigationItem.titleView = modeSegmentedControl
         renderModeControl()
-    }
-
-    @unsafe private static func makeNavigationBarPalette(contentView: UIView) -> UIView {
-        let paletteClass = NSClassFromString(NetworkDetailModePaletteRuntime.className) as! NSObject.Type
-        let allocated = unsafe paletteClass.perform(NetworkDetailModePaletteRuntime.allocateSelector)!.takeUnretainedValue()
-        let palette = unsafe (allocated as AnyObject)
-            .perform(NetworkDetailModePaletteRuntime.contentInitializerSelector, with: contentView)!
-            .takeRetainedValue() as! UIView
-        palette.setValue(1, forKey: NetworkDetailModePaletteRuntime.marginPolicyKey)
-        return palette
     }
 
     private func bindSelectedRequest(_ request: NetworkRequest?) {
@@ -473,43 +446,8 @@ package final class NetworkDetailViewController: UIViewController {
     }
 }
 
-private enum NetworkDetailModePaletteRuntime {
-    // Original: _UINavigationBarPalette
-    static let className = decoded([
-        0x02, 0x08, 0x14, 0x13, 0x3c, 0x2b, 0x34, 0x3a,
-        0x3c, 0x29, 0x34, 0x32, 0x33, 0x1f, 0x3c, 0x2f,
-        0x0d, 0x3c, 0x31, 0x38, 0x29, 0x29, 0x38,
-    ])
-    // Original: _setBottomPalette:
-    static let attachSelector = NSSelectorFromString(decoded([
-        0x02, 0x2e, 0x38, 0x29, 0x1f, 0x32, 0x29, 0x29,
-        0x32, 0x30, 0x0d, 0x3c, 0x31, 0x38, 0x29, 0x29,
-        0x38, 0x67,
-    ]))
-    // Original: alloc
-    static let allocateSelector = NSSelectorFromString(decoded([
-        0x3c, 0x31, 0x31, 0x32, 0x3e,
-    ]))
-    // Original: initWithContentView:
-    static let contentInitializerSelector = NSSelectorFromString(decoded([
-        0x34, 0x33, 0x34, 0x29, 0x0a, 0x34, 0x29, 0x35,
-        0x1e, 0x32, 0x33, 0x29, 0x38, 0x33, 0x29, 0x0b,
-        0x34, 0x38, 0x2a, 0x67,
-    ]))
-    // Original: _contentViewMarginType
-    static let marginPolicyKey = decoded([
-        0x02, 0x3e, 0x32, 0x33, 0x29, 0x38, 0x33, 0x29,
-        0x0b, 0x34, 0x38, 0x2a, 0x10, 0x3c, 0x2f, 0x3a,
-        0x34, 0x33, 0x09, 0x24, 0x2d, 0x38,
-    ])
-
-    private static func decoded(_ bytes: [UInt8]) -> String {
-        String(decoding: bytes.map { $0 ^ 0x5d }, as: UTF8.self)
-    }
-}
-
 @MainActor
-private final class NetworkDetailModePaletteContentView: UIView {
+private final class NetworkDetailSegmentedControlContentView: UIView {
     private let segmentedControl: UISegmentedControl
 
     init(segmentedControl: UISegmentedControl) {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkHeadersTextView.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkHeadersTextView.swift
@@ -90,6 +90,10 @@ final class NetworkHeadersTextView: UIView {
         updateSectionRuleRuns()
     }
 
+    var contentScrollView: UIScrollView {
+        textView
+    }
+
     private func configureTextSystem() {
         backgroundColor = .clear
         accessibilityIdentifier = "WebInspector.Network.HeadersTextView"

--- a/Sources/WebInspectorUI/Network/Detail/NetworkPreviewRoleScrollEdgeController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkPreviewRoleScrollEdgeController.swift
@@ -1,0 +1,75 @@
+#if canImport(UIKit)
+import Observation
+import ObservationBridge
+import UIKit
+
+@MainActor
+@Observable
+final class NetworkPreviewRoleScrollEdgeState {
+    var isControlVisible = false
+    var scrollView: UIScrollView?
+}
+
+@MainActor
+final class NetworkPreviewRoleScrollEdgeController {
+    let scrollEdgeState = NetworkPreviewRoleScrollEdgeState()
+    private let observationScope = ObservationScope()
+    private var interaction: UIInteraction?
+#if DEBUG
+    private var observationDelivery: ObservationDelivery?
+#endif
+
+    var isControlVisible: Bool {
+        get {
+            scrollEdgeState.isControlVisible
+        }
+        set {
+            scrollEdgeState.isControlVisible = newValue
+        }
+    }
+
+    isolated deinit {
+        observationScope.cancelAll()
+    }
+
+    func install(in containerView: UIView) {
+        guard interaction == nil else {
+            return
+        }
+        if #available(iOS 26.0, *) {
+            let interaction = UIScrollEdgeElementContainerInteraction()
+            interaction.edge = .top
+            containerView.addInteraction(interaction)
+            self.interaction = interaction
+            let delivery = observationScope.observe(scrollEdgeState) { [weak self] _, state in
+                self?.render(state)
+            }
+#if DEBUG
+            observationDelivery = delivery
+#endif
+        }
+    }
+
+    private func render(_ state: NetworkPreviewRoleScrollEdgeState) {
+        if #available(iOS 26.0, *) {
+            guard let interaction = interaction as? UIScrollEdgeElementContainerInteraction else {
+                return
+            }
+            interaction.scrollView = state.isControlVisible ? state.scrollView : nil
+        }
+    }
+}
+
+#if DEBUG
+extension NetworkPreviewRoleScrollEdgeController {
+    @available(iOS 26.0, *)
+    var interactionForTesting: UIScrollEdgeElementContainerInteraction? {
+        interaction as? UIScrollEdgeElementContainerInteraction
+    }
+
+    var observationDeliveryForTesting: ObservationDelivery? {
+        observationDelivery
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
@@ -1,11 +1,8 @@
 #if canImport(UIKit)
-import WebInspectorCore
-import ObservationBridge
 import UIKit
 
 @MainActor
 package final class NetworkListCell: UICollectionViewListCell {
-    private let observationScope = ObservationScope()
     private let statusIndicatorView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 8, height: 8)))
     private let fileTypeLabel = UILabel()
 
@@ -19,24 +16,9 @@ package final class NetworkListCell: UICollectionViewListCell {
         nil
     }
 
-    isolated deinit {
-        observationScope.cancelAll()
-    }
-
-    override package func prepareForReuse() {
-        super.prepareForReuse()
-        observationScope.cancelAll()
-    }
-
-    package func bind(request: NetworkRequest) {
-        render(displayName: request.displayName)
-        renderAccessories(request: request)
-
-        observationScope.cancelAll()
-        observationScope.observe(request) { [weak self] _, request in
-            self?.render(displayName: request.displayName)
-            self?.renderAccessories(request: request)
-        }
+    package func bind(projection: NetworkRequestDisplayProjection) {
+        render(displayName: projection.displayName)
+        renderAccessories(projection: projection)
     }
 
     private func configureStaticViews() {
@@ -79,12 +61,12 @@ package final class NetworkListCell: UICollectionViewListCell {
         contentConfiguration = content
     }
 
-    private func renderAccessories(request: NetworkRequest) {
-        let color = request.statusSeverity.color
+    private func renderAccessories(projection: NetworkRequestDisplayProjection) {
+        let color = projection.statusSeverity.color
         if statusIndicatorView.backgroundColor?.isEqual(color) != true {
             statusIndicatorView.backgroundColor = color
         }
-        let fileTypeLabelText = request.fileTypeLabel
+        let fileTypeLabelText = projection.fileTypeLabel
         if fileTypeLabel.text != fileTypeLabelText {
             fileTypeLabel.text = fileTypeLabelText
         }

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -19,6 +19,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private struct PendingSnapshotUpdate {
         var requestIDs: [NetworkRequest.ID]
+        var projectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection]
+        var reconfiguredIDs: Set<NetworkRequest.ID>
         var mode: SnapshotApplyMode
     }
 
@@ -39,6 +41,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private var needsSnapshotReloadOnNextAppearance = false
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
     private var applyingSnapshotRequestIDs: [NetworkRequest.ID]?
+    private var applyingSnapshotProjectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection]?
+    private var displayedProjectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection] = [:]
     private var isApplyingSnapshotUpdate = false
     private var isApplyingSearchPresentation = false
     private var activeSearchController: UISearchController?
@@ -141,13 +145,13 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         let model = model
         displayRequestsObservationTask = Task { @MainActor [weak self, model] in
             let stream = makeObservationBridgeStream(options: Self.snapshotStreamOptions) {
-                model.displayRequests
+                model.displayRows
             }
-            for await displayRequests in stream {
+            for await displayRows in stream {
                 guard let self else {
                     return
                 }
-                self.reloadDataFromModel(displayRequests: displayRequests)
+                self.reloadDataFromModel(displayRows: displayRows)
             }
         }
 
@@ -279,10 +283,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionIdentifier, NetworkRequest.ID> {
         let listCellRegistration = UICollectionView.CellRegistration<NetworkListCell, NetworkRequest.ID> { [weak model] cell, _, id in
-            guard let request = model?.request(for: id) else {
+            guard let projection = model?.displayProjection(for: id) else {
                 return
             }
-            cell.bind(request: request)
+            cell.bind(projection: projection)
         }
         return UICollectionViewDiffableDataSource<SectionIdentifier, NetworkRequest.ID>(
             collectionView: collectionView
@@ -296,7 +300,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func makeSnapshot(
-        requestIDs: [NetworkRequest.ID]
+        requestIDs: [NetworkRequest.ID],
+        reconfiguredIDs: Set<NetworkRequest.ID>
     ) -> NSDiffableDataSourceSnapshot<SectionIdentifier, NetworkRequest.ID> {
         precondition(
             requestIDs.count == Set(requestIDs).count,
@@ -306,6 +311,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         var snapshot = NSDiffableDataSourceSnapshot<SectionIdentifier, NetworkRequest.ID>()
         snapshot.appendSections([.main])
         snapshot.appendItems(requestIDs, toSection: .main)
+        let reconfiguredItems = requestIDs.filter { reconfiguredIDs.contains($0) }
+        if reconfiguredItems.isEmpty == false {
+            snapshot.reconfigureItems(reconfiguredItems)
+        }
         return snapshot
     }
 
@@ -313,21 +322,45 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         isViewLoaded && view.window != nil
     }
 
-    private func requestSnapshotUpdate(displayRequests: [NetworkRequest]) {
-        requestSnapshotUpdate(requestIDs: displayRequests.map(\.id))
+    private func requestSnapshotUpdate(displayRows: [NetworkRequestDisplayProjection]) {
+        let requestIDs = displayRows.map(\.id)
+        let nextProjectionByID = Dictionary(uniqueKeysWithValues: displayRows.map { ($0.id, $0) })
+        let reconfiguredIDs = Set(requestIDs.filter { id in
+            guard let previous = displayedProjectionByID[id],
+                  let next = nextProjectionByID[id] else {
+                return false
+            }
+            return previous != next
+        })
+        requestSnapshotUpdate(
+            requestIDs: requestIDs,
+            projectionByID: nextProjectionByID,
+            reconfiguredIDs: reconfiguredIDs
+        )
     }
 
-    private func requestSnapshotUpdate(requestIDs: [NetworkRequest.ID]) {
+    private func requestSnapshotUpdate(
+        requestIDs: [NetworkRequest.ID],
+        projectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection],
+        reconfiguredIDs: Set<NetworkRequest.ID>
+    ) {
         precondition(
             requestIDs.count == Set(requestIDs).count,
             "Duplicate row IDs detected in NetworkListViewController"
         )
+        var effectiveReconfiguredIDs = reconfiguredIDs
         if let applyingSnapshotRequestIDs {
-            if applyingSnapshotRequestIDs == requestIDs {
+            if applyingSnapshotRequestIDs == requestIDs && effectiveReconfiguredIDs.isEmpty {
+                effectiveReconfiguredIDs = reconfiguredIDsAgainstApplyingProjection(
+                    requestIDs: requestIDs,
+                    projectionByID: projectionByID
+                )
+            }
+            if applyingSnapshotRequestIDs == requestIDs && effectiveReconfiguredIDs.isEmpty {
                 pendingSnapshotUpdate = nil
                 return
             }
-        } else if dataSource.snapshot().itemIdentifiers == requestIDs {
+        } else if dataSource.snapshot().itemIdentifiers == requestIDs && effectiveReconfiguredIDs.isEmpty {
             pendingSnapshotUpdate = nil
             return
         }
@@ -336,7 +369,24 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             return
         }
         needsSnapshotReloadOnNextAppearance = false
-        enqueueSnapshotUpdate(requestIDs: requestIDs, mode: .apply)
+        enqueueSnapshotUpdate(
+            requestIDs: requestIDs,
+            projectionByID: projectionByID,
+            reconfiguredIDs: effectiveReconfiguredIDs,
+            mode: .apply
+        )
+    }
+
+    private func reconfiguredIDsAgainstApplyingProjection(
+        requestIDs: [NetworkRequest.ID],
+        projectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection]
+    ) -> Set<NetworkRequest.ID> {
+        guard let applyingSnapshotProjectionByID else {
+            return []
+        }
+        return Set(requestIDs.filter { id in
+            applyingSnapshotProjectionByID[id] != projectionByID[id]
+        })
     }
 
     private func flushPendingSnapshotUpdateIfNeeded() {
@@ -344,21 +394,43 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             return
         }
         needsSnapshotReloadOnNextAppearance = false
-        enqueueSnapshotUpdate(requestIDs: model.displayRequests.map(\.id), mode: .reloadData)
+        let displayRows = model.displayRows
+        let projectionByID = Dictionary(uniqueKeysWithValues: displayRows.map { ($0.id, $0) })
+        enqueueSnapshotUpdate(
+            requestIDs: displayRows.map(\.id),
+            projectionByID: projectionByID,
+            reconfiguredIDs: [],
+            mode: .reloadData
+        )
     }
 
-    private func enqueueSnapshotUpdate(requestIDs: [NetworkRequest.ID], mode: SnapshotApplyMode) {
+    private func enqueueSnapshotUpdate(
+        requestIDs: [NetworkRequest.ID],
+        projectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection],
+        reconfiguredIDs: Set<NetworkRequest.ID>,
+        mode: SnapshotApplyMode
+    ) {
         if let pendingSnapshotUpdate, pendingSnapshotUpdate.requestIDs == requestIDs {
             self.pendingSnapshotUpdate = PendingSnapshotUpdate(
                 requestIDs: requestIDs,
+                projectionByID: projectionByID,
+                reconfiguredIDs: pendingSnapshotUpdate.reconfiguredIDs.union(reconfiguredIDs),
                 mode: pendingSnapshotUpdate.mode == .reloadData || mode == .reloadData ? .reloadData : .apply
             )
             return
         }
-        guard applyingSnapshotRequestIDs != nil || dataSource.snapshot().itemIdentifiers != requestIDs || mode == .reloadData else {
+        guard applyingSnapshotRequestIDs != nil
+            || dataSource.snapshot().itemIdentifiers != requestIDs
+            || reconfiguredIDs.isEmpty == false
+            || mode == .reloadData else {
             return
         }
-        pendingSnapshotUpdate = PendingSnapshotUpdate(requestIDs: requestIDs, mode: mode)
+        pendingSnapshotUpdate = PendingSnapshotUpdate(
+            requestIDs: requestIDs,
+            projectionByID: projectionByID,
+            reconfiguredIDs: reconfiguredIDs,
+            mode: mode
+        )
         applyPendingSnapshotUpdateIfNeeded()
     }
 
@@ -369,10 +441,14 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         pendingSnapshotUpdate = nil
         isApplyingSnapshotUpdate = true
         applyingSnapshotRequestIDs = update.requestIDs
+        applyingSnapshotProjectionByID = update.projectionByID
 
-        let snapshot = makeSnapshot(requestIDs: update.requestIDs)
+        let snapshot = makeSnapshot(
+            requestIDs: update.requestIDs,
+            reconfiguredIDs: update.mode == .reloadData ? [] : update.reconfiguredIDs
+        )
         let completion: () -> Void = { [weak self] in
-            self?.snapshotUpdateDidFinish()
+            self?.snapshotUpdateDidFinish(appliedProjectionByID: update.projectionByID)
         }
         switch update.mode {
         case .apply:
@@ -382,17 +458,21 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
     }
 
-    private func snapshotUpdateDidFinish() {
+    private func snapshotUpdateDidFinish(
+        appliedProjectionByID: [NetworkRequest.ID: NetworkRequestDisplayProjection]
+    ) {
+        displayedProjectionByID = appliedProjectionByID
         applyingSnapshotRequestIDs = nil
+        applyingSnapshotProjectionByID = nil
         isApplyingSnapshotUpdate = false
         renderSelectedRequestID(model.selectedRequestID)
         applyPendingSnapshotUpdateIfNeeded()
     }
 
-    private func reloadDataFromModel(displayRequests: [NetworkRequest]? = nil) {
-        let resolvedDisplayRequests = displayRequests ?? model.displayRequests
-        requestSnapshotUpdate(displayRequests: resolvedDisplayRequests)
-        renderEmptyState(isEmpty: resolvedDisplayRequests.isEmpty)
+    private func reloadDataFromModel(displayRows: [NetworkRequestDisplayProjection]? = nil) {
+        let resolvedDisplayRows = displayRows ?? model.displayRows
+        requestSnapshotUpdate(displayRows: resolvedDisplayRows)
+        renderEmptyState(isEmpty: resolvedDisplayRows.isEmpty)
     }
 
     private func renderSelectedRequestID(_ selectedRequestID: NetworkRequest.ID?) {

--- a/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
+++ b/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
@@ -43,6 +43,10 @@ package enum NetworkMediaPreviewSupport {
             if isPlayableMIMEType(normalizedMIMEType) {
                 return .previewable(.movie)
             }
+            if normalizedMIMEType.hasPrefix("audio/")
+                || normalizedMIMEType.hasPrefix("video/") {
+                return .notPreviewable
+            }
             if let type = contentType(mimeType: normalizedMIMEType) {
                 let classification = classification(for: type)
                 switch classification {
@@ -58,22 +62,14 @@ package enum NetworkMediaPreviewSupport {
                 }
                 return .notPreviewable
             }
-            if normalizedMIMEType.hasPrefix("audio/")
-                || normalizedMIMEType.hasPrefix("video/") {
-                return .notPreviewable
-            }
         }
 
         guard shouldInferFromURL(mimeType: normalizedMIMEType) else {
             return .unknown
         }
 
-        if isHLSURL(url) {
-            return .previewable(.hlsPlaylist)
-        }
-
-        if isSupportedImageURL(url) {
-            return .previewable(.image)
+        if let classification = fastURLClassification(url) {
+            return classification
         }
 
         if let type = contentType(url: url) {
@@ -170,16 +166,13 @@ package enum NetworkMediaPreviewSupport {
     }
 
     private static func isPlayableMIMEType(_ mimeType: String) -> Bool {
-        supportedAudiovisualMIMETypes.contains(mimeType) || AVURLAsset.isPlayableExtendedMIMEType(mimeType)
+        supportedAudiovisualMIMETypes.contains(mimeType)
+            || knownPlayableMIMETypes.contains(mimeType)
+            || AVURLAsset.isPlayableExtendedMIMEType(mimeType)
     }
 
     private static func isSupportedImageMIMEType(_ mimeType: String) -> Bool {
-        switch mimeType {
-        case "image/apng", "image/pjpeg", "image/x-png":
-            return true
-        default:
-            return false
-        }
+        knownImageMIMETypes.contains(mimeType)
     }
 
     private static func isSVGMIMEType(_ mimeType: String) -> Bool {
@@ -201,12 +194,26 @@ package enum NetworkMediaPreviewSupport {
     }
 
     private static func isSupportedImageURL(_ url: String?) -> Bool {
-        switch pathExtension(url) {
-        case "apng":
-            return true
-        default:
-            return false
+        pathExtension(url).map(knownImagePathExtensions.contains) == true
+    }
+
+    private static func fastURLClassification(_ url: String?) -> NetworkMediaPreviewClassification? {
+        guard let pathExtension = pathExtension(url), pathExtension.isEmpty == false else {
+            return nil
         }
+        if pathExtension == "m3u8" {
+            return .previewable(.hlsPlaylist)
+        }
+        if pathExtension == "svg" {
+            return .notPreviewable
+        }
+        if knownImagePathExtensions.contains(pathExtension) {
+            return .previewable(.image)
+        }
+        if knownPlayablePathExtensions.contains(pathExtension) {
+            return .previewable(.movie)
+        }
+        return nil
     }
 
     private static func imageClassification(url: String?) -> NetworkMediaPreviewClassification {
@@ -248,6 +255,65 @@ package enum NetworkMediaPreviewSupport {
     private static let supportedImageTypes: [UTType] = {
         (CGImageSourceCopyTypeIdentifiers() as? [String] ?? []).compactMap(UTType.init)
     }()
+
+    private static let knownImageMIMETypes: Set<String> = [
+        "image/apng",
+        "image/avif",
+        "image/bmp",
+        "image/gif",
+        "image/heic",
+        "image/heif",
+        "image/jpeg",
+        "image/jpg",
+        "image/pjpeg",
+        "image/png",
+        "image/tiff",
+        "image/webp",
+        "image/x-png",
+    ]
+
+    private static let knownPlayableMIMETypes: Set<String> = [
+        "audio/aac",
+        "audio/aiff",
+        "audio/mp3",
+        "audio/mp4",
+        "audio/mpeg",
+        "audio/wav",
+        "audio/x-aiff",
+        "audio/x-m4a",
+        "audio/x-wav",
+        "video/mp4",
+        "video/quicktime",
+        "video/x-m4v",
+    ]
+
+    private static let knownImagePathExtensions: Set<String> = [
+        "apng",
+        "avif",
+        "bmp",
+        "gif",
+        "heic",
+        "heif",
+        "jpg",
+        "jpeg",
+        "png",
+        "tif",
+        "tiff",
+        "webp",
+    ]
+
+    private static let knownPlayablePathExtensions: Set<String> = [
+        "aac",
+        "aif",
+        "aiff",
+        "caf",
+        "m4a",
+        "m4v",
+        "mov",
+        "mp3",
+        "mp4",
+        "wav",
+    ]
 
     private static let supportedAudiovisualContentTypes = AVURLAsset.audiovisualTypes().compactMap { fileType in
         UTType(fileType.rawValue)

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -20,26 +20,49 @@ package final class NetworkPanelModel {
     package private(set) var effectiveResourceFilters: Set<NetworkResourceFilter> = []
     @ObservationIgnored private let responseBodyFetchAction: ResponseBodyFetchAction?
     @ObservationIgnored private var responseBodyFetchesInFlight: Set<NetworkRequest.ID> = []
+    @ObservationIgnored private let displayProjectionCache: NetworkRequestDisplayProjectionCache
 
     package init(
         network: NetworkSession,
-        responseBodyFetchAction: ResponseBodyFetchAction? = nil
+        responseBodyFetchAction: ResponseBodyFetchAction? = nil,
+        mediaPreviewClassifier: @escaping NetworkMediaPreviewClassifier = { mimeType, url in
+            NetworkMediaPreviewSupport.classification(mimeType: mimeType, url: url)
+        }
     ) {
         self.network = network
         self.responseBodyFetchAction = responseBodyFetchAction
+        self.displayProjectionCache = NetworkRequestDisplayProjectionCache(
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
+    }
+
+    package var displayRows: [NetworkRequestDisplayProjection] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requests = network.requests
+        let effectiveResourceFilters = effectiveResourceFilters
+        displayProjectionCache.prune(keeping: Set(requests.map(\.id)))
+        let rows = requests.compactMap { request -> NetworkRequestDisplayProjection? in
+            if effectiveResourceFilters.isEmpty == false {
+                let resourceFilter = displayProjectionCache.resourceFilter(for: request)
+                guard effectiveResourceFilters.contains(resourceFilter) else {
+                    return nil
+                }
+            }
+            let projection = displayProjectionCache.projection(for: request)
+            guard projection.matchesSearchText(trimmedQuery) else {
+                return nil
+            }
+            return projection
+        }
+        return Array(rows.reversed())
+    }
+
+    package var displayRequestIDs: [NetworkRequest.ID] {
+        displayRows.map(\.id)
     }
 
     package var displayRequests: [NetworkRequest] {
-        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return network.requests
-            .filter { request in
-                if effectiveResourceFilters.isEmpty == false,
-                   effectiveResourceFilters.contains(request.resourceFilter) == false {
-                    return false
-                }
-                return request.matchesSearchText(trimmedQuery)
-            }
-            .reversed()
+        displayRequestIDs.compactMap { network.request(for: $0) }
     }
 
     package var isEmpty: Bool {
@@ -55,6 +78,13 @@ package final class NetworkPanelModel {
 
     package func request(for id: NetworkRequest.ID) -> NetworkRequest? {
         network.request(for: id)
+    }
+
+    package func displayProjection(for id: NetworkRequest.ID) -> NetworkRequestDisplayProjection? {
+        guard let request = network.request(for: id) else {
+            return nil
+        }
+        return displayProjectionCache.projection(for: request)
     }
 
     package func selectRequest(_ request: NetworkRequest?) {
@@ -92,6 +122,7 @@ package final class NetworkPanelModel {
     package func clearRequests() {
         selectedRequestID = nil
         network.reset()
+        displayProjectionCache.removeAll()
     }
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {

--- a/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
@@ -77,58 +77,6 @@ extension NetworkRequest {
         return .neutral
     }
 
-    package var resourceFilter: NetworkResourceFilter {
-        guard let response else {
-            if let resourceType {
-                return NetworkResourceFilter(resourceType: resourceType)
-            }
-            return NetworkResourceFilter(mimeType: nil, url: request.url)
-        }
-
-        let responseMimeType = mimeType(from: response)
-        if let resourceType, shouldKeepResourceTypeForURLInferredMedia(resourceType) {
-            if case .previewable = NetworkMediaPreviewSupport.classification(mimeType: responseMimeType, url: nil) {
-                return .media
-            }
-            return NetworkResourceFilter(resourceType: resourceType)
-        }
-
-        let responseURL = response.url
-        switch NetworkMediaPreviewSupport.classification(mimeType: responseMimeType, url: responseURL) {
-        case .previewable:
-            return .media
-        case .notPreviewable:
-            if resourceType == .image || resourceType == .media {
-                return .media
-            }
-            return NetworkResourceFilter(mimeType: responseMimeType, url: responseURL)
-        case .unknown:
-            break
-        }
-        if let resourceType {
-            return NetworkResourceFilter(resourceType: resourceType)
-        }
-        return NetworkResourceFilter(
-            mimeType: responseMimeType,
-            url: responseURL
-        )
-    }
-
-    package func matchesSearchText(_ query: String) -> Bool {
-        if query.isEmpty {
-            return true
-        }
-        let statusCodeLabel = response.map { String($0.status) } ?? ""
-        let candidates = [
-            request.url,
-            request.method,
-            statusCodeLabel,
-            response?.statusText ?? "",
-            fileTypeLabel,
-        ]
-        return candidates.contains { $0.localizedStandardContains(query) }
-    }
-
     package var duration: TimeInterval? {
         guard let end = finishedOrFailedTimestamp ?? lastDataReceivedTimestamp ?? responseReceivedTimestamp else {
             return nil
@@ -155,35 +103,6 @@ extension NetworkRequest {
         formatter.countStyle = .binary
         return formatter.string(fromByteCount: Int64(length))
     }
-}
-
-private func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkResourceType) -> Bool {
-    switch resourceType {
-    case .image, .media, .xhr, .fetch, .other:
-        return false
-    default:
-        return true
-    }
-}
-
-private func mimeType(from response: NetworkResponsePayload) -> String? {
-    let rawMimeType = response.mimeType ?? headerValue(named: "content-type", in: response.headers)
-    let mimeType = rawMimeType?
-        .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-        .first
-        .map(String.init)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let mimeType, mimeType.isEmpty == false else {
-        return nil
-    }
-    return mimeType
-}
-
-private func headerValue(named name: String, in headers: [String: String]) -> String? {
-    if let value = headers[name] {
-        return value
-    }
-    return headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
 }
 
 extension NetworkResourceType {

--- a/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
@@ -1,0 +1,230 @@
+import WebInspectorCore
+import Foundation
+
+package typealias NetworkMediaPreviewClassifier = (String?, String?) -> NetworkMediaPreviewClassification
+
+package struct NetworkRequestDisplayProjection: Equatable {
+    package var id: NetworkRequest.ID
+    package var displayName: String
+    package var fileTypeLabel: String
+    package var statusSeverity: NetworkStatusSeverity
+    package var resourceFilter: NetworkResourceFilter?
+    package var searchTokens: [String]
+
+    package func matchesSearchText(_ query: String) -> Bool {
+        if query.isEmpty {
+            return true
+        }
+        return searchTokens.contains { $0.localizedStandardContains(query) }
+    }
+}
+
+package struct NetworkRequestDisplayFingerprint: Equatable {
+    package var requestURL: String
+    package var requestMethod: String
+    package var resourceType: NetworkResourceType?
+    package var responseURL: String?
+    package var responseMIMEType: String?
+    package var responseDisplayMIMEType: String?
+    package var responseStatus: Int?
+    package var responseStatusText: String?
+    package var state: NetworkRequestState
+
+    @MainActor
+    package init(request: NetworkRequest) {
+        self.requestURL = request.request.url
+        self.requestMethod = request.request.method
+        self.resourceType = request.resourceType
+        self.responseURL = request.response?.url
+        if let response = request.response {
+            self.responseMIMEType = response.mimeType
+            self.responseDisplayMIMEType = networkDisplayMIMEType(from: response)
+        } else {
+            self.responseMIMEType = nil
+            self.responseDisplayMIMEType = nil
+        }
+        self.responseStatus = request.response?.status
+        self.responseStatusText = request.response?.statusText
+        self.state = request.state
+    }
+}
+
+@MainActor
+package final class NetworkRequestDisplayProjectionCache {
+    private struct Entry {
+        var fingerprint: NetworkRequestDisplayFingerprint
+        var projection: NetworkRequestDisplayProjection
+        var resourceFilter: NetworkResourceFilter?
+    }
+
+    private let mediaPreviewClassifier: NetworkMediaPreviewClassifier
+    private var entries: [NetworkRequest.ID: Entry] = [:]
+
+    package init(mediaPreviewClassifier: @escaping NetworkMediaPreviewClassifier) {
+        self.mediaPreviewClassifier = mediaPreviewClassifier
+    }
+
+    package func projection(for request: NetworkRequest) -> NetworkRequestDisplayProjection {
+        let fingerprint = NetworkRequestDisplayFingerprint(request: request)
+        if let entry = entries[request.id], entry.fingerprint == fingerprint {
+            return entry.projection
+        }
+
+        let projection = NetworkRequestDisplayProjection(
+            id: request.id,
+            displayName: request.displayName,
+            fileTypeLabel: request.fileTypeLabel,
+            statusSeverity: request.statusSeverity,
+            resourceFilter: nil,
+            searchTokens: Self.searchTokens(for: request)
+        )
+        entries[request.id] = Entry(fingerprint: fingerprint, projection: projection, resourceFilter: nil)
+        return projection
+    }
+
+    package func resourceFilter(for request: NetworkRequest) -> NetworkResourceFilter {
+        let fingerprint = NetworkRequestDisplayFingerprint(request: request)
+        if let entry = entries[request.id],
+           entry.fingerprint == fingerprint,
+           let resourceFilter = entry.resourceFilter {
+            return resourceFilter
+        }
+
+        let resourceFilter = Self.resourceFilter(for: request, classifier: mediaPreviewClassifier)
+        var projection: NetworkRequestDisplayProjection
+        if let entry = entries[request.id], entry.fingerprint == fingerprint {
+            projection = entry.projection
+        } else {
+            projection = NetworkRequestDisplayProjection(
+                id: request.id,
+                displayName: request.displayName,
+                fileTypeLabel: request.fileTypeLabel,
+                statusSeverity: request.statusSeverity,
+                resourceFilter: nil,
+                searchTokens: Self.searchTokens(for: request)
+            )
+        }
+        projection.resourceFilter = resourceFilter
+        entries[request.id] = Entry(
+            fingerprint: fingerprint,
+            projection: projection,
+            resourceFilter: resourceFilter
+        )
+        return resourceFilter
+    }
+
+    package func prune(keeping ids: Set<NetworkRequest.ID>) {
+        entries = entries.filter { ids.contains($0.key) }
+    }
+
+    package func removeAll() {
+        entries.removeAll()
+    }
+
+    private static func searchTokens(for request: NetworkRequest) -> [String] {
+        let statusCodeLabel = request.response.map { String($0.status) } ?? ""
+        return [
+            request.request.url,
+            request.request.method,
+            statusCodeLabel,
+            request.response?.statusText ?? "",
+            request.fileTypeLabel,
+        ]
+    }
+
+    private static func resourceFilter(
+        for request: NetworkRequest,
+        classifier: NetworkMediaPreviewClassifier
+    ) -> NetworkResourceFilter {
+        guard let response = request.response else {
+            if let resourceType = request.resourceType {
+                return NetworkResourceFilter(resourceType: resourceType)
+            }
+            return resourceFilter(mimeType: nil, url: request.request.url, classifier: classifier)
+        }
+
+        let responseMimeType = networkDisplayMIMEType(from: response)
+        if let resourceType = request.resourceType,
+           shouldKeepResourceTypeForURLInferredMedia(resourceType) {
+            if case .previewable = classifier(responseMimeType, nil) {
+                return .media
+            }
+            return NetworkResourceFilter(resourceType: resourceType)
+        }
+
+        let responseURL = response.url
+        switch classifier(responseMimeType, responseURL) {
+        case .previewable:
+            return .media
+        case .notPreviewable:
+            if request.resourceType == .image || request.resourceType == .media {
+                return .media
+            }
+            return resourceFilter(mimeType: responseMimeType, url: responseURL, classifier: classifier)
+        case .unknown:
+            break
+        }
+        if let resourceType = request.resourceType {
+            return NetworkResourceFilter(resourceType: resourceType)
+        }
+        return resourceFilter(mimeType: responseMimeType, url: responseURL, classifier: classifier)
+    }
+
+    private static func resourceFilter(
+        mimeType: String?,
+        url: String,
+        classifier: NetworkMediaPreviewClassifier
+    ) -> NetworkResourceFilter {
+        let normalizedMimeType = mimeType?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first?
+            .lowercased() ?? ""
+        let pathExtension = URL(string: url)?.pathExtension.lowercased() ?? ""
+
+        if case .previewable = classifier(mimeType, url) {
+            return .media
+        }
+        if normalizedMimeType == "text/css" || pathExtension == "css" {
+            return .stylesheet
+        }
+        if normalizedMimeType.hasPrefix("font/") || ["woff", "woff2", "ttf", "otf"].contains(pathExtension) {
+            return .font
+        }
+        if normalizedMimeType.contains("javascript") || ["js", "mjs"].contains(pathExtension) {
+            return .script
+        }
+        if normalizedMimeType.contains("html") {
+            return .document
+        }
+        return .other
+    }
+}
+
+private func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkResourceType) -> Bool {
+    switch resourceType {
+    case .image, .media, .xhr, .fetch, .other:
+        return false
+    default:
+        return true
+    }
+}
+
+private func networkDisplayMIMEType(from response: NetworkResponsePayload) -> String? {
+    let rawMimeType = response.mimeType ?? networkHeaderValue(named: "content-type", in: response.headers)
+    let mimeType = rawMimeType?
+        .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+        .first
+        .map(String.init)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let mimeType, mimeType.isEmpty == false else {
+        return nil
+    }
+    return mimeType
+}
+
+private func networkHeaderValue(named name: String, in headers: [String: String]) -> String? {
+    if let value = headers[name] {
+        return value
+    }
+    return headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+}

--- a/Sources/WebInspectorUI/Network/NetworkStatusSeverity.swift
+++ b/Sources/WebInspectorUI/Network/NetworkStatusSeverity.swift
@@ -2,7 +2,7 @@
 import UIKit
 #endif
 
-package enum NetworkStatusSeverity: Sendable {
+package enum NetworkStatusSeverity: Equatable, Sendable {
     case success
     case notice
     case warning

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -135,7 +135,8 @@ struct NetworkDetailViewControllerTests {
             #expect(contentView.frame.maxY == bounds.maxY)
         }
         #expect(viewController.headersTextViewForTesting.frame.minY == bounds.minY)
-        #expect(viewController.previewViewForTesting.frame.minY == topInset)
+        #expect(viewController.previewViewForTesting.frame.minY == bounds.minY)
+        #expect(viewController.previewRoleControlContainerViewForTesting.frame.minY == topInset)
     }
 
     @Test
@@ -163,7 +164,7 @@ struct NetworkDetailViewControllerTests {
 
         let didRenderHeaders = await waitUntilRendered(in: viewController) {
             let text = viewController.headersTextViewForTesting.renderedTextForTesting
-            return viewController.currentModeForTesting == .headers
+            let didRenderHeaders = viewController.currentModeForTesting == .headers
                 && viewController.previewViewForTesting.isHidden
                 && viewController.headersTextViewForTesting.isHidden == false
                 && viewController.headersTextViewForTesting.usesTextKit2ForTesting
@@ -171,6 +172,12 @@ struct NetworkDetailViewControllerTests {
                 && text.contains("accept: application/json")
                 && text.contains("content-type: application/json")
                 && text.contains("200 OK")
+            if #available(iOS 26.0, *) {
+                return didRenderHeaders
+                    && viewController.contentScrollView(for: .top) === viewController.headersTextViewForTesting.contentScrollView
+                    && viewController.contentScrollView(for: .bottom) === viewController.headersTextViewForTesting.contentScrollView
+            }
+            return didRenderHeaders
         }
 
         #expect(didRenderHeaders)
@@ -187,6 +194,8 @@ struct NetworkDetailViewControllerTests {
                 return didRenderPreview
                     && viewController.previewRoleScrollEdgeInteractionForTesting?.edge == .top
                     && viewController.previewRoleScrollEdgeInteractionForTesting?.scrollView === viewController.bodyViewControllerForTesting.syntaxViewForTesting
+                    && viewController.contentScrollView(for: .top) === viewController.bodyViewControllerForTesting.syntaxViewForTesting
+                    && viewController.contentScrollView(for: .bottom) === viewController.bodyViewControllerForTesting.syntaxViewForTesting
             }
             return didRenderPreview
         }
@@ -199,6 +208,50 @@ struct NetworkDetailViewControllerTests {
                 && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
         }
         #expect(didRenderRequestPreview)
+    }
+
+    @Test
+    func previewTextBodyUsesAutomaticInsetsAsRegisteredContentScrollView() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.txt",
+                responseHeaders: ["content-type": "text/plain"],
+                responseMimeType: "text/plain"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBodyPayload(
+                body: "sample=true\nsource=preview",
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+
+        let didRenderPreview = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .preview
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "sample=true\nsource=preview"
+        }
+        #expect(didRenderPreview)
+
+        let bodyViewController = viewController.bodyViewControllerForTesting
+        window.layoutIfNeeded()
+
+        let syntaxView = bodyViewController.syntaxViewForTesting
+        #expect(syntaxView.contentInsetAdjustmentBehavior == .automatic)
+        #expect(syntaxView.frame == bodyViewController.view.bounds)
+        #expect(bodyViewController.view.frame == viewController.previewViewForTesting.bounds)
+        if #available(iOS 26.0, *) {
+            #expect(viewController.contentScrollView(for: .top) === syntaxView)
+            #expect(viewController.contentScrollView(for: .bottom) === syntaxView)
+        }
     }
 
     @Test
@@ -636,12 +689,15 @@ struct NetworkDetailViewControllerTests {
                 return didRenderImage
                     && viewController.previewRoleScrollEdgeInteractionForTesting?.edge == .top
                     && viewController.previewRoleScrollEdgeInteractionForTesting?.scrollView === imageScrollView
+                    && viewController.contentScrollView(for: .top) === imageScrollView
+                    && viewController.contentScrollView(for: .bottom) === imageScrollView
             }
             return didRenderImage
         }
         #expect(didRenderImage)
 
         let imageScrollView = viewController.bodyViewControllerForTesting.imageScrollViewForTesting
+        #expect(imageScrollView.contentInsetAdjustmentBehavior == .automatic)
         let fitScale = min(
             imageScrollView.bounds.width / imageSize.width,
             imageScrollView.bounds.height / imageSize.height

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -179,10 +179,16 @@ struct NetworkDetailViewControllerTests {
         selectMode(.preview, on: viewController)
 
         let didRenderPreview = await waitUntilRendered(in: viewController) {
-            viewController.currentModeForTesting == .preview
+            let didRenderPreview = viewController.currentModeForTesting == .preview
                 && viewController.previewViewForTesting.isHidden == false
                 && viewController.headersTextViewForTesting.isHidden
                 && viewController.isPreviewRoleControlHiddenForTesting == false
+            if #available(iOS 26.0, *) {
+                return didRenderPreview
+                    && viewController.previewRoleScrollEdgeInteractionForTesting?.edge == .top
+                    && viewController.previewRoleScrollEdgeInteractionForTesting?.scrollView === viewController.bodyViewControllerForTesting.syntaxViewForTesting
+            }
+            return didRenderPreview
         }
         #expect(didRenderPreview)
 
@@ -602,6 +608,7 @@ struct NetworkDetailViewControllerTests {
                 to: network,
                 requestID: "1",
                 url: "https://media.example.com/large.png",
+                postData: "metadata=1",
                 responseHeaders: ["content-type": "image/png"],
                 responseMimeType: "image/png"
             )
@@ -621,9 +628,16 @@ struct NetworkDetailViewControllerTests {
 
         let didRenderImage = await waitUntilRendered(in: viewController) {
             let bodyViewController = viewController.bodyViewControllerForTesting
-            return bodyViewController.isImagePreviewVisibleForTesting
+            let imageScrollView = bodyViewController.imageScrollViewForTesting
+            let didRenderImage = bodyViewController.isImagePreviewVisibleForTesting
                 && bodyViewController.syntaxViewForTesting.isHidden
                 && bodyViewController.imageViewForTesting.image?.size == imageSize
+            if #available(iOS 26.0, *) {
+                return didRenderImage
+                    && viewController.previewRoleScrollEdgeInteractionForTesting?.edge == .top
+                    && viewController.previewRoleScrollEdgeInteractionForTesting?.scrollView === imageScrollView
+            }
+            return didRenderImage
         }
         #expect(didRenderImage)
 
@@ -1309,6 +1323,7 @@ struct NetworkDetailViewControllerTests {
             viewController.modelObservationDeliveryForTesting,
             viewController.selectedRequestRenderObservationDeliveryForTesting,
             viewController.responseBodyFetchObservationDeliveryForTesting,
+            viewController.previewRoleScrollEdgeObservationDeliveryForTesting,
             viewController.bodyViewControllerForTesting.bodyObservationDeliveryForTesting,
         ].compactMap { $0 }
     }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -675,6 +675,12 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(network: network)
         model.selectRequest(request)
         let viewController = NetworkDetailViewController(model: model)
+        viewController.bodyViewControllerForTesting.additionalSafeAreaInsets = UIEdgeInsets(
+            top: 44,
+            left: 0,
+            bottom: 34,
+            right: 0
+        )
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
@@ -698,10 +704,10 @@ struct NetworkDetailViewControllerTests {
 
         let imageScrollView = viewController.bodyViewControllerForTesting.imageScrollViewForTesting
         #expect(imageScrollView.contentInsetAdjustmentBehavior == .automatic)
-        let fitScale = min(
-            imageScrollView.bounds.width / imageSize.width,
-            imageScrollView.bounds.height / imageSize.height
-        )
+        #expect(imageScrollView.contentAlignmentPoint == CGPoint(x: 0.5, y: 0.5))
+        #expect(imageScrollView.contentInset == .zero)
+        #expect(imageScrollView.adjustedContentInset.top > imageScrollView.contentInset.top)
+        let fitScale = expectedImageFitScale(scrollView: imageScrollView, imageSize: imageSize)
         let expectedMinimumZoomScale = min(1, fitScale)
         #expect(abs(imageScrollView.minimumZoomScale - expectedMinimumZoomScale) < 0.001)
         #expect(abs(imageScrollView.zoomScale - expectedMinimumZoomScale) < 0.001)
@@ -746,10 +752,7 @@ struct NetworkDetailViewControllerTests {
         window.layoutIfNeeded()
 
         let didRefitAfterBoundsChange = await waitUntilRendered(in: viewController) {
-            let fitScale = min(
-                imageScrollView.bounds.width / imageSize.width,
-                imageScrollView.bounds.height / imageSize.height
-            )
+            let fitScale = expectedImageFitScale(scrollView: imageScrollView, imageSize: imageSize)
             let expectedMinimumZoomScale = min(1, fitScale)
             return imageScrollView.bounds.height < initialBounds.height
                 && expectedMinimumZoomScale < initialMinimumZoomScale
@@ -793,8 +796,8 @@ struct NetworkDetailViewControllerTests {
         let imageScrollView = viewController.bodyViewControllerForTesting.imageScrollViewForTesting
         #expect(imageScrollView.minimumZoomScale == 1)
         #expect(imageScrollView.zoomScale == 1)
-        #expect(imageScrollView.contentInset.left > 0)
-        #expect(imageScrollView.contentInset.top > 0)
+        #expect(imageScrollView.contentInset == .zero)
+        #expect(imageScrollView.contentAlignmentPoint == CGPoint(x: 0.5, y: 0.5))
     }
 
     @Test
@@ -1340,6 +1343,22 @@ struct NetworkDetailViewControllerTests {
             context.fill(CGRect(origin: .zero, size: size))
         }
         .base64EncodedString()
+    }
+
+    private func expectedImageFitScale(scrollView: UIScrollView, imageSize: CGSize) -> CGFloat {
+        let visibleSize = imageVisibleBoundsSize(scrollView)
+        return min(
+            visibleSize.width / imageSize.width,
+            visibleSize.height / imageSize.height
+        )
+    }
+
+    private func imageVisibleBoundsSize(_ scrollView: UIScrollView) -> CGSize {
+        let adjustedInset = scrollView.adjustedContentInset
+        return CGSize(
+            width: max(scrollView.bounds.width - adjustedInset.left - adjustedInset.right, 0),
+            height: max(scrollView.bounds.height - adjustedInset.top - adjustedInset.bottom, 0)
+        )
     }
 
     private func waitUntilRendered(

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -234,6 +234,259 @@ func mediaPreviewSupportClassifiesAVIFAndExcludesSVG() {
 
 @Test
 @MainActor
+func displayProjectionCacheInvalidatesWhenResponseMIMEBecomesPreviewable() async throws {
+    let network = NetworkSession()
+    let requestID = applyPendingRequest(
+        to: network,
+        requestID: "1",
+        url: "https://api.example.com/avatar",
+        resourceType: .xhr,
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+    model.setResourceFilter(.media, enabled: true)
+
+    #expect(model.displayRequestIDs.isEmpty)
+
+    network.applyResponseReceived(
+        targetID: requestID.targetID,
+        requestID: requestID.requestID,
+        resourceType: .xhr,
+        response: NetworkResponsePayload(
+            url: "https://api.example.com/avatar",
+            status: 200,
+            statusText: "OK",
+            mimeType: "image/png"
+        ),
+        timestamp: 1.1
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(model.displayProjection(for: requestID)?.resourceFilter == .media)
+}
+
+@Test
+@MainActor
+func displayProjectionCacheInvalidatesStatusSeverity() async throws {
+    let network = NetworkSession()
+    let requestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://api.example.com/data.json",
+        resourceType: .xhr,
+        mimeType: "application/json",
+        status: 500,
+        statusText: "Server Error",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+
+    #expect(model.displayProjection(for: requestID)?.statusSeverity == .error)
+
+    network.applyResponseReceived(
+        targetID: requestID.targetID,
+        requestID: requestID.requestID,
+        resourceType: .xhr,
+        response: NetworkResponsePayload(
+            url: "https://api.example.com/data.json",
+            status: 204,
+            statusText: "No Content",
+            mimeType: "application/json"
+        ),
+        timestamp: 2
+    )
+
+    #expect(model.displayProjection(for: requestID)?.statusSeverity == .success)
+}
+
+@Test
+@MainActor
+func displayProjectionCacheInvalidatesSearchFields() async throws {
+    let network = NetworkSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let rawRequestID = NetworkRequestIdentifier("1")
+    let requestID = network.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: rawRequestID,
+        frameID: DOMFrameIdentifier("main"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: NetworkRequestPayload(url: "https://api.example.com/old", method: "POST"),
+        resourceType: .xhr,
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+
+    model.setSearchText("new-endpoint")
+    #expect(model.displayRequestIDs.isEmpty)
+
+    _ = network.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: rawRequestID,
+        frameID: DOMFrameIdentifier("main"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: NetworkRequestPayload(url: "https://api.example.com/new-endpoint", method: "PATCH"),
+        resourceType: .xhr,
+        redirectResponse: NetworkResponsePayload(url: "https://api.example.com/old", status: 302),
+        timestamp: 2
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    model.setSearchText("PATCH")
+    #expect(model.displayRequestIDs == [requestID])
+
+    model.setSearchText("json")
+    #expect(model.displayRequestIDs.isEmpty)
+
+    network.applyResponseReceived(
+        targetID: targetID,
+        requestID: rawRequestID,
+        resourceType: .xhr,
+        response: NetworkResponsePayload(
+            url: "https://api.example.com/new-endpoint",
+            status: 201,
+            statusText: "Created",
+            mimeType: "application/json"
+        ),
+        timestamp: 2.1
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    model.setSearchText("Created")
+    #expect(model.displayRequestIDs == [requestID])
+}
+
+@Test
+@MainActor
+func displayProjectionCacheInvalidatesWhenRawMIMETypeAppears() async throws {
+    let network = NetworkSession()
+    let targetID = ProtocolTargetIdentifier("page")
+    let rawRequestID = NetworkRequestIdentifier("1")
+    let requestID = network.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: rawRequestID,
+        frameID: DOMFrameIdentifier("main"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: NetworkRequestPayload(url: "https://api.example.com/resource", method: "GET"),
+        resourceType: .xhr,
+        timestamp: 1
+    )
+    network.applyResponseReceived(
+        targetID: targetID,
+        requestID: rawRequestID,
+        resourceType: .xhr,
+        response: NetworkResponsePayload(
+            url: "https://api.example.com/resource",
+            status: 200,
+            statusText: "OK",
+            headers: ["Content-Type": "application/json"],
+            mimeType: nil
+        ),
+        timestamp: 1.1
+    )
+    let model = NetworkPanelModel(network: network)
+
+    #expect(model.displayProjection(for: requestID)?.fileTypeLabel == "xhr")
+    model.setSearchText("json")
+    #expect(model.displayRequestIDs.isEmpty)
+
+    network.applyResponseReceived(
+        targetID: targetID,
+        requestID: rawRequestID,
+        resourceType: .xhr,
+        response: NetworkResponsePayload(
+            url: "https://api.example.com/resource",
+            status: 200,
+            statusText: "OK",
+            headers: ["Content-Type": "application/json"],
+            mimeType: "application/json"
+        ),
+        timestamp: 1.2
+    )
+
+    #expect(model.displayProjection(for: requestID)?.fileTypeLabel == "json")
+    #expect(model.displayRequestIDs == [requestID])
+}
+
+@Test
+@MainActor
+func displayProjectionCacheReusesMediaClassificationForUnchangedRequests() async throws {
+    let network = NetworkSession()
+    let requestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://media.example.com/clip.mp4",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 1
+    )
+    var classificationCount = 0
+    let model = NetworkPanelModel(
+        network: network,
+        mediaPreviewClassifier: { mimeType, url in
+            classificationCount += 1
+            return NetworkMediaPreviewSupport.classification(mimeType: mimeType, url: url)
+        }
+    )
+    model.setResourceFilter(.media, enabled: true)
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(classificationCount == 1)
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(model.displayRequests.map(\.id) == [requestID])
+    #expect(classificationCount == 1)
+
+    network.applyDataReceived(
+        targetID: requestID.targetID,
+        requestID: requestID.requestID,
+        dataLength: 1024,
+        encodedDataLength: 512,
+        timestamp: 2
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(classificationCount == 1)
+}
+
+@Test
+@MainActor
+func displayProjectionCacheSkipsMediaClassificationWhenUnfiltered() async throws {
+    let network = NetworkSession()
+    let requestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://media.example.com/clip.mp4",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 1
+    )
+    var classificationCount = 0
+    let model = NetworkPanelModel(
+        network: network,
+        mediaPreviewClassifier: { mimeType, url in
+            classificationCount += 1
+            return NetworkMediaPreviewSupport.classification(mimeType: mimeType, url: url)
+        }
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(model.displayProjection(for: requestID)?.displayName == "clip.mp4")
+    #expect(classificationCount == 0)
+
+    model.setSearchText("clip")
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(classificationCount == 0)
+
+    model.setResourceFilter(.media, enabled: true)
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(classificationCount == 1)
+}
+
+@Test
+@MainActor
 func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
     let network = NetworkSession()
     let requestID = applyRequest(
@@ -255,6 +508,7 @@ func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
     #expect(model.searchText == "cdn")
     #expect(model.activeResourceFilters == [.script])
     #expect(model.displayRequests.isEmpty)
+    #expect(model.displayProjection(for: requestID) == nil)
 }
 
 @MainActor
@@ -266,6 +520,8 @@ private func applyRequest(
     resourceType: NetworkResourceType,
     mimeType: String?,
     responseHeaders: [String: String] = [:],
+    status: Int = 200,
+    statusText: String = "OK",
     timestamp: Double
 ) -> NetworkRequest.ID {
     let targetID = ProtocolTargetIdentifier("page")
@@ -286,8 +542,8 @@ private func applyRequest(
         resourceType: resourceType,
         response: NetworkResponsePayload(
             url: url,
-            status: 200,
-            statusText: "OK",
+            status: status,
+            statusText: statusText,
             headers: responseHeaders,
             mimeType: mimeType
         ),


### PR DESCRIPTION
## Purpose
Improve Network list performance by avoiding repeated display classification and media preview detection while preserving the Network detail scroll-edge layout behavior.

## Changes
- Add display projection and fingerprint caching for Network list rows.
- Drive list cells from cached projections and reconfigure changed rows by ID.
- Add fast-path media preview classification before UTType / AVURLAsset fallback checks.
- Reserve preview role control space on pre-iOS 26 and fit image previews within `adjustedContentInset` while using standard scroll view alignment.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` with base `main`: findingCount 0