### PR TITLE
Persist selected DOM node highlights

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -66,6 +66,10 @@ package final class DOMSession {
         )
     }
 
+    package func containsTarget(_ targetID: ProtocolTarget.ID) -> Bool {
+        targetGraph.containsTarget(targetID)
+    }
+
     private func state(for targetID: ProtocolTarget.ID) -> DOMTargetState {
         documentStore.state(for: targetID)
     }
@@ -139,10 +143,12 @@ package final class DOMSession {
             return
         }
 
+        let previousSelectedNodeID = selection.selectedNodeID
         let resolvedMainFrameID = targetGraph.targetFrameID(for: targetID) ?? DOMFrame.ID("main:\(targetID.rawValue)")
         if currentPage.promote(targetID: targetID, mainFrameID: resolvedMainFrameID) {
             selection = DOMSelection()
             recordSelectionMutation()
+            scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         }
         _ = state(for: targetID)
         targetGraph.assignMainFrame(resolvedMainFrameID, to: targetID)
@@ -223,8 +229,10 @@ package final class DOMSession {
             targetGraph.setFrameCurrentDocumentID(nil, for: frameID)
         }
         if currentPage.clear(ifTarget: targetID) {
+            let previousSelectedNodeID = selection.selectedNodeID
             selection = DOMSelection()
             recordSelectionMutation()
+            scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         }
         documentStore.removeState(for: targetID)
         recordTreeMutation()
@@ -649,8 +657,10 @@ package final class DOMSession {
         guard selection.hasStateChange(selecting: nodeID) else {
             return
         }
+        let previousSelectedNodeID = selection.selectedNodeID
         cancelSelectionTransaction(for: selection.select(nodeID))
         recordSelectionMutation()
+        scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         syncSelectedElementStyles()
     }
 
@@ -1042,8 +1052,10 @@ package final class DOMSession {
         document.transactions.removeAll()
         clearCurrentDocumentReference(documentID, targetID: document.targetID)
         updateAllFrameDocumentProjectionStates()
+        let previousSelectedNodeID = selection.selectedNodeID
         if selection.clearSelected(ifDocument: documentID) {
             recordSelectionMutation()
+            scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
             syncSelectedElementStyles()
         }
     }
@@ -1445,11 +1457,13 @@ package final class DOMSession {
     }
 
     private func reconcileSelection() {
+        let previousSelectedNodeID = selection.selectedNodeID
         let didClearSelection = selection.clearSelectedIfStale(nodeExists: { nodeID in
             node(for: nodeID) != nil
         })
         if didClearSelection {
             recordSelectionMutation()
+            scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         }
         syncSelectedElementStyles()
     }
@@ -1501,7 +1515,17 @@ package final class DOMSession {
         cancelSelectionTransaction(for: selection.fail(failure, clearSelected: clearSelected))
         if selection.selectedNodeID != previousSelectedNodeID {
             recordSelectionMutation()
+            scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         }
+    }
+
+    private func scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: DOMNode.ID?) {
+        guard let previousSelectedNodeID,
+              selection.selectedNodeID == nil,
+              highlightController.targetID != nil else {
+            return
+        }
+        scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: previousSelectedNodeID.documentID.targetID)
     }
 
     package func syncSelectedElementStyles() {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -536,6 +536,10 @@ package final class DOMSession {
         selection.selectedNodeID
     }
 
+    package var hasPendingSelectionRequest: Bool {
+        selection.pendingRequest != nil
+    }
+
     package var selectedNode: DOMNode? {
         guard let selectedNodeID = selection.selectedNodeID else {
             return nil

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1522,7 +1522,7 @@ package final class DOMSession {
     private func scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: DOMNode.ID?) {
         guard let previousSelectedNodeID,
               selection.selectedNodeID == nil,
-              highlightController.hasActiveOrPendingHighlight else {
+              highlightController.hasPossibleVisibleHighlight else {
             return
         }
         scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: previousSelectedNodeID.documentID.targetID)

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -739,6 +739,7 @@ package final class DOMSession {
         }
 
         return DOMAction.Target(
+            nodeID: nodeID,
             documentTargetID: documentTargetID,
             rawNodeID: node.protocolNodeID,
             commandTargetID: resolvedCommandTargetID,
@@ -1524,11 +1525,16 @@ package final class DOMSession {
               selection.selectedNodeID == nil else {
             return
         }
-        let targetID = previousSelectedNodeID.documentID.targetID
-        guard let generation = highlightController.possibleVisibleGeneration(targetID: targetID) else {
+        guard let highlight = highlightController.possibleVisibleSelectionHighlight(for: previousSelectedNodeID),
+              let generation = highlight.generation else {
             return
         }
-        scheduleNodeHighlightHideIfCurrent(targetID: targetID, generation: generation)
+        scheduleNodeHighlightHideIfCurrent(
+            targetID: highlight.targetID,
+            generation: generation,
+            nodeID: previousSelectedNodeID,
+            owner: .selection
+        )
     }
 
     package func syncSelectedElementStyles() {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1522,7 +1522,7 @@ package final class DOMSession {
     private func scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: DOMNode.ID?) {
         guard let previousSelectedNodeID,
               selection.selectedNodeID == nil,
-              highlightController.targetID != nil else {
+              highlightController.hasActiveOrPendingHighlight else {
             return
         }
         scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: previousSelectedNodeID.documentID.targetID)

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -1521,11 +1521,14 @@ package final class DOMSession {
 
     private func scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: DOMNode.ID?) {
         guard let previousSelectedNodeID,
-              selection.selectedNodeID == nil,
-              highlightController.hasPossibleVisibleHighlight else {
+              selection.selectedNodeID == nil else {
             return
         }
-        scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: previousSelectedNodeID.documentID.targetID)
+        let targetID = previousSelectedNodeID.documentID.targetID
+        guard let generation = highlightController.possibleVisibleGeneration(targetID: targetID) else {
+            return
+        }
+        scheduleNodeHighlightHideIfCurrent(targetID: targetID, generation: generation)
     }
 
     package func syncSelectedElementStyles() {

--- a/Sources/WebInspectorCore/DOM/DOMProtocol.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProtocol.swift
@@ -3,6 +3,11 @@ import WebInspectorTransport
 package enum DOMAction {}
 package enum DOMCommand {}
 
+package enum DOMPageHighlightOwner: Equatable, Sendable {
+    case selection
+    case transient
+}
+
 package extension DOMDocument {
     struct LifetimeID: RawRepresentable, Hashable, Comparable, Codable, Sendable {
         package let rawValue: UInt64
@@ -240,17 +245,20 @@ package extension DOMCommand {
 
 package extension DOMAction {
     struct Target: Equatable, Hashable, Sendable {
+        package var nodeID: DOMNode.ID
         package var documentTargetID: ProtocolTarget.ID
         package var rawNodeID: DOMNode.ProtocolID
         package var commandTargetID: ProtocolTarget.ID
         package var commandNodeID: DOMCommand.NodeID
 
         package init(
+            nodeID: DOMNode.ID,
             documentTargetID: ProtocolTarget.ID,
             rawNodeID: DOMNode.ProtocolID,
             commandTargetID: ProtocolTarget.ID,
             commandNodeID: DOMCommand.NodeID
         ) {
+            self.nodeID = nodeID
             self.documentTargetID = documentTargetID
             self.rawNodeID = rawNodeID
             self.commandTargetID = commandTargetID

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -124,6 +124,13 @@ final class DOMSessionElementPickerController {
         return true
     }
 
+    func isCurrentEnablingSession(_ session: Session) -> Bool {
+        guard case let .enabling(currentSession) = phase else {
+            return false
+        }
+        return currentSession === session
+    }
+
     func currentAcceptingSession() -> Session? {
         phase.acceptingSession()
     }

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -6,11 +6,15 @@ final class DOMSessionHighlightController {
     struct PossibleVisibleHighlight: Equatable {
         var targetID: ProtocolTarget.ID
         var generation: UInt64?
+        var nodeID: DOMNode.ID?
+        var owner: DOMPageHighlightOwner?
     }
 
     private struct PossibleVisibleTarget: Equatable {
         var targetID: ProtocolTarget.ID
         var generation: UInt64
+        var nodeID: DOMNode.ID?
+        var owner: DOMPageHighlightOwner?
     }
 
     // WebKit does not expose the current overlay state, and a task can be
@@ -36,14 +40,23 @@ final class DOMSessionHighlightController {
             highlights.append(
                 PossibleVisibleHighlight(
                     targetID: targetID,
-                    generation: possibleVisibleGeneration(targetID: targetID)
+                    generation: possibleVisibleGeneration(targetID: targetID),
+                    nodeID: possibleVisibleNodeID(targetID: targetID),
+                    owner: possibleVisibleOwner(targetID: targetID)
                 )
             )
         }
         if highlights.isEmpty,
            let fallbackTargetID,
            fallbackTargetID != preservedTargetID {
-            highlights.append(PossibleVisibleHighlight(targetID: fallbackTargetID, generation: nil))
+            highlights.append(
+                PossibleVisibleHighlight(
+                    targetID: fallbackTargetID,
+                    generation: nil,
+                    nodeID: nil,
+                    owner: nil
+                )
+            )
         }
         return highlights
     }
@@ -52,10 +65,57 @@ final class DOMSessionHighlightController {
         possibleVisibleTargets.first { $0.targetID == targetID }?.generation
     }
 
-    func markHighlightMayBeVisible(targetID: ProtocolTarget.ID) {
+    func possibleVisibleNodeID(targetID: ProtocolTarget.ID) -> DOMNode.ID? {
+        possibleVisibleTargets.first { $0.targetID == targetID }?.nodeID
+    }
+
+    func possibleVisibleOwner(targetID: ProtocolTarget.ID) -> DOMPageHighlightOwner? {
+        possibleVisibleTargets.first { $0.targetID == targetID }?.owner
+    }
+
+    func possibleVisibleSelectionHighlight(for nodeID: DOMNode.ID) -> PossibleVisibleHighlight? {
+        possibleVisibleTargets.lazy
+            .filter { $0.nodeID == nodeID && $0.owner == .selection }
+            .map {
+                PossibleVisibleHighlight(
+                    targetID: $0.targetID,
+                    generation: $0.generation,
+                    nodeID: $0.nodeID,
+                    owner: $0.owner
+                )
+            }
+            .first
+    }
+
+    func isPossibleVisibleHighlight(
+        targetID: ProtocolTarget.ID,
+        generation: UInt64,
+        nodeID: DOMNode.ID?,
+        owner: DOMPageHighlightOwner?
+    ) -> Bool {
+        possibleVisibleTargets.contains {
+            $0.targetID == targetID
+                && $0.generation == generation
+                && (nodeID == nil || $0.nodeID == nodeID)
+                && (owner == nil || $0.owner == owner)
+        }
+    }
+
+    func markHighlightMayBeVisible(
+        targetID: ProtocolTarget.ID,
+        nodeID: DOMNode.ID? = nil,
+        owner: DOMPageHighlightOwner? = nil
+    ) {
         nextGeneration &+= 1
         clearHighlight(targetID: targetID)
-        possibleVisibleTargets.append(PossibleVisibleTarget(targetID: targetID, generation: nextGeneration))
+        possibleVisibleTargets.append(
+            PossibleVisibleTarget(
+                targetID: targetID,
+                generation: nextGeneration,
+                nodeID: nodeID,
+                owner: owner
+            )
+        )
     }
 
     func clearHighlight(targetID: ProtocolTarget.ID) {

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -3,7 +3,58 @@ import WebInspectorTransport
 
 @MainActor
 final class DOMSessionHighlightController {
+    struct Request: Equatable {
+        var id: UInt64
+        var targetID: ProtocolTarget.ID
+    }
+
     var targetID: ProtocolTarget.ID?
+    private var nextRequestRawID: UInt64 = 0
+    private var pendingRequest: Request?
+
+    var pendingTargetID: ProtocolTarget.ID? {
+        pendingRequest?.targetID
+    }
+
+    var hasActiveOrPendingHighlight: Bool {
+        targetID != nil || pendingRequest != nil
+    }
+
+    func beginHighlight(targetID: ProtocolTarget.ID) -> Request {
+        nextRequestRawID &+= 1
+        let request = Request(id: nextRequestRawID, targetID: targetID)
+        pendingRequest = request
+        return request
+    }
+
+    func completeHighlight(_ request: Request) {
+        guard pendingRequest == request else {
+            return
+        }
+        targetID = request.targetID
+        pendingRequest = nil
+    }
+
+    func cancelHighlight(_ request: Request) {
+        guard pendingRequest == request else {
+            return
+        }
+        pendingRequest = nil
+    }
+
+    func clearHighlight(targetID: ProtocolTarget.ID) {
+        if self.targetID == targetID {
+            self.targetID = nil
+        }
+        if pendingRequest?.targetID == targetID {
+            pendingRequest = nil
+        }
+    }
+
+    func clearAll() {
+        targetID = nil
+        pendingRequest = nil
+    }
 }
 
 @MainActor

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -3,57 +3,46 @@ import WebInspectorTransport
 
 @MainActor
 final class DOMSessionHighlightController {
-    struct Request: Equatable {
-        var id: UInt64
-        var targetID: ProtocolTarget.ID
+    // WebKit does not expose the current overlay state, and a task can be
+    // cancelled after a highlight command has reached the backend. Track
+    // targets that may still need an explicit hide instead of tying ownership
+    // to command replies.
+    private var possibleVisibleTargetIDs: [ProtocolTarget.ID] = []
+
+    var hasPossibleVisibleHighlight: Bool {
+        !possibleVisibleTargetIDs.isEmpty
     }
 
-    var targetID: ProtocolTarget.ID?
-    private var nextRequestRawID: UInt64 = 0
-    private var pendingRequest: Request?
-
-    var pendingTargetID: ProtocolTarget.ID? {
-        pendingRequest?.targetID
-    }
-
-    var hasActiveOrPendingHighlight: Bool {
-        targetID != nil || pendingRequest != nil
-    }
-
-    func beginHighlight(targetID: ProtocolTarget.ID) -> Request {
-        nextRequestRawID &+= 1
-        let request = Request(id: nextRequestRawID, targetID: targetID)
-        pendingRequest = request
-        return request
-    }
-
-    func completeHighlight(_ request: Request) {
-        guard pendingRequest == request else {
-            return
+    func possibleVisibleTargets(
+        preferredFirst preferredTargetID: ProtocolTarget.ID?,
+        fallbackTargetID: ProtocolTarget.ID?,
+        preserving preservedTargetID: ProtocolTarget.ID?
+    ) -> [ProtocolTarget.ID] {
+        var targetIDs: [ProtocolTarget.ID] = []
+        let candidates = [preferredTargetID] + possibleVisibleTargetIDs.map(Optional.some)
+        for targetID in candidates.compactMap(\.self)
+        where targetID != preservedTargetID && !targetIDs.contains(targetID) {
+            targetIDs.append(targetID)
         }
-        targetID = request.targetID
-        pendingRequest = nil
+        if targetIDs.isEmpty,
+           let fallbackTargetID,
+           fallbackTargetID != preservedTargetID {
+            targetIDs.append(fallbackTargetID)
+        }
+        return targetIDs
     }
 
-    func cancelHighlight(_ request: Request) {
-        guard pendingRequest == request else {
-            return
-        }
-        pendingRequest = nil
+    func markHighlightMayBeVisible(targetID: ProtocolTarget.ID) {
+        clearHighlight(targetID: targetID)
+        possibleVisibleTargetIDs.append(targetID)
     }
 
     func clearHighlight(targetID: ProtocolTarget.ID) {
-        if self.targetID == targetID {
-            self.targetID = nil
-        }
-        if pendingRequest?.targetID == targetID {
-            pendingRequest = nil
-        }
+        possibleVisibleTargetIDs.removeAll { $0 == targetID }
     }
 
     func clearAll() {
-        targetID = nil
-        pendingRequest = nil
+        possibleVisibleTargetIDs.removeAll()
     }
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -3,14 +3,20 @@ import WebInspectorTransport
 
 @MainActor
 final class DOMSessionHighlightController {
+    private struct PossibleVisibleTarget: Equatable {
+        var targetID: ProtocolTarget.ID
+        var generation: UInt64
+    }
+
     // WebKit does not expose the current overlay state, and a task can be
     // cancelled after a highlight command has reached the backend. Track
     // targets that may still need an explicit hide instead of tying ownership
     // to command replies.
-    private var possibleVisibleTargetIDs: [ProtocolTarget.ID] = []
+    private var possibleVisibleTargets: [PossibleVisibleTarget] = []
+    private var nextGeneration: UInt64 = 0
 
     var hasPossibleVisibleHighlight: Bool {
-        !possibleVisibleTargetIDs.isEmpty
+        !possibleVisibleTargets.isEmpty
     }
 
     func possibleVisibleTargets(
@@ -19,7 +25,7 @@ final class DOMSessionHighlightController {
         preserving preservedTargetID: ProtocolTarget.ID?
     ) -> [ProtocolTarget.ID] {
         var targetIDs: [ProtocolTarget.ID] = []
-        let candidates = [preferredTargetID] + possibleVisibleTargetIDs.map(Optional.some)
+        let candidates = [preferredTargetID] + possibleVisibleTargets.map { Optional.some($0.targetID) }
         for targetID in candidates.compactMap(\.self)
         where targetID != preservedTargetID && !targetIDs.contains(targetID) {
             targetIDs.append(targetID)
@@ -32,17 +38,29 @@ final class DOMSessionHighlightController {
         return targetIDs
     }
 
+    func possibleVisibleGeneration(targetID: ProtocolTarget.ID) -> UInt64? {
+        possibleVisibleTargets.first { $0.targetID == targetID }?.generation
+    }
+
     func markHighlightMayBeVisible(targetID: ProtocolTarget.ID) {
+        nextGeneration &+= 1
         clearHighlight(targetID: targetID)
-        possibleVisibleTargetIDs.append(targetID)
+        possibleVisibleTargets.append(PossibleVisibleTarget(targetID: targetID, generation: nextGeneration))
     }
 
     func clearHighlight(targetID: ProtocolTarget.ID) {
-        possibleVisibleTargetIDs.removeAll { $0 == targetID }
+        possibleVisibleTargets.removeAll { $0.targetID == targetID }
+    }
+
+    func clearHighlight(targetID: ProtocolTarget.ID, matchingGeneration generation: UInt64?) {
+        guard let generation else {
+            return
+        }
+        possibleVisibleTargets.removeAll { $0.targetID == targetID && $0.generation == generation }
     }
 
     func clearAll() {
-        possibleVisibleTargetIDs.removeAll()
+        possibleVisibleTargets.removeAll()
     }
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -3,6 +3,11 @@ import WebInspectorTransport
 
 @MainActor
 final class DOMSessionHighlightController {
+    struct PossibleVisibleHighlight: Equatable {
+        var targetID: ProtocolTarget.ID
+        var generation: UInt64?
+    }
+
     private struct PossibleVisibleTarget: Equatable {
         var targetID: ProtocolTarget.ID
         var generation: UInt64
@@ -19,23 +24,28 @@ final class DOMSessionHighlightController {
         !possibleVisibleTargets.isEmpty
     }
 
-    func possibleVisibleTargets(
+    func possibleVisibleHighlights(
         preferredFirst preferredTargetID: ProtocolTarget.ID?,
         fallbackTargetID: ProtocolTarget.ID?,
         preserving preservedTargetID: ProtocolTarget.ID?
-    ) -> [ProtocolTarget.ID] {
-        var targetIDs: [ProtocolTarget.ID] = []
+    ) -> [PossibleVisibleHighlight] {
+        var highlights: [PossibleVisibleHighlight] = []
         let candidates = [preferredTargetID] + possibleVisibleTargets.map { Optional.some($0.targetID) }
         for targetID in candidates.compactMap(\.self)
-        where targetID != preservedTargetID && !targetIDs.contains(targetID) {
-            targetIDs.append(targetID)
+        where targetID != preservedTargetID && !highlights.contains(where: { $0.targetID == targetID }) {
+            highlights.append(
+                PossibleVisibleHighlight(
+                    targetID: targetID,
+                    generation: possibleVisibleGeneration(targetID: targetID)
+                )
+            )
         }
-        if targetIDs.isEmpty,
+        if highlights.isEmpty,
            let fallbackTargetID,
            fallbackTargetID != preservedTargetID {
-            targetIDs.append(fallbackTargetID)
+            highlights.append(PossibleVisibleHighlight(targetID: fallbackTargetID, generation: nil))
         }
-        return targetIDs
+        return highlights
     }
 
     func possibleVisibleGeneration(targetID: ProtocolTarget.ID) -> UInt64? {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -195,6 +195,7 @@ extension DOMSession {
             includeCurrentPageFallback: false
         )
         guard !Task.isCancelled,
+              !isSelectingElement,
               let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
@@ -337,6 +338,18 @@ extension DOMSession {
         syncElementPickerSelectionState()
 
         do {
+            await hideStaleHighlights(
+                preferredHideTargetID: nil,
+                preserving: nil,
+                includeCurrentPageFallback: false
+            )
+            guard !Task.isCancelled else {
+                clearElementPickerState(invalidatePendingSelection: true)
+                return
+            }
+            guard elementPicker.isCurrentEnablingSession(pickerSession) else {
+                return
+            }
             guard let intent = setInspectModeEnabledIntent(targetID: targetID, enabled: true) else {
                 recordElementPickerFailure(reason: "inspectModeUnavailable", targetID: targetID)
                 throw InspectorSession.Error("DOM inspect mode is not available.")

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -173,6 +173,7 @@ extension DOMSession {
         if !hasPendingSelectionRequest,
            let selectedNodeID,
            let intent = highlightNodeIntent(for: selectedNodeID) {
+            let selectionRevisionBeforeRestore = selectionRevision
             let selectedHighlightTargetID: ProtocolTarget.ID? = if case let .highlightNode(target) = intent {
                 target.commandTargetID
             } else {
@@ -183,6 +184,13 @@ extension DOMSession {
                 preserving: selectedHighlightTargetID,
                 includeCurrentPageFallback: false
             )
+            guard !isSelectingElement,
+                  !hasPendingSelectionRequest,
+                  self.selectedNodeID == selectedNodeID,
+                  selectionRevision == selectionRevisionBeforeRestore,
+                  let intent = highlightNodeIntent(for: selectedNodeID) else {
+                return
+            }
             do {
                 try await perform(intent)
             } catch {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -272,12 +272,14 @@ extension DOMSession {
               !isSelectingElement else {
             return
         }
+        guard highlightController.possibleVisibleGeneration(targetID: targetID) == generation else {
+            return
+        }
         if selectedNodeID != nil {
             await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
             return
         }
-        guard !hasPendingSelectionRequest,
-              highlightController.possibleVisibleGeneration(targetID: targetID) == generation else {
+        guard !hasPendingSelectionRequest else {
             return
         }
         guard containsTarget(targetID) else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -158,7 +158,8 @@ extension DOMSession {
             preserving: highlightedTargetID,
             includeCurrentPageFallback: false
         )
-        guard let intent = highlightNodeIntent(for: nodeID) else {
+        guard !Task.isCancelled,
+              let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
         do {
@@ -219,7 +220,7 @@ extension DOMSession {
         )
     }
 
-    private func scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) {
+    package func scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) {
         Task { @MainActor [weak self] in
             await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
         }
@@ -237,6 +238,12 @@ extension DOMSession {
             targetIDs.append(targetID)
         }
         for targetID in targetIDs {
+            guard containsTarget(targetID) else {
+                if highlightController.targetID == targetID {
+                    highlightController.targetID = nil
+                }
+                continue
+            }
             guard let intent = hideHighlightIntent(targetID: targetID) else {
                 continue
             }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -305,6 +305,9 @@ extension DOMSession {
             fallbackTargetID: fallbackTargetID,
             preserving: preservedTargetID
         ) {
+            guard !Task.isCancelled else {
+                return
+            }
             guard containsTarget(targetID) else {
                 highlightController.clearHighlight(targetID: targetID)
                 continue

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -347,6 +347,16 @@ extension DOMSession {
         recordError?(InspectorSession.Error(String(describing: error)))
     }
 
+    private func restoreSelectedNodeHighlightAfterPickerInterruption() async {
+        guard selectedNodeID != nil else {
+            return
+        }
+        let restoreTask = Task { @MainActor [weak self] in
+            await self?.restoreSelectedNodeHighlightOrHide()
+        }
+        await restoreTask.value
+    }
+
     package func toggleElementPicker() async {
         if isSelectingElement {
             await cancelElementPicker()
@@ -394,8 +404,9 @@ extension DOMSession {
                 preserving: nil,
                 includeCurrentPageFallback: false
             )
-            guard !Task.isCancelled else {
+            if Task.isCancelled {
                 clearElementPickerState(invalidatePendingSelection: true)
+                await restoreSelectedNodeHighlightAfterPickerInterruption()
                 return
             }
             guard elementPicker.isCurrentEnablingSession(pickerSession) else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -166,6 +166,28 @@ extension DOMSession {
         }
     }
 
+    package func restoreSelectedNodeHighlightOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) async {
+        if !hasPendingSelectionRequest,
+           let selectedNodeID,
+           let intent = highlightNodeIntent(for: selectedNodeID) {
+            do {
+                try await perform(intent)
+            } catch {
+                recordError?(InspectorSession.Error(String(describing: error)))
+            }
+            return
+        }
+
+        guard let intent = hideHighlightIntent(targetID: preferredHideTargetID ?? highlightController.targetID) else {
+            return
+        }
+        do {
+            try await perform(intent)
+        } catch {
+            recordError?(InspectorSession.Error(String(describing: error)))
+        }
+    }
+
     package func toggleElementPicker() async {
         if isSelectingElement {
             await cancelElementPicker()
@@ -233,6 +255,7 @@ extension DOMSession {
         clearElementPickerState(invalidatePendingSelection: true)
         guard let targetID,
               let intent = setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
+            await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
             return
         }
         do {
@@ -240,6 +263,7 @@ extension DOMSession {
         } catch {
             recordError?(InspectorSession.Error(String(describing: error)))
         }
+        await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
     }
 
     package func copySelectedNodeText(_ kind: DOMNode.CopyTextKind) async throws -> String {
@@ -555,6 +579,8 @@ extension DOMSession {
             return
         }
         let selectedStyleID = try? selectedCSSNodeStylesID().get()
+        let selectionRevisionBeforeEvent = selectionRevision
+        let hadPendingSelectionRequest = hasPendingSelectionRequest
         try protocolCommands.applyDOMEvent(event, to: self)
         if let selectedStyleID,
            let targetID = event.targetID,
@@ -568,6 +594,12 @@ extension DOMSession {
         }
         if event.method == "DOM.setChildNodes" {
             startPendingFrameOwnerHydration()
+        }
+        if hadPendingSelectionRequest,
+           !hasPendingSelectionRequest,
+           selectionRevision != selectionRevisionBeforeEvent,
+           !isSelectingElement {
+            await restoreSelectedNodeHighlightOrHide()
         }
     }
 
@@ -973,6 +1005,7 @@ extension DOMSession {
         let targetID = session.targetID
         clearElementPickerState()
         guard let intent = setInspectModeEnabledIntent(targetID: targetID, enabled: false) else {
+            await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
             return
         }
         do {
@@ -980,6 +1013,7 @@ extension DOMSession {
         } catch {
             recordError?(InspectorSession.Error(String(describing: error)))
         }
+        await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
     }
 
     private func requireCommandChannel(requiresActiveConnection: Bool = true) throws -> ProtocolCommandChannel {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -80,17 +80,15 @@ extension DOMSession {
         _ intent: DOMCommand.Intent,
         requiresActiveConnection: Bool
     ) async throws -> ProtocolCommand.Result {
-        let highlightRequest: DOMSessionHighlightController.Request? = if case let .highlightNode(target) = intent {
-            highlightController.beginHighlight(targetID: target.commandTargetID)
-        } else {
-            nil
+        if case let .highlightNode(target) = intent {
+            highlightController.markHighlightMayBeVisible(targetID: target.commandTargetID)
         }
         let result: ProtocolCommand.Result
         do {
             result = try await send(intent, requiresActiveConnection: requiresActiveConnection)
         } catch {
-            if let highlightRequest {
-                highlightController.cancelHighlight(highlightRequest)
+            if let missingTargetID = missingTargetID(from: error) {
+                clearHighlightOwnershipIfMissingTarget(missingTargetID, for: intent)
             }
             throw error
         }
@@ -114,9 +112,7 @@ extension DOMSession {
         case .requestChildNodes:
             break
         case .highlightNode:
-            if let highlightRequest {
-                highlightController.completeHighlight(highlightRequest)
-            }
+            break
         case let .hideHighlight(targetID):
             highlightController.clearHighlight(targetID: targetID)
         case .setInspectModeEnabled,
@@ -127,6 +123,28 @@ extension DOMSession {
             break
         }
         return result
+    }
+
+    private func missingTargetID(from error: any Error) -> ProtocolTarget.ID? {
+        guard let transportError = error as? TransportSession.Error,
+              case let .missingTarget(targetID) = transportError else {
+            return nil
+        }
+        return targetID
+    }
+
+    private func clearHighlightOwnershipIfMissingTarget(
+        _ missingTargetID: ProtocolTarget.ID,
+        for intent: DOMCommand.Intent
+    ) {
+        switch intent {
+        case let .highlightNode(target) where target.commandTargetID == missingTargetID:
+            highlightController.clearHighlight(targetID: missingTargetID)
+        case let .hideHighlight(targetID) where targetID == missingTargetID:
+            highlightController.clearHighlight(targetID: missingTargetID)
+        default:
+            break
+        }
     }
 
     @discardableResult
@@ -183,14 +201,11 @@ extension DOMSession {
     }
 
     package func hideNodeHighlight() async {
-        guard let intent = hideHighlightIntent(targetID: highlightController.targetID) else {
-            return
-        }
-        do {
-            try await perform(intent)
-        } catch {
-            recordError?(InspectorSession.Error(String(describing: error)))
-        }
+        await hideStaleHighlights(
+            preferredHideTargetID: nil,
+            preserving: nil,
+            includeCurrentPageFallback: true
+        )
     }
 
     package func restoreSelectedNodeHighlightOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) async {
@@ -244,18 +259,12 @@ extension DOMSession {
         preserving preservedTargetID: ProtocolTarget.ID?,
         includeCurrentPageFallback: Bool
     ) async {
-        var targetIDs: [ProtocolTarget.ID] = []
         let fallbackTargetID = includeCurrentPageFallback ? currentPageTargetID : nil
-        for targetID in [
-            preferredHideTargetID,
-            highlightController.targetID,
-            highlightController.pendingTargetID,
-            fallbackTargetID,
-        ].compactMap(\.self)
-        where targetID != preservedTargetID && !targetIDs.contains(targetID) {
-            targetIDs.append(targetID)
-        }
-        for targetID in targetIDs {
+        for targetID in highlightController.possibleVisibleTargets(
+            preferredFirst: preferredHideTargetID,
+            fallbackTargetID: fallbackTargetID,
+            preserving: preservedTargetID
+        ) {
             guard containsTarget(targetID) else {
                 highlightController.clearHighlight(targetID: targetID)
                 continue

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -261,6 +261,39 @@ extension DOMSession {
         }
     }
 
+    package func scheduleNodeHighlightHideIfCurrent(targetID: ProtocolTarget.ID, generation: UInt64) {
+        Task { @MainActor [weak self] in
+            await self?.hideNodeHighlightIfCurrent(targetID: targetID, generation: generation)
+        }
+    }
+
+    package func hideNodeHighlightIfCurrent(targetID: ProtocolTarget.ID, generation: UInt64) async {
+        guard !Task.isCancelled,
+              !isSelectingElement else {
+            return
+        }
+        if selectedNodeID != nil {
+            await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
+            return
+        }
+        guard !hasPendingSelectionRequest,
+              highlightController.possibleVisibleGeneration(targetID: targetID) == generation else {
+            return
+        }
+        guard containsTarget(targetID) else {
+            highlightController.clearHighlight(targetID: targetID, matchingGeneration: generation)
+            return
+        }
+        guard let intent = hideHighlightIntent(targetID: targetID) else {
+            return
+        }
+        do {
+            try await perform(intent)
+        } catch {
+            recordPageHighlightErrorUnlessCancelled(error)
+        }
+    }
+
     private func hideStaleHighlights(
         preferredHideTargetID: ProtocolTarget.ID?,
         preserving preservedTargetID: ProtocolTarget.ID?,

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -201,7 +201,7 @@ extension DOMSession {
         do {
             try await perform(intent)
         } catch {
-            recordError?(InspectorSession.Error(String(describing: error)))
+            recordPageHighlightErrorUnlessCancelled(error)
         }
     }
 
@@ -231,7 +231,8 @@ extension DOMSession {
                 preserving: selectedHighlightTargetID,
                 includeCurrentPageFallback: false
             )
-            guard !isSelectingElement,
+            guard !Task.isCancelled,
+                  !isSelectingElement,
                   !hasPendingSelectionRequest,
                   self.selectedNodeID == selectedNodeID,
                   selectionRevision == selectionRevisionBeforeRestore,
@@ -241,7 +242,7 @@ extension DOMSession {
             do {
                 try await perform(intent)
             } catch {
-                recordError?(InspectorSession.Error(String(describing: error)))
+                recordPageHighlightErrorUnlessCancelled(error)
             }
             return
         }
@@ -279,10 +280,19 @@ extension DOMSession {
             }
             do {
                 try await perform(intent)
+            } catch is CancellationError {
+                return
             } catch {
                 recordError?(InspectorSession.Error(String(describing: error)))
             }
         }
+    }
+
+    private func recordPageHighlightErrorUnlessCancelled(_ error: any Error) {
+        guard !(error is CancellationError) else {
+            return
+        }
+        recordError?(InspectorSession.Error(String(describing: error)))
     }
 
     package func toggleElementPicker() async {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -399,6 +399,7 @@ extension DOMSession {
                 details: "error=\(error)"
             )
             clearElementPickerState(invalidatePendingSelection: true)
+            await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
             throw error
         }
     }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -148,6 +148,19 @@ extension DOMSession {
         guard let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
+        let highlightedTargetID: ProtocolTarget.ID? = if case let .highlightNode(target) = intent {
+            target.commandTargetID
+        } else {
+            nil
+        }
+        await hideStaleHighlights(
+            preferredHideTargetID: nil,
+            preserving: highlightedTargetID,
+            includeCurrentPageFallback: false
+        )
+        guard let intent = highlightNodeIntent(for: nodeID) else {
+            return
+        }
         do {
             try await perform(intent)
         } catch {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -170,6 +170,16 @@ extension DOMSession {
         if !hasPendingSelectionRequest,
            let selectedNodeID,
            let intent = highlightNodeIntent(for: selectedNodeID) {
+            let selectedHighlightTargetID: ProtocolTarget.ID? = if case let .highlightNode(target) = intent {
+                target.commandTargetID
+            } else {
+                nil
+            }
+            await hideStaleHighlights(
+                preferredHideTargetID: preferredHideTargetID,
+                preserving: selectedHighlightTargetID,
+                includeCurrentPageFallback: false
+            )
             do {
                 try await perform(intent)
             } catch {
@@ -178,9 +188,22 @@ extension DOMSession {
             return
         }
 
+        await hideStaleHighlights(
+            preferredHideTargetID: preferredHideTargetID,
+            preserving: nil,
+            includeCurrentPageFallback: true
+        )
+    }
+
+    private func hideStaleHighlights(
+        preferredHideTargetID: ProtocolTarget.ID?,
+        preserving preservedTargetID: ProtocolTarget.ID?,
+        includeCurrentPageFallback: Bool
+    ) async {
         var targetIDs: [ProtocolTarget.ID] = []
-        for targetID in [preferredHideTargetID, highlightController.targetID, currentPageTargetID].compactMap(\.self)
-        where !targetIDs.contains(targetID) {
+        let fallbackTargetID = includeCurrentPageFallback ? currentPageTargetID : nil
+        for targetID in [preferredHideTargetID, highlightController.targetID, fallbackTargetID].compactMap(\.self)
+        where targetID != preservedTargetID && !targetIDs.contains(targetID) {
             targetIDs.append(targetID)
         }
         for targetID in targetIDs {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -1153,7 +1153,7 @@ extension DOMSession {
                 return
             }
             recordElementPickerFailure(reason: "targetDestroyedBeforeInspectEvent", targetID: activeTargetID)
-            clearElementPickerState(invalidatePendingSelection: true)
+            clearElementPickerStateAfterTargetLifecycleInterruption(activeTargetID: activeTargetID)
         case "Target.didCommitProvisionalTarget":
             guard let targetCommit,
                   targetCommit.consumedOldTargetID == activeTargetID else {
@@ -1164,10 +1164,15 @@ extension DOMSession {
                 targetID: activeTargetID,
                 details: "newTarget=\(targetCommit.newTargetID.rawValue)"
             )
-            clearElementPickerState(invalidatePendingSelection: true)
+            clearElementPickerStateAfterTargetLifecycleInterruption(activeTargetID: activeTargetID)
         default:
             return
         }
+    }
+
+    private func clearElementPickerStateAfterTargetLifecycleInterruption(activeTargetID: ProtocolTarget.ID) {
+        clearElementPickerState(invalidatePendingSelection: true)
+        scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: activeTargetID)
     }
 
     private func selectedStylesShouldRefresh(after event: ProtocolEvent) -> Bool {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -29,7 +29,7 @@ extension DOMSession {
         commandChannel = nil
         recordError = nil
         elementStyles.unbindProtocolChannel()
-        highlightController.targetID = nil
+        highlightController.clearAll()
         clearElementPickerState(invalidatePendingSelection: true)
         clearDeleteUndoHistory()
         recordCommandAvailabilityMutation()
@@ -80,7 +80,20 @@ extension DOMSession {
         _ intent: DOMCommand.Intent,
         requiresActiveConnection: Bool
     ) async throws -> ProtocolCommand.Result {
-        let result = try await send(intent, requiresActiveConnection: requiresActiveConnection)
+        let highlightRequest: DOMSessionHighlightController.Request? = if case let .highlightNode(target) = intent {
+            highlightController.beginHighlight(targetID: target.commandTargetID)
+        } else {
+            nil
+        }
+        let result: ProtocolCommand.Result
+        do {
+            result = try await send(intent, requiresActiveConnection: requiresActiveConnection)
+        } catch {
+            if let highlightRequest {
+                highlightController.cancelHighlight(highlightRequest)
+            }
+            throw error
+        }
 
         switch intent {
         case .getDocument:
@@ -100,12 +113,12 @@ extension DOMSession {
             }
         case .requestChildNodes:
             break
-        case let .highlightNode(target):
-            highlightController.targetID = target.commandTargetID
-        case let .hideHighlight(targetID):
-            if highlightController.targetID == targetID {
-                highlightController.targetID = nil
+        case .highlightNode:
+            if let highlightRequest {
+                highlightController.completeHighlight(highlightRequest)
             }
+        case let .hideHighlight(targetID):
+            highlightController.clearHighlight(targetID: targetID)
         case .setInspectModeEnabled,
              .getOuterHTML,
              .removeNode,
@@ -233,15 +246,18 @@ extension DOMSession {
     ) async {
         var targetIDs: [ProtocolTarget.ID] = []
         let fallbackTargetID = includeCurrentPageFallback ? currentPageTargetID : nil
-        for targetID in [preferredHideTargetID, highlightController.targetID, fallbackTargetID].compactMap(\.self)
+        for targetID in [
+            preferredHideTargetID,
+            highlightController.targetID,
+            highlightController.pendingTargetID,
+            fallbackTargetID,
+        ].compactMap(\.self)
         where targetID != preservedTargetID && !targetIDs.contains(targetID) {
             targetIDs.append(targetID)
         }
         for targetID in targetIDs {
             guard containsTarget(targetID) else {
-                if highlightController.targetID == targetID {
-                    highlightController.targetID = nil
-                }
+                highlightController.clearHighlight(targetID: targetID)
                 continue
             }
             guard let intent = hideHighlightIntent(targetID: targetID) else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -181,7 +181,8 @@ extension DOMSession {
     }
 
     package func highlightNode(for nodeID: DOMNode.ID) async {
-        guard let intent = highlightNodeIntent(for: nodeID) else {
+        guard !isSelectingElement,
+              let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
         let highlightedTargetID: ProtocolTarget.ID? = if case let .highlightNode(target) = intent {
@@ -192,7 +193,8 @@ extension DOMSession {
         await hideStaleHighlights(
             preferredHideTargetID: nil,
             preserving: highlightedTargetID,
-            includeCurrentPageFallback: false
+            includeCurrentPageFallback: false,
+            abortIfSelectingElement: true
         )
         guard !Task.isCancelled,
               !isSelectingElement,
@@ -230,7 +232,8 @@ extension DOMSession {
             await hideStaleHighlights(
                 preferredHideTargetID: preferredHideTargetID,
                 preserving: selectedHighlightTargetID,
-                includeCurrentPageFallback: false
+                includeCurrentPageFallback: false,
+                abortIfSelectingElement: true
             )
             guard !Task.isCancelled,
                   !isSelectingElement,
@@ -251,7 +254,8 @@ extension DOMSession {
         await hideStaleHighlights(
             preferredHideTargetID: preferredHideTargetID,
             preserving: nil,
-            includeCurrentPageFallback: true
+            includeCurrentPageFallback: true,
+            abortIfSelectingElement: true
         )
     }
 
@@ -299,7 +303,8 @@ extension DOMSession {
     private func hideStaleHighlights(
         preferredHideTargetID: ProtocolTarget.ID?,
         preserving preservedTargetID: ProtocolTarget.ID?,
-        includeCurrentPageFallback: Bool
+        includeCurrentPageFallback: Bool,
+        abortIfSelectingElement: Bool = false
     ) async {
         let fallbackTargetID = includeCurrentPageFallback ? currentPageTargetID : nil
         for highlight in highlightController.possibleVisibleHighlights(
@@ -308,6 +313,9 @@ extension DOMSession {
             preserving: preservedTargetID
         ) {
             guard !Task.isCancelled else {
+                return
+            }
+            guard !abortIfSelectingElement || !isSelectingElement else {
                 return
             }
             let targetID = highlight.targetID

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -78,10 +78,15 @@ extension DOMSession {
     @discardableResult
     private func perform(
         _ intent: DOMCommand.Intent,
-        requiresActiveConnection: Bool
+        requiresActiveConnection: Bool,
+        highlightOwner: DOMPageHighlightOwner? = nil
     ) async throws -> ProtocolCommand.Result {
         if case let .highlightNode(target) = intent {
-            highlightController.markHighlightMayBeVisible(targetID: target.commandTargetID)
+            highlightController.markHighlightMayBeVisible(
+                targetID: target.commandTargetID,
+                nodeID: target.nodeID,
+                owner: highlightOwner
+            )
         }
         let hideGeneration: UInt64? = if case let .hideHighlight(targetID) = intent {
             highlightController.possibleVisibleGeneration(targetID: targetID)
@@ -180,8 +185,12 @@ extension DOMSession {
         }
     }
 
-    package func highlightNode(for nodeID: DOMNode.ID) async {
+    package func highlightNode(
+        for nodeID: DOMNode.ID,
+        owner: DOMPageHighlightOwner = .transient
+    ) async {
         guard !isSelectingElement,
+              canHighlightNode(nodeID, owner: owner),
               let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
@@ -198,13 +207,23 @@ extension DOMSession {
         )
         guard !Task.isCancelled,
               !isSelectingElement,
+              canHighlightNode(nodeID, owner: owner),
               let intent = highlightNodeIntent(for: nodeID) else {
             return
         }
         do {
-            try await perform(intent)
+            try await perform(intent, requiresActiveConnection: true, highlightOwner: owner)
         } catch {
             recordPageHighlightErrorUnlessCancelled(error)
+        }
+    }
+
+    private func canHighlightNode(_ nodeID: DOMNode.ID, owner: DOMPageHighlightOwner) -> Bool {
+        switch owner {
+        case .selection:
+            !hasPendingSelectionRequest && selectedNodeID == nodeID
+        case .transient:
+            true
         }
     }
 
@@ -244,7 +263,7 @@ extension DOMSession {
                 return
             }
             do {
-                try await perform(intent)
+                try await perform(intent, requiresActiveConnection: true, highlightOwner: .selection)
             } catch {
                 recordPageHighlightErrorUnlessCancelled(error)
             }
@@ -265,18 +284,38 @@ extension DOMSession {
         }
     }
 
-    package func scheduleNodeHighlightHideIfCurrent(targetID: ProtocolTarget.ID, generation: UInt64) {
+    package func scheduleNodeHighlightHideIfCurrent(
+        targetID: ProtocolTarget.ID,
+        generation: UInt64,
+        nodeID: DOMNode.ID? = nil,
+        owner: DOMPageHighlightOwner? = nil
+    ) {
         Task { @MainActor [weak self] in
-            await self?.hideNodeHighlightIfCurrent(targetID: targetID, generation: generation)
+            await self?.hideNodeHighlightIfCurrent(
+                targetID: targetID,
+                generation: generation,
+                nodeID: nodeID,
+                owner: owner
+            )
         }
     }
 
-    package func hideNodeHighlightIfCurrent(targetID: ProtocolTarget.ID, generation: UInt64) async {
+    package func hideNodeHighlightIfCurrent(
+        targetID: ProtocolTarget.ID,
+        generation: UInt64,
+        nodeID: DOMNode.ID? = nil,
+        owner: DOMPageHighlightOwner? = nil
+    ) async {
         guard !Task.isCancelled,
               !isSelectingElement else {
             return
         }
-        guard highlightController.possibleVisibleGeneration(targetID: targetID) == generation else {
+        guard highlightController.isPossibleVisibleHighlight(
+            targetID: targetID,
+            generation: generation,
+            nodeID: nodeID,
+            owner: owner
+        ) else {
             return
         }
         if selectedNodeID != nil {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -83,6 +83,11 @@ extension DOMSession {
         if case let .highlightNode(target) = intent {
             highlightController.markHighlightMayBeVisible(targetID: target.commandTargetID)
         }
+        let hideGeneration: UInt64? = if case let .hideHighlight(targetID) = intent {
+            highlightController.possibleVisibleGeneration(targetID: targetID)
+        } else {
+            nil
+        }
         let result: ProtocolCommand.Result
         do {
             result = try await send(intent, requiresActiveConnection: requiresActiveConnection)
@@ -114,7 +119,7 @@ extension DOMSession {
         case .highlightNode:
             break
         case let .hideHighlight(targetID):
-            highlightController.clearHighlight(targetID: targetID)
+            highlightController.clearHighlight(targetID: targetID, matchingGeneration: hideGeneration)
         case .setInspectModeEnabled,
              .getOuterHTML,
              .removeNode,

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -167,6 +167,9 @@ extension DOMSession {
     }
 
     package func restoreSelectedNodeHighlightOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) async {
+        guard !isSelectingElement else {
+            return
+        }
         if !hasPendingSelectionRequest,
            let selectedNodeID,
            let intent = highlightNodeIntent(for: selectedNodeID) {
@@ -193,6 +196,12 @@ extension DOMSession {
             preserving: nil,
             includeCurrentPageFallback: true
         )
+    }
+
+    private func scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) {
+        Task { @MainActor [weak self] in
+            await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
+        }
     }
 
     private func hideStaleHighlights(
@@ -629,7 +638,7 @@ extension DOMSession {
            !hasPendingSelectionRequest,
            selectionRevision != selectionRevisionBeforeEvent,
            !isSelectingElement {
-            await restoreSelectedNodeHighlightOrHide()
+            scheduleSelectedNodeHighlightRestoreOrHide()
         }
     }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -178,13 +178,20 @@ extension DOMSession {
             return
         }
 
-        guard let intent = hideHighlightIntent(targetID: preferredHideTargetID ?? highlightController.targetID) else {
-            return
+        var targetIDs: [ProtocolTarget.ID] = []
+        for targetID in [preferredHideTargetID, highlightController.targetID, currentPageTargetID].compactMap(\.self)
+        where !targetIDs.contains(targetID) {
+            targetIDs.append(targetID)
         }
-        do {
-            try await perform(intent)
-        } catch {
-            recordError?(InspectorSession.Error(String(describing: error)))
+        for targetID in targetIDs {
+            guard let intent = hideHighlightIntent(targetID: targetID) else {
+                continue
+            }
+            do {
+                try await perform(intent)
+            } catch {
+                recordError?(InspectorSession.Error(String(describing: error)))
+            }
         }
     }
 

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -302,7 +302,7 @@ extension DOMSession {
         includeCurrentPageFallback: Bool
     ) async {
         let fallbackTargetID = includeCurrentPageFallback ? currentPageTargetID : nil
-        for targetID in highlightController.possibleVisibleTargets(
+        for highlight in highlightController.possibleVisibleHighlights(
             preferredFirst: preferredHideTargetID,
             fallbackTargetID: fallbackTargetID,
             preserving: preservedTargetID
@@ -310,8 +310,13 @@ extension DOMSession {
             guard !Task.isCancelled else {
                 return
             }
+            let targetID = highlight.targetID
+            if let generation = highlight.generation,
+               highlightController.possibleVisibleGeneration(targetID: targetID) != generation {
+                continue
+            }
             guard containsTarget(targetID) else {
-                highlightController.clearHighlight(targetID: targetID)
+                highlightController.clearHighlight(targetID: targetID, matchingGeneration: highlight.generation)
                 continue
             }
             guard let intent = hideHighlightIntent(targetID: targetID) else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -347,12 +347,12 @@ extension DOMSession {
         recordError?(InspectorSession.Error(String(describing: error)))
     }
 
-    private func restoreSelectedNodeHighlightAfterPickerInterruption() async {
+    private func restoreSelectedNodeHighlightAfterPickerInterruption(preferredHideTargetID: ProtocolTarget.ID? = nil) async {
         guard selectedNodeID != nil else {
             return
         }
         let restoreTask = Task { @MainActor [weak self] in
-            await self?.restoreSelectedNodeHighlightOrHide()
+            await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
         }
         await restoreTask.value
     }
@@ -428,7 +428,7 @@ extension DOMSession {
                 details: "error=\(error)"
             )
             clearElementPickerState(invalidatePendingSelection: true)
-            await restoreSelectedNodeHighlightOrHide(preferredHideTargetID: targetID)
+            await restoreSelectedNodeHighlightAfterPickerInterruption(preferredHideTargetID: targetID)
             throw error
         }
     }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -910,6 +910,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             guard let self else {
                 return
             }
+            guard !self.dom.isSelectingElement else {
+                return
+            }
             switch reason {
             case .selection:
                 guard self.dom.selectedNodeID == nodeID else {
@@ -929,7 +932,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard let self,
-                  self.hoveredNodeID == nil else {
+                  self.hoveredNodeID == nil,
+                  !self.dom.isSelectingElement else {
                 return
             }
             await restoreHighlightAction?()

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -939,7 +939,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         clearHoveredRow()
         pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
-            guard let self,
+            guard !Task.isCancelled,
+                  let self,
                   self.hoveredNodeID == nil,
                   !self.dom.isSelectingElement else {
                 return

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -8,7 +8,7 @@ import UIKit
 @MainActor
 final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegate {
     typealias RequestChildrenAction = @MainActor (DOMNode.ID) async -> Bool
-    typealias HighlightNodeAction = @MainActor (DOMNode.ID) async -> Void
+    typealias HighlightNodeAction = @MainActor (DOMNode.ID, DOMPageHighlightOwner) async -> Void
     typealias RestoreHighlightAction = @MainActor () async -> Void
     typealias CopyNodeTextAction = DOMTreeMenuCopyNodeTextAction
     typealias DeleteNodesAction = DOMTreeMenuDeleteNodesAction
@@ -118,6 +118,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private enum PageHighlightReason {
         case selection
         case hover
+
+        var owner: DOMPageHighlightOwner {
+            switch self {
+            case .selection:
+                .selection
+            case .hover:
+                .transient
+            }
+        }
     }
 
     init(
@@ -930,7 +939,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             guard !Task.isCancelled else {
                 return
             }
-            await highlightNodeAction?(nodeID)
+            await highlightNodeAction?(nodeID, reason.owner)
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -70,6 +70,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private let expansionState = DOMTreeTextView.ExpansionState()
     private lazy var renderedRowsBuilder = DOMTreeTextView.RenderedRowsBuilder(dom: dom, expansionState: expansionState)
     private var hoveredNodeID: DOMNode.ID?
+    private var pageHighlightTask: Task<Void, Never>?
     private var requestedChildNodeIDs: Set<DOMNode.ID> = []
     private let findDecorationState = DOMTreeTextView.FindDecorationState()
     private var hoverRowRects: [CGRect] = []
@@ -148,6 +149,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     isolated deinit {
+        pageHighlightTask?.cancel()
         reloadScheduler.cancel()
         documentObservation?.cancel()
         selectionObservation?.cancel()
@@ -905,9 +907,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func highlightPageNode(_ nodeID: DOMNode.ID, reason: PageHighlightReason) {
-        Task { @MainActor [weak self, highlightNodeAction] in
+        pageHighlightTask?.cancel()
+        pageHighlightTask = Task { @MainActor [weak self, highlightNodeAction] in
             await Task.yield()
-            guard let self else {
+            guard !Task.isCancelled,
+                  let self else {
                 return
             }
             guard !self.dom.isSelectingElement else {
@@ -923,11 +927,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                     return
                 }
             }
+            guard !Task.isCancelled else {
+                return
+            }
             await highlightNodeAction?(nodeID)
         }
     }
 
     private func clearHoveredRowAndRestoreSelectionHighlight() {
+        pageHighlightTask?.cancel()
         clearHoveredRow()
         Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -937,7 +937,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func clearHoveredRowAndRestoreSelectionHighlight() {
         pageHighlightTask?.cancel()
         clearHoveredRow()
-        Task { @MainActor [weak self, restoreHighlightAction] in
+        pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard let self,
                   self.hoveredNodeID == nil,

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -9,7 +9,7 @@ import UIKit
 final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegate {
     typealias RequestChildrenAction = @MainActor (DOMNode.ID) async -> Bool
     typealias HighlightNodeAction = @MainActor (DOMNode.ID) async -> Void
-    typealias HideHighlightAction = @MainActor () async -> Void
+    typealias RestoreHighlightAction = @MainActor () async -> Void
     typealias CopyNodeTextAction = DOMTreeMenuCopyNodeTextAction
     typealias DeleteNodesAction = DOMTreeMenuDeleteNodesAction
 
@@ -93,7 +93,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var markedTextStyleStorage: [NSAttributedString.Key: Any]?
     private let requestChildrenAction: RequestChildrenAction?
     private let highlightNodeAction: HighlightNodeAction?
-    private let hideHighlightAction: HideHighlightAction?
+    private let restoreHighlightAction: RestoreHighlightAction?
     weak var inputDelegate: UITextInputDelegate?
 #if DEBUG
     private let performanceCounters = DOMTreeTextView.PerformanceCounters()
@@ -114,18 +114,23 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         Self.paragraphLineHeight
     }
 
+    private enum PageHighlightReason {
+        case selection
+        case hover
+    }
+
     init(
         dom: DOMSession,
         requestChildrenAction: RequestChildrenAction? = nil,
         highlightNodeAction: HighlightNodeAction? = nil,
-        hideHighlightAction: HideHighlightAction? = nil,
+        restoreHighlightAction: RestoreHighlightAction? = nil,
         copyNodeTextAction: CopyNodeTextAction? = nil,
         deleteNodesAction: DeleteNodesAction? = nil
     ) {
         self.dom = dom
         self.requestChildrenAction = requestChildrenAction
         self.highlightNodeAction = highlightNodeAction
-        self.hideHighlightAction = hideHighlightAction
+        self.restoreHighlightAction = restoreHighlightAction
         self.menuModel = DOMTreeMenuModel(
             dom: dom,
             copyNodeTextAction: copyNodeTextAction,
@@ -300,20 +305,12 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         switch recognizer.state {
         case .began, .changed:
             guard let row = row(at: recognizer.location(in: textContentView)) else {
-                clearHoveredRow()
-                Task { @MainActor [hideHighlightAction] in await hideHighlightAction?() }
+                clearHoveredRowAndRestoreSelectionHighlight()
                 return
             }
-            if hoveredNodeID != row.node.id {
-                hoveredNodeID = row.node.id
-                updateContentDecorations()
-            }
-            Task { @MainActor [highlightNodeAction, nodeID = row.node.id] in
-                await highlightNodeAction?(nodeID)
-            }
+            hover(row: row)
         case .ended, .cancelled, .failed:
-            clearHoveredRow()
-            Task { @MainActor [hideHighlightAction] in await hideHighlightAction?() }
+            clearHoveredRowAndRestoreSelectionHighlight()
         default:
             break
         }
@@ -789,6 +786,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func select(_ node: DOMNode) {
         multiSelection.notePrimarySelection(node.id)
         dom.selectNode(node.id)
+        highlightPageNode(node.id, reason: .selection)
     }
 
     private func toggleMultiSelection(row: DOMTreeTextView.Line) {
@@ -896,6 +894,46 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
         hoveredNodeID = nil
         updateContentDecorations()
+    }
+
+    private func hover(row: DOMTreeTextView.Line) {
+        if hoveredNodeID != row.node.id {
+            hoveredNodeID = row.node.id
+            updateContentDecorations()
+        }
+        highlightPageNode(row.node.id, reason: .hover)
+    }
+
+    private func highlightPageNode(_ nodeID: DOMNode.ID, reason: PageHighlightReason) {
+        Task { @MainActor [weak self, highlightNodeAction] in
+            await Task.yield()
+            guard let self else {
+                return
+            }
+            switch reason {
+            case .selection:
+                guard self.dom.selectedNodeID == nodeID else {
+                    return
+                }
+            case .hover:
+                guard self.hoveredNodeID == nodeID else {
+                    return
+                }
+            }
+            await highlightNodeAction?(nodeID)
+        }
+    }
+
+    private func clearHoveredRowAndRestoreSelectionHighlight() {
+        clearHoveredRow()
+        Task { @MainActor [weak self, restoreHighlightAction] in
+            await Task.yield()
+            guard let self,
+                  self.hoveredNodeID == nil else {
+                return
+            }
+            await restoreHighlightAction?()
+        }
     }
 
     private func presentDOMMenu(for nodes: [DOMNode], at location: CGPoint) {
@@ -2113,6 +2151,17 @@ extension DOMTreeTextView {
             clearMultiSelection(keepingLast: row.node.id)
             select(row.node)
         }
+    }
+
+    func hoverRowForTesting(containing text: String) {
+        guard let row = rows.first(where: { $0.text.contains(text) }) else {
+            return
+        }
+        hover(row: row)
+    }
+
+    func endHoverForTesting() {
+        clearHoveredRowAndRestoreSelectionHighlight()
     }
 
     func decorateFindTextForTesting(query: String) {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -24,8 +24,8 @@ package final class DOMTreeViewController: UIViewController {
             highlightNodeAction: { [weak inspection] nodeID in
                 await inspection?.dom.highlightNode(for: nodeID)
             },
-            hideHighlightAction: { [weak inspection] in
-                await inspection?.dom.hideNodeHighlight()
+            restoreHighlightAction: { [weak inspection] in
+                await inspection?.dom.restoreSelectedNodeHighlightOrHide()
             },
             copyNodeTextAction: { [weak inspection] nodeID, kind in
                 guard let inspection else {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -21,8 +21,8 @@ package final class DOMTreeViewController: UIViewController {
             requestChildrenAction: { [weak inspection] nodeID in
                 await inspection?.dom.requestChildNodes(for: nodeID) ?? false
             },
-            highlightNodeAction: { [weak inspection] nodeID in
-                await inspection?.dom.highlightNode(for: nodeID)
+            highlightNodeAction: { [weak inspection] nodeID, owner in
+                await inspection?.dom.highlightNode(for: nodeID, owner: owner)
             },
             restoreHighlightAction: { [weak inspection] in
                 await inspection?.dom.restoreSelectedNodeHighlightOrHide()

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -1175,6 +1175,7 @@ func selectedNodeActionIntentsUseCommandIdentity() async throws {
     let htmlID = try #require((await session.snapshot()).currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
 
     let identity = DOMAction.Target(
+        nodeID: htmlID,
         documentTargetID: pageTargetID,
         rawNodeID: .init(2),
         commandTargetID: pageTargetID,
@@ -1208,6 +1209,7 @@ func frameDocumentActionIdentityUsesMainTargetScopedCommandNode() async throws {
     #expect(await session.removeNodeIntent(for: frameHTMLID, commandTargetID: pageTargetID) == .removeNode(target: identity))
 
     let highlightIdentity = DOMAction.Target(
+        nodeID: frameHTMLID,
         documentTargetID: frameTargetID,
         rawNodeID: .init(2),
         commandTargetID: frameTargetID,

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4959,6 +4959,79 @@ func cancelledBeginElementPickerRestoresSelectedHighlightAfterStaleHide() async 
 }
 
 @Test
+func cancelledBeginElementPickerRestoresSelectedHighlightAfterEnableCancellation() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(pageHTMLID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let countBeforeBeginHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    let enable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeBeginHideReply
+    )
+    #expect(try boolParameter("enabled", in: enable.message) == true)
+
+    let countBeforeCancel = await backend.sentTargetMessages().count
+    beginPickerTask.cancel()
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeCancel
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    do {
+        try await beginPickerTask.value
+        Issue.record("Expected beginElementPicker to fail")
+    } catch {
+    }
+    #expect(await session.attachment.dom.isSelectingElement == false)
+}
+
+@Test
 func cancelledDirectHighlightIsHiddenBeforeRestoringSelection() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3889,6 +3889,82 @@ func pendingPickerSelectionHidesPreviousFrameHighlight() async throws {
 }
 
 @Test
+func directHighlightHidesPreviousTargetBeforeHighlightingNewTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHighlight
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+
+    let countBeforePageHighlight = await backend.sentTargetMessages().count
+    let pageHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let frameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforePageHighlight
+    )
+    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+    let countBeforeFrameHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: frameHide.targetIdentifier,
+        messageID: try messageID(frameHide.message),
+        result: "{}"
+    )
+    let pageHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHideReply
+    )
+    #expect(pageHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: pageHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: pageHighlight.targetIdentifier,
+        messageID: try messageID(pageHighlight.message),
+        result: "{}"
+    )
+    await pageHighlightTask.value
+}
+
+@Test
 func restoreSelectedFrameHighlightHidesPageHoverHighlight() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3965,6 +3965,119 @@ func directHighlightHidesPreviousTargetBeforeHighlightingNewTarget() async throw
 }
 
 @Test
+func staleHideReplyDoesNotForgetNewerHighlightOnSameTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeInitialHighlight = await backend.sentTargetMessages().count
+    let initialHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let initialHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeInitialHighlight
+    )
+    #expect(initialHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: initialHighlight.targetIdentifier,
+        messageID: try messageID(initialHighlight.message),
+        result: "{}"
+    )
+    await initialHighlightTask.value
+
+    let countBeforeHide = await backend.sentTargetMessages().count
+    let hideTask = Task {
+        await session.attachment.dom.hideNodeHighlight()
+    }
+    let staleHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeHide
+    )
+    #expect(staleHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    let countBeforeReplacementHighlight = await backend.sentTargetMessages().count
+    let replacementHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let replacementHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeReplacementHighlight
+    )
+    #expect(replacementHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: replacementHighlight.targetIdentifier,
+        messageID: try messageID(replacementHighlight.message),
+        result: "{}"
+    )
+    await replacementHighlightTask.value
+
+    await receiveTargetReply(
+        transport,
+        targetID: staleHide.targetIdentifier,
+        messageID: try messageID(staleHide.message),
+        result: "{}"
+    )
+    await hideTask.value
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let pageHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeFrameHighlight
+    )
+    #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let countBeforePageHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pageHide.targetIdentifier,
+        messageID: try messageID(pageHide.message),
+        result: "{}"
+    )
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforePageHideReply
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(try integerParameter("nodeId", in: frameHighlight.message) == 102)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+}
+
+@Test
 func documentInvalidationHidesSelectedNodeHighlight() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4553,6 +4553,83 @@ func beginElementPickerDoesNotEnableInspectModeAfterCancelDuringStaleHide() asyn
 }
 
 @Test
+func beginElementPickerRestoresSelectedHighlightWhenEnableFails() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(pageHTMLID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let countBeforeBeginHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    let enable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeBeginHideReply
+    )
+    #expect(try boolParameter("enabled", in: enable.message) == true)
+    let countBeforeEnableError = await backend.sentTargetMessages().count
+    await receiveTargetErrorReply(
+        transport,
+        targetID: enable.targetIdentifier,
+        messageID: try messageID(enable.message),
+        message: "Cannot enable inspect mode"
+    )
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeEnableError
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    do {
+        try await beginPickerTask.value
+        Issue.record("Expected beginElementPicker to fail")
+    } catch {
+    }
+    #expect(await session.attachment.dom.isSelectingElement == false)
+}
+
+@Test
 func cancelledBeginElementPickerDoesNotEnableInspectModeAfterStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4078,6 +4078,31 @@ func staleHideReplyDoesNotForgetNewerHighlightOnSameTarget() async throws {
 }
 
 @Test
+func cancelledDirectHighlightDoesNotRecordError() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    #expect(highlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    highlightTask.cancel()
+    await highlightTask.value
+
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func documentInvalidationHidesSelectedNodeHighlight() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4570,6 +4570,29 @@ func staleHideSnapshotDoesNotHideNewerLaterTargetHighlight() async throws {
 }
 
 @Test
+func directHighlightDoesNotHideStaleHighlightWhilePickerIsActive() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    await session.attachment.dom.highlightController.markHighlightMayBeVisible(targetID: .frameAd)
+    await MainActor.run {
+        session.attachment.dom.isSelectingElement = true
+    }
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    await session.attachment.dom.highlightNode(for: pageHTMLID)
+
+    #expect(await backend.sentTargetMessages().count == countBeforeHighlight)
+}
+
+@Test
 func directHighlightStopsWhenPickerStartsDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3829,7 +3829,36 @@ func pendingPickerSelectionHidesPreviousFrameHighlight() async throws {
     )
     await previousHighlightTask.value
 
-    try await beginPicker(session: session, transport: transport, backend: backend)
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginPickerHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginPickerHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+    let sentCountBeforeBeginPickerHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: beginPickerHide.targetIdentifier,
+        messageID: try messageID(beginPickerHide.message),
+        result: "{}"
+    )
+    let enable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeBeginPickerHideReply
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: enable.targetIdentifier,
+        messageID: try messageID(enable.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
     await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"pending-node-object"},"hints":{}}}"#)
     let requestNode = try await waitForTargetMessage(
@@ -3862,23 +3891,10 @@ func pendingPickerSelectionHidesPreviousFrameHighlight() async throws {
         after: sentCountBeforeDisableReply
     )
     #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
-    let sentCountBeforePageHideReply = await backend.sentTargetMessages().count
     await receiveTargetReply(
         transport,
         targetID: pageHide.targetIdentifier,
         messageID: try messageID(pageHide.message),
-        result: "{}"
-    )
-    let frameHide = try await waitForTargetMessage(
-        backend,
-        method: "DOM.hideHighlight",
-        after: sentCountBeforePageHideReply
-    )
-    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
-    await receiveTargetReply(
-        transport,
-        targetID: frameHide.targetIdentifier,
-        messageID: try messageID(frameHide.message),
         result: "{}"
     )
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -4259,6 +4275,231 @@ func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
     )
     await pageHighlightTask.value
     #expect(await backend.sentTargetMessages().count == countBeforeHideReply)
+}
+
+@Test
+func directHighlightStopsWhenPickerStartsDuringStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHighlight
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+
+    let countBeforePageHighlight = await backend.sentTargetMessages().count
+    let pageHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let originalFrameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforePageHighlight
+    )
+    #expect(originalFrameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let pickerFrameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(pickerFrameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+    let countBeforePickerHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pickerFrameHide.targetIdentifier,
+        messageID: try messageID(pickerFrameHide.message),
+        result: "{}"
+    )
+    let enable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforePickerHideReply
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: enable.targetIdentifier,
+        messageID: try messageID(enable.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+    #expect(await session.attachment.dom.isSelectingElement)
+
+    let countBeforeOriginalHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: originalFrameHide.targetIdentifier,
+        messageID: try messageID(originalFrameHide.message),
+        result: "{}"
+    )
+    await pageHighlightTask.value
+    #expect(await backend.sentTargetMessages().count == countBeforeOriginalHideReply)
+}
+
+@Test
+func beginElementPickerDoesNotEnableInspectModeAfterCancelDuringStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    #expect(highlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    let countBeforeCancel = await backend.sentTargetMessages().count
+    let cancelTask = Task {
+        await session.attachment.dom.cancelElementPicker()
+    }
+    let disable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeCancel
+    )
+    #expect(try boolParameter("enabled", in: disable.message) == false)
+    let countBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disable.targetIdentifier,
+        messageID: try messageID(disable.message),
+        result: "{}"
+    )
+    let cancelHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeDisableReply
+    )
+    #expect(cancelHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: cancelHide.targetIdentifier,
+        messageID: try messageID(cancelHide.message),
+        result: "{}"
+    )
+    await cancelTask.value
+
+    let countBeforeBeginHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+    #expect(await session.attachment.dom.isSelectingElement == false)
+    #expect(await backend.sentTargetMessages().count == countBeforeBeginHideReply)
+}
+
+@Test
+func cancelledBeginElementPickerDoesNotEnableInspectModeAfterStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    beginPickerTask.cancel()
+    let countBeforeBeginHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+    #expect(await session.attachment.dom.isSelectingElement == false)
+    #expect(await backend.sentTargetMessages().count == countBeforeBeginHideReply)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4129,7 +4129,7 @@ func documentInvalidationHidesSelectedNodeHighlight() async throws {
 
     let countBeforeHighlight = await backend.sentTargetMessages().count
     let highlightTask = Task {
-        await session.attachment.dom.highlightNode(for: htmlID)
+        await session.attachment.dom.highlightNode(for: htmlID, owner: .selection)
     }
     let highlight = try await waitForTargetMessage(
         backend,
@@ -4178,7 +4178,7 @@ func selectionClearHidesInFlightSelectedNodeHighlight() async throws {
 
     let countBeforeHighlight = await backend.sentTargetMessages().count
     let highlightTask = Task {
-        await session.attachment.dom.highlightNode(for: htmlID)
+        await session.attachment.dom.highlightNode(for: htmlID, owner: .selection)
     }
     let highlight = try await waitForTargetMessage(
         backend,
@@ -4258,6 +4258,62 @@ func staleSelectionClearDoesNotHideNewerSameTargetHighlight() async throws {
         result: "{}"
     )
     await newerHighlightTask.value
+}
+
+@Test
+func selectionClearDoesNotHideNewerTransientHighlightOnSameTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+
+    await session.attachment.dom.selectNode(htmlID)
+    let countBeforeSelectionHighlight = await backend.sentTargetMessages().count
+    let selectionHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID, owner: .selection)
+    }
+    let selectionHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeSelectionHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: selectionHighlight.targetIdentifier,
+        messageID: try messageID(selectionHighlight.message),
+        result: "{}"
+    )
+    await selectionHighlightTask.value
+
+    let countBeforeTransientHighlight = await backend.sentTargetMessages().count
+    let transientHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: bodyID, owner: .transient)
+    }
+    let transientHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeTransientHighlight
+    )
+    #expect(try integerParameter("nodeId", in: transientHighlight.message) == 4)
+
+    let countBeforeSelectionClear = await backend.sentTargetMessages().count
+    await session.attachment.dom.selectNode(nil)
+    await Task.yield()
+
+    #expect(await backend.sentTargetMessages().count == countBeforeSelectionClear)
+    #expect(await session.attachment.dom.highlightController.possibleVisibleNodeID(targetID: .pageMain) == bodyID)
+    #expect(await session.attachment.dom.highlightController.possibleVisibleOwner(targetID: .pageMain) == .transient)
+
+    await receiveTargetReply(
+        transport,
+        targetID: transientHighlight.targetIdentifier,
+        messageID: try messageID(transientHighlight.message),
+        result: "{}"
+    )
+    await transientHighlightTask.value
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3349,6 +3349,98 @@ func targetCommitClearsElementPickerForOldTarget() async throws {
 }
 
 @Test
+func targetCommitDuringPickerStartRestoresSelectedFrameHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+    await session.attachment.dom.selectNode(frameHTMLID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID, owner: .selection)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(try integerParameter("nodeId", in: frameHighlight.message) == 102)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+
+    let countBeforeTargetCommit = await backend.sentTargetMessages().count
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"page-main","newTargetId":"page-next"}}"#,
+        in: session
+    )
+    await session.attachment.dom.waitUntilElementPickerIdle()
+    #expect(await session.attachment.dom.isSelectingElement == false)
+
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeTargetCommit
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 102)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+
+    let methodsAfterPickerStart = await backend.sentTargetMessages()
+        .dropFirst(countBeforeBeginPicker)
+        .compactMap { try? messageMethod($0.message) }
+    #expect(!methodsAfterPickerStart.contains("DOM.setInspectModeEnabled"))
+}
+
+@Test
 func subframeCommitDoesNotClearPageElementPicker() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3754,6 +3754,107 @@ func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
 }
 
 @Test
+func pendingPickerSelectionHidesPreviousFrameHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+    await session.attachment.dom.selectNode(frameHTMLID)
+    let countBeforePreviousHighlight = await backend.sentTargetMessages().count
+    let previousHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let previousHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforePreviousHighlight
+    )
+    #expect(previousHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: previousHighlight.targetIdentifier,
+        messageID: try messageID(previousHighlight.message),
+        result: "{}"
+    )
+    await previousHighlightTask.value
+
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"pending-node-object"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeInspect
+    )
+    let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":999}"#
+    )
+    let disable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRequestReply
+    )
+    let sentCountBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disable.targetIdentifier,
+        messageID: try messageID(disable.message),
+        result: "{}"
+    )
+    let pageHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: sentCountBeforeDisableReply
+    )
+    #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let sentCountBeforePageHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pageHide.targetIdentifier,
+        messageID: try messageID(pageHide.message),
+        result: "{}"
+    )
+    let frameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: sentCountBeforePageHideReply
+    )
+    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHide.targetIdentifier,
+        messageID: try messageID(frameHide.message),
+        result: "{}"
+    )
+    await session.attachment.dom.waitUntilElementPickerIdle()
+
+    let pendingSnapshot = await session.attachment.dom.snapshot()
+    #expect(pendingSnapshot.selection.selectedNodeID == frameHTMLID)
+    #expect(pendingSnapshot.selection.pendingRequest != nil)
+}
+
+@Test
 func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3965,6 +3965,194 @@ func directHighlightHidesPreviousTargetBeforeHighlightingNewTarget() async throw
 }
 
 @Test
+func documentInvalidationHidesSelectedNodeHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(htmlID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    #expect(highlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeInvalidation = await backend.sentTargetMessages().count
+    await receiveAndApplyTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#,
+        in: session
+    )
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeInvalidation
+    )
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    #expect(await session.attachment.dom.selectedNodeID == nil)
+}
+
+@Test
+func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHighlight
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+
+    let countBeforePageHighlight = await backend.sentTargetMessages().count
+    let pageHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let frameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforePageHighlight
+    )
+    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+
+    pageHighlightTask.cancel()
+    let countBeforeHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: frameHide.targetIdentifier,
+        messageID: try messageID(frameHide.message),
+        result: "{}"
+    )
+    await pageHighlightTask.value
+    #expect(await backend.sentTargetMessages().count == countBeforeHideReply)
+}
+
+@Test
+func directHighlightSkipsDestroyedPreviousTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHighlight
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetDestroyed","params":{"targetId":"frame-ad"}}"#,
+        in: session
+    )
+
+    let countBeforePageHighlight = await backend.sentTargetMessages().count
+    let pageHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let pageHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforePageHighlight
+    )
+    #expect(pageHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: pageHighlight.message) == 2)
+    let newMethods = await backend.sentTargetMessages()
+        .dropFirst(countBeforePageHighlight)
+        .compactMap { try? messageMethod($0.message) }
+    #expect(newMethods == ["DOM.highlightNode"])
+    await receiveTargetReply(
+        transport,
+        targetID: pageHighlight.targetIdentifier,
+        messageID: try messageID(pageHighlight.message),
+        result: "{}"
+    )
+    await pageHighlightTask.value
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func restoreSelectedFrameHighlightHidesPageHoverHighlight() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3138,6 +3138,7 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
         targetID: .pageMain,
         message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-path"]}]}}"#
     )
+    await expectProtocolEventApplied(setChildNodesSequence, in: session)
     let restoredHighlight = try await waitForTargetMessage(
         backend,
         method: "DOM.highlightNode",
@@ -3151,7 +3152,6 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
         messageID: try messageID(restoredHighlight.message),
         result: "{}"
     )
-    await expectProtocolEventApplied(setChildNodesSequence, in: session)
 
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
     #expect(await selectedNode.nodeName == "DIV")
@@ -3261,6 +3261,40 @@ func restoreSelectedNodeHighlightHidesWhenSelectionIsMissing() async throws {
         result: "{}"
     )
     await restoreTask.value
+}
+
+@Test
+func restoreSelectedNodeHighlightNoOpsWhileElementPickerIsActive() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(htmlID)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    #expect(await session.attachment.dom.isSelectingElement)
+
+    let sentCount = await backend.sentTargetMessages().count
+    await session.attachment.dom.restoreSelectedNodeHighlightOrHide()
+    #expect(await backend.sentTargetMessages().count == sentCount)
+
+    let sentCountBeforeCancel = await backend.sentTargetMessages().count
+    let cancelTask = Task {
+        await session.attachment.dom.cancelElementPicker()
+    }
+    let disableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeCancel
+    )
+    try await replyToPickerDisableAndRestoredHighlight(
+        disableMessage,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 2
+    )
+    await cancelTask.value
 }
 
 @Test
@@ -3734,6 +3768,7 @@ func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
         targetID: .pageMain,
         message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-picked"]}]}}"#
     )
+    await expectProtocolEventApplied(setChildNodesSequence, in: session)
     let restoredHighlight = try await waitForTargetMessage(
         backend,
         method: "DOM.highlightNode",
@@ -3747,7 +3782,6 @@ func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
         messageID: try messageID(restoredHighlight.message),
         result: "{}"
     )
-    await expectProtocolEventApplied(setChildNodesSequence, in: session)
 
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
     #expect(await selectedNode.attributes == [WebInspectorCore.DOMNode.Attribute(name: "id", value: "late-picked")])

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2751,11 +2751,12 @@ func lazyIframeOwnerFrameIdIsNotTreatedAsChildFrameIdentity() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeInspect
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .frameAd,
+        expectedNodeID: 104
     )
     await session.attachment.dom.waitUntilElementPickerIdle()
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
@@ -3131,12 +3132,26 @@ func requestNodeReplyBeforePathPushKeepsSelectionPendingUntilParentArrives() asy
     })
     #expect(await session.lastError == nil)
 
-    await receiveAndApplyTargetDispatch(
+    let sentCountBeforePathPush = await backend.sentTargetMessages().count
+    let setChildNodesSequence = await receiveTargetDispatch(
         transport,
         targetID: .pageMain,
-        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-path"]}]}}"#,
-        in: session
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-path"]}]}}"#
     )
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: sentCountBeforePathPush
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 999)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    await expectProtocolEventApplied(setChildNodesSequence, in: session)
 
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
     #expect(await selectedNode.nodeName == "DIV")
@@ -3178,15 +3193,74 @@ func elementPickerBeginAndCancelToggleInspectMode() async throws {
         after: sentCountBeforeCancel
     )
     #expect(try boolParameter("enabled", in: disableMessage.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: disableMessage.targetIdentifier,
-        messageID: try messageID(disableMessage.message),
-        result: "{}"
+    try await replyToPickerDisableAndHiddenHighlight(
+        disableMessage,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain
     )
     await cancelTask.value
 
     #expect(await session.attachment.dom.isSelectingElement == false)
+}
+
+@Test
+func elementPickerCancelRestoresExistingSelectedNodeHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(htmlID)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+
+    let sentCountBeforeCancel = await backend.sentTargetMessages().count
+    let cancelTask = Task {
+        await session.attachment.dom.cancelElementPicker()
+    }
+    let disableMessage = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeCancel
+    )
+    #expect(try boolParameter("enabled", in: disableMessage.message) == false)
+    try await replyToPickerDisableAndRestoredHighlight(
+        disableMessage,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 2
+    )
+    await cancelTask.value
+
+    #expect(await session.attachment.dom.selectedNodeID == htmlID)
+    #expect(await session.attachment.dom.isSelectingElement == false)
+}
+
+@Test
+func restoreSelectedNodeHighlightHidesWhenSelectionIsMissing() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let restoreTask = Task {
+        await session.attachment.dom.restoreSelectedNodeHighlightOrHide()
+    }
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: sentCount
+    )
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await restoreTask.value
 }
 
 @Test
@@ -3364,11 +3438,12 @@ func elementPickerIgnoresInspectEventBeforeInspectModeReply() async throws {
         after: sentCountBeforeRequestReply
     )
     #expect(try boolParameter("enabled", in: disableMessage.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: disableMessage.targetIdentifier,
-        messageID: try messageID(disableMessage.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disableMessage,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3406,11 +3481,11 @@ func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() asyn
         after: sentCountBeforeCancel
     )
     #expect(try boolParameter("enabled", in: cancelDisable.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: cancelDisable.targetIdentifier,
-        messageID: try messageID(cancelDisable.message),
-        result: "{}"
+    try await replyToPickerDisableAndHiddenHighlight(
+        cancelDisable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain
     )
     await cancelTask.value
 
@@ -3477,11 +3552,12 @@ func restartedElementPickerIgnoresStaleInspectEventBeforeInspectModeReply() asyn
         after: sentCountBeforeRequestReply
     )
     #expect(try boolParameter("enabled", in: disable.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3517,11 +3593,11 @@ func staleInspectEventCompletionDoesNotCancelRestartedPicker() async throws {
         after: sentCountBeforeCancel
     )
     #expect(try boolParameter("enabled", in: cancelDisable.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: cancelDisable.targetIdentifier,
-        messageID: try messageID(cancelDisable.message),
-        result: "{}"
+    try await replyToPickerDisableAndHiddenHighlight(
+        cancelDisable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain
     )
     await cancelTask.value
 
@@ -3597,17 +3673,84 @@ func inspectorInspectSelectsRequestedNodeAndDisablesPicker() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
     #expect(await selectedNode.nodeName == "DIV")
     #expect(await session.attachment.dom.isSelectingElement == false)
+}
+
+@Test
+func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let previousNodeID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(previousNodeID)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+    let sentCountBeforeInspect = await backend.sentTargetMessages().count
+
+    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"pending-node-object"},"hints":{}}}"#)
+    let requestNode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.requestNode",
+        after: sentCountBeforeInspect
+    )
+    let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: requestNode.targetIdentifier,
+        messageID: try messageID(requestNode.message),
+        result: #"{"nodeId":999}"#
+    )
+    let disable = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: sentCountBeforeRequestReply
+    )
+    try await replyToPickerDisableAndHiddenHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain
+    )
+    await session.attachment.dom.waitUntilElementPickerIdle()
+
+    let pendingSnapshot = await session.attachment.dom.snapshot()
+    #expect(pendingSnapshot.selection.selectedNodeID == previousNodeID)
+    #expect(pendingSnapshot.selection.pendingRequest != nil)
+
+    let sentCountBeforePathPush = await backend.sentTargetMessages().count
+    let setChildNodesSequence = await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.setChildNodes","params":{"parentId":2,"nodes":[{"nodeId":999,"nodeType":1,"nodeName":"DIV","localName":"div","attributes":["id","late-picked"]}]}}"#
+    )
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: sentCountBeforePathPush
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 999)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    await expectProtocolEventApplied(setChildNodesSequence, in: session)
+
+    let selectedNode = try #require(await session.attachment.dom.selectedNode)
+    #expect(await selectedNode.attributes == [WebInspectorCore.DOMNode.Attribute(name: "id", value: "late-picked")])
 }
 
 @Test
@@ -3644,11 +3787,12 @@ func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3719,11 +3863,12 @@ func inspectorInspectRecordedExecutionContextOverridesEventTargetHint() async th
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .frameAd,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3767,11 +3912,12 @@ func inspectorInspectOpaqueObjectIDFallsBackToPickerTarget() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3834,11 +3980,12 @@ func targetScopedInspectorInspectUsesEventTargetAsFallback() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .frameAd,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3902,11 +4049,12 @@ func targetScopedInspectorInspectFallsBackToEventTargetWhenContextIsUnrecorded()
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeRequestReply
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .frameAd,
+        expectedNodeID: 3
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -3934,11 +4082,12 @@ func domInspectSelectsKnownProtocolNodeWithoutRequestNode() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeInspect
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 2
     )
 
     let selectedNode = try #require(await session.attachment.dom.selectedNode)
@@ -3978,11 +4127,12 @@ func domInspectReloadsDocumentBeforeFailingUnknownProtocolNode() async throws {
         method: "DOM.setInspectModeEnabled",
         after: sentCountBeforeInspect
     )
-    await receiveTargetReply(
-        transport,
-        targetID: disable.targetIdentifier,
-        messageID: try messageID(disable.message),
-        result: "{}"
+    try await replyToPickerDisableAndRestoredHighlight(
+        disable,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain,
+        expectedNodeID: 4
     )
 
     await session.attachment.dom.waitUntilElementPickerIdle()
@@ -4461,11 +4611,11 @@ func reloadDOMDocumentCancelsActiveElementPickerBeforeReplacingDocument() async 
         after: countBeforeReload
     )
     #expect(try boolParameter("enabled", in: disablePicker.message) == false)
-    await receiveTargetReply(
-        transport,
-        targetID: disablePicker.targetIdentifier,
-        messageID: try messageID(disablePicker.message),
-        result: "{}"
+    try await replyToPickerDisableAndHiddenHighlight(
+        disablePicker,
+        transport: transport,
+        backend: backend,
+        expectedTargetID: .pageMain
     )
     let getDocument = try await waitForTargetMessage(backend, method: "DOM.getDocument", after: countBeforeReload)
     await receiveTargetReply(
@@ -5052,6 +5202,115 @@ private func beginPicker(
     try await beginTask.value
 }
 
+@discardableResult
+private func replyToPickerDisableAndRestoredHighlight(
+    _ disableMessage: SentTargetMessage,
+    transport: TransportSession,
+    backend: FakeTransportBackend,
+    expectedTargetID: ProtocolTarget.ID? = nil,
+    expectedNodeID: Int? = nil
+) async throws -> SentTargetMessage {
+    let sentCountBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disableMessage.targetIdentifier,
+        messageID: try messageID(disableMessage.message),
+        result: "{}"
+    )
+    let firstMessage = try await waitForNextTargetMessage(
+        backend,
+        after: sentCountBeforeDisableReply
+    )
+    switch try messageMethod(firstMessage.message) {
+    case "DOM.highlightNode":
+        let highlight = firstMessage
+        if let expectedTargetID {
+            #expect(highlight.targetIdentifier == expectedTargetID)
+        }
+        if let expectedNodeID {
+            #expect(try integerParameter("nodeId", in: highlight.message) == expectedNodeID)
+        }
+        await receiveTargetReply(
+            transport,
+            targetID: highlight.targetIdentifier,
+            messageID: try messageID(highlight.message),
+            result: "{}"
+        )
+        return highlight
+    case "DOM.hideHighlight":
+        let sentCountBeforeHideReply = await backend.sentTargetMessages().count
+        await receiveTargetReply(
+            transport,
+            targetID: firstMessage.targetIdentifier,
+            messageID: try messageID(firstMessage.message),
+            result: "{}"
+        )
+        let highlight = try await waitForTargetMessage(
+            backend,
+            method: "DOM.highlightNode",
+            after: sentCountBeforeHideReply
+        )
+        if let expectedTargetID {
+            #expect(highlight.targetIdentifier == expectedTargetID)
+        }
+        if let expectedNodeID {
+            #expect(try integerParameter("nodeId", in: highlight.message) == expectedNodeID)
+        }
+        await receiveTargetReply(
+            transport,
+            targetID: highlight.targetIdentifier,
+            messageID: try messageID(highlight.message),
+            result: "{}"
+        )
+        return highlight
+    default:
+        throw InspectorSession.Error("Expected DOM.highlightNode or DOM.hideHighlight after disabling inspect mode.")
+    }
+}
+
+private func waitForNextTargetMessage(
+    _ backend: FakeTransportBackend,
+    after count: Int = 0
+) async throws -> SentTargetMessage {
+    try await waitForBackendTargetMessage(
+        backend,
+        method: nil,
+        ordinal: 0,
+        after: count
+    )
+}
+
+@discardableResult
+private func replyToPickerDisableAndHiddenHighlight(
+    _ disableMessage: SentTargetMessage,
+    transport: TransportSession,
+    backend: FakeTransportBackend,
+    expectedTargetID: ProtocolTarget.ID? = nil
+) async throws -> SentTargetMessage {
+    let sentCountBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disableMessage.targetIdentifier,
+        messageID: try messageID(disableMessage.message),
+        result: "{}"
+    )
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: sentCountBeforeDisableReply
+    )
+    if let expectedTargetID {
+        #expect(hideHighlight.targetIdentifier == expectedTargetID)
+    }
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    return hideHighlight
+}
+
 private func hydratePageHTMLChildren(
     session: InspectorSession,
     transport: TransportSession,
@@ -5133,7 +5392,7 @@ private func waitForTargetMessage(
 
 private func waitForBackendTargetMessage(
     _ backend: FakeTransportBackend,
-    method: String,
+    method: String?,
     ordinal: Int,
     after count: Int,
     timeout: Duration = .seconds(5)
@@ -5144,15 +5403,19 @@ private func waitForBackendTargetMessage(
         }
 
         group.addTask {
-            try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
+            if let method {
+                try await backend.waitForTargetMessage(method: method, ordinal: ordinal, after: count)
+            } else {
+                try await backend.waitForTargetMessage(ordinal: ordinal, after: count)
+            }
         }
         group.addTask {
             try await Task.sleep(for: timeout)
-            throw TransportSession.Error.replyTimeout(method: method, targetID: nil)
+            throw TransportSession.Error.replyTimeout(method: method ?? "target message", targetID: nil)
         }
 
         guard let message = try await group.next() else {
-            throw TransportSession.Error.replyTimeout(method: method, targetID: nil)
+            throw TransportSession.Error.replyTimeout(method: method ?? "target message", targetID: nil)
         }
         return message
     }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4014,6 +4014,50 @@ func documentInvalidationHidesSelectedNodeHighlight() async throws {
 }
 
 @Test
+func selectionClearHidesInFlightSelectedNodeHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(htmlID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    #expect(highlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    let countBeforeSelectionClear = await backend.sentTargetMessages().count
+    await session.attachment.dom.selectNode(nil)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeSelectionClear
+    )
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    #expect(await session.attachment.dom.selectedNodeID == nil)
+}
+
+@Test
 func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3855,6 +3855,84 @@ func pendingPickerSelectionHidesPreviousFrameHighlight() async throws {
 }
 
 @Test
+func restoreSelectedFrameHighlightHidesPageHoverHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+    await session.attachment.dom.selectNode(frameHTMLID)
+
+    let countBeforeHoverHighlight = await backend.sentTargetMessages().count
+    let hoverHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let hoverHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHoverHighlight
+    )
+    #expect(hoverHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: hoverHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: hoverHighlight.targetIdentifier,
+        messageID: try messageID(hoverHighlight.message),
+        result: "{}"
+    )
+    await hoverHighlightTask.value
+
+    let countBeforeRestore = await backend.sentTargetMessages().count
+    let restoreTask = Task {
+        await session.attachment.dom.restoreSelectedNodeHighlightOrHide()
+    }
+    let pageHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeRestore
+    )
+    #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let countBeforePageHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pageHide.targetIdentifier,
+        messageID: try messageID(pageHide.message),
+        result: "{}"
+    )
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforePageHideReply
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(try integerParameter("nodeId", in: frameHighlight.message) == 102)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await restoreTask.value
+}
+
+@Test
 func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3967,6 +3967,92 @@ func restoreSelectedFrameHighlightHidesPageHoverHighlight() async throws {
 }
 
 @Test
+func restoreSelectedHighlightStopsWhenSelectionChangesDuringStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+    await session.attachment.dom.selectNode(frameHTMLID)
+
+    let countBeforeHoverHighlight = await backend.sentTargetMessages().count
+    let hoverHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let hoverHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHoverHighlight
+    )
+    #expect(hoverHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: hoverHighlight.targetIdentifier,
+        messageID: try messageID(hoverHighlight.message),
+        result: "{}"
+    )
+    await hoverHighlightTask.value
+
+    let countBeforeRestore = await backend.sentTargetMessages().count
+    let restoreTask = Task {
+        await session.attachment.dom.restoreSelectedNodeHighlightOrHide()
+    }
+    let pageHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeRestore
+    )
+    #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    await session.attachment.dom.selectNode(pageHTMLID)
+    let countBeforeReplacementHighlight = await backend.sentTargetMessages().count
+    let replacementHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let replacementHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeReplacementHighlight
+    )
+    #expect(replacementHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: replacementHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: replacementHighlight.targetIdentifier,
+        messageID: try messageID(replacementHighlight.message),
+        result: "{}"
+    )
+    await replacementHighlightTask.value
+
+    let countBeforeHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pageHide.targetIdentifier,
+        messageID: try messageID(pageHide.message),
+        result: "{}"
+    )
+    await restoreTask.value
+    #expect(await backend.sentTargetMessages().count == countBeforeHideReply)
+}
+
+@Test
 func inspectorInspectWaitsForPathPushEventsBeforeSelectingNode() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4124,6 +4124,86 @@ func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
 }
 
 @Test
+func cancelledDirectHighlightIsHiddenBeforeRestoringSelection() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+    await session.attachment.dom.selectNode(frameHTMLID)
+
+    let countBeforeHoverHighlight = await backend.sentTargetMessages().count
+    let hoverHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let pageHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHoverHighlight
+    )
+    #expect(pageHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: pageHighlight.message) == 2)
+
+    hoverHighlightTask.cancel()
+    await hoverHighlightTask.value
+    await receiveTargetReply(
+        transport,
+        targetID: pageHighlight.targetIdentifier,
+        messageID: try messageID(pageHighlight.message),
+        result: "{}"
+    )
+
+    let countBeforeRestore = await backend.sentTargetMessages().count
+    let restoreTask = Task {
+        await session.attachment.dom.restoreSelectedNodeHighlightOrHide()
+    }
+    let pageHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeRestore
+    )
+    #expect(pageHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+    let countBeforePageHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: pageHide.targetIdentifier,
+        messageID: try messageID(pageHide.message),
+        result: "{}"
+    )
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforePageHideReply
+    )
+    #expect(frameHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(try integerParameter("nodeId", in: frameHighlight.message) == 102)
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await restoreTask.value
+}
+
+@Test
 func directHighlightSkipsDestroyedPreviousTarget() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4608,10 +4608,12 @@ func beginElementPickerRestoresSelectedHighlightWhenEnableFails() async throws {
         messageID: try messageID(enable.message),
         message: "Cannot enable inspect mode"
     )
-    let restoredHighlight = try await waitForTargetMessage(
+    let restoredHighlight = try await waitForBackendTargetMessage(
         backend,
         method: "DOM.highlightNode",
-        after: countBeforeEnableError
+        ordinal: 0,
+        after: countBeforeEnableError,
+        timeout: .seconds(15)
     )
     #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
     #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 2)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4377,6 +4377,102 @@ func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
 }
 
 @Test
+func cancelledStaleHideStopsBeforeClearingNextTarget() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeFrameHighlight = await backend.sentTargetMessages().count
+    let frameHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let frameHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFrameHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: frameHighlight.targetIdentifier,
+        messageID: try messageID(frameHighlight.message),
+        result: "{}"
+    )
+    await frameHighlightTask.value
+
+    let countBeforePageHighlight = await backend.sentTargetMessages().count
+    let pageHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let failedFrameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforePageHighlight
+    )
+    #expect(failedFrameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+    let countBeforeFailedFrameHideReply = await backend.sentTargetMessages().count
+    await receiveTargetErrorReply(
+        transport,
+        targetID: failedFrameHide.targetIdentifier,
+        messageID: try messageID(failedFrameHide.message),
+        message: "Cannot hide frame highlight"
+    )
+    let pageHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeFailedFrameHideReply
+    )
+    #expect(pageHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: pageHighlight.targetIdentifier,
+        messageID: try messageID(pageHighlight.message),
+        result: "{}"
+    )
+    await pageHighlightTask.value
+
+    let countBeforeHideAll = await backend.sentTargetMessages().count
+    let hideTask = Task {
+        await session.attachment.dom.hideNodeHighlight()
+    }
+    let frameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeHideAll
+    )
+    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+
+    hideTask.cancel()
+    let countBeforeFrameHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: frameHide.targetIdentifier,
+        messageID: try messageID(frameHide.message),
+        result: "{}"
+    )
+    await hideTask.value
+    #expect(await backend.sentTargetMessages().count == countBeforeFrameHideReply)
+}
+
+@Test
 func directHighlightStopsWhenPickerStartsDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4212,6 +4212,105 @@ func selectionClearHidesInFlightSelectedNodeHighlight() async throws {
 }
 
 @Test
+func staleSelectionClearDoesNotHideNewerSameTargetHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeInitialHighlight = await backend.sentTargetMessages().count
+    let initialHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let initialHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeInitialHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: initialHighlight.targetIdentifier,
+        messageID: try messageID(initialHighlight.message),
+        result: "{}"
+    )
+    await initialHighlightTask.value
+    let staleGeneration = try #require(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain))
+
+    let countBeforeNewerHighlight = await backend.sentTargetMessages().count
+    let newerHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let newerHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeNewerHighlight
+    )
+
+    let countBeforeStaleClear = await backend.sentTargetMessages().count
+    await session.attachment.dom.hideNodeHighlightIfCurrent(targetID: .pageMain, generation: staleGeneration)
+    #expect(await backend.sentTargetMessages().count == countBeforeStaleClear)
+
+    await receiveTargetReply(
+        transport,
+        targetID: newerHighlight.targetIdentifier,
+        messageID: try messageID(newerHighlight.message),
+        result: "{}"
+    )
+    await newerHighlightTask.value
+}
+
+@Test
+func staleSelectionClearRestoresCurrentSelectionHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+
+    await session.attachment.dom.selectNode(htmlID)
+    let countBeforeInitialHighlight = await backend.sentTargetMessages().count
+    let initialHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let initialHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeInitialHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: initialHighlight.targetIdentifier,
+        messageID: try messageID(initialHighlight.message),
+        result: "{}"
+    )
+    await initialHighlightTask.value
+    let staleGeneration = try #require(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain))
+
+    await session.attachment.dom.selectNode(bodyID)
+    let countBeforeStaleClear = await backend.sentTargetMessages().count
+    let staleClearTask = Task {
+        await session.attachment.dom.hideNodeHighlightIfCurrent(targetID: .pageMain, generation: staleGeneration)
+    }
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeStaleClear
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 4)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    await staleClearTask.value
+}
+
+@Test
 func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4311,6 +4311,59 @@ func staleSelectionClearRestoresCurrentSelectionHighlight() async throws {
 }
 
 @Test
+func staleSelectionClearDoesNotRestoreSelectionOverNewerHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await hydratePageHTMLChildren(session: session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
+
+    await session.attachment.dom.selectNode(htmlID)
+    let countBeforeInitialHighlight = await backend.sentTargetMessages().count
+    let initialHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let initialHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeInitialHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: initialHighlight.targetIdentifier,
+        messageID: try messageID(initialHighlight.message),
+        result: "{}"
+    )
+    await initialHighlightTask.value
+    let staleGeneration = try #require(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain))
+
+    await session.attachment.dom.selectNode(bodyID)
+    let countBeforeNewerHighlight = await backend.sentTargetMessages().count
+    let newerHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let newerHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeNewerHighlight
+    )
+
+    let countBeforeStaleClear = await backend.sentTargetMessages().count
+    await session.attachment.dom.hideNodeHighlightIfCurrent(targetID: .pageMain, generation: staleGeneration)
+    #expect(await backend.sentTargetMessages().count == countBeforeStaleClear)
+
+    await receiveTargetReply(
+        transport,
+        targetID: newerHighlight.targetIdentifier,
+        messageID: try messageID(newerHighlight.message),
+        result: "{}"
+    )
+    await newerHighlightTask.value
+}
+
+@Test
 func directHighlightStopsWhenCancelledDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4526,6 +4526,50 @@ func cancelledStaleHideStopsBeforeClearingNextTarget() async throws {
 }
 
 @Test
+func staleHideSnapshotDoesNotHideNewerLaterTargetHighlight() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+
+    await session.attachment.dom.highlightController.markHighlightMayBeVisible(targetID: .frameAd)
+    await session.attachment.dom.highlightController.markHighlightMayBeVisible(targetID: .pageMain)
+    let stalePageGeneration = try #require(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain))
+
+    let countBeforeHideAll = await backend.sentTargetMessages().count
+    let hideTask = Task {
+        await session.attachment.dom.hideNodeHighlight()
+    }
+    let frameHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeHideAll
+    )
+    #expect(frameHide.targetIdentifier == ProtocolTarget.ID.frameAd)
+
+    await session.attachment.dom.highlightController.markHighlightMayBeVisible(targetID: .pageMain)
+    let newerPageGeneration = try #require(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain))
+    #expect(newerPageGeneration != stalePageGeneration)
+
+    let countBeforeFrameHideReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: frameHide.targetIdentifier,
+        messageID: try messageID(frameHide.message),
+        result: "{}"
+    )
+    await hideTask.value
+
+    #expect(await backend.sentTargetMessages().count == countBeforeFrameHideReply)
+    #expect(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain) == newerPageGeneration)
+}
+
+@Test
 func directHighlightStopsWhenPickerStartsDuringStaleHide() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -4883,8 +4883,8 @@ func cancelledBeginElementPickerDoesNotEnableInspectModeAfterStaleHide() async t
     )
     #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
 
+    let countBeforeCancel = await backend.sentTargetMessages().count
     beginPickerTask.cancel()
-    let countBeforeBeginHideReply = await backend.sentTargetMessages().count
     await receiveTargetReply(
         transport,
         targetID: beginHide.targetIdentifier,
@@ -4893,7 +4893,69 @@ func cancelledBeginElementPickerDoesNotEnableInspectModeAfterStaleHide() async t
     )
     try await beginPickerTask.value
     #expect(await session.attachment.dom.isSelectingElement == false)
-    #expect(await backend.sentTargetMessages().count == countBeforeBeginHideReply)
+    #expect(await backend.sentTargetMessages().count == countBeforeCancel)
+}
+
+@Test
+func cancelledBeginElementPickerRestoresSelectedHighlightAfterStaleHide() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let pageHTMLID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(pageHTMLID)
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: pageHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeBeginPicker = await backend.sentTargetMessages().count
+    let beginPickerTask = Task {
+        try await session.attachment.dom.beginElementPicker()
+    }
+    let beginHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeBeginPicker
+    )
+    #expect(beginHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    let countBeforeCancel = await backend.sentTargetMessages().count
+    beginPickerTask.cancel()
+    await receiveTargetReply(
+        transport,
+        targetID: beginHide.targetIdentifier,
+        messageID: try messageID(beginHide.message),
+        result: "{}"
+    )
+    let restoredHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeCancel
+    )
+    #expect(restoredHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try integerParameter("nodeId", in: restoredHighlight.message) == 2)
+    await receiveTargetReply(
+        transport,
+        targetID: restoredHighlight.targetIdentifier,
+        messageID: try messageID(restoredHighlight.message),
+        result: "{}"
+    )
+    try await beginPickerTask.value
+    #expect(await session.attachment.dom.isSelectingElement == false)
 }
 
 @Test

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -1629,6 +1629,10 @@ func domHighlightCommandUsesNonRevealingVisibleHighlightConfig() throws {
     let command = try DOMProtocolCommands().command(
         for: .highlightNode(
             target: .init(
+                nodeID: DOMNode.ID(
+                    documentID: DOMDocument.ID(targetID: .init("page-A"), localDocumentLifetimeID: .init(1)),
+                    nodeID: .init(42)
+                ),
                 documentTargetID: .init("page-A"),
                 rawNodeID: .init(42),
                 commandTargetID: .init("page-A"),
@@ -1667,6 +1671,10 @@ func domNavigationActionCommandsUseExpectedProtocolPayloads() throws {
     #expect(disableParameters["highlightConfig"] == nil)
 
     let identity = DOMAction.Target(
+        nodeID: DOMNode.ID(
+            documentID: DOMDocument.ID(targetID: targetID, localDocumentLifetimeID: .init(1)),
+            nodeID: .init(42)
+        ),
         documentTargetID: targetID,
         rawNodeID: .init(42),
         commandTargetID: targetID,
@@ -1688,6 +1696,10 @@ func domNavigationActionCommandsUseExpectedProtocolPayloads() throws {
 @Test
 func domActionCommandsEncodeScopedCommandNodeIDs() throws {
     let identity = DOMAction.Target(
+        nodeID: DOMNode.ID(
+            documentID: DOMDocument.ID(targetID: .init("frame-A"), localDocumentLifetimeID: .init(1)),
+            nodeID: .init(42)
+        ),
         documentTargetID: .init("frame-A"),
         rawNodeID: .init(42),
         commandTargetID: .init("page-main"),

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -92,6 +92,35 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func pageHighlightActionsAreSuppressedWhileElementPickerIsActive() async throws {
+        let session = makeDOMSession()
+        session.isSelectingElement = true
+        let highlightRecorder = NodeActionRecorder()
+        let restoreRecorder = VoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { nodeID in
+                highlightRecorder.record(nodeID)
+            },
+            restoreHighlightAction: {
+                restoreRecorder.record()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.hoverRowForTesting(containing: "<article")
+        view.endHoverForTesting()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(session.selectedNode?.localName == "input")
+        #expect(highlightRecorder.recordedNodeIDs.isEmpty)
+        #expect(restoreRecorder.recordCount == 0)
+    }
+
+    @Test
     func expandedElementRendersChildrenAndClosingTag() throws {
         let view = makeTreeView()
 
@@ -283,38 +312,42 @@ private final class NodeRequestRecorder {
 
 @MainActor
 private final class NodeActionRecorder {
-    private var nodeID: DOMNode.ID?
+    private var nodeIDs: [DOMNode.ID] = []
     private var continuation: CheckedContinuation<DOMNode.ID, Never>?
 
     func record(_ nodeID: DOMNode.ID) {
-        self.nodeID = nodeID
+        nodeIDs.append(nodeID)
         continuation?.resume(returning: nodeID)
         continuation = nil
     }
 
     func nextNodeID() async -> DOMNode.ID {
-        if let nodeID {
+        if let nodeID = nodeIDs.first {
             return nodeID
         }
         return await withCheckedContinuation { continuation in
             self.continuation = continuation
         }
     }
+
+    var recordedNodeIDs: [DOMNode.ID] {
+        nodeIDs
+    }
 }
 
 @MainActor
 private final class VoidActionRecorder {
-    private var didRecord = false
+    private(set) var recordCount = 0
     private var continuation: CheckedContinuation<Void, Never>?
 
     func record() {
-        didRecord = true
+        recordCount += 1
         continuation?.resume()
         continuation = nil
     }
 
     func next() async {
-        if didRecord {
+        if recordCount > 0 {
             return
         }
         await withCheckedContinuation { continuation in

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -92,6 +92,36 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hoverHighlightCancelsPendingRestoreHighlight() async throws {
+        let session = makeDOMSession()
+        let highlightRecorder = NodeActionRecorder()
+        let restoreRecorder = CancellableVoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { nodeID in
+                highlightRecorder.record(nodeID)
+            },
+            restoreHighlightAction: {
+                await restoreRecorder.run()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.hoverRowForTesting(containing: "<article")
+        view.endHoverForTesting()
+        await restoreRecorder.nextStart()
+        highlightRecorder.removeAll()
+
+        view.hoverRowForTesting(containing: "<input disabled>")
+        await restoreRecorder.nextCancellation()
+        let highlightedNodeID = await highlightRecorder.nextNodeID()
+
+        #expect(session.node(for: highlightedNodeID)?.localName == "input")
+    }
+
+    @Test
     func pageHighlightActionsAreSuppressedWhileElementPickerIsActive() async throws {
         let session = makeDOMSession()
         session.isSelectingElement = true
@@ -333,6 +363,10 @@ private final class NodeActionRecorder {
     var recordedNodeIDs: [DOMNode.ID] {
         nodeIDs
     }
+
+    func removeAll() {
+        nodeIDs.removeAll(keepingCapacity: true)
+    }
 }
 
 @MainActor
@@ -352,6 +386,44 @@ private final class VoidActionRecorder {
         }
         await withCheckedContinuation { continuation in
             self.continuation = continuation
+        }
+    }
+}
+
+@MainActor
+private final class CancellableVoidActionRecorder {
+    private(set) var startedCount = 0
+    private(set) var cancellationCount = 0
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var cancellationContinuation: CheckedContinuation<Void, Never>?
+
+    func run() async {
+        startedCount += 1
+        startContinuation?.resume()
+        startContinuation = nil
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+        cancellationCount += 1
+        cancellationContinuation?.resume()
+        cancellationContinuation = nil
+    }
+
+    func nextStart() async {
+        if startedCount > 0 {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.startContinuation = continuation
+        }
+    }
+
+    func nextCancellation() async {
+        if cancellationCount > 0 {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.cancellationContinuation = continuation
         }
     }
 }

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -92,6 +92,31 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func repeatedHoverEndCancelsPendingRestoreHighlight() async throws {
+        let session = makeDOMSession()
+        let restoreRecorder = VoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { _ in },
+            restoreHighlightAction: {
+                restoreRecorder.record()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.hoverRowForTesting(containing: "<article")
+        view.endHoverForTesting()
+        view.endHoverForTesting()
+        await restoreRecorder.next()
+        await Task.yield()
+
+        #expect(session.selectedNode?.localName == "input")
+        #expect(restoreRecorder.recordCount == 1)
+    }
+
+    @Test
     func hoverHighlightCancelsPendingRestoreHighlight() async throws {
         let session = makeDOMSession()
         let highlightRecorder = NodeActionRecorder()

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -55,8 +55,8 @@ struct DOMTreeTextViewTests {
         let recorder = NodeActionRecorder()
         let view = DOMTreeTextView(
             dom: session,
-            highlightNodeAction: { nodeID in
-                recorder.record(nodeID)
+            highlightNodeAction: { nodeID, owner in
+                recorder.record(nodeID, owner: owner)
             }
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
@@ -67,6 +67,7 @@ struct DOMTreeTextViewTests {
 
         #expect(session.selectedNode?.id == highlightedNodeID)
         #expect(session.node(for: highlightedNodeID)?.localName == "input")
+        #expect(recorder.recordedOwners == [.selection])
     }
 
     @Test
@@ -75,7 +76,7 @@ struct DOMTreeTextViewTests {
         let restoreRecorder = VoidActionRecorder()
         let view = DOMTreeTextView(
             dom: session,
-            highlightNodeAction: { _ in },
+            highlightNodeAction: { _, _ in },
             restoreHighlightAction: {
                 restoreRecorder.record()
             }
@@ -97,7 +98,7 @@ struct DOMTreeTextViewTests {
         let restoreRecorder = VoidActionRecorder()
         let view = DOMTreeTextView(
             dom: session,
-            highlightNodeAction: { _ in },
+            highlightNodeAction: { _, _ in },
             restoreHighlightAction: {
                 restoreRecorder.record()
             }
@@ -123,8 +124,8 @@ struct DOMTreeTextViewTests {
         let restoreRecorder = CancellableVoidActionRecorder()
         let view = DOMTreeTextView(
             dom: session,
-            highlightNodeAction: { nodeID in
-                highlightRecorder.record(nodeID)
+            highlightNodeAction: { nodeID, owner in
+                highlightRecorder.record(nodeID, owner: owner)
             },
             restoreHighlightAction: {
                 await restoreRecorder.run()
@@ -144,6 +145,7 @@ struct DOMTreeTextViewTests {
         let highlightedNodeID = await highlightRecorder.nextNodeID()
 
         #expect(session.node(for: highlightedNodeID)?.localName == "input")
+        #expect(highlightRecorder.recordedOwners == [.transient])
     }
 
     @Test
@@ -154,8 +156,8 @@ struct DOMTreeTextViewTests {
         let restoreRecorder = VoidActionRecorder()
         let view = DOMTreeTextView(
             dom: session,
-            highlightNodeAction: { nodeID in
-                highlightRecorder.record(nodeID)
+            highlightNodeAction: { nodeID, owner in
+                highlightRecorder.record(nodeID, owner: owner)
             },
             restoreHighlightAction: {
                 restoreRecorder.record()
@@ -368,10 +370,12 @@ private final class NodeRequestRecorder {
 @MainActor
 private final class NodeActionRecorder {
     private var nodeIDs: [DOMNode.ID] = []
+    private var owners: [DOMPageHighlightOwner] = []
     private var continuation: CheckedContinuation<DOMNode.ID, Never>?
 
-    func record(_ nodeID: DOMNode.ID) {
+    func record(_ nodeID: DOMNode.ID, owner: DOMPageHighlightOwner) {
         nodeIDs.append(nodeID)
+        owners.append(owner)
         continuation?.resume(returning: nodeID)
         continuation = nil
     }
@@ -389,8 +393,13 @@ private final class NodeActionRecorder {
         nodeIDs
     }
 
+    var recordedOwners: [DOMPageHighlightOwner] {
+        owners
+    }
+
     func removeAll() {
         nodeIDs.removeAll(keepingCapacity: true)
+        owners.removeAll(keepingCapacity: true)
     }
 }
 

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -50,6 +50,48 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func primaryClickingRowHighlightsSelectedPageNode() async throws {
+        let session = makeDOMSession()
+        let recorder = NodeActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { nodeID in
+                recorder.record(nodeID)
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        let highlightedNodeID = await recorder.nextNodeID()
+
+        #expect(session.selectedNode?.id == highlightedNodeID)
+        #expect(session.node(for: highlightedNodeID)?.localName == "input")
+    }
+
+    @Test
+    func hoverEndRestoresSelectedPageHighlight() async throws {
+        let session = makeDOMSession()
+        let restoreRecorder = VoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { _ in },
+            restoreHighlightAction: {
+                restoreRecorder.record()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.hoverRowForTesting(containing: "<article")
+        view.endHoverForTesting()
+        await restoreRecorder.next()
+
+        #expect(session.selectedNode?.localName == "input")
+    }
+
+    @Test
     func expandedElementRendersChildrenAndClosingTag() throws {
         let view = makeTreeView()
 
@@ -234,6 +276,48 @@ private final class NodeRequestRecorder {
             return nodeID
         }
         return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+@MainActor
+private final class NodeActionRecorder {
+    private var nodeID: DOMNode.ID?
+    private var continuation: CheckedContinuation<DOMNode.ID, Never>?
+
+    func record(_ nodeID: DOMNode.ID) {
+        self.nodeID = nodeID
+        continuation?.resume(returning: nodeID)
+        continuation = nil
+    }
+
+    func nextNodeID() async -> DOMNode.ID {
+        if let nodeID {
+            return nodeID
+        }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+@MainActor
+private final class VoidActionRecorder {
+    private var didRecord = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func record() {
+        didRecord = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func next() async {
+        if didRecord {
+            return
+        }
+        await withCheckedContinuation { continuation in
             self.continuation = continuation
         }
     }


### PR DESCRIPTION
## Purpose
Persist the page-side DOM highlight for selected nodes during touch-driven WebInspectorKit interactions, including element picker completion and DOM tree selection.

## Changes
- Restore the selected DOM node highlight after element picker completion, cancellation, picker start interruption, and target lifecycle interruption.
- Move page highlight ownership into Core as target-scoped possible-visible overlay state, including conservative cleanup for cancellation, stale generations, and detached targets.
- Revalidate selection, hover, cancellation, picker state, and highlight generations before sending restored or replacement highlights.
- Hide stale hover/selection highlights before restoring or highlighting another target.
- Send page-side highlights from DOM tree row selection and restore the selected highlight after hover ends.
- Suppress DOM tree page highlight and restore actions while the element picker is active.
- Keep DOM tree hover and restore operations under one cancellable page-highlight task.

## Testing
- `swift test` (380 tests)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` (481 tests)
- `codex-review` against pinned `main` base `refs/pr-fix/base/162/ef9d884c0e9c7ed4bf2a754e94162dd9c184d219`
