### PR TITLE
Update SyntaxEditorUI to 0.14.0

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2cbdfac2da3d31592682336a6fab67ed46079ec1",
-        "version" : "0.13.0"
+        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
+        "version" : "0.14.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2cbdfac2da3d31592682336a6fab67ed46079ec1",
-        "version" : "0.13.0"
+        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
+        "version" : "0.14.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.13.0"
+            exact: "0.14.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -255,14 +255,11 @@ final class NetworkBodyViewController: UIViewController {
         syntaxKind: NetworkBody.SyntaxKind
     ) {
         let language = syntaxKind.language
-        if syntaxModel.language != language {
-            syntaxModel.language = language
-        }
         if syntaxModel.theme != .default {
             syntaxModel.theme = .default
         }
-        if syntaxModel.text != text {
-            syntaxModel.replaceText(text)
+        if syntaxModel.text != text || syntaxModel.language != language {
+            syntaxModel.replaceContents(text: text, language: language)
         }
         showSyntaxPreview()
     }

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "2cbdfac2da3d31592682336a6fab67ed46079ec1",
-        "version" : "0.13.0"
+        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
+        "version" : "0.14.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Update SyntaxEditorUI to v0.14.0 and adopt the new combined content replacement API where the Network body preview reuses its editor view.

## Changes
- Bump the SyntaxEditorUI exact dependency and lockfiles to 0.14.0.
- Update Network body preview rendering to call `SyntaxEditorModel.replaceContents(text:language:)` when text or language changes.
- Preserve the existing selected-range behavior by leaving `selectedRange` unspecified.

## Testing
- `swift package resolve`
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review: no findings