### PR TITLE
Avoid snapshots for DOM event node lookup

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -9,6 +9,9 @@ package final class DOMSession {
     package private(set) var treeRevision: UInt64
     package private(set) var selectionRevision: UInt64
     package private(set) var commandAvailabilityRevision: UInt64
+    #if DEBUG
+    @ObservationIgnored package private(set) var snapshotBuildCountForTesting: UInt64 = 0
+    #endif
 
     private let targetGraph: TargetGraph
     private var currentPage: DOMCurrentPage
@@ -87,6 +90,10 @@ package final class DOMSession {
 
     private func document(for nodeID: DOMNode.ID) -> DOMDocument? {
         currentDocument(for: nodeID.documentID)
+    }
+
+    package func currentNodeID(targetID: ProtocolTarget.ID, rawNodeID: DOMNode.ProtocolID) -> DOMNode.ID? {
+        documentStore.currentNodeID(targetID: targetID, rawNodeID: rawNodeID)
     }
 
     private func attachKnownFrameTargets() {
@@ -923,7 +930,10 @@ package final class DOMSession {
     }
 
     package func snapshot() -> DOMSession.Snapshot {
-        DOMSessionSnapshotBuilder(
+        #if DEBUG
+        snapshotBuildCountForTesting &+= 1
+        #endif
+        return DOMSessionSnapshotBuilder(
             currentPageTargetID: currentPageTargetID,
             mainFrameID: mainFrameID,
             targetSnapshots: targetGraph.targetSnapshots(currentDocumentID: currentDocumentID(for:)),

--- a/Sources/WebInspectorCore/DOM/DOMProtocolDispatching.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProtocolDispatching.swift
@@ -149,7 +149,6 @@ package struct DOMProtocolCommands {
         switch event.method {
         case "DOM.setChildNodes":
             let params = try TransportMessageParser.decode(SetChildNodesParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
             if params.parentId.rawValue == 0 {
                 guard let detachedRoot = params.nodes.first?.payload else {
                     return
@@ -157,7 +156,7 @@ package struct DOMProtocolCommands {
                 session.applyDetachedRoot(targetID: targetID, payload: detachedRoot, eventSequence: event.sequence)
                 return
             }
-            if let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentId)] {
+            if let parentID = session.currentNodeID(targetID: targetID, rawNodeID: params.parentId) {
                 session.applySetChildNodes(parent: parentID, children: params.nodes.map(\.payload), eventSequence: event.sequence)
             } else {
                 session.applySetChildNodes(
@@ -169,39 +168,34 @@ package struct DOMProtocolCommands {
             }
         case "DOM.childNodeInserted":
             let params = try TransportMessageParser.decode(ChildNodeInsertedParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
-            guard let parentID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.parentNodeId)] else {
+            guard let parentID = session.currentNodeID(targetID: targetID, rawNodeID: params.parentNodeId) else {
                 return
             }
             let previousSiblingID = params.previousNodeId.flatMap {
-                snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: $0)]
+                session.currentNodeID(targetID: targetID, rawNodeID: $0)
             }
             _ = session.applyChildInserted(parent: parentID, previousSibling: previousSiblingID, child: params.node.payload)
         case "DOM.childNodeRemoved":
             let params = try TransportMessageParser.decode(ChildNodeRemovedParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
-            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+            guard let nodeID = session.currentNodeID(targetID: targetID, rawNodeID: params.nodeId) else {
                 return
             }
             session.applyNodeRemoved(nodeID)
         case "DOM.childNodeCountUpdated":
             let params = try TransportMessageParser.decode(ChildNodeCountUpdatedParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
-            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+            guard let nodeID = session.currentNodeID(targetID: targetID, rawNodeID: params.nodeId) else {
                 return
             }
             session.applyChildNodeCountUpdated(nodeID, count: params.childNodeCount)
         case "DOM.attributeModified":
             let params = try TransportMessageParser.decode(AttributeModifiedParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
-            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+            guard let nodeID = session.currentNodeID(targetID: targetID, rawNodeID: params.nodeId) else {
                 return
             }
             session.applyAttributeModified(nodeID, name: params.name, value: params.value)
         case "DOM.attributeRemoved":
             let params = try TransportMessageParser.decode(AttributeRemovedParams.self, from: event.paramsData)
-            let snapshot = session.snapshot()
-            guard let nodeID = snapshot.currentNodeIDByKey[.init(targetID: targetID, nodeID: params.nodeId)] else {
+            guard let nodeID = session.currentNodeID(targetID: targetID, rawNodeID: params.nodeId) else {
                 return
             }
             session.applyAttributeRemoved(nodeID, name: params.name)

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import WebInspectorTransport
 @testable import WebInspectorCore
@@ -950,6 +951,119 @@ func childNodeInsertedUsesWebKitPreviousSiblingSemantics() async throws {
     #expect(snapshot.nodesByID[cID]?.nextSiblingID == nil)
 }
 
+#if DEBUG
+@Test
+@MainActor
+func domProtocolMutationEventsResolveRawNodeIDsWithoutBuildingSnapshots() throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = DOMSession()
+
+    session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                DOMNode.Payload(
+                    nodeID: .init(2),
+                    nodeType: .element,
+                    nodeName: "BODY",
+                    localName: "body",
+                    regularChildren: .unrequested(count: 3)
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+
+    let baselineSnapshotBuildCount = session.snapshotBuildCountForTesting
+
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.setChildNodes",
+            targetID: pageTargetID,
+            sequence: 1,
+            params: """
+            {
+              "parentId": 2,
+              "nodes": [
+                {"nodeId": 3, "nodeType": 1, "nodeName": "A", "localName": "a"},
+                {"nodeId": 4, "nodeType": 1, "nodeName": "SECTION", "localName": "section", "childNodeCount": 0},
+                {"nodeId": 6, "nodeType": 1, "nodeName": "ASIDE", "localName": "aside"}
+              ]
+            }
+            """
+        ),
+        to: session
+    )
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.childNodeInserted",
+            targetID: pageTargetID,
+            sequence: 2,
+            params: """
+            {
+              "parentNodeId": 2,
+              "previousNodeId": 3,
+              "node": {"nodeId": 5, "nodeType": 1, "nodeName": "SPAN", "localName": "span"}
+            }
+            """
+        ),
+        to: session
+    )
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.childNodeCountUpdated",
+            targetID: pageTargetID,
+            sequence: 3,
+            params: #"{"nodeId": 4, "childNodeCount": 2}"#
+        ),
+        to: session
+    )
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.attributeModified",
+            targetID: pageTargetID,
+            sequence: 4,
+            params: #"{"nodeId": 5, "name": "class", "value": "inserted"}"#
+        ),
+        to: session
+    )
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.attributeRemoved",
+            targetID: pageTargetID,
+            sequence: 5,
+            params: #"{"nodeId": 5, "name": "class"}"#
+        ),
+        to: session
+    )
+    try session.protocolCommands.applyDOMEvent(
+        domProtocolEvent(
+            "DOM.childNodeRemoved",
+            targetID: pageTargetID,
+            sequence: 6,
+            params: #"{"nodeId": 6}"#
+        ),
+        to: session
+    )
+
+    #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
+
+    let snapshot = session.snapshot()
+    let bodyID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(2))])
+    let aID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(3))])
+    let sectionID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(4))])
+    let spanID = try #require(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(5))])
+
+    #expect(snapshot.currentNodeIDByKey[.init(targetID: pageTargetID, nodeID: .init(6))] == nil)
+    #expect(snapshot.nodesByID[bodyID]?.regularChildren.loadedChildren == [aID, spanID, sectionID])
+    #expect(snapshot.nodesByID[spanID]?.previousSiblingID == aID)
+    #expect(snapshot.nodesByID[spanID]?.nextSiblingID == sectionID)
+    #expect(snapshot.nodesByID[sectionID]?.regularChildren.knownCount == 2)
+    #expect(snapshot.nodesByID[spanID]?.attributes.isEmpty == true)
+}
+#endif
+
 @Test
 func directNodeSelectionUpdatesProjectionWithoutSnapshotModel() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
@@ -1509,6 +1623,21 @@ func selectionFailureDoesNotMutateTreeFrameOrDocumentModel() async throws {
 
 private func iframeDepth(in projection: DOMTreeProjection, iframeID: DOMNode.ID) -> Int {
     projection.rows.first(where: { $0.nodeID == iframeID })?.depth ?? -1
+}
+
+private func domProtocolEvent(
+    _ method: String,
+    targetID: ProtocolTarget.ID,
+    sequence: UInt64,
+    params: String
+) -> ProtocolEvent {
+    ProtocolEvent(
+        sequence: sequence,
+        domain: .dom,
+        method: method,
+        targetID: targetID,
+        paramsData: Data(params.utf8)
+    )
 }
 
 private func document(


### PR DESCRIPTION
## Purpose

Avoid building full DOM session snapshots for single raw node ID lookups while applying DOM protocol mutation events. The owner for current raw-node lookup is the session/document store, which already has an O(1) index.

## Changes

- Added `DOMSession.currentNodeID(targetID:rawNodeID:)` as a package-level targeted lookup wrapper around `DOMDocumentStore`.
- Updated `DOMProtocolCommands.applyDOMEvent` to use targeted lookup for `DOM.setChildNodes`, `DOM.childNodeInserted`, `DOM.childNodeRemoved`, `DOM.childNodeCountUpdated`, `DOM.attributeModified`, and `DOM.attributeRemoved`, including `previousSiblingID` resolution.
- Preserved the `DOM.setChildNodes(parentId: 0)` detached root path and the existing parent lookup fallback.
- Added DEBUG-only snapshot build counting and a regression test that applies DOM mutation events through `applyDOMEvent` without increasing the snapshot count.

## Testing

- `git diff --check`
- `swift test --filter domProtocolMutationEventsResolveRawNodeIDsWithoutBuildingSnapshots`
- `swift test --filter WebInspectorCoreTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests`
- `codex-review` finding count: 0