### PR TITLE
Fix DOM selection reveal after async row rendering

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -8,13 +8,23 @@ extension DOMTreeTextView {
         typealias IsCurrentBuild = @MainActor (DOMTreeTextView.RenderedRowsBuildRequest) -> Bool
         typealias ShouldApplyBuild = @MainActor (DOMTreeTextView.RenderedRowsBuildResult) -> Bool
         typealias ApplyBuild = @MainActor (DOMTreeTextView.RenderedRowsBuildResult) -> Void
+        typealias FinishBuild = @MainActor () -> Void
 
         private let builder: DOMTreeTextView.RenderedRowsBuilder
         private var task: Task<Void, Never>?
         private var generation: UInt64 = 0
+#if DEBUG
+        private var shouldSuspendNextBuildForTesting = false
+        private var suspendedBuildContinuationForTesting: CheckedContinuation<Void, Never>?
+        private var buildSuspensionWaitersForTesting: [CheckedContinuation<Void, Never>] = []
+#endif
 
         init(builder: DOMTreeTextView.RenderedRowsBuilder) {
             self.builder = builder
+        }
+
+        var hasCurrentBuild: Bool {
+            task != nil
         }
 
         func removeCachedMarkup(keepingCapacity: Bool) {
@@ -28,6 +38,9 @@ extension DOMTreeTextView {
         func cancel() {
             task?.cancel()
             task = nil
+#if DEBUG
+            resumeSuspendedBuildForTesting()
+#endif
         }
 
         func waitForCurrentBuild() async {
@@ -45,7 +58,8 @@ extension DOMTreeTextView {
             previousTextCapacity: Int,
             isCurrentBuild: @escaping IsCurrentBuild,
             shouldApply: ShouldApplyBuild? = nil,
-            apply: @escaping ApplyBuild
+            apply: @escaping ApplyBuild,
+            didFinish: FinishBuild? = nil
         ) {
             let request = builder.makeBuildRequest(
                 previousRowCapacity: previousRowCapacity,
@@ -54,14 +68,27 @@ extension DOMTreeTextView {
             generation &+= 1
             let buildGeneration = generation
             task?.cancel()
+#if DEBUG
+            resumeSuspendedBuildForTesting()
+#endif
             task = Task { @MainActor [weak self] in
                 guard let self else {
                     return
                 }
+                var shouldNotifyFinish = false
                 defer {
                     if generation == buildGeneration {
                         task = nil
+                        if shouldNotifyFinish {
+                            didFinish?()
+                        }
                     }
+                }
+#if DEBUG
+                await suspendBuildIfNeededForTesting()
+#endif
+                guard !Task.isCancelled else {
+                    return
                 }
                 let buildResult: DOMTreeTextView.RenderedRowsBuildResult
                 do {
@@ -70,18 +97,61 @@ extension DOMTreeTextView {
                     return
                 } catch {
                     assertionFailure("DOM tree row rendering failed: \(error)")
+                    shouldNotifyFinish = true
                     return
                 }
                 guard !Task.isCancelled,
                       generation == buildGeneration,
-                      isCurrentBuild(request),
-                      shouldApply?(buildResult) ?? true else {
+                      isCurrentBuild(request) else {
+                    return
+                }
+                guard shouldApply?(buildResult) ?? true else {
+                    shouldNotifyFinish = true
                     return
                 }
                 builder.acceptCompletedBuild(buildResult)
                 apply(buildResult)
+                shouldNotifyFinish = true
             }
         }
+
+#if DEBUG
+        func suspendNextBuildForTesting() {
+            shouldSuspendNextBuildForTesting = true
+        }
+
+        func waitForBuildSuspensionForTesting() async {
+            if suspendedBuildContinuationForTesting != nil {
+                return
+            }
+            await withCheckedContinuation { continuation in
+                buildSuspensionWaitersForTesting.append(continuation)
+            }
+        }
+
+        func resumeSuspendedBuildForTesting() {
+            guard let continuation = suspendedBuildContinuationForTesting else {
+                return
+            }
+            suspendedBuildContinuationForTesting = nil
+            continuation.resume()
+        }
+
+        private func suspendBuildIfNeededForTesting() async {
+            guard shouldSuspendNextBuildForTesting else {
+                return
+            }
+            shouldSuspendNextBuildForTesting = false
+            await withCheckedContinuation { continuation in
+                suspendedBuildContinuationForTesting = continuation
+                let waiters = buildSuspensionWaitersForTesting
+                buildSuspensionWaitersForTesting.removeAll(keepingCapacity: true)
+                for waiter in waiters {
+                    waiter.resume()
+                }
+            }
+        }
+#endif
     }
 }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -209,6 +209,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         super.layoutSubviews()
         guard lastBoundsSize != bounds.size || textContentView.frame.isEmpty else {
             layoutManager.textViewportLayoutController.layoutViewport()
+            revealPendingSelectedNodeIfPossible()
             return
         }
         lastBoundsSize = bounds.size
@@ -591,6 +592,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                     previousRows: previousRows,
                     previousText: previousText
                 )
+            },
+            didFinish: { [weak self] in
+                self?.revealPendingSelectedNodeIfPossible()
             }
         )
     }
@@ -628,7 +632,6 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         updateTextLayoutGeometry()
         updateContentDecorations()
         setNeedsLayout()
-        revealPendingSelectedNodeIfPossible()
     }
 
     private func resetLocalDocumentStateIfNeeded() {
@@ -811,10 +814,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func scrollRowToVisible(_ row: DOMTreeTextView.Line) {
-        guard let rowRect = contentRowRects(for: row).first else {
-            return
-        }
-        let headRect = rowHeadRect(for: row) ?? rowRect
+        let rowRect = modelContentRowRect(for: row)
+        let headRect = modelRowHeadRect(for: row)
         let targetRect = CGRect(
             x: Self.textInsets.left + headRect.minX,
             y: Self.textInsets.top + rowRect.minY,
@@ -822,6 +823,35 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             height: rowRect.height
         )
         scrollRectToVisible(targetRect.insetBy(dx: 0, dy: -rowRect.height), animated: true)
+    }
+
+    private func modelContentRowRect(for row: DOMTreeTextView.Line) -> CGRect {
+        // DOM tree rows are fixed-height; reveal must not depend on TextKit fragment rects while layout catches up.
+        CGRect(
+            x: 0,
+            y: CGFloat(row.rowIndex) * rowHeight,
+            width: max(textContentView.bounds.width, contentSize.width - Self.textInsets.left - Self.textInsets.right),
+            height: rowHeight
+        )
+    }
+
+    private func modelRowHeadRect(for row: DOMTreeTextView.Line) -> CGRect {
+        let column: Int
+        let widthInColumns: Int
+        if row.hasDisclosure {
+            column = row.depth * DOMTreeTextView.IndentMetrics.indentSpacesPerDepth
+            widthInColumns = DOMTreeTextView.IndentMetrics.disclosureSlotSpaces
+        } else {
+            column = row.depth * DOMTreeTextView.IndentMetrics.indentSpacesPerDepth
+                + DOMTreeTextView.IndentMetrics.disclosureSlotSpaces
+            widthInColumns = 1
+        }
+        return CGRect(
+            x: CGFloat(column) * Self.characterWidth,
+            y: CGFloat(row.rowIndex) * rowHeight,
+            width: CGFloat(widthInColumns) * Self.characterWidth,
+            height: rowHeight
+        )
     }
 
     private func row(at location: CGPoint) -> DOMTreeTextView.Line? {
@@ -1685,6 +1715,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
     private func revealPendingSelectedNodeIfPossible() {
         guard let selectedNodeID = selectionRevealState.pendingSelectedNodeID,
+              !renderedRowsBuildCoordinator.hasCurrentBuild,
               let row = renderedRows.row(for: selectedNodeID),
               bounds.width > 0,
               bounds.height > 0
@@ -1692,10 +1723,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             return
         }
 
-        guard let rowRect = contentRowRects(for: row).first else {
-            return
-        }
-        let headRect = rowHeadRect(for: row) ?? rowRect
+        let rowRect = modelContentRowRect(for: row)
+        let headRect = modelRowHeadRect(for: row)
         let targetRect = CGRect(
             x: max(0, Self.textInsets.left + headRect.minX - 12),
             y: Self.textInsets.top + rowRect.minY,
@@ -2164,6 +2193,18 @@ extension DOMTreeTextView {
 
     func waitForRenderedRowsForTesting() async {
         await renderedRowsBuildCoordinator.waitForCurrentBuild()
+    }
+
+    func suspendNextRenderedRowsBuildForTesting() {
+        renderedRowsBuildCoordinator.suspendNextBuildForTesting()
+    }
+
+    func waitForRenderedRowsBuildSuspensionForTesting() async {
+        await renderedRowsBuildCoordinator.waitForBuildSuspensionForTesting()
+    }
+
+    func resumeRenderedRowsBuildForTesting() {
+        renderedRowsBuildCoordinator.resumeSuspendedBuildForTesting()
     }
 
     func selectedRowRectsForTesting() -> [CGRect] {

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -242,6 +242,54 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func selectionRevealWaitsForInFlightRenderedRowsBuild() async throws {
+        let session = makeDOMSession(root: selectionRevealRaceDocument())
+        let view = await makeTreeView(session: session)
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 96)
+        view.layoutIfNeeded()
+
+        let initialSnapshot = session.snapshot()
+        let bodyID = try #require(
+            initialSnapshot.nodesByID.first { entry in
+                entry.value.localName == "body"
+            }?.key
+        )
+        let targetID = try #require(
+            initialSnapshot.nodesByID.first { entry in
+                entry.value.attributes.contains { attribute in
+                    attribute.name == "id" && attribute.value == "selected-target"
+                }
+            }?.key
+        )
+
+        view.suspendNextRenderedRowsBuildForTesting()
+        session.applySetChildNodes(
+            parent: bodyID,
+            children: selectionRevealRaceBodyChildren(prefixCount: 80)
+        )
+        await view.waitForRenderedRowsBuildSuspensionForTesting()
+
+        session.selectNode(targetID)
+        await Task.yield()
+
+        view.resumeRenderedRowsBuildForTesting()
+        await view.waitForRenderedRowsForTesting()
+
+        let selectedLine = try #require(
+            view.renderedLineSnapshotsForTesting.first { snapshot in
+                snapshot.text.contains("id=\"selected-target\"")
+            }
+        )
+        let selectedRowY = CGFloat(selectedLine.rowIndex) * view.rowHeightForTesting
+        let visibleMinY = view.contentOffset.y
+        let visibleMaxY = view.contentOffset.y + view.bounds.height
+
+        #expect(view.contentOffset.y > view.bounds.height)
+        #expect(selectedRowY >= visibleMinY - view.rowHeightForTesting)
+        #expect(selectedRowY + view.rowHeightForTesting <= visibleMaxY + view.rowHeightForTesting)
+    }
+
+    @Test
     func documentResetClearsLocalExpansionStateEvenWhenNodeIDsRepeat() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)
@@ -577,6 +625,55 @@ private func documentWithDeferredArticle() -> DOMNode.Payload {
                 ])
             ),
         ])
+    )
+}
+
+private func selectionRevealRaceDocument() -> DOMNode.Payload {
+    DOMNode.Payload(
+        nodeID: .init(1),
+        nodeType: .document,
+        nodeName: "#document",
+        regularChildren: .loaded([
+            DOMNode.Payload(
+                nodeID: .init(2),
+                nodeType: .element,
+                nodeName: "HTML",
+                localName: "html",
+                regularChildren: .loaded([
+                    DOMNode.Payload(
+                        nodeID: .init(3),
+                        nodeType: .element,
+                        nodeName: "BODY",
+                        localName: "body",
+                        regularChildren: .loaded([
+                            selectionRevealRaceTargetNode(),
+                        ])
+                    ),
+                ])
+            ),
+        ])
+    )
+}
+
+private func selectionRevealRaceBodyChildren(prefixCount: Int) -> [DOMNode.Payload] {
+    (0..<prefixCount).map { index in
+        DOMNode.Payload(
+            nodeID: .init(1_000 + index),
+            nodeType: .element,
+            nodeName: "DIV",
+            localName: "div",
+            attributes: [DOMNode.Attribute(name: "id", value: "prefix-\(index)")]
+        )
+    } + [selectionRevealRaceTargetNode()]
+}
+
+private func selectionRevealRaceTargetNode() -> DOMNode.Payload {
+    DOMNode.Payload(
+        nodeID: .init(4),
+        nodeType: .element,
+        nodeName: "DIV",
+        localName: "div",
+        attributes: [DOMNode.Attribute(name: "id", value: "selected-target")]
     )
 }
 


### PR DESCRIPTION
## Purpose
Fix DOM tree selection reveal scrolling to the wrong position after async rendered-row updates.

## Changes
- Keep pending selection reveal blocked while a rendered rows build is still in flight.
- Run the deferred reveal once the current rendered rows build settles.
- Use fixed DOM row geometry for reveal scroll targets instead of TextKit fragment rects, so scroll position is based on the current rendered row model.
- Add a regression test that suspends a rendered rows build, changes the row order, selects a node, then verifies reveal waits for the settled rows.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeTextViewTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests`
- Codex review: no findings

## Screenshots
Not applicable.
