### PR TITLE
[codex] Index DOM find decoration ranges

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeFindDecorationState.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeFindDecorationState.swift
@@ -5,13 +5,21 @@ import UIKit
 extension DOMTreeTextView {
     @MainActor
     final class FindDecorationState {
-        private(set) var foundRanges: [NSRange] = []
-        private(set) var highlightedRanges: [NSRange] = []
+        private var foundRangeIndex = OrderedRangeIndex()
+        private var highlightedRangeIndex = OrderedRangeIndex()
         private var batchDepth = 0
         private var pendingInvalidationRanges: [NSRange] = []
 
+        var foundRanges: [NSRange] {
+            foundRangeIndex.ranges
+        }
+
+        var highlightedRanges: [NSRange] {
+            highlightedRangeIndex.ranges
+        }
+
         var isEmpty: Bool {
-            foundRanges.isEmpty && highlightedRanges.isEmpty
+            foundRangeIndex.isEmpty && highlightedRangeIndex.isEmpty
         }
 
         func decorate(_ clampedRange: NSRange, style: UITextSearchFoundTextStyle) -> [NSRange] {
@@ -21,28 +29,21 @@ extension DOMTreeTextView {
 
             switch style {
             case .normal:
-                guard foundRanges.contains(clampedRange) || highlightedRanges.contains(clampedRange) else {
+                guard remove(clampedRange) else {
                     return []
                 }
-                remove(clampedRange)
             case .found:
-                guard !foundRanges.contains(clampedRange) || highlightedRanges.contains(clampedRange) else {
+                guard decorateFound(clampedRange) else {
                     return []
                 }
-                remove(clampedRange)
-                foundRanges.append(clampedRange)
             case .highlighted:
-                guard foundRanges.contains(clampedRange) || !highlightedRanges.contains(clampedRange) else {
+                guard decorateHighlighted(clampedRange) else {
                     return []
                 }
-                remove(clampedRange)
-                highlightedRanges.append(clampedRange)
             @unknown default:
-                guard !foundRanges.contains(clampedRange) || highlightedRanges.contains(clampedRange) else {
+                guard decorateFound(clampedRange) else {
                     return []
                 }
-                remove(clampedRange)
-                foundRanges.append(clampedRange)
             }
             return invalidatedRanges([clampedRange])
         }
@@ -52,8 +53,8 @@ extension DOMTreeTextView {
             guard !previousRanges.isEmpty else {
                 return []
             }
-            foundRanges.removeAll()
-            highlightedRanges.removeAll()
+            foundRangeIndex.removeAll()
+            highlightedRangeIndex.removeAll()
             return invalidatedRanges(previousRanges)
         }
 
@@ -75,9 +76,43 @@ extension DOMTreeTextView {
             return ranges
         }
 
-        private func remove(_ range: NSRange) {
-            foundRanges.removeAll { $0 == range }
-            highlightedRanges.removeAll { $0 == range }
+        private func decorateFound(_ range: NSRange) -> Bool {
+            let isFound = foundRangeIndex.contains(range)
+            let isHighlighted = highlightedRangeIndex.contains(range)
+            guard !isFound || isHighlighted else {
+                return false
+            }
+            if isFound {
+                foundRangeIndex.remove(range)
+            }
+            if isHighlighted {
+                highlightedRangeIndex.remove(range)
+            }
+            foundRangeIndex.append(range)
+            return true
+        }
+
+        private func decorateHighlighted(_ range: NSRange) -> Bool {
+            let isFound = foundRangeIndex.contains(range)
+            let isHighlighted = highlightedRangeIndex.contains(range)
+            guard isFound || !isHighlighted else {
+                return false
+            }
+            if isFound {
+                foundRangeIndex.remove(range)
+            }
+            if isHighlighted {
+                highlightedRangeIndex.remove(range)
+            }
+            highlightedRangeIndex.append(range)
+            return true
+        }
+
+        @discardableResult
+        private func remove(_ range: NSRange) -> Bool {
+            let removedFound = foundRangeIndex.remove(range)
+            let removedHighlighted = highlightedRangeIndex.remove(range)
+            return removedFound || removedHighlighted
         }
 
         private func invalidatedRanges(_ ranges: [NSRange]) -> [NSRange] {
@@ -89,6 +124,93 @@ extension DOMTreeTextView {
                 return []
             }
             return ranges
+        }
+
+        private struct OrderedRangeIndex {
+            private var slots: [NSRange?] = []
+            private var positionsByRange: [NSRange: Int] = [:]
+            private var cachedRanges: [NSRange] = []
+            private var isCacheValid = true
+            private var liveCount = 0
+
+            var ranges: [NSRange] {
+                mutating get {
+                    if !isCacheValid {
+                        rebuildCache()
+                    }
+                    return cachedRanges
+                }
+            }
+
+            var isEmpty: Bool {
+                liveCount == 0
+            }
+
+            func contains(_ range: NSRange) -> Bool {
+                positionsByRange[range] != nil
+            }
+
+            mutating func append(_ range: NSRange) {
+                guard positionsByRange[range] == nil else {
+                    return
+                }
+                positionsByRange[range] = slots.count
+                slots.append(range)
+                liveCount += 1
+                if isCacheValid {
+                    cachedRanges.append(range)
+                }
+            }
+
+            @discardableResult
+            mutating func remove(_ range: NSRange) -> Bool {
+                guard let position = positionsByRange.removeValue(forKey: range) else {
+                    return false
+                }
+
+                slots[position] = nil
+                liveCount -= 1
+                isCacheValid = false
+                compactIfNeeded()
+                return true
+            }
+
+            mutating func removeAll() {
+                slots.removeAll()
+                positionsByRange.removeAll()
+                cachedRanges.removeAll()
+                isCacheValid = true
+                liveCount = 0
+            }
+
+            private mutating func rebuildCache() {
+                var ranges: [NSRange] = []
+                ranges.reserveCapacity(liveCount)
+                for case let range? in slots {
+                    ranges.append(range)
+                }
+                cachedRanges = ranges
+                isCacheValid = true
+            }
+
+            private mutating func compactIfNeeded() {
+                guard slots.count > 64, liveCount * 2 < slots.count else {
+                    return
+                }
+
+                var compactedSlots: [NSRange?] = []
+                compactedSlots.reserveCapacity(liveCount)
+                var compactedPositions: [NSRange: Int] = [:]
+                compactedPositions.reserveCapacity(liveCount)
+
+                for range in slots.compactMap(\.self) {
+                    compactedPositions[range] = compactedSlots.count
+                    compactedSlots.append(range)
+                }
+
+                slots = compactedSlots
+                positionsByRange = compactedPositions
+            }
         }
     }
 }

--- a/Tests/WebInspectorUITests/DOMTreeFindDecorationStateTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeFindDecorationStateTests.swift
@@ -1,0 +1,103 @@
+#if canImport(UIKit)
+import Testing
+import UIKit
+@testable import WebInspectorUI
+
+@MainActor
+struct DOMTreeFindDecorationStateTests {
+    @Test
+    func duplicateDecorateKeepsSingleRangeAndSkipsInvalidation() {
+        let state = DOMTreeTextView.FindDecorationState()
+        let range = NSRange(location: 4, length: 2)
+
+        #expect(state.decorate(range, style: .found) == [range])
+        #expect(state.decorate(range, style: .found).isEmpty)
+        #expect(state.foundRanges == [range])
+        #expect(state.highlightedRanges.isEmpty)
+
+        #expect(state.decorate(range, style: .highlighted) == [range])
+        #expect(state.decorate(range, style: .highlighted).isEmpty)
+        #expect(state.foundRanges.isEmpty)
+        #expect(state.highlightedRanges == [range])
+    }
+
+    @Test
+    func highlightTransitionMovesRangesBetweenDecorationsInPublishOrder() {
+        let state = DOMTreeTextView.FindDecorationState()
+        let first = NSRange(location: 1, length: 1)
+        let second = NSRange(location: 6, length: 3)
+
+        #expect(state.decorate(first, style: .found) == [first])
+        #expect(state.decorate(second, style: .found) == [second])
+        #expect(state.foundRanges == [first, second])
+
+        #expect(state.decorate(first, style: .highlighted) == [first])
+        #expect(state.foundRanges == [second])
+        #expect(state.highlightedRanges == [first])
+
+        #expect(state.decorate(first, style: .found) == [first])
+        #expect(state.foundRanges == [second, first])
+        #expect(state.highlightedRanges.isEmpty)
+    }
+
+    @Test
+    func normalDecorationRemovesExistingRangeOnly() {
+        let state = DOMTreeTextView.FindDecorationState()
+        let found = NSRange(location: 2, length: 2)
+        let highlighted = NSRange(location: 10, length: 4)
+        let missing = NSRange(location: 20, length: 1)
+
+        #expect(state.decorate(found, style: .found) == [found])
+        #expect(state.decorate(highlighted, style: .highlighted) == [highlighted])
+
+        #expect(state.decorate(missing, style: .normal).isEmpty)
+        #expect(state.foundRanges == [found])
+        #expect(state.highlightedRanges == [highlighted])
+
+        #expect(state.decorate(highlighted, style: .normal) == [highlighted])
+        #expect(state.foundRanges == [found])
+        #expect(state.highlightedRanges.isEmpty)
+
+        #expect(state.decorate(found, style: .normal) == [found])
+        #expect(state.isEmpty)
+    }
+
+    @Test
+    func clearInvalidatesPreviousRangesAndEmptiesState() {
+        let state = DOMTreeTextView.FindDecorationState()
+        let firstFound = NSRange(location: 0, length: 1)
+        let secondFound = NSRange(location: 5, length: 2)
+        let highlighted = NSRange(location: 12, length: 3)
+
+        #expect(state.decorate(firstFound, style: .found) == [firstFound])
+        #expect(state.decorate(highlighted, style: .highlighted) == [highlighted])
+        #expect(state.decorate(secondFound, style: .found) == [secondFound])
+
+        #expect(state.clear() == [firstFound, secondFound, highlighted])
+        #expect(state.isEmpty)
+        #expect(state.foundRanges.isEmpty)
+        #expect(state.highlightedRanges.isEmpty)
+        #expect(state.clear().isEmpty)
+    }
+
+    @Test
+    func batchInvalidationDefersRangesUntilOuterBatchEnds() {
+        let state = DOMTreeTextView.FindDecorationState()
+        let first = NSRange(location: 3, length: 1)
+        let second = NSRange(location: 9, length: 2)
+
+        state.beginBatch()
+        state.beginBatch()
+
+        #expect(state.decorate(first, style: .found).isEmpty)
+        #expect(state.decorate(second, style: .highlighted).isEmpty)
+        #expect(state.endBatch().isEmpty)
+        #expect(state.decorate(first, style: .highlighted).isEmpty)
+
+        #expect(state.endBatch() == [first, second, first])
+        #expect(state.endBatch().isEmpty)
+        #expect(state.foundRanges.isEmpty)
+        #expect(state.highlightedRanges == [second, first])
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Add an ordered range index inside `DOMTreeTextView.FindDecorationState` for find decoration membership and removal.
- Preserve the public `foundRanges` and `highlightedRanges` array ordering through a cached ordered range view.
- Add unit coverage for duplicate decoration, highlight transitions, normal removal, clear, and batch invalidation.

## Why

Publishing many DOM tree find hits previously checked and removed ranges by scanning arrays on the MainActor. That made large result sets quadratic as `.found` decorations were published.

## Validation

- `swift test --filter DOMTreeFindDecorationState` (build passed; SwiftPM/macOS ran 0 UIKit tests)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeFindDecorationStateTests`
- `git diff --check`
- `codex-review` findings: 0