### PR TITLE
Improve network request display names

### DIFF
--- a/Sources/WebInspectorUI/Network/List/NetworkResourceFilter.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkResourceFilter.swift
@@ -2,7 +2,8 @@ import WebInspectorCore
 import Foundation
 
 extension NetworkRequest.Display {
-    package enum ResourceFilter: String, CaseIterable, Hashable, Sendable, Identifiable {        case all
+    package enum ResourceFilter: String, CaseIterable, Hashable, Sendable, Identifiable {
+        case all
         case document
         case stylesheet
         case media
@@ -86,24 +87,40 @@ extension NetworkRequest.Display {
         }
 
         init(mimeType: String?, url: String) {
+            let urlSummary = NetworkRequest.Display.URLSummary(url: url)
+            self = Self.inferred(
+                mimeType: mimeType,
+                pathExtension: urlSummary.pathExtension,
+                mediaPreviewClassification: NetworkRequest.Display.MediaPreviewSupport.classification(
+                    mimeType: mimeType,
+                    url: url
+                )
+            )
+        }
+
+        package static func inferred(
+            mimeType: String?,
+            pathExtension: String?,
+            mediaPreviewClassification: NetworkRequest.Display.MediaPreviewClassification
+        ) -> NetworkRequest.Display.ResourceFilter {
             let normalizedMimeType = mimeType?
                 .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
                 .first?
                 .lowercased() ?? ""
-            let pathExtension = URL(string: url)?.pathExtension.lowercased() ?? ""
+            let pathExtension = pathExtension ?? ""
 
-            if case .previewable = NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url) {
-                self = .media
+            if case .previewable = mediaPreviewClassification {
+                return .media
             } else if normalizedMimeType == "text/css" || pathExtension == "css" {
-                self = .stylesheet
+                return .stylesheet
             } else if normalizedMimeType.hasPrefix("font/") || ["woff", "woff2", "ttf", "otf"].contains(pathExtension) {
-                self = .font
+                return .font
             } else if normalizedMimeType.contains("javascript") || ["js", "mjs"].contains(pathExtension) {
-                self = .script
+                return .script
             } else if normalizedMimeType.contains("html") {
-                self = .document
+                return .document
             } else {
-                self = .other
+                return .other
             }
         }
     }

--- a/Sources/WebInspectorUI/Network/NetworkDisplayURLSummary.swift
+++ b/Sources/WebInspectorUI/Network/NetworkDisplayURLSummary.swift
@@ -1,0 +1,117 @@
+import Foundation
+import WebInspectorCore
+
+extension NetworkRequest.Display {
+    package struct URLSummary: Equatable, Sendable {
+        package var rawURL: String
+        package var displayName: String
+        package var pathExtension: String?
+        package var authority: String?
+        package var decodedPath: String?
+        package var searchTokens: [String]
+
+        package init(url rawURL: String) {
+            self.rawURL = rawURL
+
+            guard rawURL.range(of: "data:", options: [.anchored, .caseInsensitive]) == nil else {
+                self.displayName = rawURL
+                self.pathExtension = nil
+                self.authority = nil
+                self.decodedPath = nil
+                self.searchTokens = Self.uniqueNonEmpty([rawURL])
+                return
+            }
+
+            guard let components = Self.components(for: rawURL) else {
+                self.displayName = rawURL
+                self.pathExtension = nil
+                self.authority = nil
+                self.decodedPath = nil
+                self.searchTokens = Self.uniqueNonEmpty([rawURL])
+                return
+            }
+
+            let encodedPath = components.percentEncodedPath
+            let decodedPath = encodedPath.isEmpty ? nil : (encodedPath.removingPercentEncoding ?? encodedPath)
+            let encodedLastSegment = encodedPath
+                .split(separator: "/", omittingEmptySubsequences: true)
+                .last
+                .map(String.init)
+            let lastSegment = encodedLastSegment.map { $0.removingPercentEncoding ?? $0 }
+            let authority = Self.authority(from: components)
+            let pathExtension = Self.pathExtension(from: lastSegment)
+            let displayName = Self.firstNonEmpty([
+                lastSegment,
+                authority,
+                decodedPath,
+                rawURL,
+            ]) ?? ""
+
+            self.displayName = displayName
+            self.pathExtension = pathExtension
+            self.authority = authority
+            self.decodedPath = decodedPath
+            self.searchTokens = Self.uniqueNonEmpty([
+                rawURL,
+                displayName,
+                authority,
+                decodedPath,
+                pathExtension,
+            ])
+        }
+
+        private static func components(for rawURL: String) -> URLComponents? {
+            if let components = URLComponents(string: rawURL, encodingInvalidCharacters: false) {
+                return components
+            }
+            guard rawURL.unicodeScalars.contains(where: { $0.value > 0x7f }) else {
+                return nil
+            }
+            return URLComponents(string: rawURL, encodingInvalidCharacters: true)
+        }
+
+        private static func authority(from components: URLComponents) -> String? {
+            guard let host = components.host, host.isEmpty == false else {
+                return nil
+            }
+            guard let port = components.port else {
+                return host
+            }
+            return "\(host):\(port)"
+        }
+
+        private static func pathExtension(from displayPathSegment: String?) -> String? {
+            guard let displayPathSegment, displayPathSegment.isEmpty == false else {
+                return nil
+            }
+            let fileName = displayPathSegment
+                .split(separator: "/", omittingEmptySubsequences: false)
+                .last
+                .map(String.init) ?? displayPathSegment
+            guard let periodIndex = fileName.lastIndex(of: "."),
+                  periodIndex != fileName.startIndex,
+                  periodIndex != fileName.index(before: fileName.endIndex) else {
+                return nil
+            }
+            return String(fileName[fileName.index(after: periodIndex)...]).lowercased()
+        }
+
+        private static func firstNonEmpty(_ values: [String?]) -> String? {
+            values.first { value in
+                value?.isEmpty == false
+            } ?? nil
+        }
+
+        private static func uniqueNonEmpty(_ values: [String?]) -> [String] {
+            var seen: Set<String> = []
+            var result: [String] = []
+            for value in values {
+                guard let value, value.isEmpty == false, seen.insert(value).inserted else {
+                    continue
+                }
+                result.append(value)
+            }
+            return result
+        }
+    }
+}

--- a/Sources/WebInspectorUI/Network/NetworkDisplayURLSummary.swift
+++ b/Sources/WebInspectorUI/Network/NetworkDisplayURLSummary.swift
@@ -64,9 +64,6 @@ extension NetworkRequest.Display {
             if let components = URLComponents(string: rawURL, encodingInvalidCharacters: false) {
                 return components
             }
-            guard rawURL.unicodeScalars.contains(where: { $0.value > 0x7f }) else {
-                return nil
-            }
             return URLComponents(string: rawURL, encodingInvalidCharacters: true)
         }
 

--- a/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
+++ b/Sources/WebInspectorUI/Network/NetworkMediaPreviewSupport.swift
@@ -240,7 +240,7 @@ extension NetworkRequest.Display {
             guard let url else {
                 return nil
             }
-            return URL(string: url)?.pathExtension.lowercased()
+            return NetworkRequest.Display.URLSummary(url: url).pathExtension
         }
 
         private static func shouldInferFromURL(mimeType: String?) -> Bool {

--- a/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequest+Display.swift
@@ -3,20 +3,7 @@ import Foundation
 
 extension NetworkRequest {
     package var displayName: String {
-        if let url = URL(string: request.url) {
-            let last = url.lastPathComponent
-            if !last.isEmpty {
-                return last
-            }
-            if let host = url.host {
-                return host
-            }
-        }
-        return request.url
-    }
-
-    package var host: String? {
-        URL(string: request.url)?.host
+        NetworkRequest.Display.URLSummary(url: request.url).displayName
     }
 
     package var statusLabel: String {
@@ -36,23 +23,11 @@ extension NetworkRequest {
     }
 
     package var fileTypeLabel: String {
-        if let mimeType = response?.mimeType,
-           let subtype = mimeType
-            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-            .first?
-            .split(separator: "/")
-            .last,
-           subtype.isEmpty == false {
-            return subtype.lowercased()
-        }
-        if let pathExtension = URL(string: request.url)?.pathExtension,
-           pathExtension.isEmpty == false {
-            return pathExtension.lowercased()
-        }
-        if let resourceType {
-            return resourceType.displayLabel
-        }
-        return "-"
+        NetworkRequest.Display.fileTypeLabel(
+            mimeType: response?.mimeType,
+            resourceType: resourceType,
+            urlSummary: NetworkRequest.Display.URLSummary(url: request.url)
+        )
     }
 
     package var statusSeverity: NetworkRequest.Display.StatusSeverity {
@@ -102,6 +77,32 @@ extension NetworkRequest {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .binary
         return formatter.string(fromByteCount: Int64(length))
+    }
+}
+
+extension NetworkRequest.Display {
+    package static func fileTypeLabel(
+        mimeType: String?,
+        resourceType: NetworkRequest.ResourceType?,
+        urlSummary: NetworkRequest.Display.URLSummary
+    ) -> String {
+        if let mimeType,
+           let subtype = mimeType
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first?
+            .split(separator: "/")
+            .last,
+           subtype.isEmpty == false {
+            return subtype.lowercased()
+        }
+        if let pathExtension = urlSummary.pathExtension,
+           pathExtension.isEmpty == false {
+            return pathExtension
+        }
+        if let resourceType {
+            return resourceType.displayLabel
+        }
+        return "-"
     }
 }
 

--- a/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
@@ -10,7 +10,8 @@ extension NetworkRequest.Display {
 }
 
 extension NetworkRequest.Display {
-    package struct Projection: Equatable, Identifiable {        package var id: NetworkRequest.ID
+    package struct Projection: Equatable, Identifiable {
+        package var id: NetworkRequest.ID
         package var displayName: String
         package var fileTypeLabel: String
         package var statusSeverity: NetworkRequest.Display.StatusSeverity
@@ -27,7 +28,8 @@ extension NetworkRequest.Display {
 }
 
 extension NetworkRequest.Display {
-    package struct Fingerprint: Equatable {        package var requestURL: String
+    package struct Fingerprint: Equatable {
+        package var requestURL: String
         package var requestMethod: String
         package var resourceType: NetworkRequest.ResourceType?
         package var responseURL: String?
@@ -58,8 +60,32 @@ extension NetworkRequest.Display {
 }
 
 extension NetworkRequest.Display {
+    private struct ProjectionInputs {
+        var requestURLSummary: NetworkRequest.Display.URLSummary
+        var responseURLSummary: NetworkRequest.Display.URLSummary?
+        var responseDisplayMIMEType: String?
+        var fileTypeLabel: String
+
+        @MainActor
+        init(request: NetworkRequest) {
+            requestURLSummary = NetworkRequest.Display.URLSummary(url: request.request.url)
+            responseURLSummary = request.response.map { NetworkRequest.Display.URLSummary(url: $0.url) }
+            if let response = request.response {
+                responseDisplayMIMEType = networkDisplayMIMEType(from: response)
+            } else {
+                responseDisplayMIMEType = nil
+            }
+            fileTypeLabel = NetworkRequest.Display.fileTypeLabel(
+                mimeType: request.response?.mimeType,
+                resourceType: request.resourceType,
+                urlSummary: requestURLSummary
+            )
+        }
+    }
+
     @MainActor
-    package final class ProjectionCache {        private struct Entry {
+    package final class ProjectionCache {
+        private struct Entry {
             var fingerprint: NetworkRequest.Display.Fingerprint
             var projection: NetworkRequest.Display.Projection
             var resourceFilter: NetworkRequest.Display.ResourceFilter?
@@ -78,14 +104,8 @@ extension NetworkRequest.Display {
                 return entry.projection
             }
 
-            let projection = NetworkRequest.Display.Projection(
-                id: request.id,
-                displayName: request.displayName,
-                fileTypeLabel: request.fileTypeLabel,
-                statusSeverity: request.statusSeverity,
-                resourceFilter: nil,
-                searchTokens: Self.searchTokens(for: request)
-            )
+            let inputs = NetworkRequest.Display.ProjectionInputs(request: request)
+            let projection = Self.projection(for: request, inputs: inputs)
             entries[request.id] = Entry(fingerprint: fingerprint, projection: projection, resourceFilter: nil)
             return projection
         }
@@ -98,19 +118,13 @@ extension NetworkRequest.Display {
                 return resourceFilter
             }
 
-            let resourceFilter = Self.resourceFilter(for: request, classifier: mediaPreviewClassifier)
+            let inputs = NetworkRequest.Display.ProjectionInputs(request: request)
+            let resourceFilter = Self.resourceFilter(for: request, inputs: inputs, classifier: mediaPreviewClassifier)
             var projection: NetworkRequest.Display.Projection
             if let entry = entries[request.id], entry.fingerprint == fingerprint {
                 projection = entry.projection
             } else {
-                projection = NetworkRequest.Display.Projection(
-                    id: request.id,
-                    displayName: request.displayName,
-                    fileTypeLabel: request.fileTypeLabel,
-                    statusSeverity: request.statusSeverity,
-                    resourceFilter: nil,
-                    searchTokens: Self.searchTokens(for: request)
-                )
+                projection = Self.projection(for: request, inputs: inputs)
             }
             projection.resourceFilter = resourceFilter
             entries[request.id] = Entry(
@@ -129,29 +143,50 @@ extension NetworkRequest.Display {
             entries.removeAll()
         }
 
-        private static func searchTokens(for request: NetworkRequest) -> [String] {
+        private static func projection(
+            for request: NetworkRequest,
+            inputs: NetworkRequest.Display.ProjectionInputs
+        ) -> NetworkRequest.Display.Projection {
+            NetworkRequest.Display.Projection(
+                id: request.id,
+                displayName: inputs.requestURLSummary.displayName,
+                fileTypeLabel: inputs.fileTypeLabel,
+                statusSeverity: request.statusSeverity,
+                resourceFilter: nil,
+                searchTokens: Self.searchTokens(for: request, inputs: inputs)
+            )
+        }
+
+        private static func searchTokens(
+            for request: NetworkRequest,
+            inputs: NetworkRequest.Display.ProjectionInputs
+        ) -> [String] {
             let statusCodeLabel = request.response.map { String($0.status) } ?? ""
-            return [
-                request.request.url,
-                request.request.method,
-                statusCodeLabel,
-                request.response?.statusText ?? "",
-                request.fileTypeLabel,
-            ]
+            return uniqueNonEmpty(
+                inputs.requestURLSummary.searchTokens
+                + (inputs.responseURLSummary?.searchTokens ?? [])
+                + [
+                    request.request.method,
+                    statusCodeLabel,
+                    request.response?.statusText ?? "",
+                    inputs.fileTypeLabel,
+                ]
+            )
         }
 
         private static func resourceFilter(
             for request: NetworkRequest,
+            inputs: NetworkRequest.Display.ProjectionInputs,
             classifier: NetworkRequest.Display.MediaPreviewClassifier
         ) -> NetworkRequest.Display.ResourceFilter {
             guard let response = request.response else {
                 if let resourceType = request.resourceType {
                     return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
                 }
-                return Self.resourceFilter(mimeType: nil, url: request.request.url, classifier: classifier)
+                return Self.resourceFilter(mimeType: nil, urlSummary: inputs.requestURLSummary, classifier: classifier)
             }
 
-            let responseMimeType = networkDisplayMIMEType(from: response)
+            let responseMimeType = inputs.responseDisplayMIMEType
             if let resourceType = request.resourceType,
                shouldKeepResourceTypeForURLInferredMedia(resourceType) {
                 if case .previewable = classifier(responseMimeType, nil) {
@@ -160,51 +195,43 @@ extension NetworkRequest.Display {
                 return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
             }
 
-            let responseURL = response.url
-            switch classifier(responseMimeType, responseURL) {
+            let responseURLSummary = inputs.responseURLSummary ?? NetworkRequest.Display.URLSummary(url: response.url)
+            switch classifier(responseMimeType, responseURLSummary.rawURL) {
             case .previewable:
                 return .media
             case .notPreviewable:
                 if request.resourceType == .image || request.resourceType == .media {
                     return .media
                 }
-                return Self.resourceFilter(mimeType: responseMimeType, url: responseURL, classifier: classifier)
+                return Self.resourceFilter(mimeType: responseMimeType, urlSummary: responseURLSummary, classifier: classifier)
             case .unknown:
                 break
             }
             if let resourceType = request.resourceType {
                 return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
             }
-            return Self.resourceFilter(mimeType: responseMimeType, url: responseURL, classifier: classifier)
+            return Self.resourceFilter(mimeType: responseMimeType, urlSummary: responseURLSummary, classifier: classifier)
         }
 
         private static func resourceFilter(
             mimeType: String?,
-            url: String,
+            urlSummary: NetworkRequest.Display.URLSummary,
             classifier: NetworkRequest.Display.MediaPreviewClassifier
         ) -> NetworkRequest.Display.ResourceFilter {
-            let normalizedMimeType = mimeType?
-                .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-                .first?
-                .lowercased() ?? ""
-            let pathExtension = URL(string: url)?.pathExtension.lowercased() ?? ""
+            NetworkRequest.Display.ResourceFilter.inferred(
+                mimeType: mimeType,
+                pathExtension: urlSummary.pathExtension,
+                mediaPreviewClassification: classifier(mimeType, urlSummary.rawURL)
+            )
+        }
 
-            if case .previewable = classifier(mimeType, url) {
-                return .media
+        private static func uniqueNonEmpty(_ values: [String]) -> [String] {
+            var seen: Set<String> = []
+            var result: [String] = []
+            for value in values where value.isEmpty == false && seen.insert(value).inserted {
+                result.append(value)
             }
-            if normalizedMimeType == "text/css" || pathExtension == "css" {
-                return .stylesheet
-            }
-            if normalizedMimeType.hasPrefix("font/") || ["woff", "woff2", "ttf", "otf"].contains(pathExtension) {
-                return .font
-            }
-            if normalizedMimeType.contains("javascript") || ["js", "mjs"].contains(pathExtension) {
-                return .script
-            }
-            if normalizedMimeType.contains("html") {
-                return .document
-            }
-            return .other
+            return result
         }
     }
 }

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -40,6 +40,36 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
     #expect(requests.map(\.id.requestID.rawValue) == ["2"])
 }
 
+@Test(
+    "Network display names use URL path segments with authority fallback",
+    arguments: [
+        ("https://www.google.com/", "www.google.com"),
+        ("https://www.google.com", "www.google.com"),
+        ("https://example.com/foo/", "foo"),
+        ("https://example.com/a%20b", "a b"),
+        ("https://example.com/a%2Fb", "a/b"),
+        ("https://example.com/画像.png", "画像.png"),
+        ("https://example.com:8443/", "example.com:8443"),
+        ("about:blank", "blank"),
+        ("data:text/plain,hello", "data:text/plain,hello"),
+    ]
+)
+@MainActor
+func displayProjectionUsesReadableURLDisplayName(url: String, expectedDisplayName: String) async throws {
+    let network = NetworkSession()
+    let requestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: url,
+        resourceType: .document,
+        mimeType: "text/html",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+
+    #expect(model.displayProjection(for: requestID)?.displayName == expectedDisplayName)
+}
+
 @Test
 @MainActor
 func mediaFilterIncludesPreviewableMediaResponses() async throws {
@@ -213,6 +243,7 @@ func mediaPreviewSupportClassifiesAVIFAndExcludesSVG() {
     #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: "image/x-png", url: nil) == .image)
     #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: "image/pjpeg", url: nil) == .image)
     #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: "image/x-unknown", url: "https://cdn.example.com/photo.png") == .image)
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: nil, url: "https://cdn.example.com/画像.png") == .image)
     #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == nil)
     #expect(NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: "image/svg+xml", url: "https://cdn.example.com/icon.svg") == .notPreviewable)
     #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(mimeType: "text/javascript", url: "https://cdn.example.com/player.mp4") == nil)

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -49,6 +49,8 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
         ("https://example.com/a%20b", "a b"),
         ("https://example.com/a%2Fb", "a/b"),
         ("https://example.com/画像.png", "画像.png"),
+        ("https://cdn.example.com/photo 1.png", "photo 1.png"),
+        ("https://cdn.example.com/photo%ZZ.png", "photo%ZZ.png"),
         ("https://example.com:8443/", "example.com:8443"),
         ("about:blank", "blank"),
         ("data:text/plain,hello", "data:text/plain,hello"),
@@ -68,6 +70,37 @@ func displayProjectionUsesReadableURLDisplayName(url: String, expectedDisplayNam
     let model = NetworkPanelModel(network: network)
 
     #expect(model.displayProjection(for: requestID)?.displayName == expectedDisplayName)
+}
+
+@Test
+@MainActor
+func displayProjectionUsesEncodingFallbackForURLDerivedLabelsAndFilters() async throws {
+    let network = NetworkSession()
+    let spacedURLRequestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://cdn.example.com/photo 1.png",
+        resourceType: .fetch,
+        mimeType: nil,
+        timestamp: 1
+    )
+    let invalidEscapeRequestID = applyRequest(
+        to: network,
+        requestID: "2",
+        url: "https://cdn.example.com/photo%ZZ.png",
+        resourceType: .fetch,
+        mimeType: nil,
+        timestamp: 2
+    )
+    let model = NetworkPanelModel(network: network)
+
+    #expect(model.displayProjection(for: spacedURLRequestID)?.displayName == "photo 1.png")
+    #expect(model.displayProjection(for: spacedURLRequestID)?.fileTypeLabel == "png")
+    #expect(model.displayProjection(for: invalidEscapeRequestID)?.displayName == "photo%ZZ.png")
+    #expect(model.displayProjection(for: invalidEscapeRequestID)?.fileTypeLabel == "png")
+
+    model.setResourceFilter(.media, enabled: true)
+    #expect(model.displayRequestIDs == [invalidEscapeRequestID, spacedURLRequestID])
 }
 
 @Test


### PR DESCRIPTION
## Purpose
Fix network request titles so root URLs such as `https://www.google.com/` show a useful authority instead of `/`, and make URL-derived display data consistent across the network UI.

## Changes
- Add `NetworkRequest.Display.URLSummary` as the shared URL display projection.
- Use the summary for display name, file type labels, search tokens, media preview extension checks, and resource filter inference.
- Preserve raw `data:` display names and add authority fallback for root URLs, including explicit ports.
- Retry URLComponents encoded fallback after strict parse failures so raw CDP URL strings with spaces, invalid percent escapes, or Unicode paths still produce path-based labels and URL-inferred media filters.
- Add table coverage for root URLs, decoded path segments, encoded slashes, Unicode path names, invalid ASCII URL characters, `about:blank`, and `data:` URLs.

## Testing
- `swift test --filter 'displayProjectionUsesReadableURLDisplayName|displayProjectionUsesEncodingFallbackForURLDerivedLabelsAndFilters|mediaPreviewSupportClassifiesAVIFAndExcludesSVG|mediaFilterIncludesPreviewableMediaResponses|displayProjectionCacheSkipsMediaClassificationWhenUnfiltered'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review --base refs/pr-fix/base/160/d188ecf7d124ef89a2bf52ae5b0641659ca583d9` returned no findings.
