### PR TITLE
Smooth Monocly loading progress transitions

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -14,6 +14,13 @@ final class BrowserPageViewController: UIViewController {
         case regularNavigationBar
     }
 
+    private enum ProgressIndicator {
+        static let height: CGFloat = 2
+        static let showAnimationDuration: TimeInterval = 0.12
+        static let completionHoldDuration: UInt64 = 120_000_000
+        static let hideAnimationDuration: TimeInterval = 0.18
+    }
+
     private let store: BrowserStore
     private let inspectorSession: WebInspectorSession
     private let launchConfiguration: BrowserLaunchConfiguration
@@ -52,6 +59,8 @@ final class BrowserPageViewController: UIViewController {
     private var inspectorWindowObserverID: UUID?
     private var didAutoPresentInspector = false
     private var progressHeightConstraint: NSLayoutConstraint?
+    private var progressHideTask: Task<Void, Never>?
+    private var progressHideAnimator: UIViewPropertyAnimator?
     private var currentChromePlacement: ChromePlacement?
     var onSelectedWebViewInstalled: ((WKWebView) -> Void)?
 
@@ -75,6 +84,8 @@ final class BrowserPageViewController: UIViewController {
     }
 
     isolated deinit {
+        progressHideTask?.cancel()
+        progressHideAnimator?.stopAnimation(true)
         viewportCoordinator?.invalidate()
         observationScope.cancelAll()
         if let inspectorWindowObserverID {
@@ -136,6 +147,8 @@ final class BrowserPageViewController: UIViewController {
 
         progressView.translatesAutoresizingMaskIntoConstraints = false
         progressView.trackTintColor = .clear
+        progressView.isHidden = true
+        progressView.alpha = 0
         view.addSubview(progressView)
         progressHeightConstraint = progressView.heightAnchor.constraint(equalToConstant: 0)
 
@@ -452,12 +465,102 @@ final class BrowserPageViewController: UIViewController {
         navigationItem.title = store.displayTitle
         syncNavigationButtonStates(store: store)
 
-        let progressIsVisible = store.isShowingProgress
-        progressView.progress = Float(store.estimatedProgress)
-        progressView.isHidden = progressIsVisible == false
-        progressHeightConstraint?.constant = progressIsVisible ? 2 : 0
+        renderProgressIndicator(
+            isVisible: store.isShowingProgress,
+            progress: store.estimatedProgress
+        )
 
         view.backgroundColor = store.underPageBackgroundColor ?? .clear
+    }
+
+    private func renderProgressIndicator(isVisible: Bool, progress: Double) {
+        let progress = normalizedProgress(progress)
+
+        if isVisible {
+            showProgressIndicator()
+            setProgressIndicatorProgress(progress)
+            return
+        }
+
+        if progressView.isHidden == false {
+            setProgressIndicatorProgress(progress)
+        }
+        scheduleProgressIndicatorHide()
+    }
+
+    private func showProgressIndicator() {
+        progressHideTask?.cancel()
+        progressHideTask = nil
+        progressHideAnimator?.stopAnimation(true)
+        progressHideAnimator = nil
+
+        let wasHidden = progressView.isHidden
+        if wasHidden {
+            progressView.isHidden = false
+            progressView.alpha = 0
+        }
+        progressHeightConstraint?.constant = ProgressIndicator.height
+
+        guard progressView.alpha < 1 else {
+            return
+        }
+
+        UIView.animate(withDuration: ProgressIndicator.showAnimationDuration) {
+            self.progressView.alpha = 1
+        }
+    }
+
+    private func scheduleProgressIndicatorHide() {
+        guard progressView.isHidden == false || progressView.alpha > 0 else {
+            return
+        }
+        guard progressHideTask == nil else {
+            return
+        }
+
+        progressHideTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: ProgressIndicator.completionHoldDuration)
+            } catch {
+                return
+            }
+            guard let self, Task.isCancelled == false, self.store.isShowingProgress == false else {
+                return
+            }
+
+            let animator = UIViewPropertyAnimator(duration: ProgressIndicator.hideAnimationDuration, curve: .easeOut) {
+                self.progressView.alpha = 0
+            }
+            self.progressHideAnimator = animator
+            animator.addCompletion { [weak self] position in
+                guard let self, position == .end, self.store.isShowingProgress == false else {
+                    return
+                }
+
+                self.progressView.isHidden = true
+                self.progressHeightConstraint?.constant = 0
+                self.progressView.setProgress(0, animated: false)
+                self.progressHideAnimator = nil
+                self.progressHideTask = nil
+            }
+            animator.startAnimation()
+        }
+    }
+
+    private func setProgressIndicatorProgress(_ progress: Float) {
+        let currentProgress = progressView.progress
+        guard currentProgress != progress else {
+            return
+        }
+
+        let shouldAnimate = progressView.isHidden == false
+            && progressView.alpha > 0
+            && progress > currentProgress
+        progressView.setProgress(progress, animated: shouldAnimate)
+    }
+
+    private func normalizedProgress(_ progress: Double) -> Float {
+        Float(min(1, max(0, progress)))
     }
 
     private func maybeAutoPresentInspectorIfNeeded() {

--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -17,8 +17,14 @@ final class BrowserPageViewController: UIViewController {
     private enum ProgressIndicator {
         static let height: CGFloat = 2
         static let showAnimationDuration: TimeInterval = 0.12
+        static let progressAnimationDuration: TimeInterval = 0.18
         static let completionHoldDuration: UInt64 = 120_000_000
         static let hideAnimationDuration: TimeInterval = 0.18
+        static let animationOptions: UIView.AnimationOptions = [
+            .allowUserInteraction,
+            .beginFromCurrentState,
+            .curveEaseInOut,
+        ]
     }
 
     private let store: BrowserStore
@@ -60,7 +66,6 @@ final class BrowserPageViewController: UIViewController {
     private var didAutoPresentInspector = false
     private var progressHeightConstraint: NSLayoutConstraint?
     private var progressHideTask: Task<Void, Never>?
-    private var progressHideAnimator: UIViewPropertyAnimator?
     private var currentChromePlacement: ChromePlacement?
     var onSelectedWebViewInstalled: ((WKWebView) -> Void)?
 
@@ -85,7 +90,6 @@ final class BrowserPageViewController: UIViewController {
 
     isolated deinit {
         progressHideTask?.cancel()
-        progressHideAnimator?.stopAnimation(true)
         viewportCoordinator?.invalidate()
         observationScope.cancelAll()
         if let inspectorWindowObserverID {
@@ -491,8 +495,7 @@ final class BrowserPageViewController: UIViewController {
     private func showProgressIndicator() {
         progressHideTask?.cancel()
         progressHideTask = nil
-        progressHideAnimator?.stopAnimation(true)
-        progressHideAnimator = nil
+        progressView.layer.removeAllAnimations()
 
         let wasHidden = progressView.isHidden
         if wasHidden {
@@ -505,7 +508,11 @@ final class BrowserPageViewController: UIViewController {
             return
         }
 
-        UIView.animate(withDuration: ProgressIndicator.showAnimationDuration) {
+        UIView.animate(
+            withDuration: ProgressIndicator.showAnimationDuration,
+            delay: 0,
+            options: ProgressIndicator.animationOptions
+        ) {
             self.progressView.alpha = 1
         }
     }
@@ -528,22 +535,22 @@ final class BrowserPageViewController: UIViewController {
                 return
             }
 
-            let animator = UIViewPropertyAnimator(duration: ProgressIndicator.hideAnimationDuration, curve: .easeOut) {
+            UIView.animate(
+                withDuration: ProgressIndicator.hideAnimationDuration,
+                delay: 0,
+                options: ProgressIndicator.animationOptions
+            ) {
                 self.progressView.alpha = 0
-            }
-            self.progressHideAnimator = animator
-            animator.addCompletion { [weak self] position in
-                guard let self, position == .end, self.store.isShowingProgress == false else {
+            } completion: { [weak self] finished in
+                guard let self, finished, self.store.isShowingProgress == false else {
                     return
                 }
 
                 self.progressView.isHidden = true
                 self.progressHeightConstraint?.constant = 0
                 self.progressView.setProgress(0, animated: false)
-                self.progressHideAnimator = nil
                 self.progressHideTask = nil
             }
-            animator.startAnimation()
         }
     }
 
@@ -553,10 +560,20 @@ final class BrowserPageViewController: UIViewController {
             return
         }
 
-        let shouldAnimate = progressView.isHidden == false
-            && progressView.alpha > 0
-            && progress > currentProgress
-        progressView.setProgress(progress, animated: shouldAnimate)
+        guard progressView.isHidden == false,
+              progressView.alpha > 0,
+              progress > currentProgress else {
+            progressView.setProgress(progress, animated: false)
+            return
+        }
+
+        UIView.animate(
+            withDuration: ProgressIndicator.progressAnimationDuration,
+            delay: 0,
+            options: ProgressIndicator.animationOptions
+        ) {
+            self.progressView.setProgress(progress, animated: true)
+        }
     }
 
     private func normalizedProgress(_ progress: Double) -> Float {

--- a/Monocly/Monocly/Models/BrowserStore.swift
+++ b/Monocly/Monocly/Models/BrowserStore.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import Observation
+import ObjectiveC
 import OSLog
 import WebKit
 
@@ -304,6 +305,10 @@ private enum BrowserTabStoreSPI {
     static let setHistoryDelegateSelector = NSSelectorFromString(
         deobfuscate([":", "Delegate", "History", "_set"])
     )
+    // _webView:navigation:didSameDocumentNavigation:
+    static let sameDocumentNavigationSelector = NSSelectorFromString(
+        deobfuscate([":", "Navigation", "Document", "Same", "did", ":", "navigation", ":", "webView", "_"])
+    )
     static let maximumHistoryMenuItemCount = 20
 }
 
@@ -340,9 +345,10 @@ private enum BrowserTabStoreSPI {
     @ObservationIgnored private var restoredInteractionState: Data?
     @ObservationIgnored private var canSaveWebViewInteractionState = true
     @ObservationIgnored var onStateChanged: (() -> Void)?
+    @ObservationIgnored private static var didInstallSameDocumentNavigationDelegateMethod = false
 
     var isShowingProgress: Bool {
-        isLoading && estimatedProgress < 1.0
+        isLoading
     }
 
     var displayTitle: String {
@@ -421,6 +427,7 @@ private enum BrowserTabStoreSPI {
         configureRefreshControl()
 #endif
 
+        Self.installSameDocumentNavigationDelegateMethodIfNeeded()
         webView.navigationDelegate = self
         webView.uiDelegate = self
         configureHistoryDelegateIfAvailable()
@@ -437,6 +444,8 @@ private enum BrowserTabStoreSPI {
         }
         if webView.goBack() != nil {
             markWebViewInteractionStatePendingNavigation()
+            beginLoadingProgress()
+            notifyStateChanged()
         }
     }
 
@@ -446,16 +455,22 @@ private enum BrowserTabStoreSPI {
         }
         if webView.goForward() != nil {
             markWebViewInteractionStatePendingNavigation()
+            beginLoadingProgress()
+            notifyStateChanged()
         }
     }
 
     func go(to item: WKBackForwardListItem) {
         if spiGoToHistoryItem(item) {
             markWebViewInteractionStatePendingNavigation()
+            beginLoadingProgress()
+            notifyStateChanged()
             return
         }
         if webView.go(to: item) != nil {
             markWebViewInteractionStatePendingNavigation()
+            beginLoadingProgress()
+            notifyStateChanged()
         }
     }
 
@@ -466,7 +481,9 @@ private enum BrowserTabStoreSPI {
         pageTitle = nil
         currentURL = url
         hasLoadedInitialRequest = true
-        webView.load(URLRequest(url: url))
+        if webView.load(URLRequest(url: url)) != nil {
+            beginLoadingProgress()
+        }
         notifyStateChanged()
     }
 
@@ -491,7 +508,9 @@ private enum BrowserTabStoreSPI {
         } else {
             initialRequestLoadCount += 1
             markWebViewInteractionStatePendingNavigation()
-            webView.load(URLRequest(url: initialURL))
+            if webView.load(URLRequest(url: initialURL)) != nil {
+                beginLoadingProgress()
+            }
         }
         notifyStateChanged()
     }
@@ -614,6 +633,11 @@ private enum BrowserTabStoreSPI {
         canSaveWebViewInteractionState = false
     }
 
+    private func beginLoadingProgress() {
+        isLoading = true
+        estimatedProgress = .zero
+    }
+
     private func markWebViewInteractionStateSynchronized() {
         canSaveWebViewInteractionState = true
     }
@@ -713,6 +737,26 @@ private enum BrowserTabStoreSPI {
         webView.perform(BrowserTabStoreSPI.setHistoryDelegateSelector, with: self)
     }
 
+    private static func installSameDocumentNavigationDelegateMethodIfNeeded() {
+        guard didInstallSameDocumentNavigationDelegateMethod == false else {
+            return
+        }
+        guard let method = class_getInstanceMethod(
+            Self.self,
+            #selector(handleSameDocumentNavigationBridge(_:navigation:navigationType:))
+        ) else {
+            return
+        }
+
+        class_addMethod(
+            Self.self,
+            BrowserTabStoreSPI.sameDocumentNavigationSelector,
+            method_getImplementation(method),
+            method_getTypeEncoding(method)
+        )
+        didInstallSameDocumentNavigationDelegateMethod = true
+    }
+
 #if canImport(UIKit)
     private func configureRefreshControl() {
         let control = UIRefreshControl()
@@ -723,7 +767,10 @@ private enum BrowserTabStoreSPI {
 
     @objc private func handleRefreshControl() {
         markWebViewInteractionStatePendingNavigation()
-        webView.reload()
+        if webView.reload() != nil {
+            beginLoadingProgress()
+            notifyStateChanged()
+        }
     }
 
     private func endRefreshingIfNeeded() {
@@ -753,8 +800,7 @@ extension BrowserTabStore: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         markWebViewInteractionStatePendingNavigation()
-        isLoading = true
-        estimatedProgress = .zero
+        beginLoadingProgress()
         notifyStateChanged()
     }
 
@@ -857,6 +903,12 @@ extension BrowserTabStore {
     func _webView(_ webView: WKWebView!, didUpdateHistoryTitle title: String!, forURL url: URL!) {
         invalidateHistoryIfNeeded()
         notifyStateChanged()
+    }
+
+    @objc(browserTabStoreHandleWebView:navigation:navigationType:)
+    func handleSameDocumentNavigationBridge(_ webView: WKWebView!, navigation: WKNavigation!, navigationType: Int64) {
+        syncNavigationState(from: webView)
+        markWebViewInteractionStateSynchronizedIfNavigationSettled()
     }
 }
 

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -375,6 +375,59 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func loadingProgressRemainsVisibleAtCompletedEstimatedProgressUntilNavigationSettles() throws {
+        let store = BrowserStore(
+            url: try #require(URL(string: "about:blank")),
+            automaticallyLoadsInitialRequest: false,
+            sessionStore: nil
+        )
+        let tab = try #require(store.selectedTab)
+
+        tab.webView(tab.webView, didStartProvisionalNavigation: nil)
+        tab.estimatedProgress = 1
+
+        #expect(tab.isShowingProgress)
+        #expect(store.isShowingProgress)
+    }
+
+    @Test
+    func explicitNavigationShowsProgressImmediatelyFromCompletedPreviousProgress() throws {
+        let store = BrowserStore(
+            url: try #require(URL(string: "about:blank")),
+            automaticallyLoadsInitialRequest: false,
+            sessionStore: nil
+        )
+        let tab = try #require(store.selectedTab)
+        tab.isLoading = false
+        tab.estimatedProgress = 1
+        let nextURL = try #require(URL(string: "https://example.com/next"))
+
+        store.load(url: nextURL)
+
+        #expect(store.currentURL == nextURL)
+        #expect(tab.isLoading)
+        #expect(tab.estimatedProgress == .zero)
+        #expect(store.isShowingProgress)
+    }
+
+    @Test
+    func sameDocumentNavigationSettlesProgressStartedForHistoryNavigation() throws {
+        let store = BrowserStore(
+            url: try #require(URL(string: "about:blank")),
+            automaticallyLoadsInitialRequest: false,
+            sessionStore: nil
+        )
+        let tab = try #require(store.selectedTab)
+        tab.isLoading = true
+        tab.estimatedProgress = 0.5
+
+        tab.handleSameDocumentNavigationBridge(tab.webView, navigation: nil, navigationType: 0)
+
+        #expect(tab.isLoading == false)
+        #expect(store.isShowingProgress == false)
+    }
+
+    @Test
     func autosavePreservesPendingRestoredStateForUnselectedTabs() throws {
         try withTemporarySessionStore { sessionStore, _ in
             let selectedID = UUID()


### PR DESCRIPTION
## Purpose

Fix Monocly's loading progress indicator so it animates correctly and does not flicker when navigation starts happen back-to-back.

## Changes

- Animate increasing `UIProgressView` updates with `setProgress(_:animated:)` while keeping resets immediate.
- Keep the indicator visible for the full loading lifetime, then hide it through a cancelable delayed fade-out.
- Reset loading progress on new navigations, including back/forward/history navigations.
- Add an obfuscated private same-document navigation delegate selector with the original selector preserved in a comment, and install the delegate bridge at runtime.
- Add regression coverage for completed estimated progress, repeated explicit loads, and same-document navigation settling.

## Testing

- `git diff --check`
- `xcodebuild build-for-testing -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test-without-building -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `$codex-review` on the final diff: no findings