### PR TITLE
Refactor inspector API naming toward SwiftUI conventions

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSModel.swift
+++ b/Sources/WebInspectorCore/CSS/CSSModel.swift
@@ -293,7 +293,7 @@ package final class CSSRule: Equatable {
 }
 
 @Observable
-package final class CSSComputedStyleProperty: Equatable {
+package final class CSSComputedStyleProperty: Equatable, Identifiable {
     /// Computed-style rows are keyed by CSS property name in the computed list.
     package var id: String {
         name
@@ -319,7 +319,7 @@ package final class CSSComputedStyleProperty: Equatable {
 
 package extension CSSStyle {
     @Observable
-    final class Section: Equatable {
+    final class Section: Equatable, Identifiable {
         package var id: CSSStyle.Section.ID
         package var kind: CSSStyle.Section.Kind
         package var title: String
@@ -351,7 +351,7 @@ package extension CSSStyle {
 
 @MainActor
 @Observable
-package final class CSSNodeStyles {
+package final class CSSNodeStyles: Identifiable {
     private enum RefreshPhase: Equatable {
         case idle
         case refreshing(sequence: UInt64)
@@ -370,20 +370,20 @@ package final class CSSNodeStyles {
         }
     }
 
-    package let identity: CSSNodeStyles.Identity
-    package var state: CSSNodeStyles.State
+    package let id: CSSNodeStyles.ID
+    package var phase: CSSNodeStyles.Phase
     package var sections: [CSSStyle.Section]
     package var computedProperties: [CSSComputedStyleProperty]
     @ObservationIgnored private var refreshPhase: RefreshPhase
 
     package init(
-        identity: CSSNodeStyles.Identity,
-        state: CSSNodeStyles.State = .loading,
+        id: CSSNodeStyles.ID,
+        phase: CSSNodeStyles.Phase = .loading,
         sections: [CSSStyle.Section] = [],
         computedProperties: [CSSComputedStyleProperty] = []
     ) {
-        self.identity = identity
-        self.state = state
+        self.id = id
+        self.phase = phase
         self.sections = sections
         self.computedProperties = computedProperties
         refreshPhase = .idle
@@ -394,12 +394,12 @@ package final class CSSNodeStyles {
     }
 
     fileprivate func beginRefresh(sequence: UInt64) {
-        state = .loading
+        phase = .loading
         refreshPhase = .refreshing(sequence: sequence)
     }
 
     fileprivate func isActiveRefresh(_ token: CSSStyle.RefreshToken) -> Bool {
-        identity == token.identity && refreshPhase.sequence == token.sequence
+        id == token.id && refreshPhase.sequence == token.sequence
     }
 
     fileprivate func clearRefresh(_ token: CSSStyle.RefreshToken) {
@@ -416,11 +416,11 @@ package final class CSSNodeStyles {
     fileprivate func cancelRefresh(sequence: UInt64?) -> Bool {
         guard let activeSequence = refreshPhase.sequence,
               sequence.map({ $0 == activeSequence }) ?? true,
-              state == .loading else {
+              phase == .loading else {
             return false
         }
         refreshPhase = .idle
-        state = .needsRefresh
+        phase = .needsRefresh
         return true
     }
 }
@@ -432,35 +432,35 @@ private struct CSSStyleSheetHeaderKey: Equatable, Hashable {
 
 @MainActor
 private struct CSSSelectedStyleCoordinator {
-    private(set) var identity: CSSNodeStyles.Identity?
+    private(set) var id: CSSNodeStyles.ID?
     private var unavailableReason: CSSNodeStyles.UnavailableReason
 
     init() {
-        identity = nil
+        id = nil
         unavailableReason = .noSelection
     }
 
-    func state(displayedNodeStyles: CSSNodeStyles?) -> CSSNodeStyles.State {
-        displayedNodeStyles?.state ?? .unavailable(unavailableReason)
+    func phase(displayedNodeStyles: CSSNodeStyles?) -> CSSNodeStyles.Phase {
+        displayedNodeStyles?.phase ?? .unavailable(unavailableReason)
     }
 
-    mutating func select(_ identity: CSSNodeStyles.Identity) {
-        self.identity = identity
+    mutating func select(_ id: CSSNodeStyles.ID) {
+        self.id = id
         unavailableReason = .noSelection
     }
 
     mutating func markUnavailable(_ reason: CSSNodeStyles.UnavailableReason) {
-        identity = nil
+        id = nil
         unavailableReason = reason
     }
 
     mutating func markSelectedStylesUnavailable(
-        identity: CSSNodeStyles.Identity,
+        id: CSSNodeStyles.ID,
         displayedNodeStyles: CSSNodeStyles?,
         unavailableNodeStyles: CSSNodeStyles,
         reason: CSSNodeStyles.UnavailableReason
     ) -> Bool {
-        if self.identity == identity {
+        if self.id == id {
             unavailableReason = reason
             return true
         }
@@ -472,10 +472,10 @@ private struct CSSSelectedStyleCoordinator {
     }
 
     mutating func markRefreshFailed(_ token: CSSStyle.RefreshToken) -> Bool {
-        guard identity == token.identity else {
+        guard id == token.id else {
             return false
         }
-        unavailableReason = .staleNode(token.identity.nodeID)
+        unavailableReason = .staleNode(token.id.nodeID)
         return true
     }
 
@@ -485,12 +485,12 @@ private struct CSSSelectedStyleCoordinator {
     ) -> Bool {
         var didClearDisplayedNodeStyles = false
         if let displayedNodeStyles,
-           displayedNodeStyles.identity.targetID == targetID {
-            unavailableReason = .staleNode(displayedNodeStyles.identity.nodeID)
+           displayedNodeStyles.id.targetID == targetID {
+            unavailableReason = .staleNode(displayedNodeStyles.id.nodeID)
             didClearDisplayedNodeStyles = true
         }
-        if identity?.targetID == targetID {
-            identity = nil
+        if id?.targetID == targetID {
+            id = nil
         }
         return didClearDisplayedNodeStyles
     }
@@ -504,33 +504,33 @@ private struct CSSNodeStyleStore {
         stylesByNodeID.removeAll()
     }
 
-    func nodeStyles(for identity: CSSNodeStyles.Identity) -> CSSNodeStyles? {
-        guard let nodeStyles = stylesByNodeID[identity.nodeID],
-              nodeStyles.identity == identity else {
+    func nodeStyles(for id: CSSNodeStyles.ID) -> CSSNodeStyles? {
+        guard let nodeStyles = stylesByNodeID[id.nodeID],
+              nodeStyles.id == id else {
             return nil
         }
         return nodeStyles
     }
 
     mutating func ensureNodeStyles(
-        for identity: CSSNodeStyles.Identity,
-        initialState: CSSNodeStyles.State = .loading
+        for id: CSSNodeStyles.ID,
+        initialPhase: CSSNodeStyles.Phase = .loading
     ) -> CSSNodeStyles {
-        if let nodeStyles = nodeStyles(for: identity) {
+        if let nodeStyles = nodeStyles(for: id) {
             return nodeStyles
         }
-        let nodeStyles = CSSNodeStyles(identity: identity, state: initialState)
-        stylesByNodeID[identity.nodeID] = nodeStyles
+        let nodeStyles = CSSNodeStyles(id: id, phase: initialPhase)
+        stylesByNodeID[id.nodeID] = nodeStyles
         return nodeStyles
     }
 
     func nodeStyles(targetID: ProtocolTarget.ID) -> [CSSNodeStyles] {
-        stylesByNodeID.values.filter { $0.identity.targetID == targetID }
+        stylesByNodeID.values.filter { $0.id.targetID == targetID }
     }
 
     func nodeStyles(targetID: ProtocolTarget.ID, protocolNodeID: DOMNode.ProtocolID) -> CSSNodeStyles? {
         stylesByNodeID.values.first {
-            $0.identity.targetID == targetID && $0.identity.protocolNodeID == protocolNodeID
+            $0.id.targetID == targetID && $0.id.protocolNodeID == protocolNodeID
         }
     }
 
@@ -539,18 +539,18 @@ private struct CSSNodeStyleStore {
         including shouldMark: (CSSNodeStyles) -> Bool
     ) {
         for nodeStyles in stylesByNodeID.values
-        where nodeStyles.identity.targetID == targetID && shouldMark(nodeStyles) {
-            guard !(nodeStyles.state == .loading && nodeStyles.isRefreshing) else {
+        where nodeStyles.id.targetID == targetID && shouldMark(nodeStyles) {
+            guard !(nodeStyles.phase == .loading && nodeStyles.isRefreshing) else {
                 continue
             }
-            nodeStyles.state = .needsRefresh
+            nodeStyles.phase = .needsRefresh
             nodeStyles.clearRefresh()
         }
     }
 
     mutating func removeStyles(targetID: ProtocolTarget.ID) -> Bool {
         let removedIDs = stylesByNodeID
-            .filter { $0.value.identity.targetID == targetID }
+            .filter { $0.value.id.targetID == targetID }
             .map(\.key)
         guard !removedIDs.isEmpty else {
             return false
@@ -613,12 +613,12 @@ package final class CSSSession {
     }
 
     package private(set) var selectedNodeStyles: CSSNodeStyles?
-    package var selectedState: CSSNodeStyles.State {
-        selection.state(displayedNodeStyles: selectedNodeStyles)
+    package var selectedPhase: CSSNodeStyles.Phase {
+        selection.phase(displayedNodeStyles: selectedNodeStyles)
     }
 
-    package func nodeStyles(for identity: CSSNodeStyles.Identity) -> CSSNodeStyles? {
-        nodeStyleStore.nodeStyles(for: identity)
+    package func nodeStyles(for id: CSSNodeStyles.ID) -> CSSNodeStyles? {
+        nodeStyleStore.nodeStyles(for: id)
     }
 
     private var selection: CSSSelectedStyleCoordinator
@@ -657,37 +657,37 @@ package final class CSSSession {
         try await refreshCoordinator.perform(intent)
     }
 
-    package func fetchRefreshResults(for identity: CSSNodeStyles.Identity) async throws -> RefreshResults {
-        try await refreshCoordinator.fetchRefreshResults(for: identity)
+    package func fetchRefreshResults(for id: CSSNodeStyles.ID) async throws -> RefreshResults {
+        try await refreshCoordinator.fetchRefreshResults(for: id)
     }
 
     package func setStyleTextResult(from result: ProtocolCommand.Result) throws -> CSSStyle.Payload {
         try refreshCoordinator.setStyleTextResult(from: result)
     }
 
-    package func selectNodeStyles(identity: CSSNodeStyles.Identity) {
-        selection.select(identity)
-        let nodeStyles = ensureNodeStyles(for: identity, initialState: .needsRefresh)
+    package func selectNodeStyles(id: CSSNodeStyles.ID) {
+        selection.select(id)
+        let nodeStyles = ensureNodeStyles(for: id, initialPhase: .needsRefresh)
         selectCurrentNodeStyles(nodeStyles)
     }
 
     package func markSelectedNodeUnavailable(_ reason: CSSNodeStyles.UnavailableReason) {
         selection.markUnavailable(reason)
-        guard selectedNodeStyles != nil || selectedState != .unavailable(reason) else {
+        guard selectedNodeStyles != nil || selectedPhase != .unavailable(reason) else {
             return
         }
         selectedNodeStyles = nil
     }
 
     package func markSelectedNodeStylesUnavailable(
-        identity: CSSNodeStyles.Identity,
+        id: CSSNodeStyles.ID,
         reason: CSSNodeStyles.UnavailableReason
     ) {
-        let nodeStyles = ensureNodeStyles(for: identity)
-        nodeStyles.state = .unavailable(reason)
+        let nodeStyles = ensureNodeStyles(for: id)
+        nodeStyles.phase = .unavailable(reason)
         nodeStyles.clearRefresh()
         guard selection.markSelectedStylesUnavailable(
-            identity: identity,
+            id: id,
             displayedNodeStyles: selectedNodeStyles,
             unavailableNodeStyles: nodeStyles,
             reason: reason
@@ -697,22 +697,17 @@ package final class CSSSession {
         selectedNodeStyles = nil
     }
 
-    package func refreshState(forSelected identity: CSSNodeStyles.Identity) -> CSSNodeStyles.State? {
-        nodeStyles(for: identity)?.state
+    package func refreshPhase(forSelected id: CSSNodeStyles.ID) -> CSSNodeStyles.Phase? {
+        nodeStyles(for: id)?.phase
     }
 
-    package func beginRefresh(identity: CSSNodeStyles.Identity) -> CSSStyle.RefreshToken? {
-        guard identity.targetCapabilities.contains(.css) else {
-            markSelectedNodeUnavailable(.cssUnavailableForTarget(identity.targetID))
-            return nil
-        }
-
+    package func beginRefresh(id: CSSNodeStyles.ID) -> CSSStyle.RefreshToken {
         nextRefreshSequence &+= 1
-        let nodeStyles = ensureNodeStyles(for: identity)
+        let nodeStyles = ensureNodeStyles(for: id)
         nodeStyles.beginRefresh(sequence: nextRefreshSequence)
-        selection.select(identity)
+        selection.select(id)
         selectCurrentNodeStyles(nodeStyles)
-        return CSSStyle.RefreshToken(identity: identity, sequence: nextRefreshSequence)
+        return CSSStyle.RefreshToken(id: id, sequence: nextRefreshSequence)
     }
 
     package func applyRefresh(
@@ -721,7 +716,7 @@ package final class CSSSession {
         inline: CSSStyle.InlineStylesPayload,
         computed: [CSSComputedStyleProperty.Payload]
     ) {
-        guard let nodeStyles = nodeStyleStore.nodeStyles(for: token.identity),
+        guard let nodeStyles = nodeStyleStore.nodeStyles(for: token.id),
               nodeStyles.isActiveRefresh(token) else {
             return
         }
@@ -729,7 +724,7 @@ package final class CSSSession {
         CSSStyle.Reconciler.updateSections(
             in: nodeStyles,
             with: CSSStyle.SectionBuilder.makeSections(
-                identity: token.identity,
+                id: token.id,
                 matched: matched,
                 inline: inline,
                 styleSheetHeaders: styleSheetHeaders
@@ -739,9 +734,9 @@ package final class CSSSession {
             in: nodeStyles,
             with: computed.map(CSSComputedStyleProperty.init(payload:))
         )
-        nodeStyles.state = .loaded
+        nodeStyles.phase = .loaded
         nodeStyles.clearRefresh(token)
-        if selection.identity == token.identity {
+        if selection.id == token.id {
             selectCurrentNodeStyles(nodeStyles)
         }
     }
@@ -755,31 +750,31 @@ package final class CSSSession {
     }
 
     package func markRefreshFailed(_ token: CSSStyle.RefreshToken, message: String) {
-        guard let nodeStyles = nodeStyleStore.nodeStyles(for: token.identity),
+        guard let nodeStyles = nodeStyleStore.nodeStyles(for: token.id),
               nodeStyles.isActiveRefresh(token) else {
             return
         }
-        nodeStyles.state = .failed(message)
+        nodeStyles.phase = .failed(message)
         nodeStyles.clearRefresh(token)
         if selection.markRefreshFailed(token) {
             selectedNodeStyles = nil
         }
     }
 
-    package func cancelRefresh(identity: CSSNodeStyles.Identity) {
-        cancelRefresh(identity: identity, sequence: nil)
+    package func cancelRefresh(id: CSSNodeStyles.ID) {
+        cancelRefresh(id: id, sequence: nil)
     }
 
     package func cancelRefresh(_ token: CSSStyle.RefreshToken) {
-        cancelRefresh(identity: token.identity, sequence: token.sequence)
+        cancelRefresh(id: token.id, sequence: token.sequence)
     }
 
-    private func cancelRefresh(identity: CSSNodeStyles.Identity, sequence: UInt64?) {
-        guard let nodeStyles = nodeStyles(for: identity),
+    private func cancelRefresh(id: CSSNodeStyles.ID, sequence: UInt64?) {
+        guard let nodeStyles = nodeStyles(for: id),
               nodeStyles.cancelRefresh(sequence: sequence) else {
             return
         }
-        if selection.identity == identity {
+        if selection.id == id {
             selectCurrentNodeStyles(nodeStyles)
         }
     }
@@ -818,10 +813,10 @@ package final class CSSSession {
         guard let current = nodeStyleStore.nodeStyles(targetID: targetID, protocolNodeID: nodeID) else {
             return
         }
-        guard !(current.state == .loading && current.isRefreshing) else {
+        guard !(current.phase == .loading && current.isRefreshing) else {
             return
         }
-        current.state = .needsRefresh
+        current.phase = .needsRefresh
         current.clearRefresh()
     }
 
@@ -837,9 +832,9 @@ package final class CSSSession {
 
     package func setStyleTextIntent(for propertyID: CSSProperty.ID, enabled: Bool) -> CSSCommand.Intent? {
         guard let nodeStyles = selectedNodeStyles,
-              selection.identity == nodeStyles.identity,
-              case .loaded = selectedState,
-              case .loaded = nodeStyles.state,
+              selection.id == nodeStyles.id,
+              case .loaded = selectedPhase,
+              case .loaded = nodeStyles.phase,
               let (sectionIndex, propertyIndex) = Self.locateProperty(propertyID, in: nodeStyles.sections),
               nodeStyles.sections[sectionIndex].isEditable else {
             return nil
@@ -857,18 +852,18 @@ package final class CSSSession {
               let text = CSSStyle.TextRewriter.rewrittenStyleText(style: style, propertyIndex: propertyIndex, enabled: enabled) else {
             return nil
         }
-        return .setStyleText(targetID: nodeStyles.identity.targetID, styleID: propertyID.styleID, text: text)
+        return .setStyleText(targetID: nodeStyles.id.targetID, styleID: propertyID.styleID, text: text)
     }
 
     private func selectCurrentNodeStyles(_ nodeStyles: CSSNodeStyles) {
-        switch nodeStyles.state {
+        switch nodeStyles.phase {
         case .unavailable, .failed:
             guard selectedNodeStyles != nil else {
                 return
             }
             selectedNodeStyles = nil
         case .loading, .loaded, .needsRefresh:
-            selection.select(nodeStyles.identity)
+            selection.select(nodeStyles.id)
             guard selectedNodeStyles !== nodeStyles else {
                 return
             }
@@ -877,10 +872,10 @@ package final class CSSSession {
     }
 
     private func ensureNodeStyles(
-        for identity: CSSNodeStyles.Identity,
-        initialState: CSSNodeStyles.State = .loading
+        for id: CSSNodeStyles.ID,
+        initialPhase: CSSNodeStyles.Phase = .loading
     ) -> CSSNodeStyles {
-        nodeStyleStore.ensureNodeStyles(for: identity, initialState: initialState)
+        nodeStyleStore.ensureNodeStyles(for: id, initialPhase: initialPhase)
     }
 
     package func applySetStyleTextResult(
@@ -908,7 +903,7 @@ package final class CSSSession {
                 if let rule = section.rule {
                     rule.style = section.style
                 }
-                nodeStyles.state = .needsRefresh
+                nodeStyles.phase = .needsRefresh
             }
         }
     }

--- a/Sources/WebInspectorCore/CSS/CSSProtocol.swift
+++ b/Sources/WebInspectorCore/CSS/CSSProtocol.swift
@@ -297,11 +297,11 @@ package extension CSSStyle {
     }
 
     struct RefreshToken: Equatable, Sendable {
-        package var identity: CSSNodeStyles.Identity
+        package var id: CSSNodeStyles.ID
         package var sequence: UInt64
 
-        package init(identity: CSSNodeStyles.Identity, sequence: UInt64) {
-            self.identity = identity
+        package init(id: CSSNodeStyles.ID, sequence: UInt64) {
+            self.id = id
             self.sequence = sequence
         }
     }
@@ -639,25 +639,22 @@ package extension CSSComputedStyleProperty {
 }
 
 package extension CSSNodeStyles {
-    struct Identity: Equatable, Hashable, Sendable {
+    struct ID: Equatable, Hashable, Sendable {
         package var nodeID: DOMNode.ID
         package var targetID: ProtocolTarget.ID
         package var documentID: DOMDocument.ID
         package var protocolNodeID: DOMNode.ProtocolID
-        package var targetCapabilities: ProtocolTarget.Capabilities
 
         package init(
             nodeID: DOMNode.ID,
             targetID: ProtocolTarget.ID,
             documentID: DOMDocument.ID,
-            protocolNodeID: DOMNode.ProtocolID,
-            targetCapabilities: ProtocolTarget.Capabilities
+            protocolNodeID: DOMNode.ProtocolID
         ) {
             self.nodeID = nodeID
             self.targetID = targetID
             self.documentID = documentID
             self.protocolNodeID = protocolNodeID
-            self.targetCapabilities = targetCapabilities
         }
     }
 
@@ -668,7 +665,7 @@ package extension CSSNodeStyles {
         case cssUnavailableForTarget(ProtocolTarget.ID)
     }
 
-    enum State: Equatable, Sendable {
+    enum Phase: Equatable, Sendable {
         case loading
         case loaded
         case unavailable(UnavailableReason)
@@ -703,9 +700,9 @@ package extension CSSStyle.Section {
 package extension CSSCommand {
     enum Intent: Equatable, Sendable {
         case enable(targetID: ProtocolTarget.ID)
-        case getMatchedStyles(identity: CSSNodeStyles.Identity, includePseudo: Bool = true, includeInherited: Bool = true)
-        case getInlineStyles(identity: CSSNodeStyles.Identity)
-        case getComputedStyle(identity: CSSNodeStyles.Identity)
+        case getMatchedStyles(id: CSSNodeStyles.ID, includePseudo: Bool = true, includeInherited: Bool = true)
+        case getInlineStyles(id: CSSNodeStyles.ID)
+        case getComputedStyle(id: CSSNodeStyles.ID)
         case setStyleText(targetID: ProtocolTarget.ID, styleID: CSSStyle.ID, text: String)
     }
 }

--- a/Sources/WebInspectorCore/CSS/CSSProtocolDispatching.swift
+++ b/Sources/WebInspectorCore/CSS/CSSProtocolDispatching.swift
@@ -10,30 +10,30 @@ package struct CSSProtocolCommands {
                 method: "CSS.enable",
                 routing: .target(targetID)
             )
-        case let .getMatchedStyles(identity, includePseudo, includeInherited):
+        case let .getMatchedStyles(id, includePseudo, includeInherited):
             return ProtocolCommand(
                 domain: .css,
                 method: "CSS.getMatchedStylesForNode",
-                routing: .target(identity.targetID),
+                routing: .target(id.targetID),
                 parametersData: try data([
-                    "nodeId": identity.protocolNodeID.rawValue,
+                    "nodeId": id.protocolNodeID.rawValue,
                     "includePseudo": includePseudo,
                     "includeInherited": includeInherited,
                 ])
             )
-        case let .getInlineStyles(identity):
+        case let .getInlineStyles(id):
             return ProtocolCommand(
                 domain: .css,
                 method: "CSS.getInlineStylesForNode",
-                routing: .target(identity.targetID),
-                parametersData: try data(["nodeId": identity.protocolNodeID.rawValue])
+                routing: .target(id.targetID),
+                parametersData: try data(["nodeId": id.protocolNodeID.rawValue])
             )
-        case let .getComputedStyle(identity):
+        case let .getComputedStyle(id):
             return ProtocolCommand(
                 domain: .css,
                 method: "CSS.getComputedStyleForNode",
-                routing: .target(identity.targetID),
-                parametersData: try data(["nodeId": identity.protocolNodeID.rawValue])
+                routing: .target(id.targetID),
+                parametersData: try data(["nodeId": id.protocolNodeID.rawValue])
             )
         case let .setStyleText(targetID, styleID, text):
             return ProtocolCommand(

--- a/Sources/WebInspectorCore/CSS/CSSStyleRefreshCoordinator.swift
+++ b/Sources/WebInspectorCore/CSS/CSSStyleRefreshCoordinator.swift
@@ -85,15 +85,15 @@ extension CSSSession {
         return try await commandChannel.send(try protocolCommands.command(for: intent))
     }
 
-    func fetchRefreshResults(for identity: CSSNodeStyles.Identity) async throws -> CSSSession.RefreshResults {
+    func fetchRefreshResults(for id: CSSNodeStyles.ID) async throws -> CSSSession.RefreshResults {
         do {
-            return try await fetchRefreshResultsWithoutCompatibilityRetry(for: identity)
+            return try await fetchRefreshResultsWithoutCompatibilityRetry(for: id)
         } catch {
             guard shouldRetryAfterEnablingCSSAgent(error) else {
                 throw error
             }
-            try await enableAgentForCompatibility(targetID: identity.targetID)
-            return try await fetchRefreshResultsWithoutCompatibilityRetry(for: identity)
+            try await enableAgentForCompatibility(targetID: id.targetID)
+            return try await fetchRefreshResultsWithoutCompatibilityRetry(for: id)
         }
     }
 
@@ -102,11 +102,11 @@ extension CSSSession {
     }
 
     private func fetchRefreshResultsWithoutCompatibilityRetry(
-        for identity: CSSNodeStyles.Identity
+        for id: CSSNodeStyles.ID
     ) async throws -> CSSSession.RefreshResults {
-        async let matched = performRefreshCommand(.getMatchedStyles(identity: identity))
-        async let inline = performRefreshCommand(.getInlineStyles(identity: identity))
-        async let computed = performRefreshCommand(.getComputedStyle(identity: identity))
+        async let matched = performRefreshCommand(.getMatchedStyles(id: id))
+        async let inline = performRefreshCommand(.getInlineStyles(id: id))
+        async let computed = performRefreshCommand(.getComputedStyle(id: id))
         let results = await (matched, inline, computed)
         let failures = [results.0, results.1, results.2].compactMap(\.failure)
         if failures.contains(where: \.isCancellation) {

--- a/Sources/WebInspectorCore/CSS/CSSStyleSectionBuilder.swift
+++ b/Sources/WebInspectorCore/CSS/CSSStyleSectionBuilder.swift
@@ -5,7 +5,7 @@ extension CSSStyle {
     @MainActor
     enum SectionBuilder {
     static func makeSections(
-        identity: CSSNodeStyles.Identity,
+        id: CSSNodeStyles.ID,
         matched: CSSStyle.MatchedStylesPayload,
         inline: CSSStyle.InlineStylesPayload,
         styleSheetHeaders: CSSStyleSheetHeaderRegistry
@@ -16,7 +16,7 @@ extension CSSStyle {
         if let inlineStyle = inline.inlineStyle {
             appendSection(
                 &sections,
-                identity: identity,
+                id: id,
                 ordinal: &ordinal,
                 kind: .inlineStyle,
                 title: "element.style",
@@ -28,7 +28,7 @@ extension CSSStyle {
         for match in matched.matchedRules.reversed() {
             appendRuleSection(
                 &sections,
-                identity: identity,
+                id: id,
                 ordinal: &ordinal,
                 match: match,
                 kind: .rule,
@@ -39,7 +39,7 @@ extension CSSStyle {
         if let attributesStyle = inline.attributesStyle {
             appendSection(
                 &sections,
-                identity: identity,
+                id: id,
                 ordinal: &ordinal,
                 kind: .attributesStyle,
                 title: "Attributes",
@@ -52,7 +52,7 @@ extension CSSStyle {
             for match in pseudo.matches.reversed() {
                 appendRuleSection(
                     &sections,
-                    identity: identity,
+                    id: id,
                     ordinal: &ordinal,
                     match: match,
                     kind: .pseudoElement(pseudo.pseudoID),
@@ -65,7 +65,7 @@ extension CSSStyle {
             if let inlineStyle = inherited.inlineStyle {
                 appendSection(
                     &sections,
-                    identity: identity,
+                    id: id,
                     ordinal: &ordinal,
                     kind: .inheritedInlineStyle(ancestorIndex: ancestorIndex),
                     title: "Inherited element.style",
@@ -76,7 +76,7 @@ extension CSSStyle {
             for match in inherited.matchedRules.reversed() {
                 appendRuleSection(
                     &sections,
-                    identity: identity,
+                    id: id,
                     ordinal: &ordinal,
                     match: match,
                     kind: .inheritedRule(ancestorIndex: ancestorIndex),
@@ -117,7 +117,7 @@ extension CSSStyle {
 
     private static func appendRuleSection(
         _ sections: inout [CSSStyle.Section],
-        identity: CSSNodeStyles.Identity,
+        id: CSSNodeStyles.ID,
         ordinal: inout Int,
         match: CSSRule.MatchPayload,
         kind: CSSStyle.Section.Kind,
@@ -132,7 +132,7 @@ extension CSSStyle {
             sourceLine: match.rule.sourceLine,
             styleSheetSourceLocation: styleSheetHeaders.sourceLocation(
                 for: match.rule,
-                targetID: identity.targetID
+                targetID: id.targetID
             ),
             origin: match.rule.origin,
             style: ruleStyle,
@@ -141,7 +141,7 @@ extension CSSStyle {
         )
         sections.append(
             CSSStyle.Section(
-                id: .init(nodeID: identity.nodeID, kind: kind, ordinal: ordinal),
+                id: .init(nodeID: id.nodeID, kind: kind, ordinal: ordinal),
                 kind: kind,
                 title: rule.selectorList.text,
                 rule: rule,
@@ -154,7 +154,7 @@ extension CSSStyle {
 
     private static func appendSection(
         _ sections: inout [CSSStyle.Section],
-        identity: CSSNodeStyles.Identity,
+        id: CSSNodeStyles.ID,
         ordinal: inout Int,
         kind: CSSStyle.Section.Kind,
         title: String,
@@ -163,7 +163,7 @@ extension CSSStyle {
     ) {
         sections.append(
             CSSStyle.Section(
-                id: .init(nodeID: identity.nodeID, kind: kind, ordinal: ordinal),
+                id: .init(nodeID: id.nodeID, kind: kind, ordinal: ordinal),
                 kind: kind,
                 title: title,
                 style: normalizedStyle(style, isEditable: isEditable, ruleOrigin: nil),

--- a/Sources/WebInspectorCore/Console/ConsoleModel.swift
+++ b/Sources/WebInspectorCore/Console/ConsoleModel.swift
@@ -21,7 +21,7 @@ extension ConsoleMessage {
 
 @MainActor
 @Observable
-package final class ConsoleMessage {
+package final class ConsoleMessage: Identifiable {
     package let id: ID
     package var source: ConsoleMessage.Source
     package var level: ConsoleMessage.Level

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -558,20 +558,20 @@ package final class DOMSession {
         return false
     }
 
-    package func selectedCSSNodeStyleIdentity() -> Result<CSSNodeStyles.Identity, CSSNodeStyles.UnavailableReason> {
+    package func selectedCSSNodeStylesID() -> Result<CSSNodeStyles.ID, CSSNodeStyles.UnavailableReason> {
         guard let selectedNodeID = selection.selectedNodeID else {
             return .failure(.noSelection)
         }
-        return cssNodeStyleIdentity(for: selectedNodeID)
+        return cssNodeStylesID(for: selectedNodeID)
     }
 
     package var selectedNodeStyles: CSSNodeStyles? {
         elementStyles.selectedNodeStyles
     }
 
-    package func cssNodeStyleIdentity(
+    package func cssNodeStylesID(
         for nodeID: DOMNode.ID
-    ) -> Result<CSSNodeStyles.Identity, CSSNodeStyles.UnavailableReason> {
+    ) -> Result<CSSNodeStyles.ID, CSSNodeStyles.UnavailableReason> {
         guard let node = node(for: nodeID) else {
             return .failure(.staleNode(nodeID))
         }
@@ -584,12 +584,11 @@ package final class DOMSession {
             return .failure(.cssUnavailableForTarget(targetID))
         }
         return .success(
-            CSSNodeStyles.Identity(
+            CSSNodeStyles.ID(
                 nodeID: nodeID,
                 targetID: targetID,
                 documentID: nodeID.documentID,
-                protocolNodeID: node.protocolNodeID,
-                targetCapabilities: capabilities
+                protocolNodeID: node.protocolNodeID
             )
         )
     }
@@ -708,10 +707,10 @@ package final class DOMSession {
         documentStore.clearOwnerHydrationTransactions(targetID: targetID)
     }
 
-    package func actionIdentity(
+    package func actionTarget(
         for nodeID: DOMNode.ID,
         commandTargetID: ProtocolTarget.ID? = nil
-    ) -> DOMAction.Identity? {
+    ) -> DOMAction.Target? {
         guard let node = node(for: nodeID),
               let resolvedCommandTargetID = commandTargetID ?? currentPageTargetID,
               targetGraph.containsTarget(resolvedCommandTargetID) else {
@@ -725,7 +724,7 @@ package final class DOMSession {
             .scoped(targetID: documentTargetID, nodeID: node.protocolNodeID)
         }
 
-        return DOMAction.Identity(
+        return DOMAction.Target(
             documentTargetID: documentTargetID,
             rawNodeID: node.protocolNodeID,
             commandTargetID: resolvedCommandTargetID,
@@ -738,10 +737,10 @@ package final class DOMSession {
         commandTargetID: ProtocolTarget.ID? = nil
     ) -> DOMCommand.Intent? {
         let resolvedCommandTargetID = commandTargetID ?? nodeID.documentID.targetID
-        guard let identity = actionIdentity(for: nodeID, commandTargetID: resolvedCommandTargetID) else {
+        guard let target = actionTarget(for: nodeID, commandTargetID: resolvedCommandTargetID) else {
             return nil
         }
-        return .highlightNode(identity: identity)
+        return .highlightNode(target: target)
     }
 
     package func hideHighlightIntent(targetID: ProtocolTarget.ID? = nil) -> DOMCommand.Intent? {
@@ -766,20 +765,20 @@ package final class DOMSession {
         for nodeID: DOMNode.ID,
         commandTargetID: ProtocolTarget.ID? = nil
     ) -> DOMCommand.Intent? {
-        guard let identity = actionIdentity(for: nodeID, commandTargetID: commandTargetID) else {
+        guard let target = actionTarget(for: nodeID, commandTargetID: commandTargetID) else {
             return nil
         }
-        return .getOuterHTML(identity: identity)
+        return .getOuterHTML(target: target)
     }
 
     package func removeNodeIntent(
         for nodeID: DOMNode.ID,
         commandTargetID: ProtocolTarget.ID? = nil
     ) -> DOMCommand.Intent? {
-        guard let identity = actionIdentity(for: nodeID, commandTargetID: commandTargetID) else {
+        guard let target = actionTarget(for: nodeID, commandTargetID: commandTargetID) else {
             return nil
         }
-        return .removeNode(identity: identity)
+        return .removeNode(target: target)
     }
 
     package func selectedNodeCopyText(_ kind: DOMNode.CopyTextKind) -> String? {
@@ -1502,9 +1501,9 @@ package final class DOMSession {
     }
 
     package func syncSelectedElementStyles() {
-        switch selectedCSSNodeStyleIdentity() {
-        case let .success(identity):
-            elementStyles.selectNodeStyles(identity: identity)
+        switch selectedCSSNodeStylesID() {
+        case let .success(id):
+            elementStyles.selectNodeStyles(id: id)
         case let .failure(reason):
             elementStyles.markSelectedNodeUnavailable(reason)
         }

--- a/Sources/WebInspectorCore/DOM/DOMModelTypes.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModelTypes.swift
@@ -3,7 +3,7 @@ import WebInspectorTransport
 
 @MainActor
 @Observable
-package final class DOMTarget {
+package final class DOMTarget: Identifiable {
     package let id: ProtocolTarget.ID
     package var kind: ProtocolTarget.Kind
     package var frameID: DOMFrame.ID?
@@ -45,7 +45,7 @@ package final class DOMTargetState {
 
 @MainActor
 @Observable
-package final class DOMFrame {
+package final class DOMFrame: Identifiable {
     package typealias ID = ProtocolFrame.ID
 
     package let id: ID
@@ -156,7 +156,7 @@ package extension DOMDocument {
 
 @MainActor
 @Observable
-package final class DOMDocument {
+package final class DOMDocument: Identifiable {
     package let id: ID
     package let targetID: ProtocolTarget.ID
     package let localDocumentLifetimeID: DOMDocument.LifetimeID
@@ -164,7 +164,7 @@ package final class DOMDocument {
     package let rootNodeID: DOMNode.ID
     private var nodeIndex: DOMDocument.NodeIndex
     package var transactions: [DOMTransaction.ID: DOMTransaction]
-    package var nextTransactionID: UInt64
+    package var nextTransactionRawID: UInt64
 
     package init(
         id: ID,
@@ -184,7 +184,7 @@ package final class DOMDocument {
             currentNodeIDByProtocolNodeID: currentNodeIDByProtocolNodeID
         )
         transactions = [:]
-        nextTransactionID = 0
+        nextTransactionRawID = 0
     }
 
     package var nodesByID: [DOMNode.ID: DOMNode] {
@@ -232,14 +232,14 @@ package final class DOMDocument {
         nodeIndex.removeNode(nodeID, ifCurrentFor: rawNodeID)
     }
 
-    package func nextTransactionIdentifier() -> DOMTransaction.ID {
-        nextTransactionID &+= 1
-        return DOMTransaction.ID(nextTransactionID)
+    package func nextTransactionID() -> DOMTransaction.ID {
+        nextTransactionRawID &+= 1
+        return DOMTransaction.ID(nextTransactionRawID)
     }
 
     @discardableResult
     package func startTransaction(kind: DOMTransaction.Kind, issuedSequence: UInt64) -> DOMTransaction.ID {
-        let transactionID = nextTransactionIdentifier()
+        let transactionID = nextTransactionID()
         transactions[transactionID] = DOMTransaction(
             id: transactionID,
             targetID: targetID,
@@ -363,7 +363,7 @@ package extension DOMNode {
 
 @MainActor
 @Observable
-package final class DOMNode {
+package final class DOMNode: Identifiable {
     package let id: ID
     package let protocolNodeID: DOMNode.ProtocolID
     package var nodeType: DOMNode.Kind

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -123,7 +123,7 @@ package struct DOMTreeProjection: Equatable, Sendable {
 }
 
 package extension DOMTarget {
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: ProtocolTarget.ID
         package var kind: ProtocolTarget.Kind
         package var frameID: DOMFrame.ID?
@@ -150,7 +150,7 @@ package extension DOMTarget.Snapshot {
 }
 
 package extension DOMFrame {
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: DOMFrame.ID
         package var parentFrameID: DOMFrame.ID?
         package var childFrameIDs: Set<DOMFrame.ID>
@@ -166,7 +166,7 @@ package extension DOMDocument {
         case invalidated
     }
 
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: DOMDocument.ID
         package var targetID: ProtocolTarget.ID
         package var localDocumentLifetimeID: DOMDocument.LifetimeID
@@ -214,7 +214,7 @@ package extension DOMNode {
         }
     }
 
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: DOMNode.ID
         package var protocolNodeID: DOMNode.ProtocolID
         package var nodeType: DOMNode.Kind
@@ -245,7 +245,7 @@ package extension DOMNode {
 }
 
 package extension DOMSelection.Request {
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: DOMSelection.Request.ID
         package var targetID: ProtocolTarget.ID
         package var documentID: DOMDocument.ID
@@ -261,7 +261,7 @@ package extension DOMTargetState {
 }
 
 package extension DOMTransaction {
-    struct Snapshot: Equatable, Sendable {
+    struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: DOMTransaction.ID
         package var targetID: ProtocolTarget.ID
         package var documentID: DOMDocument.ID

--- a/Sources/WebInspectorCore/DOM/DOMProtocol.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProtocol.swift
@@ -228,18 +228,18 @@ package extension DOMCommand {
         case getDocument(targetID: ProtocolTarget.ID)
         case requestChildNodes(targetID: ProtocolTarget.ID, nodeID: DOMNode.ProtocolID, depth: Int)
         case requestNode(selectionRequestID: DOMSelection.Request.ID, targetID: ProtocolTarget.ID, objectID: String)
-        case highlightNode(identity: DOMAction.Identity)
+        case highlightNode(target: DOMAction.Target)
         case hideHighlight(targetID: ProtocolTarget.ID)
         case setInspectModeEnabled(targetID: ProtocolTarget.ID, enabled: Bool)
-        case getOuterHTML(identity: DOMAction.Identity)
-        case removeNode(identity: DOMAction.Identity)
+        case getOuterHTML(target: DOMAction.Target)
+        case removeNode(target: DOMAction.Target)
         case undo(targetID: ProtocolTarget.ID)
         case redo(targetID: ProtocolTarget.ID)
     }
 }
 
 package extension DOMAction {
-    struct Identity: Equatable, Hashable, Sendable {
+    struct Target: Equatable, Hashable, Sendable {
         package var documentTargetID: ProtocolTarget.ID
         package var rawNodeID: DOMNode.ProtocolID
         package var commandTargetID: ProtocolTarget.ID

--- a/Sources/WebInspectorCore/DOM/DOMProtocolDispatching.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProtocolDispatching.swift
@@ -27,13 +27,13 @@ package struct DOMProtocolCommands {
                 routing: .target(targetID),
                 parametersData: try data(["objectId": objectID])
             )
-        case let .highlightNode(identity):
+        case let .highlightNode(target):
             return ProtocolCommand(
                 domain: .dom,
                 method: "DOM.highlightNode",
-                routing: .target(identity.commandTargetID),
+                routing: .target(target.commandTargetID),
                 parametersData: try data([
-                    "nodeId": nodeIDValue(identity.commandNodeID),
+                    "nodeId": nodeIDValue(target.commandNodeID),
                     "reveal": false,
                     "highlightConfig": highlightConfig(),
                 ])
@@ -55,19 +55,19 @@ package struct DOMProtocolCommands {
                 routing: .target(targetID),
                 parametersData: try data(parameters)
             )
-        case let .getOuterHTML(identity):
+        case let .getOuterHTML(target):
             return ProtocolCommand(
                 domain: .dom,
                 method: "DOM.getOuterHTML",
-                routing: .target(identity.commandTargetID),
-                parametersData: try data(["nodeId": nodeIDValue(identity.commandNodeID)])
+                routing: .target(target.commandTargetID),
+                parametersData: try data(["nodeId": nodeIDValue(target.commandNodeID)])
             )
-        case let .removeNode(identity):
+        case let .removeNode(target):
             return ProtocolCommand(
                 domain: .dom,
                 method: "DOM.removeNode",
-                routing: .target(identity.commandTargetID),
-                parametersData: try data(["nodeId": nodeIDValue(identity.commandNodeID)])
+                routing: .target(target.commandTargetID),
+                parametersData: try data(["nodeId": nodeIDValue(target.commandNodeID)])
             )
         case let .undo(targetID):
             return ProtocolCommand(

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -230,8 +230,8 @@ final class DOMSessionElementStyleHydrationController {
         return true
     }
 
-    func isRefreshing(identity: CSSNodeStyles.Identity) -> Bool {
-        activeRefresh?.token.identity == identity
+    func isRefreshing(id: CSSNodeStyles.ID) -> Bool {
+        activeRefresh?.token.id == id
     }
 
     @discardableResult

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -100,8 +100,8 @@ extension DOMSession {
             }
         case .requestChildNodes:
             break
-        case let .highlightNode(identity):
-            highlightController.targetID = identity.commandTargetID
+        case let .highlightNode(target):
+            highlightController.targetID = target.commandTargetID
         case let .hideHighlight(targetID):
             if highlightController.targetID == targetID {
                 highlightController.targetID = nil
@@ -416,31 +416,29 @@ extension DOMSession {
             return
         }
 
-        switch selectedCSSNodeStyleIdentity() {
-        case let .success(identity):
-            reconcileSelectedNodeStyles(identity)
+        switch selectedCSSNodeStylesID() {
+        case let .success(id):
+            reconcileSelectedNodeStyles(id)
         case let .failure(reason):
             cancelSelectedNodeStyleHydrationRefresh()
             elementStyles.markSelectedNodeUnavailable(reason)
         }
     }
 
-    private func reconcileSelectedNodeStyles(_ identity: CSSNodeStyles.Identity) {
-        switch elementStyles.refreshState(forSelected: identity) {
+    private func reconcileSelectedNodeStyles(_ id: CSSNodeStyles.ID) {
+        switch elementStyles.refreshPhase(forSelected: id) {
         case nil, .needsRefresh:
-            hydrateSelectedNodeStyles(identity)
+            hydrateSelectedNodeStyles(id)
         case .loading, .loaded, .failed(_), .unavailable(_):
             return
         }
     }
 
-    private func hydrateSelectedNodeStyles(_ identity: CSSNodeStyles.Identity) {
-        guard styleHydration.isRefreshing(identity: identity) == false else {
+    private func hydrateSelectedNodeStyles(_ id: CSSNodeStyles.ID) {
+        guard styleHydration.isRefreshing(id: id) == false else {
             return
         }
-        guard let token = elementStyles.beginRefresh(identity: identity) else {
-            return
-        }
+        let token = elementStyles.beginRefresh(id: id)
 
         if let cancelledToken = styleHydration.startRefresh(token: token, operation: { [weak self] token in
             guard let self else {
@@ -470,33 +468,31 @@ extension DOMSession {
     }
 
     private func refreshSelectedNodeStyles() async throws {
-        switch selectedCSSNodeStyleIdentity() {
-        case let .success(identity):
-            try await refreshStyles(for: identity)
+        switch selectedCSSNodeStylesID() {
+        case let .success(id):
+            try await refreshStyles(for: id)
         case let .failure(reason):
             elementStyles.markSelectedNodeUnavailable(reason)
         }
     }
 
-    private func refreshStyles(for identity: CSSNodeStyles.Identity) async throws {
-        guard try await selectedStyleRefreshTargetIsLive(identity) else {
+    private func refreshStyles(for id: CSSNodeStyles.ID) async throws {
+        guard try await selectedStyleRefreshTargetIsLive(id) else {
             return
         }
-        guard let token = elementStyles.beginRefresh(identity: identity) else {
-            return
-        }
+        let token = elementStyles.beginRefresh(id: id)
         try await refreshStyles(for: token)
     }
 
     private func refreshStyles(for token: CSSStyle.RefreshToken) async throws {
-        let identity = token.identity
-        guard try await selectedStyleRefreshTargetIsLive(identity) else {
+        let id = token.id
+        guard try await selectedStyleRefreshTargetIsLive(id) else {
             return
         }
         do {
-            let results = try await elementStyles.fetchRefreshResults(for: identity)
-            guard case let .success(currentIdentity) = selectedCSSNodeStyleIdentity(),
-                  currentIdentity == identity else {
+            let results = try await elementStyles.fetchRefreshResults(for: id)
+            guard case let .success(currentID) = selectedCSSNodeStylesID(),
+                  currentID == id else {
                 return
             }
 
@@ -515,11 +511,11 @@ extension DOMSession {
         }
     }
 
-    private func selectedStyleRefreshTargetIsLive(_ identity: CSSNodeStyles.Identity) async throws -> Bool {
+    private func selectedStyleRefreshTargetIsLive(_ id: CSSNodeStyles.ID) async throws -> Bool {
         let commandChannel = try requireCommandChannel()
-        let targetExists = await commandChannel.snapshot().targetsByID[identity.targetID] != nil
+        let targetExists = await commandChannel.snapshot().targetsByID[id.targetID] != nil
         guard targetExists else {
-            elementStyles.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+            elementStyles.markSelectedNodeStylesUnavailable(id: id, reason: .staleNode(id.nodeID))
             return false
         }
         return true
@@ -558,15 +554,15 @@ extension DOMSession {
             syncSelectedElementStyles()
             return
         }
-        let selectedStyleIdentity = try? selectedCSSNodeStyleIdentity().get()
+        let selectedStyleID = try? selectedCSSNodeStylesID().get()
         try protocolCommands.applyDOMEvent(event, to: self)
-        if let selectedStyleIdentity,
+        if let selectedStyleID,
            let targetID = event.targetID,
-           selectedStyleIdentity.targetID == targetID {
-            if selectedNodeID != selectedStyleIdentity.nodeID {
+           selectedStyleID.targetID == targetID {
+            if selectedNodeID != selectedStyleID.nodeID {
                 removeElementStyles(targetID: targetID)
             } else if selectedStylesShouldRefresh(after: event) {
-                elementStyles.markNeedsRefresh(targetID: targetID, nodeID: selectedStyleIdentity.protocolNodeID)
+                elementStyles.markNeedsRefresh(targetID: targetID, nodeID: selectedStyleID.protocolNodeID)
                 reconcileSelectedNodeStyleHydrationIfNeeded()
             }
         }
@@ -1001,8 +997,8 @@ extension DOMSession {
             throw InspectorSession.Error("Inspector session is not attached.")
         }
         let commandTargetID = try currentPageTargetForDOMAction()
-        guard let identity = actionIdentity(for: nodeID, commandTargetID: commandTargetID),
-              let intent = removeNodeIntent(for: nodeID, commandTargetID: identity.commandTargetID) else {
+        guard let target = actionTarget(for: nodeID, commandTargetID: commandTargetID),
+              let intent = removeNodeIntent(for: nodeID, commandTargetID: target.commandTargetID) else {
             throw InspectorSession.Error("DOM node is no longer available.")
         }
         let documentID = nodeID.documentID
@@ -1014,8 +1010,8 @@ extension DOMSession {
         recordError?(nil)
 
         return DOMSessionDeleteUndoState(
-            documentTargetID: identity.documentTargetID,
-            commandTargetID: identity.commandTargetID,
+            documentTargetID: target.documentTargetID,
+            commandTargetID: target.commandTargetID,
             documentID: documentID
         )
     }

--- a/Sources/WebInspectorCore/Docs/CSSModelResearch.md
+++ b/Sources/WebInspectorCore/Docs/CSSModelResearch.md
@@ -20,7 +20,7 @@ CSS is node-scoped, but it is not DOM-owned state.
   stylesheet invalidation, and style-specific protocol events.
 - The DOM/CSS handoff is the currently selected live DOM node plus a CSS
   node-styles object.
-- CSS commands use the selected node's command identity: owning target, active
+- CSS commands use the selected node styles ID: owning target, active
   document generation, and raw protocol node id for that target.
 - If the selected node is non-element, stale, or owned by a target that does
   not expose CSS, CSS reports an unavailable state instead of mutating DOM
@@ -30,7 +30,7 @@ The high-level dependency is:
 
 ```text
 DOM selection -> selected DOMNode.ID
-  -> CSSSession stylesForNode(selected node command identity)
+  -> CSSSession stylesForNode(selected node styles ID)
     -> matched rules + inline styles + computed styles
     -> observable DOMNodeStyles-like object
       -> style rules list and computed list render directly

--- a/Sources/WebInspectorCore/Docs/DOMModelResearch.md
+++ b/Sources/WebInspectorCore/Docs/DOMModelResearch.md
@@ -128,7 +128,7 @@ Transitional or incomplete upstream areas:
   `InspectorDOMAgent` and has upstream FIXME notes to extract shared
   tree-building/binding logic and avoid traversing child frames that have their
   own frame agent;
-- frame target identity threading: current `TargetInfo` does not carry
+- frame target routing context: current `TargetInfo` does not carry
   `frameId`, `parentFrameId`, or owner node id even though the model relation
   exists conceptually;
 - ad iframe refresh and provisional frame commit behavior: upstream has target
@@ -684,9 +684,9 @@ The DOM-side contract is only the boundary:
   projection.
 - CSS owns style refresh, cascade ordering, computed properties, stylesheet
   invalidation, and style-specific protocol events.
-- The handoff from DOM to CSS is the selected live DOM node plus its command
-  identity: owning target, active document generation, and raw protocol node id
-  for that target.
+- The handoff from DOM to CSS is the selected live DOM node plus its node styles
+  ID: owning target, active document generation, and raw protocol node id for
+  that target.
 - CSS does not repair DOM selection or mutate DOM projection. If the selected
   node is not an element, is stale, or belongs to a target without CSS support,
   CSS reports an unavailable state.

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -33,7 +33,7 @@ extension NetworkBody {
 }
 
 extension NetworkBody {
-    package enum FetchState: Equatable, Sendable {        case available
+    package enum Phase: Equatable, Sendable {        case available
         case fetching
         case loaded
         case failed(NetworkBody.FetchError)
@@ -160,7 +160,7 @@ package final class NetworkBody {
         }
     }
     package private(set) var isTruncated: Bool
-    package var fetchState: NetworkBody.FetchState
+    package var phase: NetworkBody.Phase
     package private(set) var sourceSyntaxKind: NetworkBody.SyntaxKind {
         didSet {
             invalidatePreparedTextRepresentation()
@@ -178,7 +178,7 @@ package final class NetworkBody {
         isBase64Encoded: Bool = false,
         isTruncated: Bool = false,
         sourceSyntaxKind: NetworkBody.SyntaxKind = .plainText,
-        fetchState: NetworkBody.FetchState? = nil
+        phase: NetworkBody.Phase? = nil
     ) {
         self.role = role
         self.kind = kind
@@ -186,7 +186,7 @@ package final class NetworkBody {
         self.size = size ?? full?.utf8.count
         self.isBase64Encoded = isBase64Encoded
         self.isTruncated = isTruncated
-        self.fetchState = fetchState ?? (full == nil ? .available : .loaded)
+        self.phase = phase ?? (full == nil ? .available : .loaded)
         self.sourceSyntaxKind = sourceSyntaxKind
         self.textRepresentation = nil
         self.textRepresentationSyntaxKind = .plainText
@@ -198,7 +198,7 @@ package final class NetworkBody {
     }
 
     package var needsFetch: Bool {
-        switch fetchState {
+        switch phase {
         case .available:
             full == nil
         case .fetching, .loaded, .failed:
@@ -214,11 +214,11 @@ package final class NetworkBody {
     }
 
     package func markFetching() {
-        fetchState = .fetching
+        phase = .fetching
     }
 
     package func markFailed(_ error: NetworkBody.FetchError) {
-        fetchState = .failed(error)
+        phase = .failed(error)
     }
 
     package func apply(_ payload: NetworkBody.Payload) {
@@ -228,12 +228,12 @@ package final class NetworkBody {
             isTruncated = payload.isTruncated
         }
         size = payload.size ?? payload.body.utf8.count
-        fetchState = .loaded
+        phase = .loaded
     }
 
     @discardableResult
     package func prepareTextRepresentation() -> NetworkBody.TextPreparation? {
-        guard case .loaded = fetchState else {
+        guard case .loaded = phase else {
             return nil
         }
         guard textRepresentationPreparation.needsPreparation else {
@@ -282,7 +282,7 @@ package final class NetworkBody {
             full: postData,
             size: postData.utf8.count,
             sourceSyntaxKind: hints.syntaxKind,
-            fetchState: .loaded
+            phase: .loaded
         )
     }
 
@@ -297,7 +297,7 @@ package final class NetworkBody {
             role: .response,
             kind: hints.kind,
             sourceSyntaxKind: hints.syntaxKind,
-            fetchState: .available
+            phase: .available
         )
     }
 

--- a/Sources/WebInspectorCore/Network/NetworkModel.swift
+++ b/Sources/WebInspectorCore/Network/NetworkModel.swift
@@ -2,7 +2,7 @@ import Observation
 import WebInspectorTransport
 
 extension NetworkRequest {
-    package struct RedirectHop: Equatable, Sendable {        package var id: NetworkRequest.RedirectHop.ID
+    package struct RedirectHop: Equatable, Sendable, Identifiable {        package var id: NetworkRequest.RedirectHop.ID
         package var request: NetworkRequest.Payload
         package var response: NetworkRequest.Response.Payload
         package var timestamp: Double
@@ -49,7 +49,7 @@ extension NetworkRequest.WebSocket {
 
 @MainActor
 @Observable
-package final class NetworkRequest {
+package final class NetworkRequest: Identifiable {
     package let id: ID
     package var frameID: DOMFrame.ID?
     package var loaderID: String?

--- a/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
+++ b/Sources/WebInspectorCore/Runtime/RuntimeModel.swift
@@ -3,7 +3,7 @@ import WebInspectorTransport
 
 @MainActor
 @Observable
-package final class RuntimeExecutionContext {
+package final class RuntimeExecutionContext: Identifiable {
     package let id: RuntimeContext.ID
     package var targetID: ProtocolTarget.ID
     package var runtimeAgentTargetID: ProtocolTarget.ID

--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -173,11 +173,11 @@ package actor TransportSession {
         )
     }
 
-    package func targetIdentifier(forExecutionContext key: RuntimeContext.Key) -> ProtocolTarget.ID? {
+    package func targetID(forExecutionContext key: RuntimeContext.Key) -> ProtocolTarget.ID? {
         runtimeContextRegistry.targetID(for: key)
     }
 
-    package func targetIdentifier(forFrameID frameID: ProtocolFrame.ID) -> ProtocolTarget.ID? {
+    package func targetID(forFrameID frameID: ProtocolFrame.ID) -> ProtocolTarget.ID? {
         targetRegistry.targetID(forFrameID: frameID)
     }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController+Preview.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController+Preview.swift
@@ -32,8 +32,8 @@ private enum DOMElementViewControllerPreview {
         }
 
         let css = dom.elementStyles
-        if case let .success(identity) = dom.selectedCSSNodeStyleIdentity(),
-           let token = css.beginRefresh(identity: identity) {
+        if case let .success(id) = dom.selectedCSSNodeStylesID() {
+            let token = css.beginRefresh(id: id)
             let style = previewStylePayload(styleID: styleID, cssText: previewCSSText)
             let matched = previewMatchedStyles(ruleID: ruleID, style: style)
             let inline = CSSStyle.InlineStylesPayload()

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -171,10 +171,10 @@ package final class DOMElementViewController: UICollectionViewController {
         let elementStyles = inspection.dom.elementStyles
         let token = withPortableContinuousObservation { [weak self, elementStyles] _ in
             let selectedNodeStyles = elementStyles.selectedNodeStyles
-            let selectedState = elementStyles.selectedState
+            let selectedPhase = elementStyles.selectedPhase
             self?.bindSelectedNodeStyles(
                 selectedNodeStyles,
-                unavailableState: selectedState
+                unavailableState: selectedPhase
             )
         }
 #if DEBUG
@@ -183,7 +183,7 @@ package final class DOMElementViewController: UICollectionViewController {
         elementStylesObservation = token
     }
 
-    private func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?, unavailableState: CSSNodeStyles.State) {
+    private func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?, unavailableState: CSSNodeStyles.Phase) {
         guard let nodeStyles else {
             observedNodeStyles = nil
             selectedNodeStyleObservation?.cancel()
@@ -214,18 +214,18 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func render(_ nodeStyles: CSSNodeStyles) {
-        switch nodeStyles.state {
+        switch nodeStyles.phase {
         case .loaded:
             displayedNodeStyles = nodeStyles
             renderStyles(nodeStyles)
         case .loading, .needsRefresh:
             renderPendingStyles()
         case .unavailable, .failed:
-            render(nodeStyles.state)
+            render(nodeStyles.phase)
         }
     }
 
-    private func render(_ state: CSSNodeStyles.State) {
+    private func render(_ state: CSSNodeStyles.Phase) {
         switch state {
         case .loaded:
             return

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -218,7 +218,7 @@ final class NetworkBodyViewController: UIViewController {
             return
         }
 
-        switch body.fetchState {
+        switch body.phase {
         case .available, .fetching:
             hideMediaPreview()
             displayText = ""

--- a/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
@@ -10,7 +10,7 @@ extension NetworkRequest.Display {
 }
 
 extension NetworkRequest.Display {
-    package struct Projection: Equatable {        package var id: NetworkRequest.ID
+    package struct Projection: Equatable, Identifiable {        package var id: NetworkRequest.ID
         package var displayName: String
         package var fileTypeLabel: String
         package var statusSeverity: NetworkRequest.Display.StatusSeverity

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -23,7 +23,7 @@ func protocolTargetCapabilitiesTreatPageTargetsAsCSSCapable() {
 }
 
 @Test
-func selectedCSSNodeStyleIdentityRequiresElementCurrentNodeAndCSSTarget() async throws {
+func selectedCSSNodeStylesIDRequiresElementCurrentNodeAndCSSTarget() async throws {
     let pageTargetID = ProtocolTarget.ID("page")
     let session = await DOMSession()
     await session.applyTargetCreated(
@@ -45,12 +45,12 @@ func selectedCSSNodeStyleIdentityRequiresElementCurrentNodeAndCSSTarget() async 
     let bodyID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
 
     await session.selectNode(bodyID)
-    let identity = try #require(await session.selectedCSSNodeStyleIdentity().successValue)
+    let identity = try #require(await session.selectedCSSNodeStylesID().successValue)
     #expect(identity.targetID == pageTargetID)
     #expect(identity.protocolNodeID == .init(2))
 
     await session.selectNode(rootID)
-    #expect(await session.selectedCSSNodeStyleIdentity().failureValue == .nonElementNode(.document))
+    #expect(await session.selectedCSSNodeStylesID().failureValue == .nonElementNode(.document))
 
     await session.applyTargetCreated(.init(id: .init("plain"), kind: .page, capabilities: [.dom]))
     let plainRootID = await session.replaceDocumentRoot(
@@ -67,10 +67,10 @@ func selectedCSSNodeStyleIdentityRequiresElementCurrentNodeAndCSSTarget() async 
     let plainDocumentID = plainRootID.documentID
     let plainBodyID = DOMNode.ID(documentID: plainDocumentID, nodeID: .init(2))
     await session.selectNode(plainBodyID)
-    #expect(await session.selectedCSSNodeStyleIdentity().failureValue == .cssUnavailableForTarget(.init("plain")))
+    #expect(await session.selectedCSSNodeStylesID().failureValue == .cssUnavailableForTarget(.init("plain")))
 
     let staleNodeID = DOMNode.ID(documentID: plainDocumentID, nodeID: .init(999))
-    #expect(await session.cssNodeStyleIdentity(for: staleNodeID).failureValue == .staleNode(staleNodeID))
+    #expect(await session.cssNodeStylesID(for: staleNodeID).failureValue == .staleNode(staleNodeID))
 }
 
 @Test
@@ -98,17 +98,17 @@ func selectedNodeStylesResolvesSelectedDOMNodeThroughCSSSession() throws {
     let bodyID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
 
     session.selectNode(bodyID)
-    let identity = try #require(session.selectedCSSNodeStyleIdentity().successValue)
+    let identity = try #require(session.selectedCSSNodeStylesID().successValue)
 
     let pendingStyles = try #require(session.selectedNodeStyles)
-    #expect(pendingStyles.identity == identity)
-    #expect(pendingStyles.state == .needsRefresh)
+    #expect(pendingStyles.id == identity)
+    #expect(pendingStyles.phase == .needsRefresh)
     #expect(pendingStyles.sections.isEmpty)
 
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     let loadingStyles = try #require(session.selectedNodeStyles)
-    #expect(loadingStyles.identity == identity)
-    #expect(loadingStyles.state == .loading)
+    #expect(loadingStyles.id == identity)
+    #expect(loadingStyles.phase == .loading)
     #expect(loadingStyles.sections.isEmpty)
 
     css.applyRefresh(
@@ -129,8 +129,8 @@ func selectedNodeStylesResolvesSelectedDOMNodeThroughCSSSession() throws {
     )
 
     let loadedStyles = try #require(session.selectedNodeStyles)
-    #expect(loadedStyles.identity == identity)
-    #expect(loadedStyles.state == .loaded)
+    #expect(loadedStyles.id == identity)
+    #expect(loadedStyles.phase == .loaded)
     #expect(loadedStyles.sections.map(\.title) == ["body"])
 
     session.selectNode(rootID)
@@ -142,7 +142,7 @@ func selectedNodeStylesResolvesSelectedDOMNodeThroughCSSSession() throws {
 func cssSessionBuildsOrderedSectionsAndPropertyRowState() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -185,7 +185,7 @@ func cssSessionBuildsOrderedSectionsAndPropertyRowState() throws {
     )
 
     let selected = try #require(css.selectedNodeStyles)
-    #expect(css.selectedState == .loaded)
+    #expect(css.selectedPhase == .loaded)
     #expect(selected.sections.map(\.kind) == [.inlineStyle, .rule, .attributesStyle])
     #expect(selected.sections[0].title == "element.style")
     #expect(selected.sections[1].title == "body")
@@ -208,7 +208,7 @@ func cssSessionBuildsOrderedSectionsAndPropertyRowState() throws {
 func cssRuleSourceLocationPrefersSelectorRangeOverSourceLine() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -246,7 +246,7 @@ func cssRuleSourceLocationPrefersSelectorRangeOverSourceLine() throws {
 func cssRuleSourceLocationFallsBackToSourceLineWhenSelectorRangeIsMissing() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -287,7 +287,7 @@ func cssRuleSourceLocationAppliesStyleSheetHeaderOffset() throws {
         ),
         targetID: identity.targetID
     )
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -332,7 +332,7 @@ func cssRuleSourceLocationKeepsSubsequentLineColumnsRelativeToLineStart() throws
         ),
         targetID: identity.targetID
     )
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -390,7 +390,7 @@ func cssRuleSourceLocationScopesStyleSheetHeadersByTarget() throws {
     )
     css.removeStyleSheetHeader(styleSheetID: .init("sheet"), targetID: frameIdentity.targetID)
 
-    let token = try #require(css.beginRefresh(identity: pageIdentity))
+    let token = css.beginRefresh(id: pageIdentity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -435,7 +435,7 @@ func cssSessionRemovesStyleSheetHeadersEvenWhenTargetHasNoCachedStyles() throws 
     )
     css.removeStyles(targetID: identity.targetID)
 
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -464,7 +464,7 @@ func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
     let css = CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.applyRefresh(
         token: token,
@@ -494,7 +494,7 @@ func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
     let boxSizing = style.cssProperties[1]
     let computedDisplay = styles.computedProperties[0]
 
-    let refreshToken = try #require(css.beginRefresh(identity: identity))
+    let refreshToken = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: refreshToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -531,7 +531,7 @@ func cssSessionPreservesObservableStyleObjectsWhenRefreshingSameRows() throws {
 func cssSessionRendersMatchedRulesInCascadeOrder() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(
@@ -584,7 +584,7 @@ func cssSessionBuildsSetStyleTextIntentByCommentingAndUncommentingPropertyText()
     let css = await CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("inline"), ordinal: 0)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: .init(),
@@ -611,7 +611,7 @@ func cssSessionBuildsSetStyleTextIntentByCommentingAndUncommentingPropertyText()
     ))
 
     let disabledStyleID = CSSStyle.ID(styleSheetID: .init("rule"), ordinal: 0)
-    let disabledToken = try #require(await css.beginRefresh(identity: identity))
+    let disabledToken = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: disabledToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -642,7 +642,7 @@ func cssSessionRewritesAuthoredStyleTextWithoutSerializingInactiveRows() async t
     let css = await CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -695,7 +695,7 @@ func cssSessionRewritesOnlyDeclarationMatchesOutsideStrings() async throws {
     let css = await CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -749,7 +749,7 @@ func cssSessionTreatsCommentsAsDeclarationBoundaries() async throws {
     let identity = cssIdentity()
     let beforeCommentStyleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
     let afterCommentStyleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 1)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -822,7 +822,7 @@ func cssSessionRejectsNonEditableToggleTargets() async throws {
     let css = await CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("ua"), ordinal: 0)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -856,7 +856,7 @@ func cssSessionDoesNotSynthesizeStyleTextWhenOtherPropertiesHaveNoAuthoredText()
     let css = CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -889,7 +889,7 @@ func cssSessionDoesNotSynthesizeStyleTextWhenOtherPropertiesHaveNoAuthoredText()
 func cssSessionInFlightRefreshWinsOverInvalidation() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     css.markNeedsRefresh(targetID: identity.targetID)
     css.applyRefresh(
@@ -909,7 +909,7 @@ func cssSessionInFlightRefreshWinsOverInvalidation() throws {
         computed: []
     )
 
-    #expect(css.selectedState == .loaded)
+    #expect(css.selectedPhase == .loaded)
     #expect(css.selectedNodeStyles?.sections.map(\.title) == ["body"])
 }
 
@@ -917,7 +917,7 @@ func cssSessionInFlightRefreshWinsOverInvalidation() throws {
 func cssSessionInvalidatesOnlyNodeStylesThatReferenceChangedStyleSheet() async throws {
     let css = await CSSSession()
     let identity = cssIdentity()
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -937,10 +937,10 @@ func cssSessionInvalidatesOnlyNodeStylesThatReferenceChangedStyleSheet() async t
     )
 
     await css.markNeedsRefresh(targetID: identity.targetID, styleSheetID: .init("untracked"))
-    #expect(await css.selectedState == .loaded)
+    #expect(await css.selectedPhase == .loaded)
 
     await css.markNeedsRefresh(targetID: identity.targetID, styleSheetID: .init("tracked"))
-    #expect(await css.selectedState == .needsRefresh)
+    #expect(await css.selectedPhase == .needsRefresh)
 }
 
 @Test
@@ -948,7 +948,7 @@ func cssSessionRejectsEditIntentWhenSelectedStylesNeedRefresh() async throws {
     let css = await CSSSession()
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -986,7 +986,7 @@ func cssSessionMarksSetStyleTextPropertyAsModifiedByInspector() throws {
     let identity = cssIdentity()
     let styleID = CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 0)
     let propertyID = CSSProperty.ID(styleID: styleID, propertyIndex: 0)
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1019,7 +1019,7 @@ func cssSessionMarksSetStyleTextPropertyAsModifiedByInspector() throws {
     #expect(property.status == .disabled)
     #expect(property.isModifiedByInspector)
 
-    let refreshToken = try #require(css.beginRefresh(identity: identity))
+    let refreshToken = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: refreshToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1038,7 +1038,7 @@ func cssSessionMarksSetStyleTextPropertyAsModifiedByInspector() throws {
         computed: []
     )
 
-    #expect(css.selectedState == .loaded)
+    #expect(css.selectedPhase == .loaded)
     #expect(property.isModifiedByInspector)
 
     css.applySetStyleTextResult(
@@ -1061,7 +1061,7 @@ func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() throws {
     let pageIdentity = cssIdentity(targetID: .init("page"), nodeRawID: 2)
     let frameIdentity = cssIdentity(targetID: .init("frame"), nodeRawID: 2)
 
-    let pageToken = try #require(css.beginRefresh(identity: pageIdentity))
+    let pageToken = css.beginRefresh(id: pageIdentity)
     css.applyRefresh(
         token: pageToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1080,7 +1080,7 @@ func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() throws {
         computed: []
     )
 
-    let frameToken = try #require(css.beginRefresh(identity: frameIdentity))
+    let frameToken = css.beginRefresh(id: frameIdentity)
     css.applyRefresh(
         token: frameToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1108,8 +1108,8 @@ func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() throws {
     )
 
     let selectedFrameStyles = try #require(css.selectedNodeStyles)
-    #expect(css.selectedState == .loaded)
-    #expect(selectedFrameStyles.identity.targetID == frameIdentity.targetID)
+    #expect(css.selectedPhase == .loaded)
+    #expect(selectedFrameStyles.id.targetID == frameIdentity.targetID)
     #expect(selectedFrameStyles.sections[0].style.cssProperties[0].value == "10px")
 }
 
@@ -1118,7 +1118,7 @@ func cssSessionAppliesSetStyleTextResultOnlyToEditedTarget() throws {
 func cssSessionClearsSelectedStylesWhenTargetBecomesStale() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1140,9 +1140,9 @@ func cssSessionClearsSelectedStylesWhenTargetBecomesStale() throws {
     css.removeStyles(targetID: identity.targetID)
 
     #expect(css.selectedNodeStyles == nil)
-    #expect(css.selectedState == .unavailable(.staleNode(identity.nodeID)))
-    #expect(selectedStyles.state == .loaded)
-    #expect(css.refreshState(forSelected: identity) == nil)
+    #expect(css.selectedPhase == .unavailable(.staleNode(identity.nodeID)))
+    #expect(selectedStyles.phase == .loaded)
+    #expect(css.refreshPhase(forSelected: identity) == nil)
 }
 
 @Test
@@ -1150,7 +1150,7 @@ func cssSessionClearsSelectedStylesWhenTargetBecomesStale() throws {
 func cssSessionClearsSelectedStylesWhenCurrentStylesBecomeUnavailable() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -1169,12 +1169,12 @@ func cssSessionClearsSelectedStylesWhenCurrentStylesBecomeUnavailable() throws {
     )
     let selectedStyles = try #require(css.selectedNodeStyles)
 
-    css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+    css.markSelectedNodeStylesUnavailable(id: identity, reason: .staleNode(identity.nodeID))
 
     #expect(css.selectedNodeStyles == nil)
-    #expect(css.selectedState == .unavailable(.staleNode(identity.nodeID)))
-    #expect(selectedStyles.state == .unavailable(.staleNode(identity.nodeID)))
-    #expect(css.refreshState(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
+    #expect(css.selectedPhase == .unavailable(.staleNode(identity.nodeID)))
+    #expect(selectedStyles.phase == .unavailable(.staleNode(identity.nodeID)))
+    #expect(css.refreshPhase(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
 }
 
 @Test
@@ -1182,13 +1182,13 @@ func cssSessionClearsSelectedStylesWhenCurrentStylesBecomeUnavailable() throws {
 func cssSessionDoesNotDisplayUnavailableStylesForUnselectedIdentity() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(identity.nodeID))
+    css.markSelectedNodeStylesUnavailable(id: identity, reason: .staleNode(identity.nodeID))
 
     css.markSelectedNodeUnavailable(.noSelection)
 
     #expect(css.selectedNodeStyles == nil)
-    #expect(css.selectedState == .unavailable(.noSelection))
-    #expect(css.refreshState(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
+    #expect(css.selectedPhase == .unavailable(.noSelection))
+    #expect(css.refreshPhase(forSelected: identity) == .unavailable(.staleNode(identity.nodeID)))
 }
 
 @Test
@@ -1197,13 +1197,13 @@ func cssSessionCancelsActiveRefreshBackToNeedsRefresh() throws {
     let css = CSSSession()
     let identity = cssIdentity()
 
-    _ = try #require(css.beginRefresh(identity: identity))
-    #expect(css.selectedState == .loading)
+    _ = css.beginRefresh(id: identity)
+    #expect(css.selectedPhase == .loading)
 
-    css.cancelRefresh(identity: identity)
+    css.cancelRefresh(id: identity)
 
-    #expect(css.selectedState == .needsRefresh)
-    #expect(css.refreshState(forSelected: identity) == .needsRefresh)
+    #expect(css.selectedPhase == .needsRefresh)
+    #expect(css.refreshPhase(forSelected: identity) == .needsRefresh)
 }
 
 @Test
@@ -1212,18 +1212,18 @@ func cssSessionIgnoresStaleRefreshCancellationAfterNewRefreshBegins() throws {
     let css = CSSSession()
     let identity = cssIdentity()
 
-    let staleToken = try #require(css.beginRefresh(identity: identity))
-    let currentToken = try #require(css.beginRefresh(identity: identity))
+    let staleToken = css.beginRefresh(id: identity)
+    let currentToken = css.beginRefresh(id: identity)
 
     css.cancelRefresh(staleToken)
 
-    #expect(css.selectedState == .loading)
-    #expect(css.refreshState(forSelected: identity) == .loading)
+    #expect(css.selectedPhase == .loading)
+    #expect(css.refreshPhase(forSelected: identity) == .loading)
 
     css.cancelRefresh(currentToken)
 
-    #expect(css.selectedState == .needsRefresh)
-    #expect(css.refreshState(forSelected: identity) == .needsRefresh)
+    #expect(css.selectedPhase == .needsRefresh)
+    #expect(css.refreshPhase(forSelected: identity) == .needsRefresh)
 }
 
 @Test
@@ -1231,7 +1231,7 @@ func cssSessionIgnoresStaleRefreshCancellationAfterNewRefreshBegins() throws {
 func cssSessionRefreshDoesNotRepublishCurrentSelectedNodeStyles() throws {
     let css = CSSSession()
     let identity = cssIdentity()
-    css.selectNodeStyles(identity: identity)
+    css.selectNodeStyles(id: identity)
     let selectedStyles = try #require(css.selectedNodeStyles)
 
     let selectedNodeStylesInvalidations = Mutex(0)
@@ -1241,10 +1241,10 @@ func cssSessionRefreshDoesNotRepublishCurrentSelectedNodeStyles() throws {
         selectedNodeStylesInvalidations.withLock { $0 += 1 }
     }
 
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
 
     #expect(css.selectedNodeStyles === selectedStyles)
-    #expect(css.selectedState == .loading)
+    #expect(css.selectedPhase == .loading)
     #expect(selectedNodeStylesInvalidations.withLock { $0 } == 0)
 
     css.applyRefresh(
@@ -1265,21 +1265,20 @@ func cssSessionRefreshDoesNotRepublishCurrentSelectedNodeStyles() throws {
     )
 
     #expect(css.selectedNodeStyles === selectedStyles)
-    #expect(css.selectedState == .loaded)
+    #expect(css.selectedPhase == .loaded)
     #expect(selectedNodeStylesInvalidations.withLock { $0 } == 0)
 }
 
 private func cssIdentity(
     targetID: ProtocolTarget.ID = ProtocolTarget.ID("page"),
     nodeRawID: Int = 2
-) -> CSSNodeStyles.Identity {
+) -> CSSNodeStyles.ID {
     let documentID = DOMDocument.ID(targetID: targetID, localDocumentLifetimeID: .init(1))
-    return CSSNodeStyles.Identity(
+    return CSSNodeStyles.ID(
         nodeID: DOMNode.ID(documentID: documentID, nodeID: .init(nodeRawID)),
         targetID: targetID,
         documentID: documentID,
-        protocolNodeID: .init(nodeRawID),
-        targetCapabilities: [.css, .dom]
+        protocolNodeID: .init(nodeRawID)
     )
 }
 

--- a/Tests/WebInspectorCoreTests/CSSProtocolDispatchingTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSProtocolDispatchingTests.swift
@@ -7,7 +7,7 @@ import WebInspectorTransport
 func cssProtocolDispatchingBuildsReadCommands() throws {
     let identity = cssIdentity()
 
-    let matched = try CSSProtocolCommands().command(for: .getMatchedStyles(identity: identity))
+    let matched = try CSSProtocolCommands().command(for: .getMatchedStyles(id: identity))
     #expect(matched.method == "CSS.getMatchedStylesForNode")
     #expect(matched.routing == .target(identity.targetID))
     let matchedParams = try JSONObject(matched.parametersData)
@@ -15,11 +15,11 @@ func cssProtocolDispatchingBuildsReadCommands() throws {
     #expect(matchedParams["includePseudo"] as? Bool == true)
     #expect(matchedParams["includeInherited"] as? Bool == true)
 
-    let inline = try CSSProtocolCommands().command(for: .getInlineStyles(identity: identity))
+    let inline = try CSSProtocolCommands().command(for: .getInlineStyles(id: identity))
     #expect(inline.method == "CSS.getInlineStylesForNode")
     #expect(try JSONObject(inline.parametersData)["nodeId"] as? Int == 2)
 
-    let computed = try CSSProtocolCommands().command(for: .getComputedStyle(identity: identity))
+    let computed = try CSSProtocolCommands().command(for: .getComputedStyle(id: identity))
     #expect(computed.method == "CSS.getComputedStyleForNode")
     #expect(try JSONObject(computed.parametersData)["nodeId"] as? Int == 2)
 }
@@ -113,7 +113,7 @@ func cssProtocolDispatchingDecodesReadAndSetStyleTextResults() throws {
 func cssProtocolDispatchingAppliesTargetScopedInvalidationEvents() async throws {
     let css = await CSSSession()
     let identity = cssIdentity()
-    let token = try #require(await css.beginRefresh(identity: identity))
+    let token = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: token,
         matched: .init(),
@@ -130,9 +130,9 @@ func cssProtocolDispatchingAppliesTargetScopedInvalidationEvents() async throws 
             paramsData: Data(#"{"styleSheetId":"untracked"}"#.utf8)
         )
     )
-    #expect(await css.selectedState == .needsRefresh)
+    #expect(await css.selectedPhase == .needsRefresh)
 
-    let refreshToken = try #require(await css.beginRefresh(identity: identity))
+    let refreshToken = await css.beginRefresh(id: identity)
     await css.applyRefresh(
         token: refreshToken,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -156,7 +156,7 @@ func cssProtocolDispatchingAppliesTargetScopedInvalidationEvents() async throws 
             paramsData: Data(#"{"styleSheetId":"sheet"}"#.utf8)
         )
     )
-    #expect(await css.selectedState == .needsRefresh)
+    #expect(await css.selectedPhase == .needsRefresh)
 }
 
 @Test
@@ -186,7 +186,7 @@ func cssProtocolDispatchingRegistersStyleSheetHeaderOffsets() async throws {
         )
     )
 
-    let token = try #require(css.beginRefresh(identity: identity))
+    let token = css.beginRefresh(id: identity)
     css.applyRefresh(
         token: token,
         matched: CSSStyle.MatchedStylesPayload(matchedRules: [
@@ -214,15 +214,14 @@ func cssProtocolDispatchingRegistersStyleSheetHeaderOffsets() async throws {
     ))
 }
 
-private func cssIdentity() -> CSSNodeStyles.Identity {
+private func cssIdentity() -> CSSNodeStyles.ID {
     let targetID = ProtocolTarget.ID("page")
     let documentID = DOMDocument.ID(targetID: targetID, localDocumentLifetimeID: .init(1))
-    return CSSNodeStyles.Identity(
+    return CSSNodeStyles.ID(
         nodeID: DOMNode.ID(documentID: documentID, nodeID: .init(2)),
         targetID: targetID,
         documentID: documentID,
-        protocolNodeID: .init(2),
-        targetCapabilities: [.css, .dom]
+        protocolNodeID: .init(2)
     )
 }
 

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -1174,15 +1174,15 @@ func selectedNodeActionIntentsUseCommandIdentity() async throws {
     _ = await session.replaceDocumentRoot(pageDocumentWithoutIframe(), targetID: pageTargetID)
     let htmlID = try #require((await session.snapshot()).currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
 
-    let identity = DOMAction.Identity(
+    let identity = DOMAction.Target(
         documentTargetID: pageTargetID,
         rawNodeID: .init(2),
         commandTargetID: pageTargetID,
         commandNodeID: .protocolNode(.init(2))
     )
-    #expect(await session.actionIdentity(for: htmlID) == identity)
-    #expect(await session.outerHTMLIntent(for: htmlID) == .getOuterHTML(identity: identity))
-    #expect(await session.removeNodeIntent(for: htmlID) == .removeNode(identity: identity))
+    #expect(await session.actionTarget(for: htmlID) == identity)
+    #expect(await session.outerHTMLIntent(for: htmlID) == .getOuterHTML(target: identity))
+    #expect(await session.removeNodeIntent(for: htmlID) == .removeNode(target: identity))
 }
 
 @Test
@@ -1198,22 +1198,22 @@ func frameDocumentActionIdentityUsesMainTargetScopedCommandNode() async throws {
     _ = await session.replaceDocumentRoot(frameDocument(rootNodeID: 101), targetID: frameTargetID)
     let frameHTMLID = try #require((await session.snapshot()).currentNodeIDByKey[.init(targetID: frameTargetID, nodeID: .init(2))])
 
-    let identity = try #require(await session.actionIdentity(for: frameHTMLID, commandTargetID: pageTargetID))
+    let identity = try #require(await session.actionTarget(for: frameHTMLID, commandTargetID: pageTargetID))
 
     #expect(identity.documentTargetID == frameTargetID)
     #expect(identity.rawNodeID == .init(2))
     #expect(identity.commandTargetID == pageTargetID)
     #expect(identity.commandNodeID == .scoped(targetID: frameTargetID, nodeID: .init(2)))
-    #expect(await session.outerHTMLIntent(for: frameHTMLID, commandTargetID: pageTargetID) == .getOuterHTML(identity: identity))
-    #expect(await session.removeNodeIntent(for: frameHTMLID, commandTargetID: pageTargetID) == .removeNode(identity: identity))
+    #expect(await session.outerHTMLIntent(for: frameHTMLID, commandTargetID: pageTargetID) == .getOuterHTML(target: identity))
+    #expect(await session.removeNodeIntent(for: frameHTMLID, commandTargetID: pageTargetID) == .removeNode(target: identity))
 
-    let highlightIdentity = DOMAction.Identity(
+    let highlightIdentity = DOMAction.Target(
         documentTargetID: frameTargetID,
         rawNodeID: .init(2),
         commandTargetID: frameTargetID,
         commandNodeID: .protocolNode(.init(2))
     )
-    #expect(await session.highlightNodeIntent(for: frameHTMLID) == .highlightNode(identity: highlightIdentity))
+    #expect(await session.highlightNodeIntent(for: frameHTMLID) == .highlightNode(target: highlightIdentity))
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -97,17 +97,17 @@ func connectBootstrapsWebPageTargetWithoutDomainMetadataAsCSSCapable() async thr
 
     let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
     await session.attachment.dom.selectNode(htmlID)
-    let identity: CSSNodeStyles.Identity
-    switch await session.attachment.dom.selectedCSSNodeStyleIdentity() {
-    case let .success(resolvedIdentity):
-        identity = resolvedIdentity
+    let stylesID: CSSNodeStyles.ID
+    switch await session.attachment.dom.selectedCSSNodeStylesID() {
+    case let .success(resolvedID):
+        stylesID = resolvedID
     case let .failure(reason):
-        Issue.record("Expected CSS identity for web-page target, got \(reason)")
+        Issue.record("Expected CSS node styles ID for web-page target, got \(reason)")
         return
     }
 
     #expect(bootstrapMessages.compactMap { try? messageMethod($0.message) }.contains("CSS.enable") == false)
-    #expect(identity.targetID == ProtocolTarget.ID.pageMain)
+    #expect(stylesID.targetID == ProtocolTarget.ID.pageMain)
 }
 
 @Test
@@ -379,7 +379,7 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
     )
     let responseBody = await request.responseBody
     let body = try #require(responseBody)
-    #expect(await body.fetchState == .available)
+    #expect(await body.phase == .available)
 
     let sentCountBeforeFinish = await backend.sentTargetMessages().count
     await session.attachment.network.fetchResponseBody(for: request.id)
@@ -405,7 +405,7 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
     )
     await fetchTask.value
 
-    #expect(await body.fetchState == .loaded)
+    #expect(await body.phase == .loaded)
     #expect(await body.textRepresentation == #"{"ok":true}"#)
     let preparation = try #require(await body.prepareTextRepresentation())
     await preparation.wait()
@@ -439,7 +439,7 @@ func networkResponseBodyFetchErrorDoesNotRetry() async throws {
     let request = try #require(await session.attachment.network.request(for: .init(targetID: .pageMain, requestID: .init("request-error"))))
     let responseBody = await request.responseBody
     let body = try #require(responseBody)
-    #expect(await body.fetchState == .available)
+    #expect(await body.phase == .available)
 
     let sentCount = await backend.sentTargetMessages().count
     let fetchTask = Task {
@@ -454,7 +454,7 @@ func networkResponseBodyFetchErrorDoesNotRetry() async throws {
     )
     await fetchTask.value
 
-    guard case .failed = await body.fetchState else {
+    guard case .failed = await body.phase else {
         Issue.record("Expected response body fetch to fail")
         return
     }
@@ -489,8 +489,8 @@ func selectedElementStyleRefreshLoadsCSSSession() async throws {
     await refreshTask.value
 
     let styles = try #require(session.attachment.dom.elementStyles.selectedNodeStyles)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
-    #expect(styles.identity.nodeID == bodyID)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
+    #expect(styles.id.nodeID == bodyID)
     #expect(styles.sections.map(\.title) == ["element.style", "body"])
     #expect(styles.sections[1].style.cssProperties.first?.name == "margin")
     #expect(styles.computedProperties == [CSSComputedStyleProperty(name: "display", value: "block")])
@@ -524,10 +524,10 @@ func selectedNodeStylesTracksNewSelectionWhileElementStylesLoad() async throws {
     let session = InspectorSession(dom: dom)
 
     dom.selectNode(bodyID)
-    let bodyIdentity = try #require(dom.selectedCSSNodeStyleIdentity().successValue)
+    let bodyStylesID = try #require(dom.selectedCSSNodeStylesID().successValue)
     let bodyStyles = try applySingleRuleStyles(
         to: css,
-        identity: bodyIdentity,
+        id: bodyStylesID,
         selector: "body",
         marginValue: "0",
         marginText: "margin: 0;"
@@ -535,19 +535,19 @@ func selectedNodeStylesTracksNewSelectionWhileElementStylesLoad() async throws {
     #expect(session.attachment.dom.selectedNodeStyles === bodyStyles)
 
     dom.selectNode(inputID)
-    let inputIdentity = try #require(dom.selectedCSSNodeStyleIdentity().successValue)
+    let inputStylesID = try #require(dom.selectedCSSNodeStylesID().successValue)
     let pendingInputStyles = try #require(session.attachment.dom.selectedNodeStyles)
-    #expect(pendingInputStyles.identity == inputIdentity)
-    #expect(pendingInputStyles.state == .needsRefresh)
-    let inputToken = try #require(css.beginRefresh(identity: inputIdentity))
+    #expect(pendingInputStyles.id == inputStylesID)
+    #expect(pendingInputStyles.phase == .needsRefresh)
+    let inputToken = css.beginRefresh(id: inputStylesID)
     let loadingInputStyles = try #require(session.attachment.dom.selectedNodeStyles)
-    #expect(loadingInputStyles.identity == inputIdentity)
-    #expect(loadingInputStyles.state == .loading)
+    #expect(loadingInputStyles.id == inputStylesID)
+    #expect(loadingInputStyles.phase == .loading)
     #expect(loadingInputStyles.sections.isEmpty)
 
     let inputStyles = try applySingleRuleStyles(
         to: css,
-        identity: inputIdentity,
+        id: inputStylesID,
         token: inputToken,
         selector: "input",
         marginValue: "8px",
@@ -581,9 +581,9 @@ func selectedElementStyleHydrationLoadsCSSSessionWhenActive() async throws {
     )
 
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     let styles = try #require(session.attachment.dom.elementStyles.selectedNodeStyles)
-    #expect(styles.identity.nodeID == bodyID)
+    #expect(styles.id.nodeID == bodyID)
     #expect(styles.sections.map(\.title) == ["element.style", "body"])
 }
 
@@ -614,8 +614,8 @@ func selectedElementStyleHydrationCancellationDoesNotPublishFailure() async thro
     )
 
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == htmlID)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == htmlID)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     #expect(session.lastError == nil)
 }
 
@@ -633,10 +633,10 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
     let firstSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
     _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loading)
 
     session.attachment.dom.setSelectedNodeStyleHydrationActive(false)
-    #expect(session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
@@ -649,7 +649,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
     )
 
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     #expect(session.lastError == nil)
 }
 
@@ -669,14 +669,14 @@ func selectedElementStyleHydrationSelectionChangeStartsReplacementRefresh() asyn
 
     let firstMessages = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
     #expect(try messageParameters(firstMessages.matched.message)["nodeId"] as? Int == 4)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loading)
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.selectNode(htmlID)
     let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
     #expect(try messageParameters(secondMessages.matched.message)["nodeId"] as? Int == 2)
-    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == htmlID)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loading)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == htmlID)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loading)
     #expect(session.lastError == nil)
 }
 
@@ -741,8 +741,8 @@ func selectedElementStyleHydrationRefreshesAfterCSSEvents() async throws {
         styleSheetID: "sheet-body-refresh"
     )
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == bodyID)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == bodyID)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     let layoutChangedCount = await backend.sentTargetMessages().count
     await receiveTargetDispatch(
@@ -759,8 +759,8 @@ func selectedElementStyleHydrationRefreshesAfterCSSEvents() async throws {
         styleSheetID: "sheet-body-layout"
     )
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.identity.nodeID == bodyID)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == bodyID)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     #expect(session.lastError == nil)
 }
 
@@ -786,7 +786,7 @@ func selectedElementStyleHydrationCancelsAfterDocumentUpdateInvalidatesRoot() as
     )
 
     #expect(session.attachment.dom.currentPageRootNode == nil)
-    #expect(session.attachment.dom.elementStyles.selectedState == .unavailable(.noSelection))
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .unavailable(.noSelection))
     #expect(await backend.sentTargetMessages().count == sentCount)
 }
 
@@ -810,7 +810,7 @@ func selectedElementStyleHydrationClearsAfterSelectedTargetDestroyed() async thr
     )
 
     #expect(session.attachment.dom.selectedNodeID == nil)
-    #expect(session.attachment.dom.elementStyles.selectedState == .unavailable(.noSelection))
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .unavailable(.noSelection))
     #expect(session.lastError == nil)
 }
 
@@ -875,7 +875,7 @@ func selectedElementStyleHydrationMarksStaleWhenTransportTargetDisappearsBeforeD
     await dom.waitUntilSelectedStyleRefreshIdle()
 
     #expect(await backend.sentTargetMessages().count == sentCount)
-    #expect(css.selectedState == .unavailable(.staleNode(bodyID)))
+    #expect(css.selectedPhase == .unavailable(.staleNode(bodyID)))
     #expect(css.selectedNodeStyles == nil)
     #expect(recordedError == nil)
 }
@@ -932,8 +932,8 @@ func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() asyn
     await refreshTask.value
 
     let styles = try #require(await session.attachment.dom.elementStyles.selectedNodeStyles)
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
-    #expect(await styles.identity.nodeID == bodyID)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
+    #expect(await styles.id.nodeID == bodyID)
 }
 
 @Test
@@ -977,7 +977,7 @@ func selectedElementStyleRefreshDropsResultsWhenSelectionChanges() async throws 
     await secondRefresh.value
 
     let styles = try #require(session.attachment.dom.elementStyles.selectedNodeStyles)
-    #expect(styles.identity.nodeID == htmlID)
+    #expect(styles.id.nodeID == htmlID)
     #expect(styles.sections.map(\.title) == ["element.style", "html"])
 }
 
@@ -1040,7 +1040,7 @@ func cssPropertyToggleSendsSetStyleTextAndRefreshesStyles() async throws {
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
 
     let styles = try #require(session.attachment.dom.elementStyles.selectedNodeStyles)
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     #expect(styles.sections[1].style.cssProperties[0].isEnabled == false)
 }
 
@@ -1064,14 +1064,14 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
     let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
     try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
     await refreshTask.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyRootMessage(
         transport,
         message: #"{"method":"CSS.styleSheetChanged","params":{"styleSheetId":"sheet-body"}}"#,
         in: session
     )
-    #expect(await session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 
     let refreshAgainCount = await backend.sentTargetMessages().count
     let refreshAgain = Task {
@@ -1080,7 +1080,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
     let messagesAgain = try await waitForCSSRefreshMessages(backend, after: refreshAgainCount)
     try await replyCSSRefresh(transport: transport, messages: messagesAgain, selector: "body", styleSheetID: "sheet-body")
     await refreshAgain.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyTargetDispatch(
         transport,
@@ -1088,7 +1088,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         message: #"{"method":"DOM.attributeModified","params":{"nodeId":4,"name":"class","value":"featured"}}"#,
         in: session
     )
-    #expect(await session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 
     let refreshAfterAttributeCount = await backend.sentTargetMessages().count
     let refreshAfterAttribute = Task {
@@ -1097,7 +1097,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
     let messagesAfterAttribute = try await waitForCSSRefreshMessages(backend, after: refreshAfterAttributeCount)
     try await replyCSSRefresh(transport: transport, messages: messagesAfterAttribute, selector: "body", styleSheetID: "sheet-body")
     await refreshAfterAttribute.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyTargetDispatch(
         transport,
@@ -1105,7 +1105,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         message: #"{"method":"DOM.attributeModified","params":{"nodeId":5,"name":"class","value":"child-only"}}"#,
         in: session
     )
-    #expect(await session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 
     let refreshAfterRelatedAttributeCount = await backend.sentTargetMessages().count
     let refreshAfterRelatedAttribute = Task {
@@ -1122,7 +1122,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         styleSheetID: "sheet-body"
     )
     await refreshAfterRelatedAttribute.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyTargetDispatch(
         transport,
@@ -1130,7 +1130,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         message: #"{"method":"DOM.childNodeInserted","params":{"parentNodeId":4,"previousNodeId":5,"node":{"nodeId":6,"nodeType":1,"nodeName":"ASIDE","localName":"aside"}}}"#,
         in: session
     )
-    #expect(await session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 
     let refreshAfterChildInsertCount = await backend.sentTargetMessages().count
     let refreshAfterChildInsert = Task {
@@ -1144,7 +1144,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         styleSheetID: "sheet-body"
     )
     await refreshAfterChildInsert.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyTargetDispatch(
         transport,
@@ -1152,7 +1152,7 @@ func cssAndDOMStyleInvalidationsMarkSelectedNodeStylesNeedsRefresh() async throw
         message: #"{"method":"DOM.childNodeCountUpdated","params":{"nodeId":4,"childNodeCount":3}}"#,
         in: session
     )
-    #expect(await session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
 }
 
 @Test
@@ -1235,7 +1235,7 @@ func domMutationRemovingSelectedNodeClearsSelectedCSSNodeStyles() async throws {
     let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
     try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
     await refreshTask.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     await receiveAndApplyTargetDispatch(
         transport,
@@ -1264,7 +1264,7 @@ func localDOMDeleteClearsSelectedCSSNodeStylesWithoutBackendMutationEvent() asyn
     let messages = try await waitForCSSRefreshMessages(backend, after: sentCount)
     try await replyCSSRefresh(transport: transport, messages: messages, selector: "body", styleSheetID: "sheet-body")
     await refreshTask.value
-    #expect(await session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(await session.attachment.dom.elementStyles.selectedPhase == .loaded)
 
     let countBeforeDelete = await backend.sentTargetMessages().count
     let deleteTask = Task {
@@ -4816,7 +4816,7 @@ func selectedElementStyleHydrationWaitsForActiveAttachmentDuringBootstrap() asyn
     #expect(session.hasActiveConnection == false)
 
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
-    #expect(session.attachment.dom.elementStyles.selectedState == .needsRefresh)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
     #expect(await backend.sentTargetMessages().count == sentCount)
 
     await receiveTargetReply(
@@ -4847,7 +4847,7 @@ func selectedElementStyleHydrationWaitsForActiveAttachmentDuringBootstrap() asyn
     )
 
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
 }
 
 @MainActor
@@ -5178,7 +5178,7 @@ private func hydrateSelectedBodyStyles(
         styleSheetID: "sheet-body"
     )
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
-    #expect(session.attachment.dom.elementStyles.selectedState == .loaded)
+    #expect(session.attachment.dom.elementStyles.selectedPhase == .loaded)
     return bodyID
 }
 
@@ -5246,13 +5246,13 @@ private func cssMatchedStylesResult(
 @MainActor
 private func applySingleRuleStyles(
     to css: CSSSession,
-    identity: CSSNodeStyles.Identity,
+    id: CSSNodeStyles.ID,
     token: CSSStyle.RefreshToken? = nil,
     selector: String,
     marginValue: String,
     marginText: String
 ) throws -> CSSNodeStyles {
-    let token = try #require(token ?? css.beginRefresh(identity: identity))
+    let token = token ?? css.beginRefresh(id: id)
     let styleSheetID = CSSStyleSheet.ID("test-sheet")
     let styleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
     css.applyRefresh(
@@ -5282,7 +5282,7 @@ private func applySingleRuleStyles(
         inline: .init(),
         computed: []
     )
-    return try #require(css.nodeStyles(for: identity))
+    return try #require(css.nodeStyles(for: id))
 }
 
 private func waitForCurrentNode(

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -156,7 +156,7 @@ func requestPostDataCreatesObservableRequestBody() throws {
     )
     let body = try #require(session.request(for: key)?.requestBody)
 
-    #expect(body.fetchState == .loaded)
+    #expect(body.phase == .loaded)
     #expect(body.textRepresentation == "name=Jane Doe\ncity=Tokyo East")
     #expect(body.textRepresentationSyntaxKind == .plainText)
 }
@@ -191,7 +191,7 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() asyn
     let request = try #require(session.request(for: key))
     let body = try #require(request.responseBody)
 
-    #expect(body.fetchState == .available)
+    #expect(body.phase == .available)
     #expect(body.needsFetch)
 
     request.applyResponseBody(
@@ -201,7 +201,7 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() asyn
         )
     )
 
-    #expect(body.fetchState == .loaded)
+    #expect(body.phase == .loaded)
     #expect(body.textRepresentation == #"{"name":"codex","value":42}"#)
     #expect(body.textRepresentationSyntaxKind == .json)
 
@@ -221,7 +221,7 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
         kind: .text,
         full: #"{"first":true}"#,
         sourceSyntaxKind: .json,
-        fetchState: .loaded
+        phase: .loaded
     )
 
     let firstPreparation = try #require(body.prepareTextRepresentation())
@@ -256,7 +256,7 @@ func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
         kind: .text,
         full: "[INFO] started",
         sourceSyntaxKind: .plainText,
-        fetchState: .loaded
+        phase: .loaded
     )
 
     #expect(body.textRepresentation == "[INFO] started")

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -785,7 +785,7 @@ func runtimeExecutionContextMapsToDeliveringTarget() async throws {
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByKey[contextKey("frame-A", 7)]?.targetID == ProtocolTarget.ID("frame-A"))
-    #expect(await session.targetIdentifier(forFrameID: .init("frame-A")) == ProtocolTarget.ID("frame-A"))
+    #expect(await session.targetID(forFrameID: .init("frame-A")) == ProtocolTarget.ID("frame-A"))
 }
 
 @Test
@@ -803,7 +803,7 @@ func runtimeContextOnPagePreservesExistingFrameTargetRoute() async throws {
     let snapshot = await session.snapshot()
 
     #expect(snapshot.executionContextsByKey[contextKey("page-main", 7)]?.targetID == ProtocolTarget.ID("frame-A"))
-    #expect(await session.targetIdentifier(forFrameID: .init("frame-A")) == ProtocolTarget.ID("frame-A"))
+    #expect(await session.targetID(forFrameID: .init("frame-A")) == ProtocolTarget.ID("frame-A"))
 }
 
 @Test
@@ -1628,7 +1628,7 @@ func networkCommandIntentRoutesThroughRequestTarget() throws {
 func domHighlightCommandUsesNonRevealingVisibleHighlightConfig() throws {
     let command = try DOMProtocolCommands().command(
         for: .highlightNode(
-            identity: .init(
+            target: .init(
                 documentTargetID: .init("page-A"),
                 rawNodeID: .init(42),
                 commandTargetID: .init("page-A"),
@@ -1666,18 +1666,18 @@ func domNavigationActionCommandsUseExpectedProtocolPayloads() throws {
     #expect(disableParameters["enabled"] as? Bool == false)
     #expect(disableParameters["highlightConfig"] == nil)
 
-    let identity = DOMAction.Identity(
+    let identity = DOMAction.Target(
         documentTargetID: targetID,
         rawNodeID: .init(42),
         commandTargetID: targetID,
         commandNodeID: .protocolNode(.init(42))
     )
 
-    let outerHTML = try DOMProtocolCommands().command(for: .getOuterHTML(identity: identity))
+    let outerHTML = try DOMProtocolCommands().command(for: .getOuterHTML(target: identity))
     #expect(outerHTML.method == "DOM.getOuterHTML")
     #expect(integerValue(try jsonObject(from: outerHTML.parametersData)["nodeId"]) == 42)
 
-    let removeNode = try DOMProtocolCommands().command(for: .removeNode(identity: identity))
+    let removeNode = try DOMProtocolCommands().command(for: .removeNode(target: identity))
     #expect(removeNode.method == "DOM.removeNode")
     #expect(integerValue(try jsonObject(from: removeNode.parametersData)["nodeId"]) == 42)
 
@@ -1687,19 +1687,19 @@ func domNavigationActionCommandsUseExpectedProtocolPayloads() throws {
 
 @Test
 func domActionCommandsEncodeScopedCommandNodeIDs() throws {
-    let identity = DOMAction.Identity(
+    let identity = DOMAction.Target(
         documentTargetID: .init("frame-A"),
         rawNodeID: .init(42),
         commandTargetID: .init("page-main"),
         commandNodeID: .scoped(targetID: .init("frame-A"), nodeID: .init(42))
     )
 
-    let outerHTML = try DOMProtocolCommands().command(for: .getOuterHTML(identity: identity))
+    let outerHTML = try DOMProtocolCommands().command(for: .getOuterHTML(target: identity))
     let outerHTMLParameters = try jsonObject(from: outerHTML.parametersData)
     #expect(outerHTML.routing == .target(.init("page-main")))
     #expect(outerHTMLParameters["nodeId"] as? String == "frame-A:42")
 
-    let removeNode = try DOMProtocolCommands().command(for: .removeNode(identity: identity))
+    let removeNode = try DOMProtocolCommands().command(for: .removeNode(target: identity))
     let removeNodeParameters = try jsonObject(from: removeNode.parametersData)
     #expect(removeNode.routing == .target(.init("page-main")))
     #expect(removeNodeParameters["nodeId"] as? String == "frame-A:42")

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -152,8 +152,8 @@ struct DOMContainerTests {
         #expect(didRenderRows)
         let cellIDsBeforeUpdate = visibleCellIDs(in: viewController)
 
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        let refreshToken = try #require(css.beginRefresh(identity: identity))
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        let refreshToken = css.beginRefresh(id: identity)
         window.layoutIfNeeded()
         #expect(viewController.collectionView.isHidden == false)
         #expect(visibleCellIDs(in: viewController) == cellIDsBeforeUpdate)
@@ -200,8 +200,8 @@ struct DOMContainerTests {
         let headerBeforeUpdate = try #require(styleSectionHeaderViews(in: viewController).first)
         let headerIDBeforeUpdate = ObjectIdentifier(headerBeforeUpdate)
 
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        let refreshToken = try #require(css.beginRefresh(identity: identity))
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        let refreshToken = css.beginRefresh(id: identity)
         try applyBodyStyles(
             to: css,
             in: dom,
@@ -245,16 +245,16 @@ struct DOMContainerTests {
         #expect(didRenderBodyRows)
 
         let input = try #require(firstElement(named: "input", in: dom))
-        let bodyIdentity = try dom.selectedCSSNodeStyleIdentity().get()
+        let bodyIdentity = try dom.selectedCSSNodeStylesID().get()
         dom.selectNode(input.id)
-        let inputIdentity = try dom.selectedCSSNodeStyleIdentity().get()
-        let inputRefreshToken = try #require(css.beginRefresh(identity: inputIdentity))
+        let inputIdentity = try dom.selectedCSSNodeStylesID().get()
+        let inputRefreshToken = css.beginRefresh(id: inputIdentity)
         window.layoutIfNeeded()
 
         #expect(bodyIdentity != inputIdentity)
-        #expect(css.selectedNodeStyles?.identity == inputIdentity)
-        #expect(css.selectedState == .loading)
-        #expect(css.refreshState(forSelected: inputIdentity) == .loading)
+        #expect(css.selectedNodeStyles?.id == inputIdentity)
+        #expect(css.selectedPhase == .loading)
+        #expect(css.refreshPhase(forSelected: inputIdentity) == .loading)
         let didKeepBodyRowsWhileInputLoads = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration == nil
                 && viewController.collectionView.isHidden == false
@@ -294,8 +294,8 @@ struct DOMContainerTests {
 
         let body = try #require(firstElement(named: "body", in: dom))
         dom.selectNode(body.id)
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        #expect(css.beginRefresh(identity: identity) != nil)
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        _ = css.beginRefresh(id: identity)
 
         let didRenderPlaceholder = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
@@ -328,8 +328,8 @@ struct DOMContainerTests {
 
         let input = try #require(firstElement(named: "input", in: dom))
         dom.selectNode(input.id)
-        let inputIdentity = try dom.selectedCSSNodeStyleIdentity().get()
-        #expect(css.beginRefresh(identity: inputIdentity) != nil)
+        let inputIdentity = try dom.selectedCSSNodeStylesID().get()
+        _ = css.beginRefresh(id: inputIdentity)
         #expect(stylePropertyViews(in: viewController).map(\.declarationTextForTesting).contains("margin: 0;"))
 
         dom.selectNode(nil)
@@ -394,8 +394,8 @@ struct DOMContainerTests {
         }
         #expect(didRenderBodyRows)
 
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        css.markSelectedNodeStylesUnavailable(identity: identity, reason: .staleNode(body.id))
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        css.markSelectedNodeStylesUnavailable(id: identity, reason: .staleNode(body.id))
 
         let didClearRows = await waitUntilRendered(in: viewController) {
             viewController.contentUnavailableConfiguration != nil
@@ -1063,8 +1063,8 @@ struct DOMContainerTests {
         marginValue: String = "0",
         marginText: String = "margin: 0;"
     ) throws -> BodyStyleIDs {
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        let token = try #require(token ?? css.beginRefresh(identity: identity))
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        let token = token ?? css.beginRefresh(id: identity)
         let styleSheetID = CSSStyleSheet.ID("test-sheet")
         let styleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
         css.applyRefresh(
@@ -1128,8 +1128,8 @@ struct DOMContainerTests {
         additionalBodyProperties: [CSSProperty.Payload] = [],
         additionalRootProperties: [CSSProperty.Payload] = []
     ) throws {
-        let identity = try dom.selectedCSSNodeStyleIdentity().get()
-        let token = try #require(css.beginRefresh(identity: identity))
+        let identity = try dom.selectedCSSNodeStylesID().get()
+        let token = css.beginRefresh(id: identity)
         let styleSheetID = CSSStyleSheet.ID("variables")
         let bodyStyleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
         let rootStyleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 1)


### PR DESCRIPTION
Purpose
Align package-facing inspector model APIs with SwiftUI-style naming conventions while preserving existing UIKit-facing public API behavior.

Changes
- Rename CSS node style identity/state concepts to `CSSNodeStyles.ID`, `id`, and `Phase`.
- Rename DOM action routing context from `DOMAction.Identity` to `DOMAction.Target`.
- Rename network body loading state to `NetworkBody.Phase`.
- Move selected identifier-style APIs to `ID` suffixes where they are package-facing.
- Add `Identifiable` conformance to stable model and projection types with non-optional IDs.
- Update tests and research notes for the renamed concepts.

Testing
- `git diff --check`
- `swift test --filter WebInspectorCoreTests`
- `swift test --filter WebInspectorTransportTests`
- `swift test --filter WebInspectorUITests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review against `main`: no findings