### PR TITLE
Stabilize DOM render waits in UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
 
       - name: Run iOS tests
         run: |
+          set -o pipefail
+
           if [ "${SKIP_IOS_TESTS:-false}" = "true" ]; then
             echo "Skipping ${TEST_SCHEME}: selected Xcode cannot resolve this Swift tools version."
             exit 0
@@ -159,4 +161,17 @@ jobs:
             -destination "${DESTINATION}" \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            -maximum-concurrent-test-simulator-destinations 1
+            -maximum-concurrent-test-simulator-destinations 1 \
+            -showBuildTimingSummary \
+            -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
+            | tee "${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
+
+      - name: Upload iOS test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-diagnostics-${{ matrix.name }}
+          path: |
+            ${{ runner.temp }}/xcodebuild-${{ env.TEST_SCHEME }}.log
+            ${{ runner.temp }}/${{ env.TEST_SCHEME }}.xcresult
+          if-no-files-found: ignore

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -23,9 +23,16 @@ package final class DOMElementViewController: UICollectionViewController {
     private var displayedNodeStyles: CSSNodeStyles?
 
 #if DEBUG
+    private struct StyleRenderWaiter {
+        var continuation: CheckedContinuation<Bool, Never>
+        var timeoutTask: Task<Void, Never>
+    }
+
+    package var disablesSnapshotAnimationsForTesting = false
     package private(set) var lastSnapshotAnimatedForTesting = false
-    private var elementStylesObservationDelivery: PortableObservationTracking.Token?
-    private var selectedNodeStyleObservationDelivery: PortableObservationTracking.Token?
+    private var styleRenderGeneration = 0
+    private var nextStyleRenderWaiterID: UInt64 = 0
+    private var styleRenderWaiters: [UInt64: StyleRenderWaiter] = [:]
 #endif
 
     private lazy var dataSource = makeDataSource()
@@ -41,6 +48,9 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     isolated deinit {
+#if DEBUG
+        resolveStyleRenderWaitersForTesting(result: false)
+#endif
         inspection.dom.setSelectedNodeStyleHydrationActive(false)
         elementStylesObservation?.cancel()
         selectedNodeStyleObservation?.cancel()
@@ -177,9 +187,6 @@ package final class DOMElementViewController: UICollectionViewController {
                 unavailableState: selectedState
             )
         }
-#if DEBUG
-        elementStylesObservationDelivery = token
-#endif
         elementStylesObservation = token
     }
 
@@ -188,9 +195,6 @@ package final class DOMElementViewController: UICollectionViewController {
             observedNodeStyles = nil
             selectedNodeStyleObservation?.cancel()
             selectedNodeStyleObservation = nil
-#if DEBUG
-            selectedNodeStyleObservationDelivery = nil
-#endif
             render(unavailableState)
             return
         }
@@ -208,9 +212,6 @@ package final class DOMElementViewController: UICollectionViewController {
             self?.render(nodeStyles)
         }
         selectedNodeStyleObservation = token
-#if DEBUG
-        selectedNodeStyleObservationDelivery = token
-#endif
     }
 
     private func render(_ nodeStyles: CSSNodeStyles) {
@@ -258,6 +259,9 @@ package final class DOMElementViewController: UICollectionViewController {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
+#if DEBUG
+        finishStyleRenderForTesting()
+#endif
     }
 
     private func renderStyles(_ nodeStyles: CSSNodeStyles) {
@@ -270,7 +274,11 @@ package final class DOMElementViewController: UICollectionViewController {
     private func applyEmptySnapshot() {
         expandedUnusedVariableSectionIDs.removeAll()
         let snapshot = NSDiffableDataSourceSnapshot<CSSStyle.Section.ID, ItemIdentifier>()
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+#if DEBUG
+            self?.finishStyleRenderForTesting()
+#endif
+        }
     }
 
     private func applySnapshot(for nodeStyles: CSSNodeStyles, animatingDifferences: Bool = false) {
@@ -308,14 +316,26 @@ package final class DOMElementViewController: UICollectionViewController {
             }
         }
         let currentSnapshot = dataSource.snapshot()
-        guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
-            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
-            return
-        }
 #if DEBUG
         lastSnapshotAnimatedForTesting = animatingDifferences
 #endif
-        dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
+        guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
+            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
+#if DEBUG
+            finishStyleRenderForTesting()
+#endif
+            return
+        }
+#if DEBUG
+        let shouldAnimateSnapshot = animatingDifferences && !disablesSnapshotAnimationsForTesting
+#else
+        let shouldAnimateSnapshot = animatingDifferences
+#endif
+        dataSource.apply(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
+#if DEBUG
+            self?.finishStyleRenderForTesting()
+#endif
+        }
     }
 
     private func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
@@ -350,12 +370,57 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
 #if DEBUG
-    package var elementStylesObservationDeliveryForTesting: PortableObservationTracking.Token? {
-        elementStylesObservationDelivery
+    package var styleRenderGenerationForTesting: Int {
+        styleRenderGeneration
     }
 
-    package var selectedNodeStyleObservationDeliveryForTesting: PortableObservationTracking.Token? {
-        selectedNodeStyleObservationDelivery
+    package func waitForStyleRenderForTesting(
+        after generation: Int,
+        timeout: Duration = .seconds(1)
+    ) async -> Bool {
+        if styleRenderGeneration > generation {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            nextStyleRenderWaiterID &+= 1
+            let waiterID = nextStyleRenderWaiterID
+            let timeoutTask = Task { [weak self] in
+                do {
+                    try await Task.sleep(for: timeout)
+                } catch {
+                    return
+                }
+                self?.resolveStyleRenderWaiterForTesting(id: waiterID, result: false)
+            }
+            styleRenderWaiters[waiterID] = StyleRenderWaiter(
+                continuation: continuation,
+                timeoutTask: timeoutTask
+            )
+
+            if styleRenderGeneration > generation {
+                resolveStyleRenderWaiterForTesting(id: waiterID, result: true)
+            }
+        }
+    }
+
+    private func finishStyleRenderForTesting() {
+        styleRenderGeneration += 1
+        resolveStyleRenderWaitersForTesting(result: true)
+    }
+
+    private func resolveStyleRenderWaitersForTesting(result: Bool) {
+        for waiterID in Array(styleRenderWaiters.keys) {
+            resolveStyleRenderWaiterForTesting(id: waiterID, result: result)
+        }
+    }
+
+    private func resolveStyleRenderWaiterForTesting(id: UInt64, result: Bool) {
+        guard let waiter = styleRenderWaiters.removeValue(forKey: id) else {
+            return
+        }
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(returning: result)
     }
 #endif
 }

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -321,9 +321,13 @@ package final class DOMElementViewController: UICollectionViewController {
 #endif
         guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
             || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
+            var reconfiguredSnapshot = snapshot
+            reconfiguredSnapshot.reconfigureItems(snapshot.itemIdentifiers)
+            dataSource.apply(reconfiguredSnapshot, animatingDifferences: false) { [weak self] in
 #if DEBUG
-            finishStyleRenderForTesting()
+                self?.finishStyleRenderForTesting()
 #endif
+            }
             return
         }
 #if DEBUG

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -1049,7 +1049,9 @@ struct DOMContainerTests {
     }
 
     private func makeElementViewController(dom: DOMSession) -> DOMElementViewController {
-        DOMElementViewController(inspection: AttachedInspection(dom: dom))
+        let viewController = DOMElementViewController(inspection: AttachedInspection(dom: dom))
+        viewController.disablesSnapshotAnimationsForTesting = true
+        return viewController
     }
 
     @discardableResult
@@ -1520,17 +1522,15 @@ struct DOMContainerTests {
         in viewController: DOMElementViewController,
         condition: @escaping @MainActor @Sendable () -> Bool
     ) async -> Bool {
-        await waitForObservedCondition(
-            deliveries: {
-                [
-                    viewController.selectedNodeStyleObservationDeliveryForTesting,
-                    viewController.elementStylesObservationDeliveryForTesting,
-                ].compactMap { $0 }
-            },
-            sample: {
-                sampleRenderedCondition(in: viewController, condition: condition)
-            }
-        )
+        let generation = viewController.styleRenderGenerationForTesting
+        if sampleRenderedCondition(in: viewController, condition: condition) {
+            return true
+        }
+
+        guard await viewController.waitForStyleRenderForTesting(after: generation) else {
+            return sampleRenderedCondition(in: viewController, condition: condition)
+        }
+        return sampleRenderedCondition(in: viewController, condition: condition)
     }
 
     private func sampleRenderedCondition(

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -1520,15 +1520,25 @@ struct DOMContainerTests {
 
     private func waitUntilRendered(
         in viewController: DOMElementViewController,
+        timeout: Duration = .seconds(1),
         condition: @escaping @MainActor @Sendable () -> Bool
     ) async -> Bool {
-        let generation = viewController.styleRenderGenerationForTesting
-        if sampleRenderedCondition(in: viewController, condition: condition) {
-            return true
-        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        var generation = viewController.styleRenderGenerationForTesting
+        while clock.now < deadline {
+            if sampleRenderedCondition(in: viewController, condition: condition) {
+                return true
+            }
 
-        guard await viewController.waitForStyleRenderForTesting(after: generation) else {
-            return sampleRenderedCondition(in: viewController, condition: condition)
+            let remainingTimeout = clock.now.duration(to: deadline)
+            guard await viewController.waitForStyleRenderForTesting(
+                after: generation,
+                timeout: remainingTimeout
+            ) else {
+                return sampleRenderedCondition(in: viewController, condition: condition)
+            }
+            generation = viewController.styleRenderGenerationForTesting
         }
         return sampleRenderedCondition(in: viewController, condition: condition)
     }


### PR DESCRIPTION
## Purpose
Reduce nondeterministic CI test durations in DOM UI rendering tests by replacing observation-based polling with an explicit style render completion signal.

## Changes
- Add DEBUG-only DOM element style render generation hooks and a wait helper tied to diffable data source apply completion.
- Reconfigure retained DOM style cells when a refresh keeps the same snapshot identifiers, so render waits do not resolve before visible cells update.
- Keep DOM UI render waits alive across intermediate render generations until the condition is met or the overall timeout expires.
- Disable actual diffable snapshot animations in DOM UI tests while preserving the existing assertion that reveal requested animation.
- Upload xcodebuild logs and xcresult bundles from iOS CI runs, and include Xcode build timing summaries.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`
- `git diff --check refs/pr-fix/base/159/d8f84d6a39eae273f64a6c5c4b8fcd6f973093b4...HEAD`
- Codex review against `refs/pr-fix/base/159/d8f84d6a39eae273f64a6c5c4b8fcd6f973093b4`: clean
