### PR TITLE
Resolve warning diagnostics

### DIFF
--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
@@ -184,7 +184,7 @@ package struct DOMElementStylePresentationModel {
     }
 
     private mutating func renderPending() -> RenderResult {
-        guard let displayedSnapshot else {
+        guard displayedSnapshot != nil else {
             return renderUnavailable()
         }
         return .pending

--- a/Tests/WebInspectorUITests/UITestObservationWaits.swift
+++ b/Tests/WebInspectorUITests/UITestObservationWaits.swift
@@ -75,7 +75,7 @@ final class UITestDeinitProbe {
         return await withCheckedContinuation { continuation in
             let timeoutTask = Task { [weak self] in
                 try? await Task.sleep(for: timeout)
-                await self?.resolveWaiter(false)
+                self?.resolveWaiter(false)
             }
             waiter = Waiter(continuation: continuation, timeoutTask: timeoutTask)
         }


### PR DESCRIPTION
## Purpose
Resolve Swift warning diagnostics reported in WebInspectorUI and UITest helper code.

## Changes
- Replace an unused optional binding with a boolean `displayedSnapshot` presence check.
- Remove an unnecessary `await` from a main-actor-inherited timeout task in `UITestDeinitProbe`.

## Testing
- XcodeBuildMCP `test_sim`: 487 passed, warnings 0
- `git diff --check`
- Codex review against `main`: clean, 0 findings
