### PR TITLE
[codex] Index frame document projection owners

### DIFF
--- a/Sources/WebInspectorCore/DOM/FrameDocumentProjectionIndex.swift
+++ b/Sources/WebInspectorCore/DOM/FrameDocumentProjectionIndex.swift
@@ -24,9 +24,11 @@ package struct FrameDocumentProjection: Equatable, Sendable {
 @Observable
 package final class FrameDocumentProjectionIndex {
     private var projectionsByFrameTargetID: [ProtocolTarget.ID: FrameDocumentProjection]
+    private var frameTargetIDByOwnerNodeID: [DOMNode.ID: ProtocolTarget.ID]
 
     package init() {
         projectionsByFrameTargetID = [:]
+        frameTargetIDByOwnerNodeID = [:]
     }
 
     package var values: Dictionary<ProtocolTarget.ID, FrameDocumentProjection>.Values {
@@ -43,11 +45,16 @@ package final class FrameDocumentProjectionIndex {
 
     package func removeAll() {
         projectionsByFrameTargetID.removeAll()
+        frameTargetIDByOwnerNodeID.removeAll()
     }
 
     @discardableResult
     package func removeValue(forKey frameTargetID: ProtocolTarget.ID) -> FrameDocumentProjection? {
-        projectionsByFrameTargetID.removeValue(forKey: frameTargetID)
+        guard let projection = projectionsByFrameTargetID.removeValue(forKey: frameTargetID) else {
+            return nil
+        }
+        removeAttachedOwnerIndex(for: projection)
+        return projection
     }
 
     @discardableResult
@@ -58,8 +65,13 @@ package final class FrameDocumentProjectionIndex {
         guard var projection = projectionsByFrameTargetID.removeValue(forKey: oldTargetID) else {
             return nil
         }
+        removeAttachedOwnerIndex(for: projection)
+        if let replacedProjection = projectionsByFrameTargetID.removeValue(forKey: newTargetID) {
+            removeAttachedOwnerIndex(for: replacedProjection)
+        }
         projection.frameTargetID = newTargetID
         projectionsByFrameTargetID[newTargetID] = projection
+        insertAttachedOwnerIndex(for: projection)
         return projection
     }
 
@@ -74,6 +86,7 @@ package final class FrameDocumentProjectionIndex {
             frameDocumentID: frameDocumentID,
             state: .pending
         )
+        removeAttachedOwnerIndex(for: projection)
         projection.frameTargetID = frameTargetID
         projection.frameDocumentID = frameDocumentID
         projection.ownerNodeID = nil
@@ -86,9 +99,11 @@ package final class FrameDocumentProjectionIndex {
         guard var projection = projectionsByFrameTargetID[frameTargetID] else {
             return
         }
+        removeAttachedOwnerIndex(for: projection)
         projection.ownerNodeID = ownerNodeID
         projection.state = .attached
         projectionsByFrameTargetID[frameTargetID] = projection
+        insertAttachedOwnerIndex(for: projection)
     }
 
     package func detach(
@@ -98,6 +113,7 @@ package final class FrameDocumentProjectionIndex {
         guard var projection = projectionsByFrameTargetID[frameTargetID] else {
             return
         }
+        removeAttachedOwnerIndex(for: projection)
         projection.ownerNodeID = nil
         projection.state = state
         projectionsByFrameTargetID[frameTargetID] = projection
@@ -107,14 +123,14 @@ package final class FrameDocumentProjectionIndex {
         forOwnerNodeID ownerNodeID: DOMNode.ID,
         documentProvider: (DOMDocument.ID) -> DOMDocument?
     ) -> DOMNode.ID? {
-        for projection in projectionsByFrameTargetID.values
-            where projection.ownerNodeID == ownerNodeID && projection.state == .attached {
-            guard let document = documentProvider(projection.frameDocumentID) else {
-                continue
-            }
-            return document.rootNodeID
+        guard let frameTargetID = frameTargetIDByOwnerNodeID[ownerNodeID],
+              let projection = projectionsByFrameTargetID[frameTargetID],
+              projection.ownerNodeID == ownerNodeID,
+              projection.state == .attached,
+              let document = documentProvider(projection.frameDocumentID) else {
+            return nil
         }
-        return nil
+        return document.rootNodeID
     }
 
     package func ownerKeys(
@@ -136,6 +152,23 @@ package final class FrameDocumentProjectionIndex {
             stack.append(contentsOf: node.protocolOwnedChildren)
         }
         return keys
+    }
+
+    private func removeAttachedOwnerIndex(for projection: FrameDocumentProjection) {
+        guard projection.state == .attached,
+              let ownerNodeID = projection.ownerNodeID,
+              frameTargetIDByOwnerNodeID[ownerNodeID] == projection.frameTargetID else {
+            return
+        }
+        frameTargetIDByOwnerNodeID.removeValue(forKey: ownerNodeID)
+    }
+
+    private func insertAttachedOwnerIndex(for projection: FrameDocumentProjection) {
+        guard projection.state == .attached,
+              let ownerNodeID = projection.ownerNodeID else {
+            return
+        }
+        frameTargetIDByOwnerNodeID[ownerNodeID] = projection.frameTargetID
     }
 
     package func snapshots() -> [ProtocolTarget.ID: FrameDocumentProjection.Snapshot] {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -217,6 +217,42 @@ extension DOMTreeTextView {
         let previousRowCapacity: Int
         let previousTextCapacity: Int
         let markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+        let frameDocumentRootIDByOwnerNodeID: [DOMNode.ID: DOMNode.ID]
+
+        init(
+            domSnapshot: DOMSession.Snapshot,
+            treeRevision: UInt64,
+            expansionState: [DOMNode.ID: Bool],
+            previousRowCapacity: Int,
+            previousTextCapacity: Int,
+            markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+        ) {
+            self.domSnapshot = domSnapshot
+            self.treeRevision = treeRevision
+            self.expansionState = expansionState
+            self.previousRowCapacity = previousRowCapacity
+            self.previousTextCapacity = previousTextCapacity
+            self.markupCache = markupCache
+            self.frameDocumentRootIDByOwnerNodeID = Self.frameDocumentRootIDsByOwnerNodeID(
+                in: domSnapshot
+            )
+        }
+
+        private static func frameDocumentRootIDsByOwnerNodeID(
+            in snapshot: DOMSession.Snapshot
+        ) -> [DOMNode.ID: DOMNode.ID] {
+            var rootsByOwnerNodeID: [DOMNode.ID: DOMNode.ID] = [:]
+            for projection in snapshot.frameDocumentProjections.values
+                where projection.state == .attached {
+                guard let ownerNodeID = projection.ownerNodeID,
+                      let document = snapshot.documentsByID[projection.frameDocumentID],
+                      document.lifecycle == .loaded else {
+                    continue
+                }
+                rootsByOwnerNodeID[ownerNodeID] = document.rootNodeID
+            }
+            return rootsByOwnerNodeID
+        }
     }
 
     struct RenderedRowsBuildResult: Sendable {
@@ -459,15 +495,7 @@ extension DOMTreeTextView {
         }
 
         private func projectedFrameDocumentRootID(forOwnerNodeID ownerNodeID: DOMNode.ID) -> DOMNode.ID? {
-            for projection in request.domSnapshot.frameDocumentProjections.values
-                where projection.ownerNodeID == ownerNodeID && projection.state == .attached {
-                guard let document = request.domSnapshot.documentsByID[projection.frameDocumentID],
-                      document.lifecycle == .loaded else {
-                    continue
-                }
-                return document.rootNodeID
-            }
-            return nil
+            request.frameDocumentRootIDByOwnerNodeID[ownerNodeID]
         }
 
         private func nodeHasDisclosure(_ node: DOMNode.Snapshot) -> Bool {

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -719,6 +719,74 @@ func iframeOwnerRemovalDropsProjectionButKeepsFrameTargetMirror() async throws {
 }
 
 @Test
+@MainActor
+func frameDocumentProjectionOwnerIndexDropsStaleEntries() throws {
+    let index = FrameDocumentProjectionIndex()
+    let frameTargetID = ProtocolTarget.ID("frame-ad-target")
+    let movedFrameTargetID = ProtocolTarget.ID("frame-ad-target-committed")
+    let otherFrameTargetID = ProtocolTarget.ID("frame-other-target")
+    let pageDocumentID = DOMDocument.ID(
+        targetID: ProtocolTarget.ID("page-main"),
+        localDocumentLifetimeID: .init(1)
+    )
+    let firstFrameDocumentID = DOMDocument.ID(
+        targetID: frameTargetID,
+        localDocumentLifetimeID: .init(1)
+    )
+    let secondFrameDocumentID = DOMDocument.ID(
+        targetID: frameTargetID,
+        localDocumentLifetimeID: .init(2)
+    )
+    let ownerNodeID = DOMNode.ID(documentID: pageDocumentID, nodeID: .init(20))
+    let replacementOwnerNodeID = DOMNode.ID(documentID: pageDocumentID, nodeID: .init(21))
+    let firstRootID = DOMNode.ID(documentID: firstFrameDocumentID, nodeID: .init(101))
+    let secondRootID = DOMNode.ID(documentID: secondFrameDocumentID, nodeID: .init(201))
+    let documents = [
+        firstFrameDocumentID: projectionIndexTestDocument(id: firstFrameDocumentID, rootNodeID: firstRootID),
+        secondFrameDocumentID: projectionIndexTestDocument(id: secondFrameDocumentID, rootNodeID: secondRootID),
+    ]
+
+    func projectedRoot(for ownerNodeID: DOMNode.ID) -> DOMNode.ID? {
+        index.projectedFrameDocumentRootID(forOwnerNodeID: ownerNodeID) { documents[$0] }
+    }
+
+    index.setFrameDocument(frameTargetID: frameTargetID, frameDocumentID: firstFrameDocumentID)
+    index.attach(frameTargetID: frameTargetID, to: ownerNodeID)
+    #expect(projectedRoot(for: ownerNodeID) == firstRootID)
+
+    index.attach(frameTargetID: frameTargetID, to: replacementOwnerNodeID)
+    #expect(projectedRoot(for: ownerNodeID) == nil)
+    #expect(projectedRoot(for: replacementOwnerNodeID) == firstRootID)
+
+    index.detach(frameTargetID: frameTargetID)
+    #expect(projectedRoot(for: replacementOwnerNodeID) == nil)
+
+    index.attach(frameTargetID: frameTargetID, to: ownerNodeID)
+    index.setFrameDocument(frameTargetID: frameTargetID, frameDocumentID: secondFrameDocumentID)
+    #expect(projectedRoot(for: ownerNodeID) == nil)
+
+    index.attach(frameTargetID: frameTargetID, to: ownerNodeID)
+    #expect(projectedRoot(for: ownerNodeID) == secondRootID)
+
+    index.moveProjection(from: frameTargetID, to: movedFrameTargetID)
+    #expect(projectedRoot(for: ownerNodeID) == secondRootID)
+
+    index.setFrameDocument(frameTargetID: otherFrameTargetID, frameDocumentID: firstFrameDocumentID)
+    index.attach(frameTargetID: otherFrameTargetID, to: replacementOwnerNodeID)
+    #expect(projectedRoot(for: replacementOwnerNodeID) == firstRootID)
+
+    index.removeValue(forKey: movedFrameTargetID)
+    #expect(projectedRoot(for: ownerNodeID) == nil)
+
+    index.detach(frameTargetID: otherFrameTargetID, state: .ambiguous)
+    #expect(projectedRoot(for: replacementOwnerNodeID) == nil)
+
+    index.attach(frameTargetID: otherFrameTargetID, to: replacementOwnerNodeID)
+    index.removeAll()
+    #expect(projectedRoot(for: replacementOwnerNodeID) == nil)
+}
+
+@Test
 func visibleOrderMatchesWebKitDOMTreeOrder() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")
     let session = await DOMSession()
@@ -1734,6 +1802,18 @@ private func frameDocument(
                 ]
             ),
         ]
+    )
+}
+
+@MainActor
+private func projectionIndexTestDocument(id: DOMDocument.ID, rootNodeID: DOMNode.ID) -> DOMDocument {
+    DOMDocument(
+        id: id,
+        targetID: id.targetID,
+        lifecycle: .loaded,
+        rootNodeID: rootNodeID,
+        nodesByID: [:],
+        currentNodeIDByProtocolNodeID: [:]
     )
 }
 


### PR DESCRIPTION
## Summary
- add a secondary owner-node index to `FrameDocumentProjectionIndex`
- precompute frame-document owner root lookups once per DOM tree row build request
- cover stale owner index updates across attach, detach, move, document replacement, remove, and reset

## Why
Frame document projection lookup was repeatedly scanning all projections from both the MainActor model path and the detached DOM tree row builder. The projection index already owns this relation, so it should also own the owner-node lookup needed for projected iframe roots.

## Validation
- `swift test --filter WebInspectorCoreTests.frameDocumentProjectionOwnerIndexDropsStaleEntries`
- `git diff --check main...HEAD`
- subagent validation: `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests/DOMModelTests -only-testing:WebInspectorUITests/DOMTreeTextViewTests`
- subagent `codex-review`: no findings
