### PR TITLE
Prepare network media previews off MainActor

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -52,12 +52,7 @@ final class NetworkBodyViewController: UIViewController {
     private var metadata: NetworkBodyViewController.PreviewMetadata?
     private var hasDisplayedBody = false
     private var mediaPlayerViewController: AVPlayerViewController?
-    private var mediaTemporaryFile: MediaTemporaryFile?
-    private var mediaPreviewGeneration = 0
-    private var mediaPreviewTask: Task<Void, Never>?
-    private var pendingMediaPreviewInput: MediaPreviewInput?
-    private var displayedMediaPreviewIdentity: MediaPreviewIdentity?
-    private var failedMediaPreviewInput: MediaPreviewInput?
+    private var mediaPreviewCoordinator = MediaPreviewCoordinator()
     private var imageWidthConstraint: NSLayoutConstraint?
     private var imageHeightConstraint: NSLayoutConstraint?
     private var shouldResetImageZoomOnNextLayout = false
@@ -94,8 +89,7 @@ final class NetworkBodyViewController: UIViewController {
 
     isolated deinit {
         bodyObservation?.cancel()
-        mediaPreviewTask?.cancel()
-        removeTemporaryMediaFile(at: mediaTemporaryFile?.fileURL)
+        mediaPreviewCoordinator.cancel()
     }
 
     func display(body: NetworkBody?) {
@@ -319,60 +313,27 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func renderMediaPreview(for input: MediaPreviewInput) -> Bool {
-        guard failedMediaPreviewInput != input else {
+        let action = mediaPreviewCoordinator.preparePreview(for: input) { [weak self] result, input, generation in
+            self?.applyMediaPreviewResult(result, input: input, generation: generation)
+        }
+        switch action {
+        case .failed:
             hideMediaPreview()
             return false
-        }
-
-        if displayedMediaPreviewIdentity == .body(input) {
+        case .active:
             return true
-        }
-        if pendingMediaPreviewInput == input {
-            return true
-        }
-        if let fileURL = cachedTemporaryMediaFileURL(for: input) {
-            cancelMediaPreviewTask()
-            failedMediaPreviewInput = nil
-            displayedMediaPreviewIdentity = .body(input)
+        case .cachedMovie(let fileURL):
             showMoviePreview(fileURL)
             return true
+        case .startedLoading:
+            showMediaPreviewLoadingState()
+            return true
         }
-
-        startMediaPreviewTask(for: input)
-        return true
     }
 
     private func showRemoteMoviePreview(_ url: URL) {
-        cancelMediaPreviewTask()
-        failedMediaPreviewInput = nil
-        displayedMediaPreviewIdentity = .remoteMovie(url)
+        mediaPreviewCoordinator.prepareRemoteMovie(url)
         showMoviePreview(url)
-    }
-
-    private func startMediaPreviewTask(for input: MediaPreviewInput) {
-        cancelMediaPreviewTask()
-        failedMediaPreviewInput = nil
-        pendingMediaPreviewInput = input
-        mediaPreviewGeneration += 1
-        let generation = mediaPreviewGeneration
-        showMediaPreviewLoadingState(for: input)
-
-        let worker = Task.detached(priority: .utility) {
-            await NetworkBodyViewController.makeMediaPayload(from: input)
-        }
-        let task = Task { @MainActor [weak self, worker] in
-            let result = await withTaskCancellationHandler {
-                await worker.value
-            } onCancel: {
-                worker.cancel()
-            }
-            guard Task.isCancelled == false else {
-                result?.removeTemporaryFile()
-                return
-            }
-            self?.applyMediaPreviewResult(result, input: input, generation: generation)
-        }
-        mediaPreviewTask = task
     }
 
     private func applyMediaPreviewResult(
@@ -380,39 +341,21 @@ final class NetworkBodyViewController: UIViewController {
         input: MediaPreviewInput,
         generation: Int
     ) {
-        guard generation == mediaPreviewGeneration,
-              pendingMediaPreviewInput == input else {
-            result?.removeTemporaryFile()
+        switch mediaPreviewCoordinator.consume(result: result, input: input, generation: generation) {
+        case .ignore:
             return
-        }
-        mediaPreviewTask = nil
-        pendingMediaPreviewInput = nil
-
-        guard let result else {
-            failedMediaPreviewInput = input
-            displayedMediaPreviewIdentity = nil
+        case .fallback:
             renderBody(body)
-            return
-        }
-
-        failedMediaPreviewInput = nil
-        displayedMediaPreviewIdentity = .body(input)
-        switch result {
-        case .image(let image):
+        case .showImage(let image):
             showImagePreview(image)
-        case .movie(let temporaryFile):
-            replaceCachedTemporaryMediaFile(with: temporaryFile)
-            showMoviePreview(temporaryFile.fileURL)
+        case .showMovie(let fileURL):
+            showMoviePreview(fileURL)
         }
     }
 
-    private func showMediaPreviewLoadingState(for input: MediaPreviewInput) {
-        displayedMediaPreviewIdentity = nil
+    private func showMediaPreviewLoadingState() {
         hideImagePreview()
         removeMediaPlayerViewController()
-        if mediaTemporaryFile?.matches(input: input) != true {
-            removeCachedTemporaryMediaFile()
-        }
         if syntaxModel.text.isEmpty == false || syntaxModel.language != .plainText {
             syntaxModel.replaceContents(text: "", language: .plainText)
         }
@@ -421,34 +364,14 @@ final class NetworkBodyViewController: UIViewController {
         scrollEdgeSink?.contentScrollView = syntaxView
     }
 
-    private func cancelMediaPreviewTask() {
-        mediaPreviewGeneration += 1
-        mediaPreviewTask?.cancel()
-        mediaPreviewTask = nil
-        pendingMediaPreviewInput = nil
-    }
-
-    private func cachedTemporaryMediaFileURL(for input: MediaPreviewInput) -> URL? {
-        guard input.previewKind == .movie || input.previewKind == .hlsPlaylist,
-              let mediaTemporaryFile,
-              mediaTemporaryFile.matches(input: input),
-              FileManager.default.fileExists(atPath: mediaTemporaryFile.fileURL.path) else {
-            return nil
-        }
-        return mediaTemporaryFile.fileURL
-    }
-
-    nonisolated private static func makeMediaPayload(from input: MediaPreviewInput) async -> MediaPayload? {
+    nonisolated fileprivate static func makeMediaPayload(from input: MediaPreviewInput) async -> MediaPayload? {
         guard let data = input.data(), data.isEmpty == false else {
             return nil
         }
 
         switch input.previewKind {
         case .image:
-            var configuration = UIImageReader.Configuration()
-            configuration.preparesImagesForDisplay = true
-            let reader = UIImageReader(configuration: configuration)
-            guard let image = await reader.image(data: data) else {
+            guard let image = await makeImagePayload(data: data) else {
                 return nil
             }
             return .image(image)
@@ -457,7 +380,14 @@ final class NetworkBodyViewController: UIViewController {
         }
     }
 
-    nonisolated private static func makeTemporaryMediaPayload(
+    nonisolated fileprivate static func makeImagePayload(data: Data) async -> UIImage? {
+        var configuration = UIImageReader.Configuration()
+        configuration.preparesImagesForDisplay = true
+        let reader = UIImageReader(configuration: configuration)
+        return await reader.image(data: data)
+    }
+
+    nonisolated fileprivate static func makeTemporaryMediaPayload(
         from input: MediaPreviewInput,
         data: Data
     ) -> MediaPayload? {
@@ -479,8 +409,7 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func showSyntaxPreview() {
-        cancelMediaPreviewTask()
-        displayedMediaPreviewIdentity = nil
+        mediaPreviewCoordinator.prepareSyntaxPreview()
         hideImagePreview()
         removeMediaPlayerViewController()
         syntaxView.isHidden = false
@@ -490,7 +419,6 @@ final class NetworkBodyViewController: UIViewController {
 
     private func showImagePreview(_ image: UIImage) {
         removeMediaPlayerViewController()
-        removeCachedTemporaryMediaFile()
         syntaxView.isHidden = true
         imageScrollView.isHidden = false
         applyScrollEdgeObservedBackgrounds()
@@ -509,9 +437,6 @@ final class NetworkBodyViewController: UIViewController {
         hideImagePreview()
         syntaxView.isHidden = true
         scrollEdgeSink?.contentScrollView = nil
-        if let temporaryFileURL = mediaTemporaryFile?.fileURL, temporaryFileURL != url {
-            removeCachedTemporaryMediaFile()
-        }
 
         let playerViewController: AVPlayerViewController
         if let current = mediaPlayerViewController {
@@ -537,11 +462,9 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func hideMediaPreview() {
-        cancelMediaPreviewTask()
-        displayedMediaPreviewIdentity = nil
+        mediaPreviewCoordinator.hideMediaPreview()
         hideImagePreview()
         removeMediaPlayerViewController()
-        removeCachedTemporaryMediaFile()
         syntaxView.isHidden = false
     }
 
@@ -630,20 +553,6 @@ final class NetworkBodyViewController: UIViewController {
         self.mediaPlayerViewController = nil
     }
 
-    private func replaceCachedTemporaryMediaFile(with temporaryFile: MediaTemporaryFile) {
-        if mediaTemporaryFile?.fileURL == temporaryFile.fileURL {
-            mediaTemporaryFile = temporaryFile
-            return
-        }
-        removeCachedTemporaryMediaFile()
-        mediaTemporaryFile = temporaryFile
-    }
-
-    private func removeCachedTemporaryMediaFile() {
-        removeTemporaryMediaFile(at: mediaTemporaryFile?.fileURL)
-        mediaTemporaryFile = nil
-    }
-
     private func currentMediaURL(in playerViewController: AVPlayerViewController) -> URL? {
         (playerViewController.player?.currentItem?.asset as? AVURLAsset)?.url
     }
@@ -675,6 +584,20 @@ extension NetworkBodyViewController {
     fileprivate enum MediaPreviewIdentity: Equatable {
         case remoteMovie(URL)
         case body(MediaPreviewInput)
+    }
+
+    fileprivate enum MediaPreviewPreparationAction {
+        case failed
+        case active
+        case cachedMovie(URL)
+        case startedLoading
+    }
+
+    fileprivate enum MediaPreviewResultAction {
+        case ignore
+        case fallback
+        case showImage(UIImage)
+        case showMovie(URL)
     }
 
     fileprivate struct MediaPreviewInput: Equatable, Sendable {
@@ -710,6 +633,159 @@ private struct ImagePreviewLayoutState {
     var imageSize: CGSize
     var visibleBoundsSize: CGSize
     var minimumZoomScale: CGFloat
+}
+
+@MainActor
+private final class MediaPreviewCoordinator {
+    private var generation = 0
+    private var task: Task<Void, Never>?
+    private var pendingInput: NetworkBodyViewController.MediaPreviewInput?
+    private var displayedIdentity: NetworkBodyViewController.MediaPreviewIdentity?
+    private var failedInput: NetworkBodyViewController.MediaPreviewInput?
+    private var temporaryFile: MediaTemporaryFile?
+
+    func preparePreview(
+        for input: NetworkBodyViewController.MediaPreviewInput,
+        completion: @escaping @MainActor (
+            NetworkBodyViewController.MediaPayload?,
+            NetworkBodyViewController.MediaPreviewInput,
+            Int
+        ) -> Void
+    ) -> NetworkBodyViewController.MediaPreviewPreparationAction {
+        guard failedInput != input else {
+            return .failed
+        }
+        if displayedIdentity == .body(input) || pendingInput == input {
+            return .active
+        }
+        if let fileURL = cachedTemporaryFileURL(for: input) {
+            cancelPending()
+            failedInput = nil
+            displayedIdentity = .body(input)
+            return .cachedMovie(fileURL)
+        }
+
+        startPreparation(for: input, completion: completion)
+        return .startedLoading
+    }
+
+    func prepareRemoteMovie(_ url: URL) {
+        cancelPending()
+        failedInput = nil
+        displayedIdentity = .remoteMovie(url)
+        removeCachedTemporaryFile()
+    }
+
+    func prepareSyntaxPreview() {
+        cancelPending()
+        displayedIdentity = nil
+    }
+
+    func hideMediaPreview() {
+        cancelPending()
+        displayedIdentity = nil
+        removeCachedTemporaryFile()
+    }
+
+    func cancel() {
+        cancelPending()
+        displayedIdentity = nil
+        removeCachedTemporaryFile()
+    }
+
+    func consume(
+        result: NetworkBodyViewController.MediaPayload?,
+        input: NetworkBodyViewController.MediaPreviewInput,
+        generation: Int
+    ) -> NetworkBodyViewController.MediaPreviewResultAction {
+        guard generation == self.generation,
+              pendingInput == input else {
+            result?.removeTemporaryFile()
+            return .ignore
+        }
+        task = nil
+        pendingInput = nil
+
+        guard let result else {
+            failedInput = input
+            displayedIdentity = nil
+            return .fallback
+        }
+
+        failedInput = nil
+        displayedIdentity = .body(input)
+        switch result {
+        case .image(let image):
+            removeCachedTemporaryFile()
+            return .showImage(image)
+        case .movie(let temporaryFile):
+            replaceCachedTemporaryFile(with: temporaryFile)
+            return .showMovie(temporaryFile.fileURL)
+        }
+    }
+
+    private func startPreparation(
+        for input: NetworkBodyViewController.MediaPreviewInput,
+        completion: @escaping @MainActor (
+            NetworkBodyViewController.MediaPayload?,
+            NetworkBodyViewController.MediaPreviewInput,
+            Int
+        ) -> Void
+    ) {
+        cancelPending()
+        failedInput = nil
+        displayedIdentity = nil
+        pendingInput = input
+        generation += 1
+        let generation = generation
+
+        let worker = Task.detached(priority: .utility) {
+            await NetworkBodyViewController.makeMediaPayload(from: input)
+        }
+        task = Task { @MainActor [worker, completion] in
+            let result = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard Task.isCancelled == false else {
+                result?.removeTemporaryFile()
+                return
+            }
+            completion(result, input, generation)
+        }
+    }
+
+    private func cancelPending() {
+        generation += 1
+        task?.cancel()
+        task = nil
+        pendingInput = nil
+    }
+
+    private func cachedTemporaryFileURL(for input: NetworkBodyViewController.MediaPreviewInput) -> URL? {
+        guard input.previewKind == .movie || input.previewKind == .hlsPlaylist,
+              let temporaryFile,
+              temporaryFile.matches(input: input),
+              FileManager.default.fileExists(atPath: temporaryFile.fileURL.path) else {
+            return nil
+        }
+        return temporaryFile.fileURL
+    }
+
+    private func replaceCachedTemporaryFile(with newTemporaryFile: MediaTemporaryFile) {
+        if temporaryFile?.fileURL == newTemporaryFile.fileURL {
+            temporaryFile = newTemporaryFile
+            return
+        }
+        removeCachedTemporaryFile()
+        temporaryFile = newTemporaryFile
+    }
+
+    private func removeCachedTemporaryFile() {
+        removeTemporaryMediaFile(at: temporaryFile?.fileURL)
+        temporaryFile = nil
+    }
 }
 
 private struct MediaTemporaryFile {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -53,6 +53,11 @@ final class NetworkBodyViewController: UIViewController {
     private var hasDisplayedBody = false
     private var mediaPlayerViewController: AVPlayerViewController?
     private var mediaTemporaryFile: MediaTemporaryFile?
+    private var mediaPreviewGeneration = 0
+    private var mediaPreviewTask: Task<Void, Never>?
+    private var pendingMediaPreviewInput: MediaPreviewInput?
+    private var displayedMediaPreviewIdentity: MediaPreviewIdentity?
+    private var failedMediaPreviewInput: MediaPreviewInput?
     private var imageWidthConstraint: NSLayoutConstraint?
     private var imageHeightConstraint: NSLayoutConstraint?
     private var shouldResetImageZoomOnNextLayout = false
@@ -89,6 +94,7 @@ final class NetworkBodyViewController: UIViewController {
 
     isolated deinit {
         bodyObservation?.cancel()
+        mediaPreviewTask?.cancel()
         removeTemporaryMediaFile(at: mediaTemporaryFile?.fileURL)
     }
 
@@ -265,21 +271,21 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func renderMediaPreviewIfPossible(for body: NetworkBody) -> Bool {
-        guard let media = mediaPayload(for: body) else {
+        guard let source = mediaPreviewSource(for: body) else {
             hideMediaPreview()
             return false
         }
 
-        switch media {
-        case .image(let image):
-            showImagePreview(image)
-        case .movie(let url):
-            showMoviePreview(url)
+        switch source {
+        case .remoteMovie(let url):
+            showRemoteMoviePreview(url)
+            return true
+        case .body(let input):
+            return renderMediaPreview(for: input)
         }
-        return true
     }
 
-    private func mediaPayload(for body: NetworkBody) -> NetworkBodyViewController.MediaPayload? {
+    private func mediaPreviewSource(for body: NetworkBody) -> MediaPreviewSource? {
         guard let previewKind = NetworkRequest.Display.MediaPreviewSupport.previewKind(
             mimeType: metadata?.mimeType,
             url: metadata?.url
@@ -289,7 +295,7 @@ final class NetworkBodyViewController: UIViewController {
 
         if previewKind == .hlsPlaylist {
             if body.role == .response, let remoteURL = playableRemoteMediaURL(metadata?.url) {
-                return .movie(remoteURL)
+                return .remoteMovie(remoteURL)
             }
             if body.role == .request {
                 return nil
@@ -299,37 +305,182 @@ final class NetworkBodyViewController: UIViewController {
         guard let rawBody = body.full else {
             return nil
         }
-        let data: Data?
-        if body.isBase64Encoded {
-            data = Data(base64Encoded: rawBody)
-        } else {
-            data = rawBody.data(using: .utf8)
+        return .body(
+            MediaPreviewInput(
+                previewKind: previewKind,
+                bodyID: ObjectIdentifier(body),
+                role: body.role,
+                rawBody: rawBody,
+                isBase64Encoded: body.isBase64Encoded,
+                mimeType: metadata?.mimeType,
+                url: metadata?.url
+            )
+        )
+    }
+
+    private func renderMediaPreview(for input: MediaPreviewInput) -> Bool {
+        guard failedMediaPreviewInput != input else {
+            hideMediaPreview()
+            return false
         }
-        guard let data, data.isEmpty == false else {
+
+        if displayedMediaPreviewIdentity == .body(input) {
+            return true
+        }
+        if pendingMediaPreviewInput == input {
+            return true
+        }
+        if let fileURL = cachedTemporaryMediaFileURL(for: input) {
+            cancelMediaPreviewTask()
+            failedMediaPreviewInput = nil
+            displayedMediaPreviewIdentity = .body(input)
+            showMoviePreview(fileURL)
+            return true
+        }
+
+        startMediaPreviewTask(for: input)
+        return true
+    }
+
+    private func showRemoteMoviePreview(_ url: URL) {
+        cancelMediaPreviewTask()
+        failedMediaPreviewInput = nil
+        displayedMediaPreviewIdentity = .remoteMovie(url)
+        showMoviePreview(url)
+    }
+
+    private func startMediaPreviewTask(for input: MediaPreviewInput) {
+        cancelMediaPreviewTask()
+        failedMediaPreviewInput = nil
+        pendingMediaPreviewInput = input
+        mediaPreviewGeneration += 1
+        let generation = mediaPreviewGeneration
+        showMediaPreviewLoadingState(for: input)
+
+        let worker = Task.detached(priority: .utility) {
+            await NetworkBodyViewController.makeMediaPayload(from: input)
+        }
+        let task = Task { @MainActor [weak self, worker] in
+            let result = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard Task.isCancelled == false else {
+                result?.removeTemporaryFile()
+                return
+            }
+            self?.applyMediaPreviewResult(result, input: input, generation: generation)
+        }
+        mediaPreviewTask = task
+    }
+
+    private func applyMediaPreviewResult(
+        _ result: MediaPayload?,
+        input: MediaPreviewInput,
+        generation: Int
+    ) {
+        guard generation == mediaPreviewGeneration,
+              pendingMediaPreviewInput == input else {
+            result?.removeTemporaryFile()
+            return
+        }
+        mediaPreviewTask = nil
+        pendingMediaPreviewInput = nil
+
+        guard let result else {
+            failedMediaPreviewInput = input
+            displayedMediaPreviewIdentity = nil
+            renderBody(body)
+            return
+        }
+
+        failedMediaPreviewInput = nil
+        displayedMediaPreviewIdentity = .body(input)
+        switch result {
+        case .image(let image):
+            showImagePreview(image)
+        case .movie(let temporaryFile):
+            replaceCachedTemporaryMediaFile(with: temporaryFile)
+            showMoviePreview(temporaryFile.fileURL)
+        }
+    }
+
+    private func showMediaPreviewLoadingState(for input: MediaPreviewInput) {
+        displayedMediaPreviewIdentity = nil
+        hideImagePreview()
+        removeMediaPlayerViewController()
+        if mediaTemporaryFile?.matches(input: input) != true {
+            removeCachedTemporaryMediaFile()
+        }
+        if syntaxModel.text.isEmpty == false || syntaxModel.language != .plainText {
+            syntaxModel.replaceContents(text: "", language: .plainText)
+        }
+        syntaxView.isHidden = false
+        applyScrollEdgeObservedBackgrounds()
+        scrollEdgeSink?.contentScrollView = syntaxView
+    }
+
+    private func cancelMediaPreviewTask() {
+        mediaPreviewGeneration += 1
+        mediaPreviewTask?.cancel()
+        mediaPreviewTask = nil
+        pendingMediaPreviewInput = nil
+    }
+
+    private func cachedTemporaryMediaFileURL(for input: MediaPreviewInput) -> URL? {
+        guard input.previewKind == .movie || input.previewKind == .hlsPlaylist,
+              let mediaTemporaryFile,
+              mediaTemporaryFile.matches(input: input),
+              FileManager.default.fileExists(atPath: mediaTemporaryFile.fileURL.path) else {
+            return nil
+        }
+        return mediaTemporaryFile.fileURL
+    }
+
+    nonisolated private static func makeMediaPayload(from input: MediaPreviewInput) async -> MediaPayload? {
+        guard let data = input.data(), data.isEmpty == false else {
             return nil
         }
 
-        if previewKind == .image, let image = UIImage(data: data) {
-            return .image(image)
-        }
-
-        if previewKind == .movie || previewKind == .hlsPlaylist {
-            guard let fileURL = temporaryMediaFileURL(
-                for: body,
-                rawBody: rawBody,
-                data: data,
-                mimeType: metadata?.mimeType,
-                url: metadata?.url
-            ) else {
+        switch input.previewKind {
+        case .image:
+            var configuration = UIImageReader.Configuration()
+            configuration.preparesImagesForDisplay = true
+            let reader = UIImageReader(configuration: configuration)
+            guard let image = await reader.image(data: data) else {
                 return nil
             }
-            return .movie(fileURL)
+            return .image(image)
+        case .movie, .hlsPlaylist:
+            return makeTemporaryMediaPayload(from: input, data: data)
         }
+    }
 
-        return nil
+    nonisolated private static func makeTemporaryMediaPayload(
+        from input: MediaPreviewInput,
+        data: Data
+    ) -> MediaPayload? {
+        let fileExtension = mediaFileExtension(mimeType: input.mimeType, url: input.url)
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(fileExtension)
+        do {
+            try data.write(to: fileURL, options: [.atomic])
+            return .movie(
+                MediaTemporaryFile(
+                    input: input,
+                    fileURL: fileURL
+                )
+            )
+        } catch {
+            return nil
+        }
     }
 
     private func showSyntaxPreview() {
+        cancelMediaPreviewTask()
+        displayedMediaPreviewIdentity = nil
         hideImagePreview()
         removeMediaPlayerViewController()
         syntaxView.isHidden = false
@@ -386,6 +537,8 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func hideMediaPreview() {
+        cancelMediaPreviewTask()
+        displayedMediaPreviewIdentity = nil
         hideImagePreview()
         removeMediaPlayerViewController()
         removeCachedTemporaryMediaFile()
@@ -477,44 +630,13 @@ final class NetworkBodyViewController: UIViewController {
         self.mediaPlayerViewController = nil
     }
 
-    private func temporaryMediaFileURL(
-        for body: NetworkBody,
-        rawBody: String,
-        data: Data,
-        mimeType: String?,
-        url: String?
-    ) -> URL? {
-        if let mediaTemporaryFile,
-           mediaTemporaryFile.matches(
-               body: body,
-               rawBody: rawBody,
-               isBase64Encoded: body.isBase64Encoded,
-               mimeType: mimeType,
-               url: url
-           ),
-           FileManager.default.fileExists(atPath: mediaTemporaryFile.fileURL.path) {
-            return mediaTemporaryFile.fileURL
+    private func replaceCachedTemporaryMediaFile(with temporaryFile: MediaTemporaryFile) {
+        if mediaTemporaryFile?.fileURL == temporaryFile.fileURL {
+            mediaTemporaryFile = temporaryFile
+            return
         }
-
         removeCachedTemporaryMediaFile()
-        let fileExtension = mediaFileExtension(mimeType: mimeType, url: url)
-        let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension(fileExtension)
-        do {
-            try data.write(to: fileURL, options: [.atomic])
-            mediaTemporaryFile = MediaTemporaryFile(
-                bodyID: ObjectIdentifier(body),
-                rawBody: rawBody,
-                isBase64Encoded: body.isBase64Encoded,
-                mimeType: mimeType,
-                url: url,
-                fileURL: fileURL
-            )
-            return fileURL
-        } catch {
-            return nil
-        }
+        mediaTemporaryFile = temporaryFile
     }
 
     private func removeCachedTemporaryMediaFile() {
@@ -545,8 +667,42 @@ extension NetworkBodyViewController: UIScrollViewDelegate {
 }
 
 extension NetworkBodyViewController {
-    private enum MediaPayload {        case image(UIImage)
-        case movie(URL)
+    fileprivate enum MediaPreviewSource {
+        case remoteMovie(URL)
+        case body(MediaPreviewInput)
+    }
+
+    fileprivate enum MediaPreviewIdentity: Equatable {
+        case remoteMovie(URL)
+        case body(MediaPreviewInput)
+    }
+
+    fileprivate struct MediaPreviewInput: Equatable, Sendable {
+        var previewKind: NetworkRequest.Display.MediaPreviewKind
+        var bodyID: ObjectIdentifier
+        var role: NetworkBody.Role
+        var rawBody: String
+        var isBase64Encoded: Bool
+        var mimeType: String?
+        var url: String?
+
+        func data() -> Data? {
+            if isBase64Encoded {
+                return Data(base64Encoded: rawBody)
+            }
+            return rawBody.data(using: .utf8)
+        }
+    }
+
+    fileprivate enum MediaPayload {
+        case image(UIImage)
+        case movie(MediaTemporaryFile)
+
+        func removeTemporaryFile() {
+            if case .movie(let file) = self {
+                removeTemporaryMediaFile(at: file.fileURL)
+            }
+        }
     }
 }
 
@@ -557,25 +713,11 @@ private struct ImagePreviewLayoutState {
 }
 
 private struct MediaTemporaryFile {
-    var bodyID: ObjectIdentifier
-    var rawBody: String
-    var isBase64Encoded: Bool
-    var mimeType: String?
-    var url: String?
+    var input: NetworkBodyViewController.MediaPreviewInput
     var fileURL: URL
 
-    func matches(
-        body: NetworkBody,
-        rawBody: String,
-        isBase64Encoded: Bool,
-        mimeType: String?,
-        url: String?
-    ) -> Bool {
-        bodyID == ObjectIdentifier(body)
-            && self.rawBody == rawBody
-            && self.isBase64Encoded == isBase64Encoded
-            && self.mimeType == mimeType
-            && self.url == url
+    func matches(input: NetworkBodyViewController.MediaPreviewInput) -> Bool {
+        self.input == input
     }
 }
 


### PR DESCRIPTION
## Purpose
Reduce MainActor work while preparing Network body media previews.

## Changes
- Snapshot NetworkBody media inputs before crossing actor boundaries.
- Decode body data, prepare images with UIImageReader, and write temporary movie files in worker tasks.
- Keep UIKit updates on MainActor and guard stale async results with generation/cancellation.
- Preserve remote HLS playlist playback before bodies load.

## Testing
- git diff --check
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- codex-review self-review: no findings