### PR TITLE
Coalesce DOM document loads in DOMSession

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -8,7 +8,6 @@ package final class DOMTreeViewController: UIViewController {
     private let treeView: DOMTreeTextView
     private weak var inspection: AttachedInspection?
     private var domRootObservation: PortableObservationTracking.Token?
-    private var isEnsuringDOMDocumentLoaded = false
 
     package var domTreeUndoManager: UndoManager? {
         treeView.undoManager
@@ -125,17 +124,12 @@ package final class DOMTreeViewController: UIViewController {
             return
         }
         guard viewIfLoaded?.window != nil,
-              !isEnsuringDOMDocumentLoaded,
               !hasRoot,
               canReloadDocument else {
             return
         }
 
-        isEnsuringDOMDocumentLoaded = true
-        Task { @MainActor [weak self, weak inspection] in
-            defer {
-                self?.isEnsuringDOMDocumentLoaded = false
-            }
+        Task { @MainActor [weak inspection] in
             _ = await inspection?.dom.ensureDocumentLoaded()
         }
     }

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2152,6 +2152,57 @@ func ensureDOMDocumentLoadedReloadsInvalidatedPageDocument() async throws {
     #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
 }
 
+@Test("Regression: ensureDocumentLoaded coalesces pending page document requests")
+func ensureDOMDocumentLoadedCoalescesPendingPageDocumentRequest() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+
+    await receiveAndApplyTargetDispatch(
+        transport,
+        targetID: .pageMain,
+        message: #"{"method":"DOM.documentUpdated","params":{}}"#,
+        in: session
+    )
+    #expect(await session.attachment.dom.snapshot().currentPageDocumentID == nil)
+
+    let sentCount = await backend.sentTargetMessages().count
+    let firstEnsure = Task {
+        await session.attachment.dom.ensureDocumentLoaded()
+    }
+    let documentRequest = try await waitForTargetMessage(
+        backend,
+        method: "DOM.getDocument",
+        after: sentCount
+    )
+
+    let secondEnsure = Task {
+        await session.attachment.dom.ensureDocumentLoaded()
+    }
+    await Task.yield()
+
+    #expect(
+        await backend.sentTargetMessages().dropFirst(sentCount).compactMap { try? messageMethod($0.message) } == [
+            "DOM.getDocument",
+        ]
+    )
+
+    await receiveTargetReply(
+        transport,
+        targetID: documentRequest.targetIdentifier,
+        messageID: try messageID(documentRequest.message),
+        result: manualReloadDocumentResult
+    )
+
+    #expect(await firstEnsure.value)
+    #expect(await secondEnsure.value)
+
+    let finalSnapshot = await session.attachment.dom.snapshot()
+    #expect(finalSnapshot.currentPageDocumentID?.localDocumentLifetimeID == .init(2))
+    #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
+}
+
 @Test("Regression: documentUpdated reopens document request gate while previous getDocument is pending")
 func documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending() async throws {
     let backend = FakeTransportBackend()


### PR DESCRIPTION
## Purpose

Keep `DOMTreeViewController` responsible for visible lifecycle triggers only, while `DOMSession` owns target-scoped DOM document loading and in-flight request coalescing.

## Changes

- Removed the view-controller-local `isEnsuringDOMDocumentLoaded` gate.
- Let repeated visible `ensureDocumentLoaded()` triggers rely on the existing `DOMSessionDocumentRequestController` active-handle coalescing.
- Added a regression test proving concurrent page document ensures share one pending `DOM.getDocument` request.

## Testing

- `swift test --filter ensureDOMDocumentLoadedCoalescesPendingPageDocumentRequest`
- `swift test --filter ensureDOMDocumentLoaded`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` with no findings