### PR TITLE
Update SyntaxEditorUI to 0.12.0

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
-        "version" : "0.11.0"
+        "revision" : "859e630ec6633fa3cb632df308eec6c041207888",
+        "version" : "0.11.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
-        "version" : "0.11.0"
+        "revision" : "0230895781b2889948e93ce8502af4aa8e194362",
+        "version" : "0.12.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "48746d64be97337bcd1493ed21516df2fa896eeed8c291d9af75a734fa2330ae",
+  "originHash" : "143d458cc772b9444a9fccb5535aa7edf6f651950463850242201f6b7872d3fa",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
-        "version" : "0.11.0"
+        "revision" : "859e630ec6633fa3cb632df308eec6c041207888",
+        "version" : "0.11.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
-        "version" : "0.11.0"
+        "revision" : "0230895781b2889948e93ce8502af4aa8e194362",
+        "version" : "0.12.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/lynnswap/ObservationBridge.git",
-            exact: "0.11.0"
+            exact: "0.11.1"
         ),
         .package(
             url: "https://github.com/lynnswap/UIHostingMenu.git",
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.11.0"
+            exact: "0.12.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -17,7 +17,7 @@ final class NetworkBodyViewController: UIViewController {
         language: .json,
         isEditable: false,
         lineWrappingEnabled: true,
-        colorTheme: .v2WebInspectorPlainText,
+        theme: .default,
         drawsBackground: false
     )
     private lazy var syntaxView = SyntaxEditorView(
@@ -230,13 +230,12 @@ final class NetworkBodyViewController: UIViewController {
         text: String,
         syntaxKind: NetworkBodySyntaxKind
     ) {
-        let syntax = syntaxKind.syntax
-        if syntaxModel.language != syntax.language {
-            syntaxModel.language = syntax.language
+        let language = syntaxKind.language
+        if syntaxModel.language != language {
+            syntaxModel.language = language
         }
-        let colorTheme: SyntaxEditorColorTheme = syntax.usesPlainTextTheme ? .v2WebInspectorPlainText : .default
-        if syntaxModel.colorTheme != colorTheme {
-            syntaxModel.colorTheme = colorTheme
+        if syntaxModel.theme != .default {
+            syntaxModel.theme = .default
         }
         if syntaxModel.text != text {
             syntaxModel.replaceText(text)
@@ -583,38 +582,21 @@ private func removeTemporaryMediaFile(at url: URL?) {
     try? FileManager.default.removeItem(at: url)
 }
 
-@MainActor
-extension SyntaxEditorColorTheme {
-    static let v2WebInspectorPlainText = SyntaxEditorColorTheme(
-        baseForeground: .label,
-        bracketBackground: .clear,
-        comment: .label,
-        string: .label,
-        keyword: .label,
-        number: .label,
-        function: .label,
-        type: .label,
-        constant: .label,
-        variable: .label,
-        punctuation: .label
-    )
-}
-
 private extension NetworkBodySyntaxKind {
-    var syntax: (language: SyntaxLanguage, usesPlainTextTheme: Bool) {
+    var language: SyntaxLanguage {
         switch self {
         case .plainText:
-            (.plainText, true)
+            .plainText
         case .json:
-            (.json, false)
+            .json
         case .html:
-            (.html, false)
+            .html
         case .xml:
-            (.xml, false)
+            .xml
         case .css:
-            (.css, false)
+            .css
         case .javascript:
-            (.javascript, false)
+            .javascript
         }
     }
 }

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8fb32aec0366af0e0148d352ccc26a8e4a09bcf6fe5c9ed518e9425b4910e809",
+  "originHash" : "bfe971b548b2ed5ae81334de333ce9a6a0fa743a0110df88f48d72d20d712f20",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "9c4a7ba48cc8593e4ffe2d6fef01652d11e9afc1",
-        "version" : "0.11.0"
+        "revision" : "859e630ec6633fa3cb632df308eec6c041207888",
+        "version" : "0.11.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "aa0ce5d2dc44915310c0714fab6101f074b965ce",
-        "version" : "0.11.0"
+        "revision" : "0230895781b2889948e93ce8502af4aa8e194362",
+        "version" : "0.12.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Update SyntaxEditorUI to v0.12.0 and align WebInspectorKit with its theme API changes.

## Changes
- Bump SyntaxEditorUI to 0.12.0 and ObservationBridge to 0.11.1.
- Update all package lockfiles for the WebInspectorKit workspace, root package, and Monocly project.
- Migrate Network body preview from colorTheme to theme and use SyntaxEditorUI's built-in default theme instead of a custom plain text theme.

## Testing
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -project Monocly/Monocly.xcodeproj -scheme Monocly`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- Codex review: clean, no findings