### PR TITLE
Decode Network response body results off MainActor

### DIFF
--- a/Sources/WebInspectorCore/Network/NetworkModel.swift
+++ b/Sources/WebInspectorCore/Network/NetworkModel.swift
@@ -500,13 +500,26 @@ package final class NetworkSession {
             request.markResponseBodyFailed(.unavailable)
             return
         }
+        guard let expectedBody = request.responseBody else {
+            request.markResponseBodyFailed(.unavailable)
+            return
+        }
 
         request.markResponseBodyFetching()
         do {
             let result = try await perform(intent)
-            try protocolCommands.applyResponseBodyResult(result, to: request)
+            let payload = try await protocolCommands.responseBodyPayload(from: result)
+            guard let currentRequest = self.request(for: id),
+                  currentRequest.responseBody === expectedBody else {
+                return
+            }
+            protocolCommands.applyResponseBodyPayload(payload, to: currentRequest)
         } catch {
-            request.markResponseBodyFailed(.unknown(String(describing: error)))
+            guard let currentRequest = self.request(for: id),
+                  currentRequest.responseBody === expectedBody else {
+                return
+            }
+            currentRequest.markResponseBodyFailed(.unknown(String(describing: error)))
             recordError?(InspectorSession.Error(String(describing: error)))
         }
     }

--- a/Sources/WebInspectorCore/Network/NetworkProtocolDispatching.swift
+++ b/Sources/WebInspectorCore/Network/NetworkProtocolDispatching.swift
@@ -27,15 +27,24 @@ package struct NetworkProtocolCommands {
         }
     }
 
-    @MainActor
-    package func applyResponseBodyResult(_ result: ProtocolCommand.Result, to request: NetworkRequest) throws {
-        let payload = try TransportMessageParser.decode(ResponseBodyResult.self, from: result.resultData)
-        request.applyResponseBody(
-            NetworkBody.Payload(
-                body: payload.body,
-                base64Encoded: payload.base64Encoded
-            )
+    package func responseBodyPayload(
+        from result: ProtocolCommand.Result,
+        policy: TransportMessageParsePolicy = .default
+    ) async throws -> NetworkBody.Payload {
+        let payload = try await TransportMessageParser.decodeAsync(
+            ResponseBodyResult.self,
+            from: result.resultData,
+            policy: policy
         )
+        return NetworkBody.Payload(
+            body: payload.body,
+            base64Encoded: payload.base64Encoded
+        )
+    }
+
+    @MainActor
+    package func applyResponseBodyPayload(_ payload: NetworkBody.Payload, to request: NetworkRequest) {
+        request.applyResponseBody(payload)
     }
 
     private func parameters(
@@ -200,7 +209,7 @@ package final class NetworkProtocolEventDispatcher: ProtocolDomainEventDispatche
     }
 }
 
-private struct ResponseBodyResult: Decodable {
+private struct ResponseBodyResult: Decodable, Sendable {
     var body: String
     var base64Encoded: Bool
 }

--- a/Sources/WebInspectorTransport/TransportMessageParser.swift
+++ b/Sources/WebInspectorTransport/TransportMessageParser.swift
@@ -34,6 +34,10 @@ package struct TransportMessageParsePolicy: Equatable, Sendable {
     package func shouldParseDetached(_ message: String) -> Bool {
         message.utf8.count >= detachedParsingThresholdBytes
     }
+
+    package func shouldParseDetached(_ data: Data) -> Bool {
+        data.count >= detachedParsingThresholdBytes
+    }
 }
 
 package enum TransportMessageParser {
@@ -84,6 +88,19 @@ package enum TransportMessageParser {
 
     package static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         try JSONDecoder().decode(type, from: data)
+    }
+
+    package static func decodeAsync<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from data: Data,
+        policy: TransportMessageParsePolicy = .default
+    ) async throws -> T {
+        guard policy.shouldParseDetached(data) else {
+            return try decode(type, from: data)
+        }
+        return try await Task.detached(priority: .userInitiated) {
+            try decode(type, from: data)
+        }.value
     }
 
     package static func jsonObject(from data: Data) throws -> Any {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -414,6 +414,50 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
 }
 
 @Test
+func networkResponseBodyFetchNoOpsWhenRequestDisappearsBeforeResultApply() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.requestWillBeSent","params":{"requestId":"request-stale","frameId":"main-frame","request":{"url":"https://example.com/large.txt"},"timestamp":1}}"#
+    )
+    await receiveAndApplyTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.responseReceived","params":{"requestId":"request-stale","timestamp":2,"type":"Document","response":{"url":"https://example.com/large.txt","status":200,"mimeType":"text/plain","headers":{"content-type":"text/plain"}}}}"#,
+        in: session
+    )
+    await receiveAndApplyTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"Network.loadingFinished","params":{"requestId":"request-stale","timestamp":3}}"#,
+        in: session
+    )
+    let requestID = NetworkRequest.ID(targetID: .pageMain, requestID: .init("request-stale"))
+
+    let sentCount = await backend.sentTargetMessages().count
+    let fetchTask = Task {
+        await session.attachment.network.fetchResponseBody(for: requestID)
+    }
+    let sent = try await waitForTargetMessage(backend, method: "Network.getResponseBody", after: sentCount)
+    await session.attachment.network.reset()
+
+    await receiveTargetReply(
+        transport,
+        targetID: sent.targetIdentifier,
+        messageID: try messageID(sent.message),
+        result: #"{"body":"stale body","base64Encoded":false}"#
+    )
+    await fetchTask.value
+
+    #expect(await session.attachment.network.requestSnapshot(for: requestID) == nil)
+}
+
+@Test
 func networkResponseBodyFetchErrorDoesNotRetry() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import WebInspectorTransport
 @testable import WebInspectorCore
@@ -211,6 +212,27 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() asyn
     #expect(body.textRepresentation?.contains("\n") == true)
     #expect(body.textRepresentation?.contains(#""name""#) == true)
     #expect(body.textRepresentationSyntaxKind == .json)
+}
+
+@Test
+func networkResponseBodyResultDecodesLargePlainAndBase64Payloads() async throws {
+    let commands = NetworkProtocolCommands()
+    let plainBody = String(repeating: "plain-body-", count: 8_192)
+    let plainPayload = try await commands.responseBodyPayload(
+        from: responseBodyResult(body: plainBody, base64Encoded: false)
+    )
+
+    #expect(plainPayload.body == plainBody)
+    #expect(plainPayload.base64Encoded == false)
+
+    let base64Body = Data(String(repeating: "base64-body-", count: 8_192).utf8)
+        .base64EncodedString()
+    let base64Payload = try await commands.responseBodyPayload(
+        from: responseBodyResult(body: base64Body, base64Encoded: true)
+    )
+
+    #expect(base64Payload.body == base64Body)
+    #expect(base64Payload.base64Encoded == true)
 }
 
 @Test
@@ -797,4 +819,23 @@ func loadingFailureOnlyUpdatesMatchingTargetScopedRequest() async throws {
 
     #expect(page.state == .pending)
     #expect(frame.state == .failed(errorText: "cancelled", canceled: true))
+}
+
+private func responseBodyResult(
+    body: String,
+    base64Encoded: Bool
+) throws -> ProtocolCommand.Result {
+    let data = try JSONSerialization.data(
+        withJSONObject: [
+            "body": body,
+            "base64Encoded": base64Encoded,
+        ],
+        options: []
+    )
+    return ProtocolCommand.Result(
+        domain: .network,
+        method: "Network.getResponseBody",
+        targetID: .init("page"),
+        resultData: data
+    )
 }

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -7,6 +7,10 @@ import WebInspectorTestSupport
 private let testResponseTimeout: Duration = .milliseconds(750)
 private let testWaitTimeout: Duration = .milliseconds(750)
 
+private struct TestDecodedPayload: Decodable, Equatable, Sendable {
+    var value: String
+}
+
 @Test
 func transportMessageParserUsesPolicyForInlineAndDetachedParsing() async throws {
     let message = #"{"id":42,"method":"Runtime.consoleAPICalled","params":{"type":"log"},"result":{"ok":true}}"#
@@ -22,6 +26,24 @@ func transportMessageParserUsesPolicyForInlineAndDetachedParsing() async throws 
     #expect(inline == detached)
     #expect(inline.id == 42)
     #expect(inline.method == "Runtime.consoleAPICalled")
+}
+
+@Test
+func transportMessageParserUsesPolicyForInlineAndDetachedDecoding() async throws {
+    let data = Data(#"{"value":"decoded"}"#.utf8)
+    let inline = try await TransportMessageParser.decodeAsync(
+        TestDecodedPayload.self,
+        from: data,
+        policy: TransportMessageParsePolicy(detachedParsingThresholdBytes: .max)
+    )
+    let detached = try await TransportMessageParser.decodeAsync(
+        TestDecodedPayload.self,
+        from: data,
+        policy: TransportMessageParsePolicy(detachedParsingThresholdBytes: 0)
+    )
+
+    #expect(inline == detached)
+    #expect(detached.value == "decoded")
 }
 
 @Test


### PR DESCRIPTION
## Purpose

Reduce MainActor work when applying `Network.getResponseBody` results. Large response bodies can be megabytes, so JSON result decoding and response string allocation should happen at the transport/protocol boundary while model mutation stays on MainActor.

## Changes

- Added threshold-based async decode support to `TransportMessageParser`, matching the existing large message parse policy.
- Split Network response body result handling into off-main payload decoding and MainActor request/body mutation.
- Re-resolve the current request and response body before applying a fetch result so disappeared or replaced requests no-op.
- Added coverage for large plain/base64 response body decoding, detached decode policy behavior, and stale fetch no-op behavior.

## Testing

- `swift test --filter 'networkResponseBody|transportMessageParserUsesPolicyForInlineAndDetachedDecoding'`
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review: no findings