### PR TITLE
[codex] Move media preview preparation into coordinator

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -6,9 +6,7 @@ import SyntaxEditorUI
 import UIKit
 
 extension NetworkBodyViewController {
-    struct PreviewMetadata: Equatable {        var mimeType: String?
-        var url: String?
-    }
+    typealias PreviewMetadata = NetworkMediaPreviewMetadata
 }
 
 @MainActor
@@ -52,7 +50,7 @@ final class NetworkBodyViewController: UIViewController {
     private var metadata: NetworkBodyViewController.PreviewMetadata?
     private var hasDisplayedBody = false
     private var mediaPlayerViewController: AVPlayerViewController?
-    private var mediaPreviewCoordinator = MediaPreviewCoordinator()
+    private var mediaPreviewCoordinator = NetworkMediaPreviewCoordinator()
     private var imageWidthConstraint: NSLayoutConstraint?
     private var imageHeightConstraint: NSLayoutConstraint?
     private var shouldResetImageZoomOnNextLayout = false
@@ -265,62 +263,20 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func renderMediaPreviewIfPossible(for body: NetworkBody) -> Bool {
-        guard let source = mediaPreviewSource(for: body) else {
-            hideMediaPreview()
-            return false
-        }
-
-        switch source {
-        case .remoteMovie(let url):
-            showRemoteMoviePreview(url)
-            return true
-        case .body(let input):
-            return renderMediaPreview(for: input)
-        }
-    }
-
-    private func mediaPreviewSource(for body: NetworkBody) -> MediaPreviewSource? {
-        guard let previewKind = NetworkRequest.Display.MediaPreviewSupport.previewKind(
-            mimeType: metadata?.mimeType,
-            url: metadata?.url
-        ) else {
-            return nil
-        }
-
-        if previewKind == .hlsPlaylist {
-            if body.role == .response, let remoteURL = playableRemoteMediaURL(metadata?.url) {
-                return .remoteMovie(remoteURL)
-            }
-            if body.role == .request {
-                return nil
-            }
-        }
-
-        guard let rawBody = body.full else {
-            return nil
-        }
-        return .body(
-            MediaPreviewInput(
-                previewKind: previewKind,
-                bodyID: ObjectIdentifier(body),
-                role: body.role,
-                rawBody: rawBody,
-                isBase64Encoded: body.isBase64Encoded,
-                mimeType: metadata?.mimeType,
-                url: metadata?.url
-            )
-        )
-    }
-
-    private func renderMediaPreview(for input: MediaPreviewInput) -> Bool {
-        let action = mediaPreviewCoordinator.preparePreview(for: input) { [weak self] result, input, generation in
-            self?.applyMediaPreviewResult(result, input: input, generation: generation)
+        let action = mediaPreviewCoordinator.preparePreview(for: body, metadata: metadata) { [weak self] result in
+            self?.applyMediaPreviewResult(result)
         }
         switch action {
+        case .unavailable:
+            hideMediaPreview()
+            return false
         case .failed:
             hideMediaPreview()
             return false
         case .active:
+            return true
+        case .remoteMovie(let url):
+            showMoviePreview(url)
             return true
         case .cachedMovie(let fileURL):
             showMoviePreview(fileURL)
@@ -331,17 +287,10 @@ final class NetworkBodyViewController: UIViewController {
         }
     }
 
-    private func showRemoteMoviePreview(_ url: URL) {
-        mediaPreviewCoordinator.prepareRemoteMovie(url)
-        showMoviePreview(url)
-    }
-
     private func applyMediaPreviewResult(
-        _ result: MediaPayload?,
-        input: MediaPreviewInput,
-        generation: Int
+        _ result: NetworkMediaPreviewResultAction
     ) {
-        switch mediaPreviewCoordinator.consume(result: result, input: input, generation: generation) {
+        switch result {
         case .ignore:
             return
         case .fallback:
@@ -362,50 +311,6 @@ final class NetworkBodyViewController: UIViewController {
         syntaxView.isHidden = false
         applyScrollEdgeObservedBackgrounds()
         scrollEdgeSink?.contentScrollView = syntaxView
-    }
-
-    nonisolated fileprivate static func makeMediaPayload(from input: MediaPreviewInput) async -> MediaPayload? {
-        guard let data = input.data(), data.isEmpty == false else {
-            return nil
-        }
-
-        switch input.previewKind {
-        case .image:
-            guard let image = await makeImagePayload(data: data) else {
-                return nil
-            }
-            return .image(image)
-        case .movie, .hlsPlaylist:
-            return makeTemporaryMediaPayload(from: input, data: data)
-        }
-    }
-
-    nonisolated fileprivate static func makeImagePayload(data: Data) async -> UIImage? {
-        var configuration = UIImageReader.Configuration()
-        configuration.preparesImagesForDisplay = true
-        let reader = UIImageReader(configuration: configuration)
-        return await reader.image(data: data)
-    }
-
-    nonisolated fileprivate static func makeTemporaryMediaPayload(
-        from input: MediaPreviewInput,
-        data: Data
-    ) -> MediaPayload? {
-        let fileExtension = mediaFileExtension(mimeType: input.mimeType, url: input.url)
-        let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension(fileExtension)
-        do {
-            try data.write(to: fileURL, options: [.atomic])
-            return .movie(
-                MediaTemporaryFile(
-                    input: input,
-                    fileURL: fileURL
-                )
-            )
-        } catch {
-            return nil
-        }
     }
 
     private func showSyntaxPreview() {
@@ -575,253 +480,14 @@ extension NetworkBodyViewController: UIScrollViewDelegate {
     }
 }
 
-extension NetworkBodyViewController {
-    fileprivate enum MediaPreviewSource {
-        case remoteMovie(URL)
-        case body(MediaPreviewInput)
-    }
-
-    fileprivate enum MediaPreviewIdentity: Equatable {
-        case remoteMovie(URL)
-        case body(MediaPreviewInput)
-    }
-
-    fileprivate enum MediaPreviewPreparationAction {
-        case failed
-        case active
-        case cachedMovie(URL)
-        case startedLoading
-    }
-
-    fileprivate enum MediaPreviewResultAction {
-        case ignore
-        case fallback
-        case showImage(UIImage)
-        case showMovie(URL)
-    }
-
-    fileprivate struct MediaPreviewInput: Equatable, Sendable {
-        var previewKind: NetworkRequest.Display.MediaPreviewKind
-        var bodyID: ObjectIdentifier
-        var role: NetworkBody.Role
-        var rawBody: String
-        var isBase64Encoded: Bool
-        var mimeType: String?
-        var url: String?
-
-        func data() -> Data? {
-            if isBase64Encoded {
-                return Data(base64Encoded: rawBody)
-            }
-            return rawBody.data(using: .utf8)
-        }
-    }
-
-    fileprivate enum MediaPayload {
-        case image(UIImage)
-        case movie(MediaTemporaryFile)
-
-        func removeTemporaryFile() {
-            if case .movie(let file) = self {
-                removeTemporaryMediaFile(at: file.fileURL)
-            }
-        }
-    }
-}
-
 private struct ImagePreviewLayoutState {
     var imageSize: CGSize
     var visibleBoundsSize: CGSize
     var minimumZoomScale: CGFloat
 }
 
-@MainActor
-private final class MediaPreviewCoordinator {
-    private var generation = 0
-    private var task: Task<Void, Never>?
-    private var pendingInput: NetworkBodyViewController.MediaPreviewInput?
-    private var displayedIdentity: NetworkBodyViewController.MediaPreviewIdentity?
-    private var failedInput: NetworkBodyViewController.MediaPreviewInput?
-    private var temporaryFile: MediaTemporaryFile?
-
-    func preparePreview(
-        for input: NetworkBodyViewController.MediaPreviewInput,
-        completion: @escaping @MainActor (
-            NetworkBodyViewController.MediaPayload?,
-            NetworkBodyViewController.MediaPreviewInput,
-            Int
-        ) -> Void
-    ) -> NetworkBodyViewController.MediaPreviewPreparationAction {
-        guard failedInput != input else {
-            return .failed
-        }
-        if displayedIdentity == .body(input) || pendingInput == input {
-            return .active
-        }
-        if let fileURL = cachedTemporaryFileURL(for: input) {
-            cancelPending()
-            failedInput = nil
-            displayedIdentity = .body(input)
-            return .cachedMovie(fileURL)
-        }
-
-        startPreparation(for: input, completion: completion)
-        return .startedLoading
-    }
-
-    func prepareRemoteMovie(_ url: URL) {
-        cancelPending()
-        failedInput = nil
-        displayedIdentity = .remoteMovie(url)
-        removeCachedTemporaryFile()
-    }
-
-    func prepareSyntaxPreview() {
-        cancelPending()
-        displayedIdentity = nil
-    }
-
-    func hideMediaPreview() {
-        cancelPending()
-        displayedIdentity = nil
-        removeCachedTemporaryFile()
-    }
-
-    func cancel() {
-        cancelPending()
-        displayedIdentity = nil
-        removeCachedTemporaryFile()
-    }
-
-    func consume(
-        result: NetworkBodyViewController.MediaPayload?,
-        input: NetworkBodyViewController.MediaPreviewInput,
-        generation: Int
-    ) -> NetworkBodyViewController.MediaPreviewResultAction {
-        guard generation == self.generation,
-              pendingInput == input else {
-            result?.removeTemporaryFile()
-            return .ignore
-        }
-        task = nil
-        pendingInput = nil
-
-        guard let result else {
-            failedInput = input
-            displayedIdentity = nil
-            return .fallback
-        }
-
-        failedInput = nil
-        displayedIdentity = .body(input)
-        switch result {
-        case .image(let image):
-            removeCachedTemporaryFile()
-            return .showImage(image)
-        case .movie(let temporaryFile):
-            replaceCachedTemporaryFile(with: temporaryFile)
-            return .showMovie(temporaryFile.fileURL)
-        }
-    }
-
-    private func startPreparation(
-        for input: NetworkBodyViewController.MediaPreviewInput,
-        completion: @escaping @MainActor (
-            NetworkBodyViewController.MediaPayload?,
-            NetworkBodyViewController.MediaPreviewInput,
-            Int
-        ) -> Void
-    ) {
-        cancelPending()
-        failedInput = nil
-        displayedIdentity = nil
-        pendingInput = input
-        generation += 1
-        let generation = generation
-
-        let worker = Task.detached(priority: .utility) {
-            await NetworkBodyViewController.makeMediaPayload(from: input)
-        }
-        task = Task { @MainActor [worker, completion] in
-            let result = await withTaskCancellationHandler {
-                await worker.value
-            } onCancel: {
-                worker.cancel()
-            }
-            guard Task.isCancelled == false else {
-                result?.removeTemporaryFile()
-                return
-            }
-            completion(result, input, generation)
-        }
-    }
-
-    private func cancelPending() {
-        generation += 1
-        task?.cancel()
-        task = nil
-        pendingInput = nil
-    }
-
-    private func cachedTemporaryFileURL(for input: NetworkBodyViewController.MediaPreviewInput) -> URL? {
-        guard input.previewKind == .movie || input.previewKind == .hlsPlaylist,
-              let temporaryFile,
-              temporaryFile.matches(input: input),
-              FileManager.default.fileExists(atPath: temporaryFile.fileURL.path) else {
-            return nil
-        }
-        return temporaryFile.fileURL
-    }
-
-    private func replaceCachedTemporaryFile(with newTemporaryFile: MediaTemporaryFile) {
-        if temporaryFile?.fileURL == newTemporaryFile.fileURL {
-            temporaryFile = newTemporaryFile
-            return
-        }
-        removeCachedTemporaryFile()
-        temporaryFile = newTemporaryFile
-    }
-
-    private func removeCachedTemporaryFile() {
-        removeTemporaryMediaFile(at: temporaryFile?.fileURL)
-        temporaryFile = nil
-    }
-}
-
-private struct MediaTemporaryFile {
-    var input: NetworkBodyViewController.MediaPreviewInput
-    var fileURL: URL
-
-    func matches(input: NetworkBodyViewController.MediaPreviewInput) -> Bool {
-        self.input == input
-    }
-}
-
 private extension NetworkBodyViewController {
     static let imageZoomScaleTolerance: CGFloat = 0.001
-}
-
-private func playableRemoteMediaURL(_ url: String?) -> URL? {
-    guard let url = url.flatMap(URL.init(string:)) else {
-        return nil
-    }
-    switch url.scheme?.lowercased() {
-    case "http", "https":
-        return url
-    default:
-        return nil
-    }
-}
-
-private func mediaFileExtension(mimeType: String?, url: String?) -> String {
-    NetworkRequest.Display.MediaPreviewSupport.temporaryFileExtension(mimeType: mimeType, url: url)
-}
-
-private func removeTemporaryMediaFile(at url: URL?) {
-    guard let url else {
-        return
-    }
-    try? FileManager.default.removeItem(at: url)
 }
 
 private extension NetworkBody.SyntaxKind {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
@@ -1,0 +1,342 @@
+#if canImport(UIKit)
+import Foundation
+import UIKit
+import WebInspectorCore
+
+struct NetworkMediaPreviewMetadata: Equatable, Sendable {
+    var mimeType: String?
+    var url: String?
+}
+
+enum NetworkMediaPreviewPreparationAction {
+    case unavailable
+    case failed
+    case active
+    case remoteMovie(URL)
+    case cachedMovie(URL)
+    case startedLoading
+}
+
+enum NetworkMediaPreviewResultAction {
+    case ignore
+    case fallback
+    case showImage(UIImage)
+    case showMovie(URL)
+}
+
+@MainActor
+final class NetworkMediaPreviewCoordinator {
+    private var generation = 0
+    private var task: Task<Void, Never>?
+    private var pendingInput: NetworkMediaPreviewInput?
+    private var displayedIdentity: NetworkMediaPreviewIdentity?
+    private var failedInput: NetworkMediaPreviewInput?
+    private var temporaryFile: NetworkMediaTemporaryFile?
+
+    func preparePreview(
+        for body: NetworkBody,
+        metadata: NetworkMediaPreviewMetadata?,
+        completion: @escaping @MainActor (NetworkMediaPreviewResultAction) -> Void
+    ) -> NetworkMediaPreviewPreparationAction {
+        guard let source = mediaPreviewSource(for: body, metadata: metadata) else {
+            return .unavailable
+        }
+
+        switch source {
+        case .remoteMovie(let url):
+            prepareRemoteMovie(url)
+            return .remoteMovie(url)
+        case .body(let input):
+            return prepareBodyPreview(for: input, completion: completion)
+        }
+    }
+
+    func prepareSyntaxPreview() {
+        cancelPending()
+        displayedIdentity = nil
+    }
+
+    func hideMediaPreview() {
+        cancelPending()
+        displayedIdentity = nil
+        removeCachedTemporaryFile()
+    }
+
+    func cancel() {
+        cancelPending()
+        displayedIdentity = nil
+        removeCachedTemporaryFile()
+    }
+
+    private func mediaPreviewSource(
+        for body: NetworkBody,
+        metadata: NetworkMediaPreviewMetadata?
+    ) -> NetworkMediaPreviewSource? {
+        guard let previewKind = NetworkRequest.Display.MediaPreviewSupport.previewKind(
+            mimeType: metadata?.mimeType,
+            url: metadata?.url
+        ) else {
+            return nil
+        }
+
+        if previewKind == .hlsPlaylist {
+            if body.role == .response,
+               let remoteURL = playableRemoteMediaURL(metadata?.url) {
+                return .remoteMovie(remoteURL)
+            }
+            if body.role == .request {
+                return nil
+            }
+        }
+
+        guard let rawBody = body.full else {
+            return nil
+        }
+        return .body(
+            NetworkMediaPreviewInput(
+                previewKind: previewKind,
+                bodyID: ObjectIdentifier(body),
+                role: body.role,
+                rawBody: rawBody,
+                isBase64Encoded: body.isBase64Encoded,
+                mimeType: metadata?.mimeType,
+                url: metadata?.url
+            )
+        )
+    }
+
+    private func prepareBodyPreview(
+        for input: NetworkMediaPreviewInput,
+        completion: @escaping @MainActor (NetworkMediaPreviewResultAction) -> Void
+    ) -> NetworkMediaPreviewPreparationAction {
+        guard failedInput != input else {
+            return .failed
+        }
+        if displayedIdentity == .body(input) || pendingInput == input {
+            return .active
+        }
+        if let fileURL = cachedTemporaryFileURL(for: input) {
+            cancelPending()
+            failedInput = nil
+            displayedIdentity = .body(input)
+            return .cachedMovie(fileURL)
+        }
+
+        startPreparation(for: input, completion: completion)
+        return .startedLoading
+    }
+
+    private func prepareRemoteMovie(_ url: URL) {
+        cancelPending()
+        failedInput = nil
+        displayedIdentity = .remoteMovie(url)
+        removeCachedTemporaryFile()
+    }
+
+    private func consume(
+        result: NetworkMediaPayload?,
+        input: NetworkMediaPreviewInput,
+        generation: Int
+    ) -> NetworkMediaPreviewResultAction {
+        guard generation == self.generation,
+              pendingInput == input else {
+            result?.removeTemporaryFile()
+            return .ignore
+        }
+        task = nil
+        pendingInput = nil
+
+        guard let result else {
+            failedInput = input
+            displayedIdentity = nil
+            return .fallback
+        }
+
+        failedInput = nil
+        displayedIdentity = .body(input)
+        switch result {
+        case .image(let image):
+            removeCachedTemporaryFile()
+            return .showImage(image)
+        case .movie(let temporaryFile):
+            replaceCachedTemporaryFile(with: temporaryFile)
+            return .showMovie(temporaryFile.fileURL)
+        }
+    }
+
+    private func startPreparation(
+        for input: NetworkMediaPreviewInput,
+        completion: @escaping @MainActor (NetworkMediaPreviewResultAction) -> Void
+    ) {
+        cancelPending()
+        failedInput = nil
+        displayedIdentity = nil
+        pendingInput = input
+        generation += 1
+        let generation = generation
+
+        let worker = Task.detached(priority: .utility) {
+            await Self.makeMediaPayload(from: input)
+        }
+        task = Task { @MainActor [worker, completion] in
+            let result = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard Task.isCancelled == false else {
+                result?.removeTemporaryFile()
+                return
+            }
+            completion(consume(result: result, input: input, generation: generation))
+        }
+    }
+
+    private func cancelPending() {
+        generation += 1
+        task?.cancel()
+        task = nil
+        pendingInput = nil
+    }
+
+    private func cachedTemporaryFileURL(for input: NetworkMediaPreviewInput) -> URL? {
+        guard input.previewKind == .movie || input.previewKind == .hlsPlaylist,
+              let temporaryFile,
+              temporaryFile.matches(input: input),
+              FileManager.default.fileExists(atPath: temporaryFile.fileURL.path) else {
+            return nil
+        }
+        return temporaryFile.fileURL
+    }
+
+    private func replaceCachedTemporaryFile(with newTemporaryFile: NetworkMediaTemporaryFile) {
+        if temporaryFile?.fileURL == newTemporaryFile.fileURL {
+            temporaryFile = newTemporaryFile
+            return
+        }
+        removeCachedTemporaryFile()
+        temporaryFile = newTemporaryFile
+    }
+
+    private func removeCachedTemporaryFile() {
+        removeTemporaryMediaFile(at: temporaryFile?.fileURL)
+        temporaryFile = nil
+    }
+
+    nonisolated private static func makeMediaPayload(
+        from input: NetworkMediaPreviewInput
+    ) async -> NetworkMediaPayload? {
+        guard let data = input.data(), data.isEmpty == false else {
+            return nil
+        }
+
+        switch input.previewKind {
+        case .image:
+            guard let image = await makeImagePayload(data: data) else {
+                return nil
+            }
+            return .image(image)
+        case .movie, .hlsPlaylist:
+            return makeTemporaryMediaPayload(from: input, data: data)
+        }
+    }
+
+    nonisolated private static func makeImagePayload(data: Data) async -> UIImage? {
+        var configuration = UIImageReader.Configuration()
+        configuration.preparesImagesForDisplay = true
+        let reader = UIImageReader(configuration: configuration)
+        return await reader.image(data: data)
+    }
+
+    nonisolated private static func makeTemporaryMediaPayload(
+        from input: NetworkMediaPreviewInput,
+        data: Data
+    ) -> NetworkMediaPayload? {
+        let fileExtension = mediaFileExtension(mimeType: input.mimeType, url: input.url)
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(fileExtension)
+        do {
+            try data.write(to: fileURL, options: [.atomic])
+            return .movie(
+                NetworkMediaTemporaryFile(
+                    input: input,
+                    fileURL: fileURL
+                )
+            )
+        } catch {
+            return nil
+        }
+    }
+}
+
+private enum NetworkMediaPreviewSource {
+    case remoteMovie(URL)
+    case body(NetworkMediaPreviewInput)
+}
+
+private enum NetworkMediaPreviewIdentity: Equatable {
+    case remoteMovie(URL)
+    case body(NetworkMediaPreviewInput)
+}
+
+private struct NetworkMediaPreviewInput: Equatable, Sendable {
+    var previewKind: NetworkRequest.Display.MediaPreviewKind
+    var bodyID: ObjectIdentifier
+    var role: NetworkBody.Role
+    var rawBody: String
+    var isBase64Encoded: Bool
+    var mimeType: String?
+    var url: String?
+
+    func data() -> Data? {
+        if isBase64Encoded {
+            return Data(base64Encoded: rawBody)
+        }
+        return rawBody.data(using: .utf8)
+    }
+}
+
+private enum NetworkMediaPayload {
+    case image(UIImage)
+    case movie(NetworkMediaTemporaryFile)
+
+    func removeTemporaryFile() {
+        if case .movie(let file) = self {
+            removeTemporaryMediaFile(at: file.fileURL)
+        }
+    }
+}
+
+private struct NetworkMediaTemporaryFile {
+    var input: NetworkMediaPreviewInput
+    var fileURL: URL
+
+    func matches(input: NetworkMediaPreviewInput) -> Bool {
+        self.input == input
+    }
+}
+
+private func playableRemoteMediaURL(_ url: String?) -> URL? {
+    guard let url = url.flatMap(URL.init(string:)) else {
+        return nil
+    }
+    switch url.scheme?.lowercased() {
+    case "http", "https":
+        return url
+    default:
+        return nil
+    }
+}
+
+private func mediaFileExtension(mimeType: String?, url: String?) -> String {
+    NetworkRequest.Display.MediaPreviewSupport.temporaryFileExtension(mimeType: mimeType, url: url)
+}
+
+private func removeTemporaryMediaFile(at url: URL?) {
+    guard let url else {
+        return
+    }
+    try? FileManager.default.removeItem(at: url)
+}
+#endif


### PR DESCRIPTION
## Summary
- Move media preview source/input/identity/payload and generation/pending/failed/temp-file state into `NetworkMediaPreviewCoordinator`.
- Keep `NetworkBodyViewController` focused on consuming coordinator actions and updating installed UIKit/AVKit views.
- Preserve image preparation, async media payload generation, temporary movie reuse/cleanup, remote HLS playback, and failure fallback semantics.

## Why
`NetworkBodyViewController` was still owning preparation-specific media preview types and state after the coordinator extraction. This keeps that responsibility with the coordinator instead of leaking preparation internals into the VC.

## Validation
- `swift test --filter WebInspectorUITests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- `codex-review` uncommitted changes: 0 findings