### PR TITLE
Fix initial DOM sheet attachment race

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -8,6 +8,7 @@ package final class DOMSession {
     package var isSelectingElement: Bool
     package private(set) var treeRevision: UInt64
     package private(set) var selectionRevision: UInt64
+    package private(set) var commandAvailabilityRevision: UInt64
 
     private let targetGraph: TargetGraph
     private var currentPage: DOMCurrentPage
@@ -32,6 +33,7 @@ package final class DOMSession {
         isSelectingElement = false
         treeRevision = 0
         selectionRevision = 0
+        commandAvailabilityRevision = 0
         self.targetGraph = targetGraph
         currentPage = DOMCurrentPage()
         documentStore = DOMDocumentStore()
@@ -95,6 +97,10 @@ package final class DOMSession {
         selectionRevision &+= 1
     }
 
+    package func recordCommandAvailabilityMutation() {
+        commandAvailabilityRevision &+= 1
+    }
+
     package func reset() {
         currentPage.clear()
         targetGraph.reset()
@@ -106,6 +112,7 @@ package final class DOMSession {
         isSelectingElement = false
         recordTreeMutation()
         recordSelectionMutation()
+        recordCommandAvailabilityMutation()
     }
 
     package func applyTargetCreated(

--- a/Sources/WebInspectorCore/DOM/DOMSessionAvailability.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionAvailability.swift
@@ -20,6 +20,7 @@ extension DOMSession {
     }
 
     private var hasActiveCommandChannel: Bool {
-        commandChannel?.acceptsActiveCommands == true
+        _ = commandAvailabilityRevision
+        return commandChannel?.acceptsActiveCommands == true
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -181,11 +181,11 @@ final class DOMSessionDocumentRequestController {
 final class DOMSessionElementStyleHydrationController {
     @MainActor
     private final class Refresh {
-        let identity: CSSNodeStyles.Identity
+        let token: CSSStyle.RefreshToken
         fileprivate var task: Task<Void, Never>?
 
-        init(identity: CSSNodeStyles.Identity) {
-            self.identity = identity
+        init(token: CSSStyle.RefreshToken) {
+            self.token = token
         }
 
         func wait() async {
@@ -231,16 +231,16 @@ final class DOMSessionElementStyleHydrationController {
     }
 
     func isRefreshing(identity: CSSNodeStyles.Identity) -> Bool {
-        activeRefresh?.identity == identity
+        activeRefresh?.token.identity == identity
     }
 
     @discardableResult
     func startRefresh(
-        identity: CSSNodeStyles.Identity,
-        operation: @escaping @MainActor (CSSNodeStyles.Identity) async -> Void
-    ) -> CSSNodeStyles.Identity? {
-        let cancelledIdentity = cancelRefresh()
-        let refresh = Refresh(identity: identity)
+        token: CSSStyle.RefreshToken,
+        operation: @escaping @MainActor (CSSStyle.RefreshToken) async -> Void
+    ) -> CSSStyle.RefreshToken? {
+        let cancelledToken = cancelRefresh()
+        let refresh = Refresh(token: token)
         activeRefresh = refresh
         refresh.task = Task { @MainActor [weak self, weak refresh] in
             guard let refresh else {
@@ -249,19 +249,19 @@ final class DOMSessionElementStyleHydrationController {
             defer {
                 self?.finishRefresh(refresh)
             }
-            await operation(refresh.identity)
+            await operation(refresh.token)
         }
-        return cancelledIdentity
+        return cancelledToken
     }
 
     @discardableResult
-    func cancelRefresh() -> CSSNodeStyles.Identity? {
+    func cancelRefresh() -> CSSStyle.RefreshToken? {
         guard let refresh = activeRefresh else {
             return nil
         }
         activeRefresh = nil
         refresh.cancel()
-        return refresh.identity
+        return refresh.token
     }
 
     @discardableResult

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -409,7 +409,7 @@ extension DOMSession {
         guard styleHydration.isActive else {
             return
         }
-        guard commandChannel != nil else {
+        guard commandChannel?.acceptsActiveCommands == true else {
             return
         }
         guard currentPageRootNode != nil else {
@@ -479,6 +479,12 @@ extension DOMSession {
     }
 
     private func refreshStyles(for identity: CSSNodeStyles.Identity) async throws {
+        let commandChannel = try requireCommandChannel()
+        let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
+        guard targetExists else {
+            elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+            return
+        }
         guard let token = elementStyles.beginRefresh(identity: identity) else {
             return
         }
@@ -488,13 +494,6 @@ extension DOMSession {
     private func refreshStyles(for token: CSSStyle.RefreshToken) async throws {
         let identity = token.identity
         do {
-            let commandChannel = try requireCommandChannel()
-            let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
-            guard targetExists else {
-                elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
-                return
-            }
-
             let results = try await elementStyles.fetchRefreshResults(for: identity)
             guard case let .success(currentIdentity) = selectedCSSNodeStyleIdentity(),
                   currentIdentity == identity else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -479,10 +479,7 @@ extension DOMSession {
     }
 
     private func refreshStyles(for identity: CSSNodeStyles.Identity) async throws {
-        let commandChannel = try requireCommandChannel()
-        let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
-        guard targetExists else {
-            elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+        guard try await selectedStyleRefreshTargetIsLive(identity) else {
             return
         }
         guard let token = elementStyles.beginRefresh(identity: identity) else {
@@ -493,6 +490,9 @@ extension DOMSession {
 
     private func refreshStyles(for token: CSSStyle.RefreshToken) async throws {
         let identity = token.identity
+        guard try await selectedStyleRefreshTargetIsLive(identity) else {
+            return
+        }
         do {
             let results = try await elementStyles.fetchRefreshResults(for: identity)
             guard case let .success(currentIdentity) = selectedCSSNodeStyleIdentity(),
@@ -513,6 +513,16 @@ extension DOMSession {
             elementStyles.markRefreshFailed(token, message: String(describing: error))
             throw error
         }
+    }
+
+    private func selectedStyleRefreshTargetIsLive(_ identity: CSSNodeStyles.Identity) async throws -> Bool {
+        let commandChannel = try requireCommandChannel()
+        let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
+        guard targetExists else {
+            elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+            return false
+        }
+        return true
     }
 
     package func inspectEvent(from event: ProtocolEvent) throws -> DOMInspectEvent? {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -438,8 +438,11 @@ extension DOMSession {
         guard styleHydration.isRefreshing(identity: identity) == false else {
             return
         }
+        guard let token = elementStyles.beginRefresh(identity: identity) else {
+            return
+        }
 
-        if let cancelledIdentity = styleHydration.startRefresh(identity: identity, operation: { [weak self] identity in
+        if let cancelledToken = styleHydration.startRefresh(token: token, operation: { [weak self] token in
             guard let self else {
                 return
             }
@@ -448,7 +451,7 @@ extension DOMSession {
             }
 
             do {
-                try await self.refreshStyles(for: identity)
+                try await self.refreshStyles(for: token)
                 self.recordError?(nil)
             } catch is CancellationError {
                 return
@@ -456,13 +459,13 @@ extension DOMSession {
                 self.recordError?(InspectorSession.Error(String(describing: error)))
             }
         }) {
-            elementStyles.cancelRefresh(identity: cancelledIdentity)
+            elementStyles.cancelRefresh(cancelledToken)
         }
     }
 
     private func cancelSelectedNodeStyleHydrationRefresh() {
-        if let cancelledIdentity = styleHydration.cancelRefresh() {
-            elementStyles.cancelRefresh(identity: cancelledIdentity)
+        if let cancelledToken = styleHydration.cancelRefresh() {
+            elementStyles.cancelRefresh(cancelledToken)
         }
     }
 
@@ -476,17 +479,22 @@ extension DOMSession {
     }
 
     private func refreshStyles(for identity: CSSNodeStyles.Identity) async throws {
-        let commandChannel = try requireCommandChannel()
-        let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
-        guard targetExists else {
-            elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
-            return
-        }
         guard let token = elementStyles.beginRefresh(identity: identity) else {
             return
         }
+        try await refreshStyles(for: token)
+    }
 
+    private func refreshStyles(for token: CSSStyle.RefreshToken) async throws {
+        let identity = token.identity
         do {
+            let commandChannel = try requireCommandChannel()
+            let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
+            guard targetExists else {
+                elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+                return
+            }
+
             let results = try await elementStyles.fetchRefreshResults(for: identity)
             guard case let .success(currentIdentity) = selectedCSSNodeStyleIdentity(),
                   currentIdentity == identity else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -18,6 +18,7 @@ extension DOMSession {
         self.commandChannel = commandChannel
         self.recordError = recordError
         elementStyles.bindProtocolChannel(commandChannel)
+        recordCommandAvailabilityMutation()
         reconcileSelectedNodeStyleHydrationIfNeeded()
     }
 
@@ -31,6 +32,7 @@ extension DOMSession {
         highlightController.targetID = nil
         clearElementPickerState(invalidatePendingSelection: true)
         clearDeleteUndoHistory()
+        recordCommandAvailabilityMutation()
     }
 
     package func prepareForDocumentReload() async {

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -554,6 +554,7 @@ package final class InspectorSession {
             try await bootstrap(mainTargetID: mainTarget.targetID, connection: nextConnection)
             try ensureCurrentConnection(nextConnection)
             connectionPhase = .active(nextConnection)
+            dom.recordCommandAvailabilityMutation()
             dom.startDocumentRequestsForAttachedFrameTargets()
             startRuntimeConsoleEnableForAttachedTargets()
             lastError = nil
@@ -564,6 +565,7 @@ package final class InspectorSession {
             nextConnection.receiver?.close()
             stopPumps(nextConnection)
             connectionPhase = .idle
+            dom.recordCommandAvailabilityMutation()
             await transport.detach()
             restoreInspectabilityIfNeeded(for: nextConnection)
             unbindProtocolChannel()
@@ -584,6 +586,7 @@ package final class InspectorSession {
 
         let previousConnections = connectionPhase.connectionsForDetach
         connectionPhase = .idle
+        dom.recordCommandAvailabilityMutation()
         unbindProtocolChannel()
 
         for previousConnection in previousConnections {

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -555,6 +555,7 @@ package final class InspectorSession {
             try ensureCurrentConnection(nextConnection)
             connectionPhase = .active(nextConnection)
             dom.recordCommandAvailabilityMutation()
+            dom.reconcileSelectedNodeStyleHydrationIfNeeded()
             dom.startDocumentRequestsForAttachedFrameTargets()
             startRuntimeConsoleEnableForAttachedTargets()
             lastError = nil

--- a/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMCompactNavigationController.swift
@@ -51,6 +51,14 @@ package final class DOMCompactNavigationController: UINavigationController {
     }
 }
 
+#if DEBUG
+extension DOMCompactNavigationController {
+    var domNavigationItemsForTesting: DOMNavigationItems? {
+        domNavigationItems
+    }
+}
+#endif
+
 #Preview("DOM Compact Tree") {
     DOMCompactNavigationController(
         rootViewController: DOMTreeViewController(dom: DOMPreviewFixtures.makeDOMSession())

--- a/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
+++ b/Sources/WebInspectorUI/DOM/DOMNavigationItems.swift
@@ -49,9 +49,11 @@ package final class DOMNavigationItems: NSObject {
 
     private func startObservingInspection() {
         domObservation = withPortableContinuousObservation { [weak self, inspector] _ in
-            _ = inspector.attachment.dom.canBeginElementPicker
-            _ = inspector.attachment.dom.isSelectingElement
-            self?.renderPickItem()
+            let dom = inspector.attachment.dom
+            self?.renderPickItem(
+                isEnabled: dom.canBeginElementPicker,
+                isSelectingElement: dom.isSelectingElement
+            )
         }
     }
 
@@ -151,20 +153,34 @@ package final class DOMNavigationItems: NSObject {
     }
 
     private func updatePickItemAppearance() {
-        renderPickItem()
+        let dom = inspector.attachment.dom
+        renderPickItem(
+            isEnabled: dom.canBeginElementPicker,
+            isSelectingElement: dom.isSelectingElement
+        )
     }
 
-    private func renderPickItem() {
-        let dom = inspector.attachment.dom
-        let isEnabled = dom.canBeginElementPicker
+    private func renderPickItem(isEnabled: Bool, isSelectingElement: Bool) {
         if pickItem.isEnabled != isEnabled {
             pickItem.isEnabled = isEnabled
         }
-        let tintColor: UIColor = dom.isSelectingElement ? .tintColor : .label
+        let tintColor: UIColor = isSelectingElement ? .tintColor : .label
         if pickItem.tintColor != tintColor {
             pickItem.tintColor = tintColor
         }
     }
 }
+
+#if DEBUG
+extension DOMNavigationItems {
+    var observationDeliveryForTesting: PortableObservationTracking.Token? {
+        domObservation
+    }
+
+    var pickItemForTesting: UIBarButtonItem {
+        pickItem
+    }
+}
+#endif
 
 #endif

--- a/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMSplitViewController.swift
@@ -95,6 +95,14 @@ package final class DOMSplitViewController: UISplitViewController {
     }
 }
 
+#if DEBUG
+extension DOMSplitViewController {
+    var domNavigationItemsForTesting: DOMNavigationItems? {
+        domNavigationItems
+    }
+}
+#endif
+
 #Preview("DOM Split") {
     DOMSplitViewControllerPreview.makeViewController()
 }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -78,7 +78,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var measuredTextWidth: CGFloat = 0
     private var lastBoundsSize: CGSize = .zero
     private var lastRenderedDocumentRootID: DOMNode.ID?
-    private var lastObservedTreeRevision: UInt64?
+    private var lastRoutedTreeRevision: UInt64?
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
     private let selectionRevealState = DOMTreeTextView.SelectionRevealState()
@@ -462,8 +462,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         documentObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
             let treeRevision = dom.treeRevision
-            let shouldRouteDOMInvalidation = event.kind == .initial || lastObservedTreeRevision != treeRevision
-            lastObservedTreeRevision = treeRevision
+            let shouldRouteDOMInvalidation = event.kind == .initial || lastRoutedTreeRevision != treeRevision
+            lastRoutedTreeRevision = treeRevision
             guard shouldRouteDOMInvalidation else {
                 return
             }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -78,6 +78,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var measuredTextWidth: CGFloat = 0
     private var lastBoundsSize: CGSize = .zero
     private var lastRenderedDocumentRootID: DOMNode.ID?
+    private var lastObservedTreeRevision: UInt64?
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
     private let selectionRevealState = DOMTreeTextView.SelectionRevealState()
@@ -460,8 +461,10 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func startObservingDocument() {
         documentObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
-            _ = dom.treeRevision
-            guard event.kind == .initial || event.matches(\DOMSession.treeRevision) else {
+            let treeRevision = dom.treeRevision
+            let shouldRouteDOMInvalidation = event.kind == .initial || lastObservedTreeRevision != treeRevision
+            lastObservedTreeRevision = treeRevision
+            guard shouldRouteDOMInvalidation else {
                 return
             }
             routeDOMInvalidation(from: dom, isInitial: event.kind == .initial)

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -9,8 +9,6 @@ package final class DOMTreeViewController: UIViewController {
     private weak var inspection: AttachedInspection?
     private var domRootObservation: PortableObservationTracking.Token?
     private var isEnsuringDOMDocumentLoaded = false
-    private var lastObservedTreeRevision: UInt64?
-    private var lastObservedCommandAvailabilityRevision: UInt64?
 
     package var domTreeUndoManager: UndoManager? {
         treeView.undoManager
@@ -95,33 +93,41 @@ package final class DOMTreeViewController: UIViewController {
 
     private func startObservingDOMRoot(inspection: AttachedInspection) {
         domRootObservation?.cancel()
-        domRootObservation = withPortableContinuousObservation { [weak self, weak inspection] event in
+        domRootObservation = withPortableContinuousObservation { [weak self, weak inspection] _ in
             guard let self, let dom = inspection?.dom else {
                 return
             }
-            let treeRevision = dom.treeRevision
-            let commandAvailabilityRevision = dom.commandAvailabilityRevision
-            let shouldEnsureDocumentLoaded = event.kind == .initial
-                || lastObservedTreeRevision != treeRevision
-                || lastObservedCommandAvailabilityRevision != commandAvailabilityRevision
-            lastObservedTreeRevision = treeRevision
-            lastObservedCommandAvailabilityRevision = commandAvailabilityRevision
-            guard shouldEnsureDocumentLoaded else {
-                return
-            }
-            ensureDOMDocumentLoadedIfNeeded()
+            _ = dom.treeRevision
+            let hasRoot = dom.currentPageRootNode != nil
+            let canReloadDocument = dom.canReloadDocument
+            ensureDOMDocumentLoadedIfNeeded(
+                hasRoot: hasRoot,
+                canReloadDocument: canReloadDocument
+            )
         }
     }
 
     private func ensureDOMDocumentLoadedIfNeeded() {
+        guard let dom = inspection?.dom else {
+            return
+        }
+        ensureDOMDocumentLoadedIfNeeded(
+            hasRoot: dom.currentPageRootNode != nil,
+            canReloadDocument: dom.canReloadDocument
+        )
+    }
+
+    private func ensureDOMDocumentLoadedIfNeeded(
+        hasRoot: Bool,
+        canReloadDocument: Bool
+    ) {
         guard let inspection else {
             return
         }
-        let currentPageRootNode = inspection.dom.currentPageRootNode
         guard viewIfLoaded?.window != nil,
               !isEnsuringDOMDocumentLoaded,
-              currentPageRootNode == nil,
-              inspection.dom.canReloadDocument else {
+              !hasRoot,
+              canReloadDocument else {
             return
         }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -9,6 +9,8 @@ package final class DOMTreeViewController: UIViewController {
     private weak var inspection: AttachedInspection?
     private var domRootObservation: PortableObservationTracking.Token?
     private var isEnsuringDOMDocumentLoaded = false
+    private var lastObservedTreeRevision: UInt64?
+    private var lastObservedCommandAvailabilityRevision: UInt64?
 
     package var domTreeUndoManager: UndoManager? {
         treeView.undoManager
@@ -94,17 +96,20 @@ package final class DOMTreeViewController: UIViewController {
     private func startObservingDOMRoot(inspection: AttachedInspection) {
         domRootObservation?.cancel()
         domRootObservation = withPortableContinuousObservation { [weak self, weak inspection] event in
-            guard let dom = inspection?.dom else {
+            guard let self, let dom = inspection?.dom else {
                 return
             }
-            _ = dom.treeRevision
-            _ = dom.commandAvailabilityRevision
-            guard event.kind == .initial
-                    || event.matches(\DOMSession.treeRevision)
-                    || event.matches(\DOMSession.commandAvailabilityRevision) else {
+            let treeRevision = dom.treeRevision
+            let commandAvailabilityRevision = dom.commandAvailabilityRevision
+            let shouldEnsureDocumentLoaded = event.kind == .initial
+                || lastObservedTreeRevision != treeRevision
+                || lastObservedCommandAvailabilityRevision != commandAvailabilityRevision
+            lastObservedTreeRevision = treeRevision
+            lastObservedCommandAvailabilityRevision = commandAvailabilityRevision
+            guard shouldEnsureDocumentLoaded else {
                 return
             }
-            self?.ensureDOMDocumentLoadedIfNeeded()
+            ensureDOMDocumentLoadedIfNeeded()
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -98,7 +98,10 @@ package final class DOMTreeViewController: UIViewController {
                 return
             }
             _ = dom.treeRevision
-            guard event.kind == .initial || event.matches(\DOMSession.treeRevision) else {
+            _ = dom.commandAvailabilityRevision
+            guard event.kind == .initial
+                    || event.matches(\DOMSession.treeRevision)
+                    || event.matches(\DOMSession.commandAvailabilityRevision) else {
                 return
             }
             self?.ensureDOMDocumentLoadedIfNeeded()
@@ -112,7 +115,8 @@ package final class DOMTreeViewController: UIViewController {
         let currentPageRootNode = inspection.dom.currentPageRootNode
         guard viewIfLoaded?.window != nil,
               !isEnsuringDOMDocumentLoaded,
-              currentPageRootNode == nil else {
+              currentPageRootNode == nil,
+              inspection.dom.canReloadDocument else {
             return
         }
 
@@ -128,6 +132,10 @@ package final class DOMTreeViewController: UIViewController {
 
 #if DEBUG
 extension DOMTreeViewController {
+    var domRootObservationDeliveryForTesting: PortableObservationTracking.Token? {
+        domRootObservation
+    }
+
     var displayedDOMTreeTextViewForTesting: DOMTreeTextView {
         treeView
     }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ObservationBridge
 import Testing
 import WebInspectorTestSupport
 import WebInspectorTransport
@@ -4703,6 +4704,87 @@ func domActionAvailabilityWaitsForActiveAttachment() async throws {
     #expect(await session.hasActiveConnection)
     #expect(await session.attachment.dom.canReloadDocument)
     #expect(await session.attachment.dom.canSelectElement)
+}
+
+@MainActor
+@Test
+func domActionAvailabilityObservationFiresWhenBootstrapAttaches() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    await transport.receiveRootMessage(
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
+    )
+
+    let availabilityObservation = withPortableContinuousObservation { _ in
+        _ = session.attachment.dom.canBeginElementPicker
+    }
+    let rootObservation = withPortableContinuousObservation { _ in
+        _ = session.attachment.dom.treeRevision
+    }
+    defer {
+        availabilityObservation.cancel()
+        rootObservation.cancel()
+    }
+    let renderedAvailability = await availabilityObservation.values {
+        session.attachment.dom.canBeginElementPicker
+    }
+    let renderedRootState = await rootObservation.values {
+        session.attachment.dom.currentPageRootNode != nil
+    }
+    #expect(await renderedAvailability.waitUntilValue(false))
+    #expect(await renderedRootState.waitUntilValue(false))
+
+    let connectTask = Task {
+        try await session.connect(transport: transport)
+    }
+
+    var sentCount = 0
+    for method in ["Inspector.enable", "Inspector.initialized", "Runtime.enable"] {
+        let sent = try await waitForTargetMessage(backend, method: method, after: sentCount)
+        sentCount = await backend.sentTargetMessages().count
+        await receiveTargetReply(
+            transport,
+            targetID: sent.targetIdentifier,
+            messageID: try messageID(sent.message),
+            result: "{}"
+        )
+    }
+
+    let documentMessage = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: documentMessage.targetIdentifier,
+        messageID: try messageID(documentMessage.message),
+        result: mainDocumentResult
+    )
+
+    await session.attachment.dom.waitUntilDocumentRequestsIdle(targetID: documentMessage.targetIdentifier)
+    #expect(await renderedRootState.waitUntilValue(true))
+    #expect(session.hasActiveConnection == false)
+    #expect(session.attachment.dom.canBeginElementPicker == false)
+
+    let networkMessage = try await waitForTargetMessage(backend, method: "Network.enable", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: networkMessage.targetIdentifier,
+        messageID: try messageID(networkMessage.message),
+        result: "{}"
+    )
+
+    let consoleMessage = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    await receiveTargetReply(
+        transport,
+        targetID: consoleMessage.targetIdentifier,
+        messageID: try messageID(consoleMessage.message),
+        result: "{}"
+    )
+
+    try await connectTask.value
+    #expect(session.hasActiveConnection)
+    #expect(await renderedAvailability.waitUntilValue(true))
 }
 
 @MainActor

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4706,6 +4706,84 @@ func domActionAvailabilityWaitsForActiveAttachment() async throws {
     #expect(await session.attachment.dom.canSelectElement)
 }
 
+@Test
+@MainActor
+func selectedElementStyleHydrationWaitsForActiveAttachmentDuringBootstrap() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = InspectorSession(configuration: .test)
+    await transport.receiveRootMessage(
+        cssCapablePageTargetCreatedMessage(targetID: "page-main", frameID: "main-frame", isProvisional: false)
+    )
+
+    let connectTask = Task {
+        try await session.connect(transport: transport)
+    }
+
+    var sentCount = 0
+    for method in ["Inspector.enable", "Inspector.initialized", "Runtime.enable"] {
+        let sent = try await waitForTargetMessage(backend, method: method, after: sentCount)
+        sentCount = await backend.sentTargetMessages().count
+        await receiveTargetReply(
+            transport,
+            targetID: sent.targetIdentifier,
+            messageID: try messageID(sent.message),
+            result: "{}"
+        )
+    }
+
+    let documentMessage = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: documentMessage.targetIdentifier,
+        messageID: try messageID(documentMessage.message),
+        result: mainDocumentResult
+    )
+
+    await session.attachment.dom.waitUntilDocumentRequestsIdle(targetID: documentMessage.targetIdentifier)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    session.attachment.dom.selectNode(htmlID)
+
+    let networkMessage = try await waitForTargetMessage(backend, method: "Network.enable", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    #expect(session.hasActiveConnection == false)
+
+    session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
+    #expect(session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await backend.sentTargetMessages().count == sentCount)
+
+    await receiveTargetReply(
+        transport,
+        targetID: networkMessage.targetIdentifier,
+        messageID: try messageID(networkMessage.message),
+        result: "{}"
+    )
+
+    let consoleMessage = try await waitForTargetMessage(backend, method: "Console.enable", after: sentCount)
+    sentCount = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: consoleMessage.targetIdentifier,
+        messageID: try messageID(consoleMessage.message),
+        result: "{}"
+    )
+
+    try await connectTask.value
+    #expect(session.hasActiveConnection)
+
+    let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    try await replyCSSRefresh(
+        transport: transport,
+        messages: messages,
+        selector: "html",
+        styleSheetID: "sheet-html"
+    )
+
+    await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
+    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+}
+
 @MainActor
 @Test
 func domActionAvailabilityObservationFiresWhenBootstrapAttaches() async throws {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -815,6 +815,72 @@ func selectedElementStyleHydrationClearsAfterSelectedTargetDestroyed() async thr
 }
 
 @Test
+@MainActor
+func selectedElementStyleHydrationMarksStaleWhenTransportTargetDisappearsBeforeDOMEvent() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let css = CSSSession()
+    let dom = DOMSession(elementStyles: css)
+    var recordedError: InspectorSession.Error?
+    let channel = ProtocolCommandChannel(
+        transport: transport,
+        isCurrent: { true },
+        isAttached: { true },
+        appliedSequence: { 0 },
+        shouldEnableCompatibilityCSS: { _ in false },
+        markTargetDomainEnabled: { _, _ in }
+    )
+    dom.bindProtocolChannel(channel) { error in
+        recordedError = error
+    }
+
+    dom.applyTargetCreated(
+        .init(
+            id: .pageMain,
+            kind: .page,
+            frameID: .init("main-frame"),
+            capabilities: .pageDefault
+        ),
+        makeCurrentMainPage: true
+    )
+    _ = dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(1),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(
+                    nodeID: .init(2),
+                    nodeType: .element,
+                    nodeName: "HTML",
+                    localName: "html",
+                    regularChildren: .loaded([
+                        WebInspectorCore.DOMNode.Payload(
+                            nodeID: .init(4),
+                            nodeType: .element,
+                            nodeName: "BODY",
+                            localName: "body"
+                        ),
+                    ])
+                ),
+            ])
+        ),
+        targetID: .pageMain
+    )
+    let bodyID = try #require(dom.snapshot().currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(4))])
+    dom.selectNode(bodyID)
+
+    let sentCount = await backend.sentTargetMessages().count
+    dom.setSelectedNodeStyleHydrationActive(true)
+    await dom.waitUntilSelectedStyleRefreshIdle()
+
+    #expect(await backend.sentTargetMessages().count == sentCount)
+    #expect(css.selectedState == .unavailable(.staleNode(bodyID)))
+    #expect(css.selectedNodeStyles == nil)
+    #expect(recordedError == nil)
+}
+
+@Test
 func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -929,6 +929,10 @@ struct DOMContainerTests {
         let renderedDocumentState = await observation.values {
             dom.currentPageRootNode != nil
         }
+        let treeTextView = treeViewController.displayedDOMTreeTextViewForTesting
+        let renderedTreeText = await treeTextView.documentObservationDeliveryForTesting.values {
+            treeTextView.renderedTextForTesting
+        }
         #expect(await renderedDocumentState.waitUntilValue(false))
         #expect(await backend.sentTargetMessages().isEmpty)
 
@@ -945,6 +949,7 @@ struct DOMContainerTests {
         await dom.waitUntilDocumentRequestsIdle(targetID: documentRequest.targetIdentifier)
 
         #expect(await renderedDocumentState.waitUntilValue(true))
+        #expect(await renderedTreeText.waitUntil { $0.contains("<html") } != nil)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -950,6 +950,7 @@ struct DOMContainerTests {
 
         #expect(await renderedDocumentState.waitUntilValue(true))
         #expect(await renderedTreeText.waitUntil { $0.contains("<html") } != nil)
+        #expect(await backend.sentTargetMessages().count == 1)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -954,6 +954,15 @@ struct DOMContainerTests {
     }
 
     @Test
+    func testBackendTargetMessageWaiterTimesOutWhenMethodIsMissing() async throws {
+        let backend = RecordingTransportBackend()
+
+        await #expect(throws: TransportSession.Error.replyTimeout(method: "DOM.getDocument", targetID: nil)) {
+            try await waitForTargetMessage(backend, method: "DOM.getDocument", timeout: .milliseconds(20))
+        }
+    }
+
+    @Test
     func splitContainerInstallsTreeAndElementColumns() throws {
         let dom = makeDOMSession()
         let treeViewController = DOMTreeViewController(dom: dom)
@@ -1300,7 +1309,7 @@ struct DOMContainerTests {
             }
 
             group.addTask {
-                await backend.waitForTargetMessage(method: method)
+                try await backend.waitForTargetMessage(method: method)
             }
             group.addTask {
                 try await Task.sleep(for: timeout)
@@ -1346,12 +1355,15 @@ struct DOMContainerTests {
 
     private actor RecordingTransportBackend: TransportBackend {
         private struct TargetMessageWaiter {
+            var id: UInt64
             var method: String
-            var continuation: CheckedContinuation<RecordedTargetMessage, Never>
+            var continuation: CheckedContinuation<RecordedTargetMessage, Error>
         }
 
         private var messages: [String] = []
         private var waiters: [TargetMessageWaiter] = []
+        private var nextWaiterID: UInt64 = 0
+        private var cancelledWaiterIDs: Set<UInt64> = []
 
         func sendJSONString(_ message: String) async throws {
             messages.append(message)
@@ -1364,15 +1376,25 @@ struct DOMContainerTests {
             messages.compactMap(Self.targetMessage)
         }
 
-        func waitForTargetMessage(method: String) async -> RecordedTargetMessage {
+        func waitForTargetMessage(method: String) async throws -> RecordedTargetMessage {
+            try Task.checkCancellation()
             if let message = sentTargetMessages().first(where: { messageMethod($0.message) == method }) {
                 return message
             }
 
-            return await withCheckedContinuation { continuation in
-                waiters.append(TargetMessageWaiter(method: method, continuation: continuation))
-                resumeWaiters()
+            nextWaiterID &+= 1
+            let waiterID = nextWaiterID
+            let message = try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    registerWaiter(id: waiterID, method: method, continuation: continuation)
+                }
+            } onCancel: {
+                Task {
+                    await self.cancelWaiter(waiterID)
+                }
             }
+            try Task.checkCancellation()
+            return message
         }
 
         private func resumeWaiters() {
@@ -1382,13 +1404,41 @@ struct DOMContainerTests {
 
             var remainingWaiters: [TargetMessageWaiter] = []
             for waiter in waiters {
-                if let message = sentTargetMessages().first(where: { messageMethod($0.message) == waiter.method }) {
+                if cancelledWaiterIDs.remove(waiter.id) != nil {
+                    waiter.continuation.resume(throwing: CancellationError())
+                } else if let message = sentTargetMessages().first(where: { messageMethod($0.message) == waiter.method }) {
                     waiter.continuation.resume(returning: message)
                 } else {
                     remainingWaiters.append(waiter)
                 }
             }
             waiters = remainingWaiters
+        }
+
+        private func registerWaiter(
+            id: UInt64,
+            method: String,
+            continuation: CheckedContinuation<RecordedTargetMessage, Error>
+        ) {
+            guard cancelledWaiterIDs.remove(id) == nil else {
+                continuation.resume(throwing: CancellationError())
+                return
+            }
+            if let message = sentTargetMessages().first(where: { messageMethod($0.message) == method }) {
+                continuation.resume(returning: message)
+                return
+            }
+            waiters.append(TargetMessageWaiter(id: id, method: method, continuation: continuation))
+            resumeWaiters()
+        }
+
+        private func cancelWaiter(_ id: UInt64) {
+            guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+                cancelledWaiterIDs.insert(id)
+                return
+            }
+            let waiter = waiters.remove(at: index)
+            waiter.continuation.resume(throwing: CancellationError())
         }
 
         private static func targetMessage(_ message: String) -> RecordedTargetMessage? {

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -847,6 +847,107 @@ struct DOMContainerTests {
     }
 
     @Test
+    func compactNavigationPickButtonEnablesWhenDOMCommandsBecomeActive() async throws {
+        let targetID = ProtocolTarget.ID("page-main")
+        let backend = RecordingTransportBackend()
+        let transport = TransportSession(backend: backend, responseTimeout: nil)
+        await transport.receiveRootMessage(pageTargetCreatedMessage(targetID: targetID))
+
+        let attachmentGate = CommandAttachmentGate()
+        let dom = makeDOMSessionWithoutDocument(targetID: targetID)
+        dom.bindProtocolChannel(
+            ProtocolCommandChannel(
+                transport: transport,
+                isCurrent: { true },
+                isAttached: { attachmentGate.isAttached },
+                appliedSequence: { 0 },
+                shouldEnableCompatibilityCSS: { _ in false },
+                markTargetDomainEnabled: { _, _ in }
+            ),
+            recordError: { _ in }
+        )
+        defer {
+            dom.unbindProtocolChannel()
+        }
+
+        let session = AttachedInspection(dom: dom)
+        let inspector = InspectorSession(attachment: session)
+        let treeViewController = DOMTreeViewController(inspection: session)
+        let navigationController = DOMCompactNavigationController(
+            rootViewController: treeViewController,
+            inspector: inspector
+        )
+        let navigationItems = try #require(navigationController.domNavigationItemsForTesting)
+        let observation = try #require(navigationItems.observationDeliveryForTesting)
+        let pickItem = navigationItems.pickItemForTesting
+        let pickItemIdentity = ObjectIdentifier(pickItem)
+
+        let renderedEnabledState = await observation.values {
+            pickItem.isEnabled
+        }
+        #expect(await renderedEnabledState.waitUntilValue(false))
+
+        attachmentGate.isAttached = true
+        dom.recordCommandAvailabilityMutation()
+
+        #expect(await renderedEnabledState.waitUntilValue(true))
+        #expect(ObjectIdentifier(navigationItems.pickItemForTesting) == pickItemIdentity)
+    }
+
+    @Test
+    func treeControllerRetriesDocumentLoadWhenDOMCommandsBecomeActive() async throws {
+        let targetID = ProtocolTarget.ID("page-main")
+        let backend = RecordingTransportBackend()
+        let transport = TransportSession(backend: backend, responseTimeout: nil)
+        await transport.receiveRootMessage(pageTargetCreatedMessage(targetID: targetID))
+
+        let attachmentGate = CommandAttachmentGate()
+        let dom = makeDOMSessionWithoutDocument(targetID: targetID)
+        dom.bindProtocolChannel(
+            ProtocolCommandChannel(
+                transport: transport,
+                isCurrent: { true },
+                isAttached: { attachmentGate.isAttached },
+                appliedSequence: { 0 },
+                shouldEnableCompatibilityCSS: { _ in false },
+                markTargetDomainEnabled: { _, _ in }
+            ),
+            recordError: { _ in }
+        )
+        defer {
+            dom.unbindProtocolChannel()
+        }
+
+        let session = AttachedInspection(dom: dom)
+        let treeViewController = DOMTreeViewController(inspection: session)
+        let window = showInWindow(treeViewController)
+        defer {
+            window.isHidden = true
+        }
+
+        let observation = try #require(treeViewController.domRootObservationDeliveryForTesting)
+        let renderedDocumentState = await observation.values {
+            dom.currentPageRootNode != nil
+        }
+        #expect(await renderedDocumentState.waitUntilValue(false))
+        #expect(await backend.sentTargetMessages().isEmpty)
+
+        attachmentGate.isAttached = true
+        dom.recordCommandAvailabilityMutation()
+
+        let documentRequest = try await waitForTargetMessage(backend, method: "DOM.getDocument")
+        await receiveTargetReply(
+            transport,
+            targetID: documentRequest.targetIdentifier,
+            messageID: try messageID(documentRequest.message),
+            result: loadedDocumentResult
+        )
+        await dom.waitUntilDocumentRequestsIdle(targetID: documentRequest.targetIdentifier)
+
+        #expect(await renderedDocumentState.waitUntilValue(true))
+    }
+
+    @Test
     func splitContainerInstallsTreeAndElementColumns() throws {
         let dom = makeDOMSession()
         let treeViewController = DOMTreeViewController(dom: dom)
@@ -912,6 +1013,23 @@ struct DOMContainerTests {
             makeCurrentMainPage: true
         )
         _ = session.replaceDocumentRoot(documentNode(), targetID: targetID)
+        return session
+    }
+
+    private func makeDOMSessionWithoutDocument(
+        targetID: ProtocolTarget.ID,
+        capabilities: ProtocolTarget.Capabilities = .pageDefault
+    ) -> DOMSession {
+        let session = DOMSession()
+        session.applyTargetCreated(
+            ProtocolTarget.Record(
+                id: targetID,
+                kind: .page,
+                frameID: DOMFrame.ID("main-frame"),
+                capabilities: capabilities
+            ),
+            makeCurrentMainPage: true
+        )
         return session
     }
 
@@ -1132,6 +1250,162 @@ struct DOMContainerTests {
                 ),
             ])
         )
+    }
+
+    private var loadedDocumentResult: String {
+        ##"{"root":{"nodeId":1,"nodeType":9,"nodeName":"#document","children":[{"nodeId":2,"nodeType":1,"nodeName":"HTML","localName":"html","children":[{"nodeId":3,"nodeType":1,"nodeName":"BODY","localName":"body"}]}]}}"##
+    }
+
+    private func pageTargetCreatedMessage(targetID: ProtocolTarget.ID) -> String {
+        #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"\#(targetID.rawValue)","type":"page","frameId":"main-frame","domains":["DOM","Runtime","Target","Inspector","Network","CSS"],"isProvisional":false}}}"#
+    }
+
+    private func receiveTargetReply(
+        _ transport: TransportSession,
+        targetID: ProtocolTarget.ID,
+        messageID: UInt64,
+        result: String
+    ) async {
+        await transport.receiveRootMessage(
+            targetDispatchMessage(
+                targetID: targetID,
+                message: #"{"id":\#(messageID),"result":\#(result)}"#
+            )
+        )
+    }
+
+    private func targetDispatchMessage(
+        targetID: ProtocolTarget.ID,
+        message: String
+    ) -> String {
+        let escapedTargetID = jsonEscapedString(targetID.rawValue)
+        let escapedMessage = jsonEscapedString(message)
+        return #"{"method":"Target.dispatchMessageFromTarget","params":{"targetId":"\#(escapedTargetID)","message":"\#(escapedMessage)"}}"#
+    }
+
+    private func waitForTargetMessage(
+        _ backend: RecordingTransportBackend,
+        method: String,
+        timeout: Duration = .seconds(5)
+    ) async throws -> RecordedTargetMessage {
+        try await withThrowingTaskGroup(of: RecordedTargetMessage.self) { group in
+            defer {
+                group.cancelAll()
+            }
+
+            group.addTask {
+                await backend.waitForTargetMessage(method: method)
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw TransportSession.Error.replyTimeout(method: method, targetID: nil)
+            }
+
+            guard let message = try await group.next() else {
+                throw TransportSession.Error.replyTimeout(method: method, targetID: nil)
+            }
+            return message
+        }
+    }
+
+    private func messageID(_ message: String) throws -> UInt64 {
+        let data = try #require(message.data(using: .utf8))
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        if let number = object["id"] as? NSNumber {
+            return number.uint64Value
+        }
+        if let string = object["id"] as? String,
+           let id = UInt64(string) {
+            return id
+        }
+        throw TransportSession.Error.malformedMessage
+    }
+
+    private func jsonEscapedString(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: #"\"#, with: #"\\"#)
+            .replacingOccurrences(of: #"""#, with: #"\""#)
+            .replacingOccurrences(of: "\n", with: #"\n"#)
+            .replacingOccurrences(of: "\r", with: #"\r"#)
+    }
+
+    private struct RecordedTargetMessage: Sendable {
+        var message: String
+        var targetIdentifier: ProtocolTarget.ID
+    }
+
+    private final class CommandAttachmentGate {
+        var isAttached = false
+    }
+
+    private actor RecordingTransportBackend: TransportBackend {
+        private struct TargetMessageWaiter {
+            var method: String
+            var continuation: CheckedContinuation<RecordedTargetMessage, Never>
+        }
+
+        private var messages: [String] = []
+        private var waiters: [TargetMessageWaiter] = []
+
+        func sendJSONString(_ message: String) async throws {
+            messages.append(message)
+            resumeWaiters()
+        }
+
+        func detach() async {}
+
+        func sentTargetMessages() -> [RecordedTargetMessage] {
+            messages.compactMap(Self.targetMessage)
+        }
+
+        func waitForTargetMessage(method: String) async -> RecordedTargetMessage {
+            if let message = sentTargetMessages().first(where: { messageMethod($0.message) == method }) {
+                return message
+            }
+
+            return await withCheckedContinuation { continuation in
+                waiters.append(TargetMessageWaiter(method: method, continuation: continuation))
+                resumeWaiters()
+            }
+        }
+
+        private func resumeWaiters() {
+            guard !waiters.isEmpty else {
+                return
+            }
+
+            var remainingWaiters: [TargetMessageWaiter] = []
+            for waiter in waiters {
+                if let message = sentTargetMessages().first(where: { messageMethod($0.message) == waiter.method }) {
+                    waiter.continuation.resume(returning: message)
+                } else {
+                    remainingWaiters.append(waiter)
+                }
+            }
+            waiters = remainingWaiters
+        }
+
+        private static func targetMessage(_ message: String) -> RecordedTargetMessage? {
+            guard let data = message.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let params = object["params"] as? [String: Any],
+                  let targetID = params["targetId"] as? String,
+                  let innerMessage = params["message"] as? String else {
+                return nil
+            }
+            return RecordedTargetMessage(
+                message: innerMessage,
+                targetIdentifier: ProtocolTarget.ID(targetID)
+            )
+        }
+
+        private func messageMethod(_ message: String) -> String? {
+            guard let data = message.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return object["method"] as? String
+        }
     }
 
     private func showInWindow(_ viewController: UIViewController) -> UIWindow {


### PR DESCRIPTION
## Purpose
Fix the initial inspector sheet race where the DOM tree could remain blank and DOM command UI could stay disabled when the command channel became active after the UI had already started observing.

## Changes
- Add a DOM command availability revision and invalidate it across attach activation, detach, and protocol channel binding changes.
- Rework DOM tree loading so the controller evaluates current semantic state instead of using event matching as a correctness gate.
- Preserve installed DOM navigation items while updating picker availability, and keep DOM tree redraw routing scoped to the native text view render revision.
- Keep selected style hydration idle until attachment commands are active, validate the live transport target before token-backed style refreshes, then reconcile pending hydration on activation.
- Scope selected style hydration cancellation by refresh token and keep stale target refreshes in `.unavailable(.staleNode)` instead of publishing `.failed`.
- Make DOM UI test backend waiters cancellation-aware so missing target messages fail on the helper timeout instead of hanging.
- Add regressions for picker availability, document reload retry, rendered tree text, duplicate `DOM.getDocument` prevention, bootstrap-time style hydration, stale target style hydration, and backend waiter timeout handling.

## Testing
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests/InspectorSessionTests/selectedElementStyleHydrationMarksStaleWhenTransportTargetDisappearsBeforeDOMEvent`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMContainerTests`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests -only-testing:WebInspectorUITests/DOMContainerTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- Monocly simulator first sheet presentation: DOM tree rendered `<!DOCTYPE html>` / `<html...>`.
- Codex review against pinned PR base `refs/pr-fix/base/156/909149c37b4aabdea919948f982974fc2a4d08cd`: clean.
