### PR TITLE
[codex] Render DOM tree token colors through TextKit attributes

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -329,7 +329,6 @@ final class DOMSessionElementStyleHydrationController {
 
         func cancel() {
             task?.cancel()
-            task = nil
         }
     }
 
@@ -354,6 +353,7 @@ final class DOMSessionElementStyleHydrationController {
 
     private(set) var isActive = false
     private var activeRefresh: Refresh?
+    private var cancelledRefreshes: [Refresh] = []
     private var propertyUpdateRequests: [CSSProperty.ID: PropertyUpdateRequest] = [:]
 
     @discardableResult
@@ -396,6 +396,7 @@ final class DOMSessionElementStyleHydrationController {
         }
         activeRefresh = nil
         refresh.cancel()
+        cancelledRefreshes.append(refresh)
         return refresh.token
     }
 
@@ -430,17 +431,25 @@ final class DOMSessionElementStyleHydrationController {
     }
 
     func waitUntilRefreshIdle() async {
-        while let refresh = activeRefresh {
-            await refresh.wait()
+        while activeRefresh != nil || cancelledRefreshes.isEmpty == false {
+            if let refresh = activeRefresh {
+                await refresh.wait()
+            }
+            if let refresh = cancelledRefreshes.first {
+                await refresh.wait()
+            }
         }
     }
 
     func waitUntilIdle() async {
-        while activeRefresh != nil || propertyUpdateRequests.isEmpty == false {
+        while activeRefresh != nil || cancelledRefreshes.isEmpty == false || propertyUpdateRequests.isEmpty == false {
             if let request = propertyUpdateRequests.values.first {
                 await request.wait()
             }
             if let refresh = activeRefresh {
+                await refresh.wait()
+            }
+            if let refresh = cancelledRefreshes.first {
                 await refresh.wait()
             }
         }
@@ -454,6 +463,7 @@ final class DOMSessionElementStyleHydrationController {
 
     private func finishRefresh(_ refresh: Refresh) {
         guard activeRefresh === refresh else {
+            cancelledRefreshes.removeAll { $0 === refresh }
             return
         }
         activeRefresh = nil

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -2120,7 +2120,7 @@ extension DOMTreeTextView {
     }
 
     func textStorageForegroundColorForTesting(containing text: String) -> UIColor? {
-        let range = (unsafe textStorage.string as NSString).range(of: text)
+        let range = (textStorage.string as NSString).range(of: text)
         guard range.location != NSNotFound,
               range.location < textStorage.length
         else {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -440,6 +440,14 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         textContainer.lineFragmentPadding = 0
         textContainer.lineBreakMode = .byClipping
         layoutManager.textContainer = textContainer
+        layoutManager.renderingAttributesValidator = { [weak self] textLayoutManager, textLayoutFragment in
+            MainActor.assumeIsolated {
+                self?.validateTokenRenderingAttributes(
+                    in: textLayoutFragment,
+                    using: textLayoutManager
+                )
+            }
+        }
         layoutManager.textViewportLayoutController.delegate = viewportLayoutDelegate
         textContentStorage.addTextLayoutManager(layoutManager)
         textContentStorage.primaryTextLayoutManager = layoutManager
@@ -1045,12 +1053,6 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         )
     }
 
-    private func applyRowAttributes(to attributedText: NSMutableAttributedString) {
-        for row in rows {
-            applySyntaxAttributes(for: row, to: attributedText)
-        }
-    }
-
     private func baseTextAttributes() -> [NSAttributedString.Key: Any] {
         resolvedTextAttributes().base
     }
@@ -1066,17 +1068,111 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         return resolved
     }
 
+    private func validateTokenRenderingAttributes(
+        in textLayoutFragment: NSTextLayoutFragment,
+        using textLayoutManager: NSTextLayoutManager
+    ) {
+        let fragmentRange = textRange(for: textLayoutFragment)
+        guard fragmentRange.length > 0 else {
+            return
+        }
+
+        let resolvedAttributes = resolvedTextAttributes()
+        let fallbackColor = resolvedAttributes.tokenColors[.fallback]
+            ?? DOMTreeTextView.HighlightTheme.webInspector.textSecondary.resolvedColor(with: traitCollection)
+        let disclosureColor = DOMTreeTextView.HighlightTheme.webInspector.disclosure.resolvedColor(with: traitCollection)
+        for row in rowsIntersectingTextRange(fragmentRange) {
+            addRenderingAttribute(
+                .foregroundColor,
+                value: fallbackColor,
+                range: NSIntersectionRange(row.textRange, fragmentRange),
+                using: textLayoutManager
+            )
+            if row.hasDisclosure {
+                addRenderingAttribute(
+                    .foregroundColor,
+                    value: disclosureColor,
+                    range: NSIntersectionRange(disclosureAttachmentRange(for: row), fragmentRange),
+                    using: textLayoutManager
+                )
+            }
+            for token in row.tokens {
+                let tokenRange = NSRange(
+                    location: row.textRange.location + token.range.location,
+                    length: token.range.length
+                )
+                let color = resolvedAttributes.tokenColors[token.kind] ?? fallbackColor
+                addRenderingAttribute(
+                    .foregroundColor,
+                    value: color,
+                    range: NSIntersectionRange(tokenRange, fragmentRange),
+                    using: textLayoutManager
+                )
+            }
+        }
+    }
+
+    private func addRenderingAttribute(
+        _ attributeName: NSAttributedString.Key,
+        value: Any,
+        range: NSRange,
+        using textLayoutManager: NSTextLayoutManager
+    ) {
+        guard range.length > 0,
+              let textRange = textRange(for: range)
+        else {
+            return
+        }
+        textLayoutManager.addRenderingAttribute(attributeName, value: value, for: textRange)
+    }
+
+    private func invalidateTokenRenderingAttributes(for ranges: [NSRange]) {
+        guard !ranges.isEmpty else {
+            setNeedsDisplayForVisibleTextFragments()
+            return
+        }
+
+        var invalidatedRanges: [NSRange] = []
+        invalidatedRanges.reserveCapacity(ranges.count)
+        for range in ranges {
+            let clampedRange = clampedTextRange(range)
+            guard clampedRange.length > 0,
+                  let textRange = textRange(for: clampedRange)
+            else {
+                continue
+            }
+            layoutManager.invalidateRenderingAttributes(for: textRange)
+            invalidatedRanges.append(clampedRange)
+        }
+
+        guard !invalidatedRanges.isEmpty else {
+            setNeedsDisplayForVisibleTextFragments()
+            return
+        }
+
+        var didInvalidateFragment = false
+        for case let fragmentView as DOMTreeTextLayoutFragmentView in textContentView.subviews {
+            let fragmentRange = textRange(for: fragmentView.layoutFragment)
+            guard !Self.ranges(invalidatedRanges, intersecting: fragmentRange).isEmpty else {
+                continue
+            }
+            validateTokenRenderingAttributes(in: fragmentView.layoutFragment, using: layoutManager)
+            fragmentView.setNeedsDisplay()
+            didInvalidateFragment = true
+        }
+        if !didInvalidateFragment {
+            setNeedsDisplayForVisibleTextFragments()
+        }
+    }
+
     private func reapplyTextAttributes() {
         let fullRange = NSRange(location: 0, length: textStorage.length)
         guard fullRange.length > 0 else {
             return
         }
         textStorage.addAttributes(baseTextAttributes(), range: fullRange)
-        applyRowAttributes(to: textStorage)
         applyDisclosureAttachments(to: textStorage, rows: rows)
-        for case let fragmentView as DOMTreeTextLayoutFragmentView in textContentView.subviews {
-            fragmentView.setNeedsDisplay()
-        }
+        invalidateTokenRenderingAttributes(for: [fullRange])
     }
 
     private func rebuildTextStorage() {
@@ -1084,7 +1180,6 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             string: renderedText.isEmpty ? "\n" : renderedText,
             attributes: baseTextAttributes()
         )
-        applyRowAttributes(to: attributedText)
         applyDisclosureAttachments(to: attributedText, rows: rows)
 #if DEBUG
         performanceCounters.rebuildTextStorageCallCount += 1
@@ -1093,6 +1188,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             textStorage.setAttributedString(attributedText)
         }
         invalidateTextLayout()
+        invalidateTokenRenderingAttributes(for: rows.map(\.textRange))
     }
 
     private func updateTextStorageIncrementally(
@@ -1124,6 +1220,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
         let changedRows = Array(nextRows[diff.nextStart..<diff.nextEnd])
         applyTextAttributes(to: changedRows)
+        invalidateTokenRenderingAttributes(for: changedRows.map(\.textRange))
         if edit.range.length > 0 || !edit.replacement.isEmpty {
             setNeedsDisplayForTextRanges(changedRows.map(\.textRange))
         }
@@ -1207,25 +1304,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 continue
             }
             textStorage.addAttributes(baseTextAttributes(), range: row.textRange)
-            applySyntaxAttributes(for: row, to: textStorage)
         }
         applyDisclosureAttachments(to: textStorage, rows: rows)
-    }
-
-    private func applySyntaxAttributes(for row: DOMTreeTextView.Line, to attributedText: NSMutableAttributedString) {
-        let colors = resolvedTextAttributes().tokenColors
-        attributedText.addAttribute(
-            .foregroundColor,
-            value: colors[.fallback] ?? DOMTreeTextView.HighlightTheme.webInspector.textSecondary.resolvedColor(with: traitCollection),
-            range: row.textRange
-        )
-        for token in row.tokens {
-            attributedText.addAttribute(
-                .foregroundColor,
-                value: colors[token.kind] ?? DOMTreeTextView.HighlightTheme.webInspector.textSecondary.resolvedColor(with: traitCollection),
-                range: NSRange(location: row.textRange.location + token.range.location, length: token.range.length)
-            )
-        }
     }
 
     private func applyDisclosureAttachments(to attributedText: NSMutableAttributedString, rows: [DOMTreeTextView.Line]) {
@@ -2033,6 +2113,27 @@ extension DOMTreeTextView {
 
     var renderedTextForTesting: String {
         renderedText
+    }
+
+    var textStorageBaseForegroundColorForTesting: UIColor? {
+        baseTextAttributes()[.foregroundColor] as? UIColor
+    }
+
+    func textStorageForegroundColorForTesting(containing text: String) -> UIColor? {
+        let range = (unsafe textStorage.string as NSString).range(of: text)
+        guard range.location != NSNotFound,
+              range.location < textStorage.length
+        else {
+            return nil
+        }
+        return unsafe textStorage.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? UIColor
+    }
+
+    func tokenForegroundColorForTesting(kind: String) -> UIColor? {
+        guard let tokenKind = DOMTreeTextView.Token.Kind(rawValue: kind) else {
+            return nil
+        }
+        return resolvedTextAttributes().tokenColors[tokenKind]
     }
 
     var documentObservationDeliveryForTesting: PortableObservationTracking.Token {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -681,6 +681,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
 
     session.attachment.dom.setSelectedNodeStyleHydrationActive(false)
     #expect(session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
+    await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
@@ -717,7 +718,11 @@ func selectedElementStyleHydrationSelectionChangeStartsReplacementRefresh() asyn
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.selectNode(htmlID)
-    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+    let secondMessages = try await waitForCSSRefreshMessages(
+        backend,
+        after: secondSentCount,
+        protocolNodeID: .init(2)
+    )
     #expect(try messageParameters(secondMessages.matched.message)["nodeId"] as? Int == 2)
     #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == htmlID)
     #expect(session.attachment.dom.elementStyles.selectedPhase == .loading)
@@ -7291,12 +7296,53 @@ private struct CSSRefreshMessages {
 
 private func waitForCSSRefreshMessages(
     _ backend: FakeTransportBackend,
-    after count: Int
+    after count: Int,
+    protocolNodeID: DOMNode.ProtocolID? = nil
 ) async throws -> CSSRefreshMessages {
-    let matched = try await waitForTargetMessage(backend, method: "CSS.getMatchedStylesForNode", after: count)
-    let inline = try await waitForTargetMessage(backend, method: "CSS.getInlineStylesForNode", after: count)
-    let computed = try await waitForTargetMessage(backend, method: "CSS.getComputedStyleForNode", after: count)
+    let matched = try await waitForTargetMessage(
+        backend,
+        method: "CSS.getMatchedStylesForNode",
+        after: count,
+        protocolNodeID: protocolNodeID
+    )
+    let inline = try await waitForTargetMessage(
+        backend,
+        method: "CSS.getInlineStylesForNode",
+        after: count,
+        protocolNodeID: protocolNodeID
+    )
+    let computed = try await waitForTargetMessage(
+        backend,
+        method: "CSS.getComputedStyleForNode",
+        after: count,
+        protocolNodeID: protocolNodeID
+    )
     return CSSRefreshMessages(matched: matched, inline: inline, computed: computed)
+}
+
+private func waitForTargetMessage(
+    _ backend: FakeTransportBackend,
+    method: String,
+    after count: Int,
+    protocolNodeID: DOMNode.ProtocolID?
+) async throws -> SentTargetMessage {
+    guard let protocolNodeID else {
+        return try await waitForTargetMessage(backend, method: method, after: count)
+    }
+
+    var ordinal = 0
+    while true {
+        let message = try await waitForTargetMessage(
+            backend,
+            method: method,
+            ordinal: ordinal,
+            after: count
+        )
+        if try messageParameters(message.message)["nodeId"] as? Int == protocolNodeID.rawValue {
+            return message
+        }
+        ordinal += 1
+    }
 }
 
 private func replyCSSRefresh(

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -26,6 +26,23 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func textStorageKeepsTokenForegroundAsBaseAttributes() async throws {
+        let view = await makeTreeView()
+
+        let baseForeground = try #require(view.textStorageBaseForegroundColorForTesting)
+        let tagNameStorageForeground = try #require(view.textStorageForegroundColorForTesting(containing: "input"))
+        let attributeNameStorageForeground = try #require(view.textStorageForegroundColorForTesting(containing: "disabled"))
+        let tagNameTokenForeground = try #require(view.tokenForegroundColorForTesting(kind: "tagName"))
+        let attributeNameTokenForeground = try #require(view.tokenForegroundColorForTesting(kind: "attributeName"))
+
+        #expect(colorsEqual(tagNameStorageForeground, baseForeground))
+        #expect(colorsEqual(attributeNameStorageForeground, baseForeground))
+        #expect(!colorsEqual(tagNameStorageForeground, tagNameTokenForeground))
+        #expect(!colorsEqual(attributeNameStorageForeground, attributeNameTokenForeground))
+        #expect(view.disclosureAttachmentSnapshotsForTesting.contains { $0.hasAttachment })
+    }
+
+    @Test
     func selectingNodeUpdatesCoreSelectionAndRowDecoration() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)
@@ -386,6 +403,10 @@ private struct RenderedDOMTreeState: Equatable, Sendable {
             && text.contains("<img id=\"ad-node\">")
             && selectedRowCount == 1
     }
+}
+
+private func colorsEqual(_ lhs: UIColor, _ rhs: UIColor) -> Bool {
+    CFEqual(lhs.cgColor, rhs.cgColor)
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- move DOM tree token foreground coloring from `NSTextStorage` mutations to `NSTextLayoutManager.renderingAttributesValidator`
- keep storage-level base text attributes and disclosure attachments intact
- invalidate rendering attributes after rebuilds, incremental edits, and trait-driven color changes
- add a regression test proving token colors no longer remain in storage attributes

## Why
DOM tree rendering was writing syntax token foreground attributes into the shared TextKit storage every time rows were rebuilt or incrementally updated. Token coloring is rendering state, not semantic text storage state, and TextKit's rendering attributes validator is a better owner for fragment-local coloring.

## Validation
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeTextViewTests`
- `git diff --check main...HEAD`
- subagent `codex-review`: no findings
