### PR TITLE
Expose page user interface style

### DIFF
--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ObservationBridge
 import WebInspectorKit
 
 #if canImport(UIKit)
@@ -251,6 +252,7 @@ final class BrowserInspectorCoordinator {
 
     private weak var presentedSheetController: UIViewController?
     private let sheetObserver = InspectorSheetObserver()
+    private let sheetUserInterfaceStyleObservationScope = ObservationScope()
     private var sceneActivationRequester = BrowserInspectorSceneActivationRequester.live
     private var supportsMultipleScenesProvider: @MainActor () -> Bool = { UIApplication.shared.supportsMultipleScenes }
 
@@ -271,6 +273,7 @@ final class BrowserInspectorCoordinator {
         }
         sheetController.modalPresentationStyle = .pageSheet
         applyDefaultDetents(to: sheetController)
+        bindSheetUserInterfaceStyle(to: sheetController, inspectorSession: inspectorSession)
         presentedSheetController = sheetController
         sheetObserver.onDismiss = { [weak self, weak sheetController] in
             guard let self else {
@@ -278,6 +281,7 @@ final class BrowserInspectorCoordinator {
             }
             if self.presentedSheetController === sheetController {
                 self.presentedSheetController = nil
+                self.sheetUserInterfaceStyleObservationScope.cancelAll()
                 self.notifyPresentationStateChanged()
             }
         }
@@ -346,6 +350,7 @@ final class BrowserInspectorCoordinator {
     func invalidate() {
         sheetObserver.onDismiss = nil
         presentedSheetController = nil
+        sheetUserInterfaceStyleObservationScope.cancelAll()
     }
 
     func setSceneActivationRequesterForTesting(_ requester: BrowserInspectorSceneActivationRequester) {
@@ -437,6 +442,26 @@ final class BrowserInspectorCoordinator {
         sheet.largestUndimmedDetentIdentifier = .medium
     }
 
+    private func bindSheetUserInterfaceStyle(
+        to sheetController: UIViewController,
+        inspectorSession: WebInspectorSession
+    ) {
+        sheetUserInterfaceStyleObservationScope.cancelAll()
+        sheetUserInterfaceStyleObservationScope.observe(inspectorSession) { [weak self, weak sheetController] _, session in
+            guard let sheet = sheetController?.sheetPresentationController else {
+                return
+            }
+            self?.applySheetUserInterfaceStyle(session.pageUserInterfaceStyle, to: sheet)
+        }
+    }
+
+    private func applySheetUserInterfaceStyle(
+        _ style: UIUserInterfaceStyle,
+        to sheet: UISheetPresentationController
+    ) {
+        sheet.traitOverrides.userInterfaceStyle = style
+    }
+
     private func topViewController(from root: UIViewController?) -> UIViewController? {
         guard let root else {
             return nil
@@ -471,6 +496,7 @@ final class BrowserInspectorCoordinator {
             return
         }
         self.presentedSheetController = nil
+        sheetUserInterfaceStyleObservationScope.cancelAll()
     }
 
     private func isPresentedViewControllerInChain(

--- a/Sources/WebInspectorUI/Containers/WebInspectorPageUserInterfaceStyleObserver.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorPageUserInterfaceStyleObserver.swift
@@ -1,0 +1,102 @@
+#if canImport(UIKit)
+import UIKit
+import WebKit
+
+@MainActor
+package enum WebInspectorPageUserInterfaceStyle {
+    package static func style(
+        for color: UIColor?,
+        in traitCollection: UITraitCollection
+    ) -> UIUserInterfaceStyle {
+        guard let color else {
+            return .unspecified
+        }
+
+        let resolvedColor = color.resolvedColor(with: traitCollection)
+        guard let sRGBColorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let convertedColor = resolvedColor.cgColor.converted(
+                to: sRGBColorSpace,
+                intent: .defaultIntent,
+                options: nil
+              ),
+              let components = convertedColor.components,
+              components.count >= 3,
+              convertedColor.alpha >= 0.99 else {
+            return .unspecified
+        }
+
+        let red = components[0]
+        let green = components[1]
+        let blue = components[2]
+        let lightness = 0.5 * (max(red, green, blue) + min(red, green, blue))
+        return lightness <= 0.5 ? .dark : .light
+    }
+}
+
+@MainActor
+package final class WebInspectorPageUserInterfaceStyleObserver {
+    private weak var webView: WKWebView?
+    private let apply: @MainActor (UIUserInterfaceStyle) -> Void
+    private var backgroundObservation: NSKeyValueObservation?
+    private var traitRegistration: (any UITraitChangeRegistration)?
+
+    package init(
+        webView: WKWebView,
+        apply: @escaping @MainActor (UIUserInterfaceStyle) -> Void
+    ) {
+        self.webView = webView
+        self.apply = apply
+    }
+
+    isolated deinit {
+        invalidate()
+    }
+
+    package func start() {
+        guard let webView else {
+            apply(.unspecified)
+            return
+        }
+
+        backgroundObservation = webView.observe(
+            \.underPageBackgroundColor,
+            options: [.initial, .new]
+        ) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.publishCurrentStyle()
+            }
+        }
+
+        traitRegistration = webView.registerForTraitChanges(
+            UITraitCollection.systemTraitsAffectingColorAppearance
+        ) { [weak self] (_: WKWebView, _: UITraitCollection) in
+            self?.publishCurrentStyle()
+        }
+    }
+
+    package func invalidate() {
+        backgroundObservation?.invalidate()
+        backgroundObservation = nil
+
+        if let traitRegistration,
+           let webView {
+            webView.unregisterForTraitChanges(traitRegistration)
+        }
+        traitRegistration = nil
+    }
+
+    private func publishCurrentStyle() {
+        guard let webView else {
+            apply(.unspecified)
+            return
+        }
+
+        apply(
+            WebInspectorPageUserInterfaceStyle.style(
+                for: webView.underPageBackgroundColor,
+                in: webView.traitCollection
+            )
+        )
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -9,8 +9,13 @@ import WebInspectorCore
 public final class WebInspectorSession {
     package let inspector: InspectorSession
     package let interface: InterfaceModel
+    /// The user interface style inferred from the inspected page.
+    ///
+    /// The value is `.unspecified` until the page style is known or when no useful style can be inferred.
+    public private(set) var pageUserInterfaceStyle: UIUserInterfaceStyle = .unspecified
     @ObservationIgnored private let attachAction: @MainActor (InspectorSession, WKWebView) async throws -> Void
     @ObservationIgnored private let detachAction: @MainActor (InspectorSession) async -> Void
+    @ObservationIgnored private var pageUserInterfaceStyleObserver: WebInspectorPageUserInterfaceStyleObserver?
 
     public convenience init(tabs: [WebInspectorTab] = [.dom, .network]) {
         self.init(inspector: InspectorSession(), tabs: tabs)
@@ -33,6 +38,7 @@ public final class WebInspectorSession {
     }
 
     isolated deinit {
+        stopPageUserInterfaceStyleObservation()
         interface.removeContentCache()
     }
 
@@ -41,11 +47,40 @@ public final class WebInspectorSession {
     }
 
     public func attach(to webView: WKWebView) async throws {
-        try await attachAction(inspector, webView)
+        stopPageUserInterfaceStyleObservation()
+        do {
+            try await attachAction(inspector, webView)
+            startPageUserInterfaceStyleObservation(for: webView)
+        } catch {
+            stopPageUserInterfaceStyleObservation()
+            throw error
+        }
     }
 
     public func detach() async {
+        stopPageUserInterfaceStyleObservation()
         await detachAction(inspector)
+    }
+
+    private func startPageUserInterfaceStyleObservation(for webView: WKWebView) {
+        let observer = WebInspectorPageUserInterfaceStyleObserver(webView: webView) { [weak self] style in
+            self?.setPageUserInterfaceStyle(style)
+        }
+        pageUserInterfaceStyleObserver = observer
+        observer.start()
+    }
+
+    private func stopPageUserInterfaceStyleObservation() {
+        pageUserInterfaceStyleObserver?.invalidate()
+        pageUserInterfaceStyleObserver = nil
+        setPageUserInterfaceStyle(.unspecified)
+    }
+
+    private func setPageUserInterfaceStyle(_ style: UIUserInterfaceStyle) {
+        guard pageUserInterfaceStyle != style else {
+            return
+        }
+        pageUserInterfaceStyle = style
     }
 }
 

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -2,12 +2,15 @@
 import Testing
 import WebInspectorTransport
 import UIKit
+import WebKit
 @testable import WebInspectorCore
 @testable import WebInspectorUI
 
 @MainActor
 @Suite(.serialized)
 struct ParentContainerTests {
+    private struct AttachmentFailure: Error {}
+
     @Test
     func sessionAndViewControllerUseDOMAndNetworkTabsByDefault() {
         let session = WebInspectorSession()
@@ -15,9 +18,128 @@ struct ParentContainerTests {
 
         #expect(session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
         #expect(viewController.session.interface.tabs.map(\.id) == [WebInspectorTab.dom.id, WebInspectorTab.network.id])
+        #expect(session.pageUserInterfaceStyle == .unspecified)
         if #available(iOS 26.0, *) {
             #expect(viewController.drawsBackground)
         }
+    }
+
+    @Test
+    func pageUserInterfaceStyleUsesWebKitLightnessThreshold() {
+        let traits = UITraitCollection(userInterfaceStyle: .light)
+
+        #expect(WebInspectorPageUserInterfaceStyle.style(for: .white, in: traits) == .light)
+        #expect(WebInspectorPageUserInterfaceStyle.style(for: .black, in: traits) == .dark)
+        #expect(WebInspectorPageUserInterfaceStyle.style(for: .clear, in: traits) == .unspecified)
+        #expect(WebInspectorPageUserInterfaceStyle.style(for: nil, in: traits) == .unspecified)
+    }
+
+    @Test
+    func pageUserInterfaceStyleResolvesDynamicColorsWithWebViewTraits() {
+        let dynamicColor = UIColor { traits in
+            traits.userInterfaceStyle == .dark ? .black : .white
+        }
+
+        #expect(
+            WebInspectorPageUserInterfaceStyle.style(
+                for: dynamicColor,
+                in: UITraitCollection(userInterfaceStyle: .light)
+            ) == .light
+        )
+        #expect(
+            WebInspectorPageUserInterfaceStyle.style(
+                for: dynamicColor,
+                in: UITraitCollection(userInterfaceStyle: .dark)
+            ) == .dark
+        )
+    }
+
+    @Test
+    func sessionUpdatesPageUserInterfaceStyleFromUnderPageBackgroundColor() async throws {
+        let session = makeSessionWithNoOpAttachment()
+        let webView = WKWebView(frame: .zero)
+
+        try await session.attach(to: webView)
+        webView.underPageBackgroundColor = .black
+
+        let didApplyDarkStyle = await waitUntil {
+            session.pageUserInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        webView.underPageBackgroundColor = .white
+        let didApplyLightStyle = await waitUntil {
+            session.pageUserInterfaceStyle == .light
+        }
+        #expect(didApplyLightStyle)
+    }
+
+    @Test
+    func sessionClearsPageUserInterfaceStyleAndStopsObservingOnDetach() async throws {
+        let session = makeSessionWithNoOpAttachment()
+        let webView = WKWebView(frame: .zero)
+
+        try await session.attach(to: webView)
+        webView.underPageBackgroundColor = .black
+        let didApplyDarkStyle = await waitUntil {
+            session.pageUserInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        await session.detach()
+
+        #expect(session.pageUserInterfaceStyle == .unspecified)
+        webView.underPageBackgroundColor = .white
+        await Task.yield()
+        #expect(session.pageUserInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func sessionClearsPageUserInterfaceStyleAndStopsObservingWhenAttachFails() async throws {
+        let observedWebView = WKWebView(frame: .zero)
+        let observedWebViewID = ObjectIdentifier(observedWebView)
+        let session = makeSessionWithNoOpAttachment { _, webView in
+            if ObjectIdentifier(webView) != observedWebViewID {
+                throw AttachmentFailure()
+            }
+        }
+
+        try await session.attach(to: observedWebView)
+        observedWebView.underPageBackgroundColor = .black
+        let didApplyDarkStyle = await waitUntil {
+            session.pageUserInterfaceStyle == .dark
+        }
+        #expect(didApplyDarkStyle)
+
+        do {
+            try await session.attach(to: WKWebView(frame: .zero))
+            Issue.record("Expected attach to fail")
+        } catch {
+            #expect(error is AttachmentFailure)
+        }
+
+        #expect(session.pageUserInterfaceStyle == .unspecified)
+        observedWebView.underPageBackgroundColor = .white
+        await Task.yield()
+        #expect(session.pageUserInterfaceStyle == .unspecified)
+    }
+
+    @Test
+    func viewControllerDoesNotApplyPageUserInterfaceStyle() async throws {
+        let session = makeSessionWithNoOpAttachment()
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        let webView = WKWebView(frame: .zero)
+
+        try await session.attach(to: webView)
+        webView.underPageBackgroundColor = .black
+        let didApplyDarkStyle = await waitUntil {
+            session.pageUserInterfaceStyle == .dark
+        }
+
+        #expect(didApplyDarkStyle)
+        #expect(viewController.overrideUserInterfaceStyle == .unspecified)
     }
 
     @Test
@@ -353,6 +475,17 @@ struct ParentContainerTests {
             await Task.yield()
         }
         return false
+    }
+
+    private func makeSessionWithNoOpAttachment(
+        attachAction: @escaping @MainActor (InspectorSession, WKWebView) async throws -> Void = { _, _ in },
+        detachAction: @escaping @MainActor (InspectorSession) async -> Void = { _ in }
+    ) -> WebInspectorSession {
+        WebInspectorSession(
+            inspector: InspectorSession(),
+            attachAction: attachAction,
+            detachAction: detachAction
+        )
     }
 }
 #endif


### PR DESCRIPTION
## Purpose

Expose the inspected page user interface style so consumers can choose how to apply it.
Use the new value in Monocly to override the inspector sheet presentation style.

## Changes
- Add WebInspectorSession.pageUserInterfaceStyle.
- Observe WKWebView.underPageBackgroundColor and infer light, dark, or unspecified.
- Apply the session style to Monocly sheet presentation trait overrides.

- Add model-side coverage for style inference and observation lifecycle.
## Testing
- git diff --check
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- xcodebuild build -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'

- codex-review --base main: findingCount 0