### PR TITLE
Refactor network display row projection off MainActor

### DIFF
--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController+Preview.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController+Preview.swift
@@ -5,7 +5,7 @@ import UIKit
 @MainActor
 enum WebInspectorViewControllerPreviewFixtures {
     static func makeSession() -> WebInspectorSession {
-        WebInspectorSession(
+        let session = WebInspectorSession(
             inspector: InspectorSession(
                 attachment: AttachedInspection(
                     dom: DOMPreviewFixtures.makeDOMSession(),
@@ -13,6 +13,8 @@ enum WebInspectorViewControllerPreviewFixtures {
                 )
             )
         )
+        session.interface.networkPanelModel(for: session.attachment).refreshDisplayRowsSynchronously()
+        return session
     }
 }
 

--- a/Sources/WebInspectorUI/Network/List/NetworkListSnapshotState.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListSnapshotState.swift
@@ -46,6 +46,10 @@ extension NetworkListViewController {
             applyingRows != nil
         }
 
+        func projection(for id: NetworkRequest.ID) -> NetworkRequest.Display.Projection? {
+            applyingRows?.projectionByID[id] ?? displayedProjectionByID[id]
+        }
+
         func reconfiguredIDs(comparedTo rows: NetworkListViewController.SnapshotRows) -> Set<NetworkRequest.ID> {
             Set(rows.requestIDs.filter { id in
                 guard let previous = displayedProjectionByID[id],

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -147,17 +147,18 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         displayRowsObservation?.cancel()
         displayRowsObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
-            _ = model.displayRowsProjectionInput()
+            let projectionInput = model.displayRowsProjectionInput()
             let displayRows = model.displayRows
             guard isViewLoaded else {
-                model.scheduleDisplayRowsProjection()
+                model.scheduleDisplayRowsProjection(input: projectionInput)
                 needsSnapshotReloadOnNextAppearance = true
                 return
             }
             if event.kind == .initial {
-                model.scheduleDisplayRowsProjection()
+                model.scheduleDisplayRowsProjection(input: projectionInput)
                 reloadDataFromModel(displayRows: displayRows)
             } else {
+                model.scheduleDisplayRowsProjection(input: projectionInput)
                 scheduleThrottledDisplayRowsReload(displayRows)
             }
         }
@@ -197,7 +198,6 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             return
         }
         pendingThrottledDisplayRows = nil
-        model.scheduleDisplayRowsProjection()
         reloadDataFromModel(displayRows: displayRows)
     }
 

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -23,11 +23,6 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         var mode: SnapshotApplyMode
     }
 
-    private struct PendingDisplayRowsReload {
-        var rows: [NetworkRequest.Display.Projection]
-        var projectionInput: NetworkRequest.Display.RowsProjectionInput
-    }
-
     private static let snapshotThrottleInterval: Duration = .milliseconds(80)
 
     private let model: NetworkPanelModel
@@ -37,7 +32,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private var resourceFilterObservation: PortableObservationTracking.Token?
     private var selectedRequestObservation: PortableObservationTracking.Token?
     private let displayRowsReloadScheduler = MainActorDelayScheduler()
-    private var pendingThrottledDisplayRowsReload: PendingDisplayRowsReload?
+    private var pendingThrottledDisplayRows: [NetworkRequest.Display.Projection]?
 
     private var needsSnapshotReloadOnNextAppearance = false
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
@@ -152,21 +147,18 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         displayRowsObservation?.cancel()
         displayRowsObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
-            let projectionInput = model.displayRowsProjectionInput()
+            _ = model.displayRowsProjectionInput()
             let displayRows = model.displayRows
             guard isViewLoaded else {
-                model.scheduleDisplayRowsProjection(input: projectionInput)
+                model.scheduleDisplayRowsProjection()
                 needsSnapshotReloadOnNextAppearance = true
                 return
             }
             if event.kind == .initial {
-                model.scheduleDisplayRowsProjection(input: projectionInput)
+                model.scheduleDisplayRowsProjection()
                 reloadDataFromModel(displayRows: displayRows)
             } else {
-                scheduleThrottledDisplayRowsReload(
-                    displayRows: displayRows,
-                    projectionInput: projectionInput
-                )
+                scheduleThrottledDisplayRowsReload(displayRows)
             }
         }
 
@@ -189,14 +181,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
     }
 
-    private func scheduleThrottledDisplayRowsReload(
-        displayRows: [NetworkRequest.Display.Projection],
-        projectionInput: NetworkRequest.Display.RowsProjectionInput
-    ) {
-        pendingThrottledDisplayRowsReload = PendingDisplayRowsReload(
-            rows: displayRows,
-            projectionInput: projectionInput
-        )
+    private func scheduleThrottledDisplayRowsReload(_ displayRows: [NetworkRequest.Display.Projection]) {
+        pendingThrottledDisplayRows = displayRows
         guard displayRowsReloadScheduler.hasScheduledDelay == false else {
             return
         }
@@ -207,12 +193,12 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func flushThrottledDisplayRowsReload() {
-        guard let reload = pendingThrottledDisplayRowsReload else {
+        guard let displayRows = pendingThrottledDisplayRows else {
             return
         }
-        pendingThrottledDisplayRowsReload = nil
-        model.scheduleDisplayRowsProjection(input: reload.projectionInput)
-        reloadDataFromModel(displayRows: reload.rows)
+        pendingThrottledDisplayRows = nil
+        model.scheduleDisplayRowsProjection()
+        reloadDataFromModel(displayRows: displayRows)
     }
 
     private func configureNavigationItem() {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -23,6 +23,11 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         var mode: SnapshotApplyMode
     }
 
+    private struct PendingDisplayRowsReload {
+        var rows: [NetworkRequest.Display.Projection]
+        var projectionInput: NetworkRequest.Display.RowsProjectionInput
+    }
+
     private static let snapshotThrottleInterval: Duration = .milliseconds(80)
 
     private let model: NetworkPanelModel
@@ -32,7 +37,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private var resourceFilterObservation: PortableObservationTracking.Token?
     private var selectedRequestObservation: PortableObservationTracking.Token?
     private let displayRowsReloadScheduler = MainActorDelayScheduler()
-    private var pendingThrottledDisplayRows: [NetworkRequest.Display.Projection]?
+    private var pendingThrottledDisplayRowsReload: PendingDisplayRowsReload?
 
     private var needsSnapshotReloadOnNextAppearance = false
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
@@ -147,15 +152,21 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         displayRowsObservation?.cancel()
         displayRowsObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
+            let projectionInput = model.displayRowsProjectionInput()
             let displayRows = model.displayRows
             guard isViewLoaded else {
+                model.scheduleDisplayRowsProjection(input: projectionInput)
                 needsSnapshotReloadOnNextAppearance = true
                 return
             }
             if event.kind == .initial {
+                model.scheduleDisplayRowsProjection(input: projectionInput)
                 reloadDataFromModel(displayRows: displayRows)
             } else {
-                scheduleThrottledDisplayRowsReload(displayRows)
+                scheduleThrottledDisplayRowsReload(
+                    displayRows: displayRows,
+                    projectionInput: projectionInput
+                )
             }
         }
 
@@ -178,8 +189,14 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
     }
 
-    private func scheduleThrottledDisplayRowsReload(_ displayRows: [NetworkRequest.Display.Projection]) {
-        pendingThrottledDisplayRows = displayRows
+    private func scheduleThrottledDisplayRowsReload(
+        displayRows: [NetworkRequest.Display.Projection],
+        projectionInput: NetworkRequest.Display.RowsProjectionInput
+    ) {
+        pendingThrottledDisplayRowsReload = PendingDisplayRowsReload(
+            rows: displayRows,
+            projectionInput: projectionInput
+        )
         guard displayRowsReloadScheduler.hasScheduledDelay == false else {
             return
         }
@@ -190,11 +207,12 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func flushThrottledDisplayRowsReload() {
-        guard let displayRows = pendingThrottledDisplayRows else {
+        guard let reload = pendingThrottledDisplayRowsReload else {
             return
         }
-        pendingThrottledDisplayRows = nil
-        reloadDataFromModel(displayRows: displayRows)
+        pendingThrottledDisplayRowsReload = nil
+        model.scheduleDisplayRowsProjection(input: reload.projectionInput)
+        reloadDataFromModel(displayRows: reload.rows)
     }
 
     private func configureNavigationItem() {
@@ -315,8 +333,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionIdentifier, NetworkRequest.ID> {
-        let listCellRegistration = UICollectionView.CellRegistration<NetworkListCell, NetworkRequest.ID> { [weak model] cell, _, id in
-            guard let projection = model?.displayProjection(for: id) else {
+        let listCellRegistration = UICollectionView.CellRegistration<NetworkListCell, NetworkRequest.ID> { [weak self] cell, _, id in
+            guard let projection = self?.projectionForVisibleRow(id) else {
                 return
             }
             cell.bind(projection: projection)
@@ -330,6 +348,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
                 item: item
             )
         }
+    }
+
+    private func projectionForVisibleRow(_ id: NetworkRequest.ID) -> NetworkRequest.Display.Projection? {
+        snapshotState.projection(for: id) ?? model.displayProjection(for: id)
     }
 
     private func makeSnapshot(

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -43,8 +43,14 @@ package final class NetworkPanelModel {
         }
     }
     package private(set) var effectiveResourceFilters: Set<NetworkRequest.Display.ResourceFilter> = []
+    package private(set) var displayRows: [NetworkRequest.Display.Projection] = []
     @ObservationIgnored private let responseBodyFetchCoordinator: NetworkResponseBodyFetchCoordinator
-    @ObservationIgnored private let displayProjectionCache: NetworkRequest.Display.ProjectionCache
+    @ObservationIgnored private let displayRowsProjector: NetworkRequest.Display.RowsProjector
+    @ObservationIgnored private let synchronousDisplayProjectionCache: NetworkRequest.Display.ProjectionCache
+    @ObservationIgnored private var displayProjectionByID: [NetworkRequest.ID: NetworkRequest.Display.Projection] = [:]
+    @ObservationIgnored private var displayRowsProjectionTask: Task<Void, Never>?
+    @ObservationIgnored private var displayRowsProjectionGeneration = 0
+    @ObservationIgnored private var lastRequestedRowsProjectionInput: NetworkRequest.Display.RowsProjectionInput?
 
     package init(
         network: NetworkSession,
@@ -55,30 +61,12 @@ package final class NetworkPanelModel {
     ) {
         self.network = network
         self.responseBodyFetchCoordinator = NetworkResponseBodyFetchCoordinator(action: responseBodyFetchAction)
-        self.displayProjectionCache = NetworkRequest.Display.ProjectionCache(
-            mediaPreviewClassifier: mediaPreviewClassifier
-        )
+        self.displayRowsProjector = NetworkRequest.Display.RowsProjector(mediaPreviewClassifier: mediaPreviewClassifier)
+        self.synchronousDisplayProjectionCache = NetworkRequest.Display.ProjectionCache(mediaPreviewClassifier: mediaPreviewClassifier)
     }
 
-    package var displayRows: [NetworkRequest.Display.Projection] {
-        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let requests = network.requests
-        let effectiveResourceFilters = effectiveResourceFilters
-        displayProjectionCache.prune(keeping: Set(requests.map(\.id)))
-        let rows = requests.compactMap { request -> NetworkRequest.Display.Projection? in
-            if effectiveResourceFilters.isEmpty == false {
-                let resourceFilter = displayProjectionCache.resourceFilter(for: request)
-                guard effectiveResourceFilters.contains(resourceFilter) else {
-                    return nil
-                }
-            }
-            let projection = displayProjectionCache.projection(for: request)
-            guard projection.matchesSearchText(trimmedQuery) else {
-                return nil
-            }
-            return projection
-        }
-        return Array(rows.reversed())
+    isolated deinit {
+        displayRowsProjectionTask?.cancel()
     }
 
     package var displayRequestIDs: [NetworkRequest.ID] {
@@ -105,10 +93,7 @@ package final class NetworkPanelModel {
     }
 
     package func displayProjection(for id: NetworkRequest.ID) -> NetworkRequest.Display.Projection? {
-        guard let request = network.request(for: id) else {
-            return nil
-        }
-        return displayProjectionCache.projection(for: request)
+        displayProjectionByID[id]
     }
 
     package func selectRequest(_ request: NetworkRequest?) {
@@ -146,10 +131,99 @@ package final class NetworkPanelModel {
     package func clearRequests() {
         selectedRequestID = nil
         network.reset()
-        displayProjectionCache.removeAll()
+        cancelPendingDisplayRowsProjection()
+        applyDisplayRows([], generation: displayRowsProjectionGeneration)
+        lastRequestedRowsProjectionInput = nil
+        Task { [displayRowsProjector] in
+            await displayRowsProjector.removeAll()
+        }
+        synchronousDisplayProjectionCache.removeAll()
     }
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
         responseBodyFetchCoordinator.fetchIfNeeded(for: request)
+    }
+
+    package func displayRowsProjectionInput() -> NetworkRequest.Display.RowsProjectionInput {
+        NetworkRequest.Display.RowsProjectionInput(
+            requestSnapshots: network.requests.map(NetworkRequest.Display.RequestSnapshot.init),
+            searchText: searchText,
+            resourceFilters: effectiveResourceFilters
+        )
+    }
+
+    package func scheduleDisplayRowsProjection(
+        input: NetworkRequest.Display.RowsProjectionInput? = nil
+    ) {
+        let input = input ?? displayRowsProjectionInput()
+        guard input != lastRequestedRowsProjectionInput else {
+            return
+        }
+        lastRequestedRowsProjectionInput = input
+        cancelPendingDisplayRowsProjection()
+        let generation = displayRowsProjectionGeneration
+        let projector = displayRowsProjector
+        displayRowsProjectionTask = Task { [input, generation, projector, weak self] in
+            do {
+                let rows = try await projector.rows(for: input)
+                try Task.checkCancellation()
+                await MainActor.run {
+                    self?.applyDisplayRows(rows, generation: generation)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+        }
+    }
+
+    @discardableResult
+    package func refreshDisplayRows() async -> [NetworkRequest.Display.Projection] {
+        let input = displayRowsProjectionInput()
+        lastRequestedRowsProjectionInput = input
+        cancelPendingDisplayRowsProjection()
+        let generation = displayRowsProjectionGeneration
+        do {
+            let rows = try await displayRowsProjector.rows(for: input)
+            try Task.checkCancellation()
+            applyDisplayRows(rows, generation: generation)
+        } catch is CancellationError {
+        } catch {
+        }
+        return displayRows
+    }
+
+    @discardableResult
+    package func refreshDisplayRowsSynchronously() -> [NetworkRequest.Display.Projection] {
+        let input = displayRowsProjectionInput()
+        lastRequestedRowsProjectionInput = input
+        cancelPendingDisplayRowsProjection()
+        let generation = displayRowsProjectionGeneration
+        do {
+            let rows = try synchronousDisplayProjectionCache.rows(for: input)
+            applyDisplayRows(rows, generation: generation)
+        } catch is CancellationError {
+        } catch {
+        }
+        return displayRows
+    }
+
+    private func cancelPendingDisplayRowsProjection() {
+        displayRowsProjectionGeneration += 1
+        displayRowsProjectionTask?.cancel()
+        displayRowsProjectionTask = nil
+    }
+
+    private func applyDisplayRows(
+        _ rows: [NetworkRequest.Display.Projection],
+        generation: Int
+    ) {
+        guard generation == displayRowsProjectionGeneration else {
+            return
+        }
+        displayRows = rows
+        displayProjectionByID = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
+        displayRowsProjectionTask = nil
     }
 }

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -27,6 +27,113 @@ private final class NetworkResponseBodyFetchCoordinator {
 }
 
 @MainActor
+private final class NetworkDisplayRowsProjectionCoordinator {
+    typealias ApplyAction = @MainActor @Sendable ([NetworkRequest.Display.Projection]) -> Void
+
+    private let projector: NetworkRequest.Display.RowsProjector
+    private let synchronousCache: NetworkRequest.Display.ProjectionCache
+    private var task: Task<Void, Never>?
+    private var generation = 0
+    private var lastRequestedInput: NetworkRequest.Display.RowsProjectionInput?
+
+    init(mediaPreviewClassifier: @escaping NetworkRequest.Display.MediaPreviewClassifier) {
+        projector = NetworkRequest.Display.RowsProjector(mediaPreviewClassifier: mediaPreviewClassifier)
+        synchronousCache = NetworkRequest.Display.ProjectionCache(mediaPreviewClassifier: mediaPreviewClassifier)
+    }
+
+    isolated deinit {
+        task?.cancel()
+    }
+
+    func schedule(
+        input: NetworkRequest.Display.RowsProjectionInput,
+        apply: @escaping ApplyAction
+    ) {
+        guard input != lastRequestedInput else {
+            return
+        }
+        lastRequestedInput = input
+        cancelPending()
+        let generation = generation
+        let projector = projector
+        task = Task { [input, generation, projector, weak self] in
+            do {
+                let rows = try await projector.rows(for: input)
+                try Task.checkCancellation()
+                self?.applyIfCurrent(rows, generation: generation, apply: apply)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+        }
+    }
+
+    func refresh(
+        input: NetworkRequest.Display.RowsProjectionInput,
+        apply: ApplyAction
+    ) async {
+        lastRequestedInput = input
+        cancelPending()
+        let generation = generation
+        do {
+            let rows = try await projector.rows(for: input)
+            try Task.checkCancellation()
+            applyIfCurrent(rows, generation: generation, apply: apply)
+        } catch is CancellationError {
+        } catch {
+        }
+    }
+
+    func refreshSynchronously(
+        input: NetworkRequest.Display.RowsProjectionInput,
+        apply: ApplyAction
+    ) {
+        lastRequestedInput = input
+        cancelPending()
+        let generation = generation
+        do {
+            let rows = try synchronousCache.rows(for: input)
+            applyIfCurrent(rows, generation: generation, apply: apply)
+        } catch is CancellationError {
+        } catch {
+        }
+    }
+
+    func removeAll(apply: ApplyAction) {
+        cancelPending()
+        lastRequestedInput = nil
+        applyIfCurrent([], generation: generation, apply: apply)
+        Task { [projector] in
+            await projector.removeAll()
+        }
+        synchronousCache.removeAll()
+    }
+
+    func cancel() {
+        cancelPending()
+    }
+
+    private func cancelPending() {
+        generation += 1
+        task?.cancel()
+        task = nil
+    }
+
+    private func applyIfCurrent(
+        _ rows: [NetworkRequest.Display.Projection],
+        generation: Int,
+        apply: ApplyAction
+    ) {
+        guard generation == self.generation else {
+            return
+        }
+        apply(rows)
+        task = nil
+    }
+}
+
+@MainActor
 @Observable
 package final class NetworkPanelModel {
     package typealias ResponseBodyFetchAction = @MainActor (NetworkRequest.ID) async -> Void
@@ -45,12 +152,8 @@ package final class NetworkPanelModel {
     package private(set) var effectiveResourceFilters: Set<NetworkRequest.Display.ResourceFilter> = []
     package private(set) var displayRows: [NetworkRequest.Display.Projection] = []
     @ObservationIgnored private let responseBodyFetchCoordinator: NetworkResponseBodyFetchCoordinator
-    @ObservationIgnored private let displayRowsProjector: NetworkRequest.Display.RowsProjector
-    @ObservationIgnored private let synchronousDisplayProjectionCache: NetworkRequest.Display.ProjectionCache
+    @ObservationIgnored private let displayRowsProjectionCoordinator: NetworkDisplayRowsProjectionCoordinator
     @ObservationIgnored private var displayProjectionByID: [NetworkRequest.ID: NetworkRequest.Display.Projection] = [:]
-    @ObservationIgnored private var displayRowsProjectionTask: Task<Void, Never>?
-    @ObservationIgnored private var displayRowsProjectionGeneration = 0
-    @ObservationIgnored private var lastRequestedRowsProjectionInput: NetworkRequest.Display.RowsProjectionInput?
 
     package init(
         network: NetworkSession,
@@ -61,12 +164,13 @@ package final class NetworkPanelModel {
     ) {
         self.network = network
         self.responseBodyFetchCoordinator = NetworkResponseBodyFetchCoordinator(action: responseBodyFetchAction)
-        self.displayRowsProjector = NetworkRequest.Display.RowsProjector(mediaPreviewClassifier: mediaPreviewClassifier)
-        self.synchronousDisplayProjectionCache = NetworkRequest.Display.ProjectionCache(mediaPreviewClassifier: mediaPreviewClassifier)
+        self.displayRowsProjectionCoordinator = NetworkDisplayRowsProjectionCoordinator(
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
     }
 
     isolated deinit {
-        displayRowsProjectionTask?.cancel()
+        displayRowsProjectionCoordinator.cancel()
     }
 
     package var displayRequestIDs: [NetworkRequest.ID] {
@@ -131,13 +235,9 @@ package final class NetworkPanelModel {
     package func clearRequests() {
         selectedRequestID = nil
         network.reset()
-        cancelPendingDisplayRowsProjection()
-        applyDisplayRows([], generation: displayRowsProjectionGeneration)
-        lastRequestedRowsProjectionInput = nil
-        Task { [displayRowsProjector] in
-            await displayRowsProjector.removeAll()
+        displayRowsProjectionCoordinator.removeAll { [weak self] rows in
+            self?.applyDisplayRows(rows)
         }
-        synchronousDisplayProjectionCache.removeAll()
     }
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
@@ -156,40 +256,16 @@ package final class NetworkPanelModel {
         input: NetworkRequest.Display.RowsProjectionInput? = nil
     ) {
         let input = input ?? displayRowsProjectionInput()
-        guard input != lastRequestedRowsProjectionInput else {
-            return
-        }
-        lastRequestedRowsProjectionInput = input
-        cancelPendingDisplayRowsProjection()
-        let generation = displayRowsProjectionGeneration
-        let projector = displayRowsProjector
-        displayRowsProjectionTask = Task { [input, generation, projector, weak self] in
-            do {
-                let rows = try await projector.rows(for: input)
-                try Task.checkCancellation()
-                await MainActor.run {
-                    self?.applyDisplayRows(rows, generation: generation)
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                return
-            }
+        displayRowsProjectionCoordinator.schedule(input: input) { [weak self] rows in
+            self?.applyDisplayRows(rows)
         }
     }
 
     @discardableResult
     package func refreshDisplayRows() async -> [NetworkRequest.Display.Projection] {
         let input = displayRowsProjectionInput()
-        lastRequestedRowsProjectionInput = input
-        cancelPendingDisplayRowsProjection()
-        let generation = displayRowsProjectionGeneration
-        do {
-            let rows = try await displayRowsProjector.rows(for: input)
-            try Task.checkCancellation()
-            applyDisplayRows(rows, generation: generation)
-        } catch is CancellationError {
-        } catch {
+        await displayRowsProjectionCoordinator.refresh(input: input) { [weak self] rows in
+            self?.applyDisplayRows(rows)
         }
         return displayRows
     }
@@ -197,33 +273,14 @@ package final class NetworkPanelModel {
     @discardableResult
     package func refreshDisplayRowsSynchronously() -> [NetworkRequest.Display.Projection] {
         let input = displayRowsProjectionInput()
-        lastRequestedRowsProjectionInput = input
-        cancelPendingDisplayRowsProjection()
-        let generation = displayRowsProjectionGeneration
-        do {
-            let rows = try synchronousDisplayProjectionCache.rows(for: input)
-            applyDisplayRows(rows, generation: generation)
-        } catch is CancellationError {
-        } catch {
+        displayRowsProjectionCoordinator.refreshSynchronously(input: input) { [weak self] rows in
+            self?.applyDisplayRows(rows)
         }
         return displayRows
     }
 
-    private func cancelPendingDisplayRowsProjection() {
-        displayRowsProjectionGeneration += 1
-        displayRowsProjectionTask?.cancel()
-        displayRowsProjectionTask = nil
-    }
-
-    private func applyDisplayRows(
-        _ rows: [NetworkRequest.Display.Projection],
-        generation: Int
-    ) {
-        guard generation == displayRowsProjectionGeneration else {
-            return
-        }
+    private func applyDisplayRows(_ rows: [NetworkRequest.Display.Projection]) {
         displayRows = rows
         displayProjectionByID = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
-        displayRowsProjectionTask = nil
     }
 }

--- a/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
+++ b/Sources/WebInspectorUI/Network/NetworkRequestDisplayProjection.swift
@@ -6,11 +6,11 @@ extension NetworkRequest {
 }
 
 extension NetworkRequest.Display {
-    package typealias MediaPreviewClassifier = (String?, String?) -> NetworkRequest.Display.MediaPreviewClassification
+    package typealias MediaPreviewClassifier = @Sendable (String?, String?) -> NetworkRequest.Display.MediaPreviewClassification
 }
 
 extension NetworkRequest.Display {
-    package struct Projection: Equatable, Identifiable {
+    package struct Projection: Equatable, Identifiable, Sendable {
         package var id: NetworkRequest.ID
         package var displayName: String
         package var fileTypeLabel: String
@@ -28,7 +28,74 @@ extension NetworkRequest.Display {
 }
 
 extension NetworkRequest.Display {
-    package struct Fingerprint: Equatable {
+    package struct RequestSnapshot: Equatable, Identifiable, Sendable {
+        package var id: NetworkRequest.ID
+        package var requestURL: String
+        package var requestMethod: String
+        package var resourceType: NetworkRequest.ResourceType?
+        package var responseURL: String?
+        package var responseMIMEType: String?
+        package var responseHeaders: [String: String]
+        package var responseStatus: Int?
+        package var responseStatusText: String?
+        package var state: NetworkRequest.State
+
+        @MainActor
+        package init(request: NetworkRequest) {
+            id = request.id
+            requestURL = request.request.url
+            requestMethod = request.request.method
+            resourceType = request.resourceType
+            responseURL = request.response?.url
+            responseMIMEType = request.response?.mimeType
+            responseHeaders = request.response?.headers ?? [:]
+            responseStatus = request.response?.status
+            responseStatusText = request.response?.statusText
+            state = request.state
+        }
+
+        var statusSeverity: NetworkRequest.Display.StatusSeverity {
+            if case .failed = state {
+                return .error
+            }
+            if let responseStatus {
+                if responseStatus >= 500 {
+                    return .error
+                }
+                if responseStatus >= 400 {
+                    return .warning
+                }
+                if responseStatus >= 300 {
+                    return .notice
+                }
+                return .success
+            }
+            if state == .finished {
+                return .success
+            }
+            return .neutral
+        }
+    }
+
+    package struct RowsProjectionInput: Equatable, Sendable {
+        package var requestSnapshots: [NetworkRequest.Display.RequestSnapshot]
+        package var searchText: String
+        package var resourceFilters: Set<NetworkRequest.Display.ResourceFilter>
+
+        package init(
+            requestSnapshots: [NetworkRequest.Display.RequestSnapshot],
+            searchText: String,
+            resourceFilters: Set<NetworkRequest.Display.ResourceFilter>
+        ) {
+            self.requestSnapshots = requestSnapshots
+            self.searchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.resourceFilters = resourceFilters
+        }
+    }
+}
+
+extension NetworkRequest.Display {
+    package struct Fingerprint: Equatable, Sendable {
         package var requestURL: String
         package var requestMethod: String
         package var resourceType: NetworkRequest.ResourceType?
@@ -39,51 +106,53 @@ extension NetworkRequest.Display {
         package var responseStatusText: String?
         package var state: NetworkRequest.State
 
-        @MainActor
-        package init(request: NetworkRequest) {
-            self.requestURL = request.request.url
-            self.requestMethod = request.request.method
-            self.resourceType = request.resourceType
-            self.responseURL = request.response?.url
-            if let response = request.response {
-                self.responseMIMEType = response.mimeType
-                self.responseDisplayMIMEType = networkDisplayMIMEType(from: response)
+        package init(snapshot: NetworkRequest.Display.RequestSnapshot) {
+            requestURL = snapshot.requestURL
+            requestMethod = snapshot.requestMethod
+            resourceType = snapshot.resourceType
+            responseURL = snapshot.responseURL
+            responseMIMEType = snapshot.responseMIMEType
+            if snapshot.responseURL != nil {
+                responseDisplayMIMEType = networkDisplayMIMEType(
+                    mimeType: snapshot.responseMIMEType,
+                    headers: snapshot.responseHeaders
+                )
             } else {
-                self.responseMIMEType = nil
-                self.responseDisplayMIMEType = nil
+                responseDisplayMIMEType = nil
             }
-            self.responseStatus = request.response?.status
-            self.responseStatusText = request.response?.statusText
-            self.state = request.state
+            responseStatus = snapshot.responseStatus
+            responseStatusText = snapshot.responseStatusText
+            state = snapshot.state
         }
     }
 }
 
 extension NetworkRequest.Display {
-    private struct ProjectionInputs {
+    private struct ProjectionInputs: Sendable {
         var requestURLSummary: NetworkRequest.Display.URLSummary
         var responseURLSummary: NetworkRequest.Display.URLSummary?
         var responseDisplayMIMEType: String?
         var fileTypeLabel: String
 
-        @MainActor
-        init(request: NetworkRequest) {
-            requestURLSummary = NetworkRequest.Display.URLSummary(url: request.request.url)
-            responseURLSummary = request.response.map { NetworkRequest.Display.URLSummary(url: $0.url) }
-            if let response = request.response {
-                responseDisplayMIMEType = networkDisplayMIMEType(from: response)
+        init(snapshot: NetworkRequest.Display.RequestSnapshot) {
+            requestURLSummary = NetworkRequest.Display.URLSummary(url: snapshot.requestURL)
+            responseURLSummary = snapshot.responseURL.map { NetworkRequest.Display.URLSummary(url: $0) }
+            if snapshot.responseURL != nil {
+                responseDisplayMIMEType = networkDisplayMIMEType(
+                    mimeType: snapshot.responseMIMEType,
+                    headers: snapshot.responseHeaders
+                )
             } else {
-                responseDisplayMIMEType = nil
+                self.responseDisplayMIMEType = nil
             }
             fileTypeLabel = NetworkRequest.Display.fileTypeLabel(
-                mimeType: request.response?.mimeType,
-                resourceType: request.resourceType,
+                mimeType: snapshot.responseMIMEType,
+                resourceType: snapshot.resourceType,
                 urlSummary: requestURLSummary
             )
         }
     }
 
-    @MainActor
     package final class ProjectionCache {
         private struct Entry {
             var fingerprint: NetworkRequest.Display.Fingerprint
@@ -98,36 +167,59 @@ extension NetworkRequest.Display {
             self.mediaPreviewClassifier = mediaPreviewClassifier
         }
 
-        package func projection(for request: NetworkRequest) -> NetworkRequest.Display.Projection {
-            let fingerprint = NetworkRequest.Display.Fingerprint(request: request)
-            if let entry = entries[request.id], entry.fingerprint == fingerprint {
+        package func rows(for input: NetworkRequest.Display.RowsProjectionInput) throws -> [NetworkRequest.Display.Projection] {
+            try Task.checkCancellation()
+            prune(keeping: Set(input.requestSnapshots.map(\.id)))
+
+            var rows: [NetworkRequest.Display.Projection] = []
+            rows.reserveCapacity(input.requestSnapshots.count)
+            for snapshot in input.requestSnapshots {
+                try Task.checkCancellation()
+                if input.resourceFilters.isEmpty == false {
+                    let resourceFilter = resourceFilter(for: snapshot)
+                    guard input.resourceFilters.contains(resourceFilter) else {
+                        continue
+                    }
+                }
+                let projection = projection(for: snapshot)
+                guard projection.matchesSearchText(input.searchText) else {
+                    continue
+                }
+                rows.append(projection)
+            }
+            return Array(rows.reversed())
+        }
+
+        package func projection(for snapshot: NetworkRequest.Display.RequestSnapshot) -> NetworkRequest.Display.Projection {
+            let fingerprint = NetworkRequest.Display.Fingerprint(snapshot: snapshot)
+            if let entry = entries[snapshot.id], entry.fingerprint == fingerprint {
                 return entry.projection
             }
 
-            let inputs = NetworkRequest.Display.ProjectionInputs(request: request)
-            let projection = Self.projection(for: request, inputs: inputs)
-            entries[request.id] = Entry(fingerprint: fingerprint, projection: projection, resourceFilter: nil)
+            let inputs = NetworkRequest.Display.ProjectionInputs(snapshot: snapshot)
+            let projection = Self.projection(for: snapshot, inputs: inputs)
+            entries[snapshot.id] = Entry(fingerprint: fingerprint, projection: projection, resourceFilter: nil)
             return projection
         }
 
-        package func resourceFilter(for request: NetworkRequest) -> NetworkRequest.Display.ResourceFilter {
-            let fingerprint = NetworkRequest.Display.Fingerprint(request: request)
-            if let entry = entries[request.id],
+        package func resourceFilter(for snapshot: NetworkRequest.Display.RequestSnapshot) -> NetworkRequest.Display.ResourceFilter {
+            let fingerprint = NetworkRequest.Display.Fingerprint(snapshot: snapshot)
+            if let entry = entries[snapshot.id],
                entry.fingerprint == fingerprint,
                let resourceFilter = entry.resourceFilter {
                 return resourceFilter
             }
 
-            let inputs = NetworkRequest.Display.ProjectionInputs(request: request)
-            let resourceFilter = Self.resourceFilter(for: request, inputs: inputs, classifier: mediaPreviewClassifier)
+            let inputs = NetworkRequest.Display.ProjectionInputs(snapshot: snapshot)
+            let resourceFilter = Self.resourceFilter(for: snapshot, inputs: inputs, classifier: mediaPreviewClassifier)
             var projection: NetworkRequest.Display.Projection
-            if let entry = entries[request.id], entry.fingerprint == fingerprint {
+            if let entry = entries[snapshot.id], entry.fingerprint == fingerprint {
                 projection = entry.projection
             } else {
-                projection = Self.projection(for: request, inputs: inputs)
+                projection = Self.projection(for: snapshot, inputs: inputs)
             }
             projection.resourceFilter = resourceFilter
-            entries[request.id] = Entry(
+            entries[snapshot.id] = Entry(
                 fingerprint: fingerprint,
                 projection: projection,
                 resourceFilter: resourceFilter
@@ -144,50 +236,50 @@ extension NetworkRequest.Display {
         }
 
         private static func projection(
-            for request: NetworkRequest,
+            for snapshot: NetworkRequest.Display.RequestSnapshot,
             inputs: NetworkRequest.Display.ProjectionInputs
         ) -> NetworkRequest.Display.Projection {
             NetworkRequest.Display.Projection(
-                id: request.id,
+                id: snapshot.id,
                 displayName: inputs.requestURLSummary.displayName,
                 fileTypeLabel: inputs.fileTypeLabel,
-                statusSeverity: request.statusSeverity,
+                statusSeverity: snapshot.statusSeverity,
                 resourceFilter: nil,
-                searchTokens: Self.searchTokens(for: request, inputs: inputs)
+                searchTokens: Self.searchTokens(for: snapshot, inputs: inputs)
             )
         }
 
         private static func searchTokens(
-            for request: NetworkRequest,
+            for snapshot: NetworkRequest.Display.RequestSnapshot,
             inputs: NetworkRequest.Display.ProjectionInputs
         ) -> [String] {
-            let statusCodeLabel = request.response.map { String($0.status) } ?? ""
+            let statusCodeLabel = snapshot.responseStatus.map(String.init) ?? ""
             return uniqueNonEmpty(
                 inputs.requestURLSummary.searchTokens
                 + (inputs.responseURLSummary?.searchTokens ?? [])
                 + [
-                    request.request.method,
+                    snapshot.requestMethod,
                     statusCodeLabel,
-                    request.response?.statusText ?? "",
+                    snapshot.responseStatusText ?? "",
                     inputs.fileTypeLabel,
                 ]
             )
         }
 
         private static func resourceFilter(
-            for request: NetworkRequest,
+            for snapshot: NetworkRequest.Display.RequestSnapshot,
             inputs: NetworkRequest.Display.ProjectionInputs,
             classifier: NetworkRequest.Display.MediaPreviewClassifier
         ) -> NetworkRequest.Display.ResourceFilter {
-            guard let response = request.response else {
-                if let resourceType = request.resourceType {
+            guard let responseURL = snapshot.responseURL else {
+                if let resourceType = snapshot.resourceType {
                     return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
                 }
                 return Self.resourceFilter(mimeType: nil, urlSummary: inputs.requestURLSummary, classifier: classifier)
             }
 
             let responseMimeType = inputs.responseDisplayMIMEType
-            if let resourceType = request.resourceType,
+            if let resourceType = snapshot.resourceType,
                shouldKeepResourceTypeForURLInferredMedia(resourceType) {
                 if case .previewable = classifier(responseMimeType, nil) {
                     return .media
@@ -195,19 +287,19 @@ extension NetworkRequest.Display {
                 return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
             }
 
-            let responseURLSummary = inputs.responseURLSummary ?? NetworkRequest.Display.URLSummary(url: response.url)
+            let responseURLSummary = inputs.responseURLSummary ?? NetworkRequest.Display.URLSummary(url: responseURL)
             switch classifier(responseMimeType, responseURLSummary.rawURL) {
             case .previewable:
                 return .media
             case .notPreviewable:
-                if request.resourceType == .image || request.resourceType == .media {
+                if snapshot.resourceType == .image || snapshot.resourceType == .media {
                     return .media
                 }
                 return Self.resourceFilter(mimeType: responseMimeType, urlSummary: responseURLSummary, classifier: classifier)
             case .unknown:
                 break
             }
-            if let resourceType = request.resourceType {
+            if let resourceType = snapshot.resourceType {
                 return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
             }
             return Self.resourceFilter(mimeType: responseMimeType, urlSummary: responseURLSummary, classifier: classifier)
@@ -236,6 +328,26 @@ extension NetworkRequest.Display {
     }
 }
 
+extension NetworkRequest.Display {
+    package actor RowsProjector {
+        private let cache: NetworkRequest.Display.ProjectionCache
+
+        package init(mediaPreviewClassifier: @escaping NetworkRequest.Display.MediaPreviewClassifier) {
+            cache = NetworkRequest.Display.ProjectionCache(mediaPreviewClassifier: mediaPreviewClassifier)
+        }
+
+        package func rows(
+            for input: NetworkRequest.Display.RowsProjectionInput
+        ) throws -> [NetworkRequest.Display.Projection] {
+            try cache.rows(for: input)
+        }
+
+        package func removeAll() {
+            cache.removeAll()
+        }
+    }
+}
+
 private func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkRequest.ResourceType) -> Bool {
     switch resourceType {
     case .image, .media, .xhr, .fetch, .other:
@@ -245,8 +357,8 @@ private func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkRe
     }
 }
 
-private func networkDisplayMIMEType(from response: NetworkRequest.Response.Payload) -> String? {
-    let rawMimeType = response.mimeType ?? networkHeaderValue(named: "content-type", in: response.headers)
+private func networkDisplayMIMEType(mimeType: String?, headers: [String: String]) -> String? {
+    let rawMimeType = mimeType ?? networkHeaderValue(named: "content-type", in: headers)
     let mimeType = rawMimeType?
         .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
         .first

--- a/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
+++ b/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
@@ -12,6 +12,7 @@ enum NetworkPreviewFixtures {
     static func makePanelModel(mode: Mode) -> NetworkPanelModel {
         let network = makeNetworkSession(mode: mode)
         let model = NetworkPanelModel(network: network)
+        model.refreshDisplayRowsSynchronously()
         if mode == .detail {
             model.selectRequest(model.displayRequests.first)
         }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1,5 +1,7 @@
 #if canImport(UIKit)
+import Dispatch
 import ObservationBridge
+import Synchronization
 import Testing
 import WebInspectorTransport
 import UIKit
@@ -1247,6 +1249,49 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func listCancelsStaleDisplayProjectionBeforeThrottledReload() async throws {
+        let network = NetworkSession()
+        let request = try #require(applyRequest(
+            to: network,
+            requestID: "1",
+            url: "https://media.example.com/clip.mp4",
+            responseHeaders: ["content-type": "video/mp4"],
+            responseMimeType: "video/mp4"
+        ))
+        let requestID = request.id
+        let classifier = BlockingMediaPreviewClassifier()
+        let model = NetworkPanelModel(network: network, mediaPreviewClassifier: classifier.classify)
+        model.setResourceFilter(.media, enabled: true)
+        let listViewController = NetworkListViewController(model: model)
+        defer {
+            classifier.unblock()
+        }
+
+        #expect(await classifier.waitUntilBlocked())
+
+        let window = showInWindow(listViewController)
+        defer { window.isHidden = true }
+
+        let observation = try #require(listViewController.displayRowsObservationDeliveryForTesting)
+        let observedSearchText = await observation.values {
+            model.searchText
+        }
+        let observedDisplayRequestIDs = await observation.values {
+            model.displayRequestIDs
+        }
+
+        model.setSearchText("does-not-match")
+        #expect(await observedSearchText.waitUntilValue("does-not-match"))
+
+        classifier.unblock()
+
+        let staleDisplayRequestIDs = await observedDisplayRequestIDs.waitUntil(timeout: .milliseconds(250)) { ids in
+            ids == [requestID]
+        }
+        #expect(staleDisplayRequestIDs == nil)
+    }
+
+    @Test
     func listControllerDeallocatesWhileDisplayRequestObservationIsActive() async throws {
         let model = NetworkPanelModel(network: NetworkSession())
         let deinitProbe = UITestDeinitProbe()
@@ -1456,6 +1501,50 @@ struct NetworkDetailViewControllerTests {
             return nil
         }
         return bundle.localizedString(forKey: key, value: nil, table: nil)
+    }
+
+    private final class BlockingMediaPreviewClassifier: @unchecked Sendable {
+        private struct State: Sendable {
+            var shouldBlockNextCall = true
+            var isBlocked = false
+        }
+
+        private let state = Mutex(State())
+        private let unblockSemaphore = DispatchSemaphore(value: 0)
+
+        func classify(
+            mimeType: String?,
+            url: String?
+        ) -> NetworkRequest.Display.MediaPreviewClassification {
+            let shouldBlock = state.withLock { state in
+                guard state.shouldBlockNextCall else {
+                    return false
+                }
+                state.shouldBlockNextCall = false
+                return true
+            }
+            if shouldBlock {
+                state.withLock { state in
+                    state.isBlocked = true
+                }
+                unblockSemaphore.wait()
+            }
+            return NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url)
+        }
+
+        func waitUntilBlocked() async -> Bool {
+            for _ in 0..<100 {
+                if state.withLock({ $0.isBlocked }) {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return false
+        }
+
+        func unblock() {
+            unblockSemaphore.signal()
+        }
     }
 }
 }

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Synchronization
 import WebInspectorTransport
 @testable import WebInspectorCore
 @testable import WebInspectorUI
@@ -35,6 +36,7 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
     let model = NetworkPanelModel(network: network)
     model.setSearchText("cdn")
     model.setResourceFilter(.script, enabled: true)
+    await model.refreshDisplayRows()
 
     let requests = model.displayRequests
     #expect(requests.map(\.id.requestID.rawValue) == ["2"])
@@ -68,6 +70,7 @@ func displayProjectionUsesReadableURLDisplayName(url: String, expectedDisplayNam
         timestamp: 1
     )
     let model = NetworkPanelModel(network: network)
+    await model.refreshDisplayRows()
 
     #expect(model.displayProjection(for: requestID)?.displayName == expectedDisplayName)
 }
@@ -93,6 +96,7 @@ func displayProjectionUsesEncodingFallbackForURLDerivedLabelsAndFilters() async 
         timestamp: 2
     )
     let model = NetworkPanelModel(network: network)
+    await model.refreshDisplayRows()
 
     #expect(model.displayProjection(for: spacedURLRequestID)?.displayName == "photo 1.png")
     #expect(model.displayProjection(for: spacedURLRequestID)?.fileTypeLabel == "png")
@@ -100,6 +104,7 @@ func displayProjectionUsesEncodingFallbackForURLDerivedLabelsAndFilters() async 
     #expect(model.displayProjection(for: invalidEscapeRequestID)?.fileTypeLabel == "png")
 
     model.setResourceFilter(.media, enabled: true)
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [invalidEscapeRequestID, spacedURLRequestID])
 }
 
@@ -262,6 +267,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
 
     let model = NetworkPanelModel(network: network)
     model.setResourceFilter(.media, enabled: true)
+    await model.refreshDisplayRows()
 
     #expect(model.displayRequests.map(\.id.requestID.rawValue) == ["19", "16", "9", "8", "7", "6", "5", "4", "3", "2", "1"])
 }
@@ -309,6 +315,7 @@ func displayProjectionCacheInvalidatesWhenResponseMIMEBecomesPreviewable() async
     )
     let model = NetworkPanelModel(network: network)
     model.setResourceFilter(.media, enabled: true)
+    await model.refreshDisplayRows()
 
     #expect(model.displayRequestIDs.isEmpty)
 
@@ -325,6 +332,7 @@ func displayProjectionCacheInvalidatesWhenResponseMIMEBecomesPreviewable() async
         timestamp: 1.1
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
     #expect(model.displayProjection(for: requestID)?.resourceFilter == .media)
 }
@@ -344,6 +352,7 @@ func displayProjectionCacheInvalidatesStatusSeverity() async throws {
         timestamp: 1
     )
     let model = NetworkPanelModel(network: network)
+    await model.refreshDisplayRows()
 
     #expect(model.displayProjection(for: requestID)?.statusSeverity == .error)
 
@@ -360,6 +369,7 @@ func displayProjectionCacheInvalidatesStatusSeverity() async throws {
         timestamp: 2
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayProjection(for: requestID)?.statusSeverity == .success)
 }
 
@@ -382,6 +392,7 @@ func displayProjectionCacheInvalidatesSearchFields() async throws {
     let model = NetworkPanelModel(network: network)
 
     model.setSearchText("new-endpoint")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs.isEmpty)
 
     _ = network.applyRequestWillBeSent(
@@ -396,11 +407,14 @@ func displayProjectionCacheInvalidatesSearchFields() async throws {
         timestamp: 2
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
     model.setSearchText("PATCH")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
 
     model.setSearchText("json")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs.isEmpty)
 
     network.applyResponseReceived(
@@ -416,8 +430,10 @@ func displayProjectionCacheInvalidatesSearchFields() async throws {
         timestamp: 2.1
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
     model.setSearchText("Created")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
 }
 
@@ -451,9 +467,11 @@ func displayProjectionCacheInvalidatesWhenRawMIMETypeAppears() async throws {
         timestamp: 1.1
     )
     let model = NetworkPanelModel(network: network)
+    await model.refreshDisplayRows()
 
     #expect(model.displayProjection(for: requestID)?.fileTypeLabel == "xhr")
     model.setSearchText("json")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs.isEmpty)
 
     network.applyResponseReceived(
@@ -470,6 +488,7 @@ func displayProjectionCacheInvalidatesWhenRawMIMETypeAppears() async throws {
         timestamp: 1.2
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayProjection(for: requestID)?.fileTypeLabel == "json")
     #expect(model.displayRequestIDs == [requestID])
 }
@@ -486,22 +505,23 @@ func displayProjectionCacheReusesMediaClassificationForUnchangedRequests() async
         mimeType: "application/octet-stream",
         timestamp: 1
     )
-    var classificationCount = 0
+    let classificationCount = Mutex(0)
     let model = NetworkPanelModel(
         network: network,
         mediaPreviewClassifier: { mimeType, url in
-            classificationCount += 1
+            classificationCount.withLock { $0 += 1 }
             return NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url)
         }
     )
     model.setResourceFilter(.media, enabled: true)
+    await model.refreshDisplayRows()
 
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount == 1)
+    #expect(classificationCount.withLock { $0 } == 1)
 
     #expect(model.displayRequestIDs == [requestID])
     #expect(model.displayRequests.map(\.id) == [requestID])
-    #expect(classificationCount == 1)
+    #expect(classificationCount.withLock { $0 } == 1)
 
     network.applyDataReceived(
         targetID: requestID.targetID,
@@ -511,8 +531,9 @@ func displayProjectionCacheReusesMediaClassificationForUnchangedRequests() async
         timestamp: 2
     )
 
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount == 1)
+    #expect(classificationCount.withLock { $0 } == 1)
 }
 
 @Test
@@ -527,26 +548,29 @@ func displayProjectionCacheSkipsMediaClassificationWhenUnfiltered() async throws
         mimeType: "application/octet-stream",
         timestamp: 1
     )
-    var classificationCount = 0
+    let classificationCount = Mutex(0)
     let model = NetworkPanelModel(
         network: network,
         mediaPreviewClassifier: { mimeType, url in
-            classificationCount += 1
+            classificationCount.withLock { $0 += 1 }
             return NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url)
         }
     )
+    await model.refreshDisplayRows()
 
     #expect(model.displayRequestIDs == [requestID])
     #expect(model.displayProjection(for: requestID)?.displayName == "clip.mp4")
-    #expect(classificationCount == 0)
+    #expect(classificationCount.withLock { $0 } == 0)
 
     model.setSearchText("clip")
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount == 0)
+    #expect(classificationCount.withLock { $0 } == 0)
 
     model.setResourceFilter(.media, enabled: true)
+    await model.refreshDisplayRows()
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount == 1)
+    #expect(classificationCount.withLock { $0 } == 1)
 }
 
 @Test
@@ -566,6 +590,7 @@ func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
     model.setSearchText("cdn")
     model.setResourceFilter(.script, enabled: true)
     model.selectRequest(network.request(for: requestID))
+    await model.refreshDisplayRows()
     model.clearRequests()
 
     #expect(model.selectedRequestID == nil)


### PR DESCRIPTION
## Purpose
Move Network list display row projection, filtering, search matching, media classification, cache pruning, and reverse ordering out of the MainActor `displayRows` getter. Keep `NetworkSession` as the semantic request owner while projecting rows from Sendable request snapshots.

## Changes
- Replaced the heavy `displayRows` computed getter with stored last-completed rows on `NetworkPanelModel`.
- Added Sendable request row snapshots and an actor-backed display row projector with generation/cancellation guarding stale async results.
- Updated `NetworkListViewController` to schedule/cancel row projection immediately from fresh observation input while throttling only diffable snapshot application.
- Updated projection cache keys to use value snapshots rather than live `NetworkRequest` objects.
- Kept preview/test synchronous priming explicit via `refreshDisplayRowsSynchronously()`.
- Added regression coverage for stale row projection results during throttled list reloads.

## Testing
- `swift test --filter NetworkPanelModelTests`
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- XcodeBuildMCP: `WebInspectorUITests`
- XcodeBuildMCP: `WebInspectorCoreTests`
- XcodeBuildMCP: full `WebInspectorKit` scheme
- CI: iOS Tests (iOS 18 native), iOS Tests (iOS 26 all)

## Screenshots
Not applicable.
