### PR TITLE
Improve DOM find boundary checks

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeFindCoordinator.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeFindCoordinator.swift
@@ -421,28 +421,64 @@ extension DOMTreeTextView {
             guard offset > 0, offset < source.length else {
                 return true
             }
-            let source = source as String
-            guard let index = stringIndex(forUTF16Offset: offset, in: source) else {
-                return false
-            }
 
-            let previousIndex = source.index(before: index)
-            return !isIdentifierCharacter(source[previousIndex])
-                || !isIdentifierCharacter(source[index])
+            return !isIdentifierCharacter(containingUTF16Offset: offset - 1, in: source)
+                || !isIdentifierCharacter(containingUTF16Offset: offset, in: source)
         }
 
-        private nonisolated static func stringIndex(forUTF16Offset offset: Int, in source: String) -> String.Index? {
-            let utf16Index = source.utf16.index(source.utf16.startIndex, offsetBy: offset)
-            return String.Index(utf16Index, within: source)
-        }
-
-        private nonisolated static func isIdentifierCharacter(_ character: Character) -> Bool {
-            if character == "_" {
+        private nonisolated static func isIdentifierCharacter(
+            containingUTF16Offset offset: Int,
+            in source: NSString
+        ) -> Bool {
+            let range = source.rangeOfComposedCharacterSequence(at: offset)
+            if range.length == 1, source.character(at: range.location) == 0x5F {
                 return true
             }
-            return character.unicodeScalars.contains { scalar in
-                CharacterSet.alphanumerics.contains(scalar)
+
+            let upperBound = range.location + range.length
+            var location = range.location
+            while location < upperBound {
+                guard let scalarInfo = unicodeScalar(startingAtUTF16Offset: location, in: source, upperBound: upperBound) else {
+                    location += 1
+                    continue
+                }
+                if CharacterSet.alphanumerics.contains(scalarInfo.scalar) {
+                    return true
+                }
+                location += scalarInfo.length
             }
+
+            return false
+        }
+
+        private nonisolated static func unicodeScalar(
+            startingAtUTF16Offset offset: Int,
+            in source: NSString,
+            upperBound: Int
+        ) -> (scalar: Unicode.Scalar, length: Int)? {
+            let first = UInt32(source.character(at: offset))
+            if (0xD800...0xDBFF).contains(first) {
+                let secondOffset = offset + 1
+                guard secondOffset < upperBound else {
+                    return nil
+                }
+                let second = UInt32(source.character(at: secondOffset))
+                guard (0xDC00...0xDFFF).contains(second) else {
+                    return nil
+                }
+                let scalarValue = 0x10000 + ((first - 0xD800) << 10) + (second - 0xDC00)
+                guard let scalar = Unicode.Scalar(scalarValue) else {
+                    return nil
+                }
+                return (scalar: scalar, length: 2)
+            }
+
+            guard !(0xDC00...0xDFFF).contains(first),
+                  let scalar = Unicode.Scalar(first)
+            else {
+                return nil
+            }
+            return (scalar: scalar, length: 1)
         }
     }
 }

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -43,6 +43,61 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func findWordMatchMethodsRespectIdentifierBoundaries() {
+        let source = "foo fooBar barfoo _foo foo_bar foo2 foo-bar"
+
+        let containsRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "foo",
+            wordMatchMethod: .contains
+        )
+        let startsWithRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "foo",
+            wordMatchMethod: .startsWith
+        )
+        let fullWordRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "foo",
+            wordMatchMethod: .fullWord
+        )
+
+        #expect(containsRanges.map(\.location) == [0, 4, 14, 19, 23, 31, 36])
+        #expect(startsWithRanges.map(\.location) == [0, 4, 23, 31, 36])
+        #expect(fullWordRanges.map(\.location) == [0, 36])
+    }
+
+    @Test
+    func findWordBoundaryChecksUseComposedCharacters() {
+        let source = "e\u{301} e\u{301}x xe\u{301} e\u{301}-x"
+
+        let containsRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "\u{301}",
+            wordMatchMethod: .contains
+        )
+        let startsWithRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "\u{301}",
+            wordMatchMethod: .startsWith
+        )
+        let fullWordRanges = DOMTreeTextView.FindCoordinator.searchRanges(
+            in: source,
+            queryString: "\u{301}",
+            wordMatchMethod: .fullWord
+        )
+
+        #expect(containsRanges == [
+            NSRange(location: 0, length: 2),
+            NSRange(location: 3, length: 2),
+            NSRange(location: 8, length: 2),
+            NSRange(location: 11, length: 2),
+        ])
+        #expect(startsWithRanges.map(\.location) == [0, 3, 11])
+        #expect(fullWordRanges.map(\.location) == [0, 11])
+    }
+
+    @Test
     func selectingNodeUpdatesCoreSelectionAndRowDecoration() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)


### PR DESCRIPTION
## Summary
- Replace per-match `NSString` -> `String` bridging and UTF-16 -> `String.Index` conversion in DOM find boundary checks with local UTF-16/composed-character inspection.
- Preserve `contains`, `startsWith`, and `fullWord` behavior for `_`, alphanumerics, and composed-character aligned ranges.
- Add DOM tree find tests for identifier boundaries and composed-character range alignment.

## Validation
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeTextViewTests`
- `git diff --check`
- `codex-review` on uncommitted changes: 0 findings

## Notes
- Full `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` was attempted. The new DOM find tests passed during that run, but the run failed later in unrelated `NetworkDetailViewControllerTests.listCancelsStaleDisplayProjectionBeforeThrottledReload()` after a UI test runner unexpected exit and `simctl diagnose` timeout.