### PR TITLE
[codex] Make DOM element style presentation state observable

### DIFF
--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import WebInspectorCore
+import Observation
 import UIKit
 
 @MainActor
@@ -14,66 +15,18 @@ package struct DOMElementStylePresentationItemIdentifier: Hashable {
 }
 
 @MainActor
-package struct DOMElementStylePresentationSnapshot {
-    package struct Section {
-        package var source: CSSStyle.Section
-        package var items: [DOMElementStylePresentationItemIdentifier]
-    }
-
-    fileprivate var sourceSections: [CSSStyle.Section]
-    private var visibleSections: [Section]
-
-    package init(
-        sourceSections: [CSSStyle.Section],
-        visibleSections: [Section]
-    ) {
-        self.sourceSections = sourceSections
-        self.visibleSections = visibleSections
-    }
-
-    package func diffableSnapshot() -> NSDiffableDataSourceSnapshot<
-        CSSStyle.Section.ID,
-        DOMElementStylePresentationItemIdentifier
-    > {
-        var snapshot = NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >()
-        for section in visibleSections {
-            snapshot.appendSections([section.source.id])
-            snapshot.appendItems(section.items, toSection: section.source.id)
-        }
-        return snapshot
-    }
-
-    package func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
-        sourceSections.first { $0.id == sectionID }
-    }
-
-    package func property(
-        for item: DOMElementStylePresentationItemIdentifier,
-        in section: CSSStyle.Section
-    ) -> CSSProperty? {
-        guard case let .property(propertyID, propertyIndex) = item.kind else {
-            return nil
-        }
-        if let propertyID {
-            return section.style.cssProperties.first { $0.id == propertyID }
-        }
-        guard section.style.cssProperties.indices.contains(propertyIndex) else {
-            return nil
-        }
-        return section.style.cssProperties[propertyIndex]
-    }
+package struct DOMElementStylePresentationSection {
+    package var id: CSSStyle.Section.ID
+    package var items: [DOMElementStylePresentationItemIdentifier]
 }
 
 @MainActor
-package struct DOMElementStyleSnapshotBuilder {
-    package static func makeSnapshot(
+package enum DOMElementStyleDiffableSnapshotBuilder {
+    package static func visibleSections(
         sections: [CSSStyle.Section],
         expandedUnusedVariableSectionIDs: Set<CSSStyle.Section.ID>
-    ) -> DOMElementStylePresentationSnapshot {
-        var visibleSections: [DOMElementStylePresentationSnapshot.Section] = []
+    ) -> [DOMElementStylePresentationSection] {
+        var visibleSections: [DOMElementStylePresentationSection] = []
         let usedCSSVariables = DOMElementStyleVariableVisibility.usedCSSVariableNames(in: sections)
 
         for section in sections where !section.style.cssProperties.isEmpty {
@@ -107,46 +60,64 @@ package struct DOMElementStyleSnapshotBuilder {
                 )
             }
             visibleSections.append(
-                DOMElementStylePresentationSnapshot.Section(
-                    source: section,
+                DOMElementStylePresentationSection(
+                    id: section.id,
                     items: items
                 )
             )
         }
 
-        return DOMElementStylePresentationSnapshot(
-            sourceSections: sections,
-            visibleSections: visibleSections
-        )
+        return visibleSections
+    }
+
+    package static func makeSnapshot(
+        visibleSections: [DOMElementStylePresentationSection]
+    ) -> NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    > {
+        var snapshot = NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >()
+        for section in visibleSections {
+            snapshot.appendSections([section.id])
+            snapshot.appendItems(section.items, toSection: section.id)
+        }
+        return snapshot
     }
 }
 
 @MainActor
-package struct DOMElementStylePresentationModel {
+@Observable
+package final class DOMElementStylePresentationState {
     package enum RenderResult {
-        case loaded(DOMElementStylePresentationSnapshot)
+        case loaded(
+            NSDiffableDataSourceSnapshot<
+                CSSStyle.Section.ID,
+                DOMElementStylePresentationItemIdentifier
+            >
+        )
         case pending
         case unavailable
     }
 
-    private var expandedUnusedVariableSectionIDs = Set<CSSStyle.Section.ID>()
-    private var displayedSnapshot: DOMElementStylePresentationSnapshot?
+    @ObservationIgnored private var expandedUnusedVariableSectionIDs = Set<CSSStyle.Section.ID>()
+    @ObservationIgnored private var displayedNodeStyles: CSSNodeStyles?
+    @ObservationIgnored private var visibleSections: [DOMElementStylePresentationSection] = []
 
-    package var snapshot: DOMElementStylePresentationSnapshot? {
-        displayedSnapshot
+    package init() {}
+
+    package var visibleSectionIDs: [CSSStyle.Section.ID] {
+        visibleSections.map(\.id)
     }
 
-    package mutating func render(_ nodeStyles: CSSNodeStyles) -> RenderResult {
+    package func render(_ nodeStyles: CSSNodeStyles) -> RenderResult {
         switch nodeStyles.phase {
         case .loaded:
-            let currentSectionIDs = Set(nodeStyles.sections.map(\.id))
-            expandedUnusedVariableSectionIDs.formIntersection(currentSectionIDs)
-            let snapshot = DOMElementStyleSnapshotBuilder.makeSnapshot(
-                sections: nodeStyles.sections,
-                expandedUnusedVariableSectionIDs: expandedUnusedVariableSectionIDs
-            )
-            displayedSnapshot = snapshot
-            return .loaded(snapshot)
+            displayedNodeStyles = nodeStyles
+            rebuildVisibleSections()
+            return .loaded(diffableSnapshot())
         case .loading, .needsRefresh:
             return renderPending()
         case .unavailable, .failed:
@@ -154,11 +125,12 @@ package struct DOMElementStylePresentationModel {
         }
     }
 
-    package mutating func render(_ phase: CSSNodeStyles.Phase) -> RenderResult {
+    package func render(_ phase: CSSNodeStyles.Phase) -> RenderResult {
         switch phase {
         case .loaded:
-            if let displayedSnapshot {
-                return .loaded(displayedSnapshot)
+            if displayedNodeStyles != nil {
+                rebuildVisibleSections()
+                return .loaded(diffableSnapshot())
             }
             return renderUnavailable()
         case .loading, .needsRefresh:
@@ -168,32 +140,79 @@ package struct DOMElementStylePresentationModel {
         }
     }
 
-    package mutating func showHiddenUnusedVariables(
+    package func showHiddenUnusedVariables(
         in sectionID: CSSStyle.Section.ID
-    ) -> DOMElementStylePresentationSnapshot? {
-        guard let displayedSnapshot else {
+    ) -> NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    >? {
+        guard let displayedNodeStyles else {
+            return nil
+        }
+        let currentSectionIDs = Set(displayedNodeStyles.sections.map(\.id))
+        expandedUnusedVariableSectionIDs.formIntersection(currentSectionIDs)
+        guard currentSectionIDs.contains(sectionID) else {
             return nil
         }
         expandedUnusedVariableSectionIDs.insert(sectionID)
-        let snapshot = DOMElementStyleSnapshotBuilder.makeSnapshot(
-            sections: displayedSnapshot.sourceSections,
-            expandedUnusedVariableSectionIDs: expandedUnusedVariableSectionIDs
-        )
-        self.displayedSnapshot = snapshot
-        return snapshot
+        rebuildVisibleSections()
+        return diffableSnapshot()
     }
 
-    private mutating func renderPending() -> RenderResult {
-        guard displayedSnapshot != nil else {
+    package func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
+        displayedNodeStyles?.sections.first { $0.id == sectionID }
+    }
+
+    package func property(
+        for item: DOMElementStylePresentationItemIdentifier,
+        in section: CSSStyle.Section
+    ) -> CSSProperty? {
+        guard case let .property(propertyID, propertyIndex) = item.kind else {
+            return nil
+        }
+        if let propertyID {
+            return section.style.cssProperties.first { $0.id == propertyID }
+        }
+        guard section.style.cssProperties.indices.contains(propertyIndex) else {
+            return nil
+        }
+        return section.style.cssProperties[propertyIndex]
+    }
+
+    private func renderPending() -> RenderResult {
+        guard displayedNodeStyles != nil else {
             return renderUnavailable()
         }
         return .pending
     }
 
-    private mutating func renderUnavailable() -> RenderResult {
+    private func renderUnavailable() -> RenderResult {
         expandedUnusedVariableSectionIDs.removeAll()
-        displayedSnapshot = nil
+        displayedNodeStyles = nil
+        visibleSections = []
         return .unavailable
+    }
+
+    private func rebuildVisibleSections() {
+        guard let displayedNodeStyles else {
+            visibleSections = []
+            return
+        }
+        let currentSectionIDs = Set(displayedNodeStyles.sections.map(\.id))
+        expandedUnusedVariableSectionIDs.formIntersection(currentSectionIDs)
+        visibleSections = DOMElementStyleDiffableSnapshotBuilder.visibleSections(
+            sections: displayedNodeStyles.sections,
+            expandedUnusedVariableSectionIDs: expandedUnusedVariableSectionIDs
+        )
+    }
+
+    private func diffableSnapshot() -> NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    > {
+        DOMElementStyleDiffableSnapshotBuilder.makeSnapshot(
+            visibleSections: visibleSections
+        )
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -9,7 +9,7 @@ package final class DOMElementViewController: UICollectionViewController {
     private var elementStylesObservation: PortableObservationTracking.Token?
     private var selectedNodeStyleObservation: PortableObservationTracking.Token?
     private var observedNodeStylesID: ObjectIdentifier?
-    private var stylePresentationModel = DOMElementStylePresentationModel()
+    private let stylePresentationState = DOMElementStylePresentationState()
 
 #if DEBUG
     private struct StyleRenderWaiter {
@@ -218,14 +218,14 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func render(_ nodeStyles: CSSNodeStyles) {
-        render(stylePresentationModel.render(nodeStyles))
+        render(stylePresentationState.render(nodeStyles))
     }
 
     private func render(_ state: CSSNodeStyles.Phase) {
-        render(stylePresentationModel.render(state))
+        render(stylePresentationState.render(state))
     }
 
-    private func render(_ result: DOMElementStylePresentationModel.RenderResult) {
+    private func render(_ result: DOMElementStylePresentationState.RenderResult) {
         switch result {
         case let .loaded(snapshot):
             renderStyles(snapshot)
@@ -258,7 +258,12 @@ package final class DOMElementViewController: UICollectionViewController {
 #endif
     }
 
-    private func renderStyles(_ snapshot: DOMElementStylePresentationSnapshot) {
+    private func renderStyles(
+        _ snapshot: NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >
+    ) {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
@@ -278,10 +283,12 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func applySnapshot(
-        _ presentationSnapshot: DOMElementStylePresentationSnapshot,
+        _ snapshot: NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >,
         animatingDifferences: Bool = false
     ) {
-        let snapshot = presentationSnapshot.diffableSnapshot()
         let currentSnapshot = dataSource.snapshot()
 #if DEBUG
         lastSnapshotAnimatedForTesting = animatingDifferences
@@ -310,18 +317,18 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
-        stylePresentationModel.snapshot?.section(for: sectionID)
+        stylePresentationState.section(for: sectionID)
     }
 
     private func property(
         for item: DOMElementStylePresentationItemIdentifier,
         in section: CSSStyle.Section
     ) -> CSSProperty? {
-        stylePresentationModel.snapshot?.property(for: item, in: section)
+        stylePresentationState.property(for: item, in: section)
     }
 
     private func showHiddenUnusedVariables(in sectionID: CSSStyle.Section.ID) {
-        guard let snapshot = stylePresentationModel.showHiddenUnusedVariables(in: sectionID) else {
+        guard let snapshot = stylePresentationState.showHiddenUnusedVariables(in: sectionID) else {
             return
         }
         applySnapshot(snapshot, animatingDifferences: true)

--- a/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
+++ b/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
@@ -1,0 +1,192 @@
+#if canImport(UIKit)
+import Testing
+import WebInspectorTransport
+import UIKit
+@testable import WebInspectorCore
+@testable import WebInspectorUI
+
+extension WebInspectorUIRenderingTests {
+@MainActor
+@Suite
+struct DOMElementStylePresentationStateTests {
+    @Test
+    func presentationStateRevealsHiddenUnusedVariablesWithTransientSnapshot() throws {
+        let state = DOMElementStylePresentationState()
+        let sections = makeStyleSections(inheritedOrdinal: 0)
+        let nodeStyles = makeNodeStyles(sections: sections)
+
+        let initialSnapshot = try loadedSnapshot(from: state.render(nodeStyles))
+        #expect(initialSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1))
+        #expect(containsVisibleProperty(named: "--unused-a", in: initialSnapshot, state: state) == false)
+
+        let inheritedSection = try #require(sections.first { $0.kind == .inheritedRule(ancestorIndex: 0) })
+        let revealedSnapshot = try #require(state.showHiddenUnusedVariables(in: inheritedSection.id))
+        #expect(revealedSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1) == false)
+        #expect(containsVisibleProperty(named: "--unused-a", in: revealedSnapshot, state: state))
+    }
+
+    @Test
+    func presentationStatePrunesExpandedUnusedVariableSectionsAfterSectionRefresh() throws {
+        let state = DOMElementStylePresentationState()
+        let oldSections = makeStyleSections(inheritedOrdinal: 0, unusedVariableName: "--unused-a")
+        let nodeStyles = makeNodeStyles(sections: oldSections)
+        _ = try loadedSnapshot(from: state.render(nodeStyles))
+
+        let oldInheritedSection = try #require(oldSections.first { $0.kind == .inheritedRule(ancestorIndex: 0) })
+        _ = try #require(state.showHiddenUnusedVariables(in: oldInheritedSection.id))
+
+        let newSections = makeStyleSections(inheritedOrdinal: 1, unusedVariableName: "--unused-b")
+        nodeStyles.sections = newSections
+        let refreshedSnapshot = try loadedSnapshot(from: state.render(nodeStyles))
+
+        #expect(state.section(for: oldInheritedSection.id) == nil)
+        #expect(refreshedSnapshot.sectionIdentifiers == state.visibleSectionIDs)
+        #expect(refreshedSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1))
+        #expect(containsVisibleProperty(named: "--unused-b", in: refreshedSnapshot, state: state) == false)
+        #expect(state.showHiddenUnusedVariables(in: oldInheritedSection.id) == nil)
+    }
+
+    private func loadedSnapshot(
+        from result: DOMElementStylePresentationState.RenderResult
+    ) throws -> NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    > {
+        guard case let .loaded(snapshot) = result else {
+            Issue.record("Expected loaded style presentation state")
+            throw TestFailure()
+        }
+        return snapshot
+    }
+
+    private func containsVisibleProperty(
+        named name: String,
+        in snapshot: NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >,
+        state: DOMElementStylePresentationState
+    ) -> Bool {
+        snapshot.itemIdentifiers.contains { item in
+            guard let section = state.section(for: item.sectionID),
+                  let property = state.property(for: item, in: section) else {
+                return false
+            }
+            return property.name == name
+        }
+    }
+
+    private func makeNodeStyles(sections: [CSSStyle.Section]) -> CSSNodeStyles {
+        let targetID = ProtocolTarget.ID("page-main")
+        let documentID = DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: .init(1)
+        )
+        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+        return CSSNodeStyles(
+            id: CSSNodeStyles.ID(
+                nodeID: nodeID,
+                targetID: targetID,
+                documentID: documentID,
+                protocolNodeID: .init(1)
+            ),
+            phase: .loaded,
+            sections: sections
+        )
+    }
+
+    private func makeStyleSections(
+        inheritedOrdinal: Int,
+        unusedVariableName: String = "--unused-a"
+    ) -> [CSSStyle.Section] {
+        let targetID = ProtocolTarget.ID("page-main")
+        let documentID = DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: .init(1)
+        )
+        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+        let styleSheetID = CSSStyleSheet.ID("styles")
+
+        let ruleStyleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
+        let inheritedStyleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: inheritedOrdinal + 1)
+
+        return [
+            CSSStyle.Section(
+                id: CSSStyle.Section.ID(nodeID: nodeID, kind: .rule, ordinal: 0),
+                kind: .rule,
+                title: "body",
+                style: CSSStyle(
+                    id: ruleStyleID,
+                    cssProperties: [
+                        property(
+                            id: CSSProperty.ID(styleID: ruleStyleID, propertyIndex: 0),
+                            name: "color",
+                            value: "var(--used)",
+                            text: "color: var(--used);"
+                        ),
+                    ]
+                ),
+                isEditable: true
+            ),
+            CSSStyle.Section(
+                id: CSSStyle.Section.ID(
+                    nodeID: nodeID,
+                    kind: .inheritedRule(ancestorIndex: inheritedOrdinal),
+                    ordinal: inheritedOrdinal
+                ),
+                kind: .inheritedRule(ancestorIndex: inheritedOrdinal),
+                title: ":root",
+                style: CSSStyle(
+                    id: inheritedStyleID,
+                    cssProperties: [
+                        property(
+                            id: CSSProperty.ID(styleID: inheritedStyleID, propertyIndex: 0),
+                            name: "--used",
+                            value: "#111",
+                            text: "--used: #111;"
+                        ),
+                        property(
+                            id: CSSProperty.ID(styleID: inheritedStyleID, propertyIndex: 1),
+                            name: unusedVariableName,
+                            value: "red",
+                            text: "\(unusedVariableName): red;"
+                        ),
+                    ]
+                ),
+                isEditable: true
+            ),
+        ]
+    }
+
+    private func property(
+        id: CSSProperty.ID,
+        name: String,
+        value: String,
+        text: String
+    ) -> CSSProperty {
+        CSSProperty(
+            id: id,
+            name: name,
+            value: value,
+            text: text,
+            status: .active,
+            isEditable: true
+        )
+    }
+}
+}
+
+private struct TestFailure: Error {}
+
+@MainActor
+private extension [DOMElementStylePresentationItemIdentifier] {
+    func containsHiddenUnusedVariables(count: Int) -> Bool {
+        contains { item in
+            guard case let .hiddenUnusedVariables(hiddenCount) = item.kind else {
+                return false
+            }
+            return hiddenCount == count
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Replace the DOM element style presentation snapshot model with an @Observable final class state owner.
- Keep diffable snapshots transient and generate them only for collection view application.
- Resolve sections and CSS properties from the current CSSNodeStyles source instead of storing copied presentation snapshots.
- Add focused tests for hidden unused CSS variable reveal and stale section pruning.

## Validation
- git diff --check origin/main...HEAD
- xcodebuild -quiet test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination platform=iOS Simulator,name=iPhone 17,OS=latest -only-testing:WebInspectorUITests/DOMElementStylePresentationStateTests
- xcodebuild -quiet test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination platform=iOS Simulator,name=iPhone 17,OS=latest -only-testing:WebInspectorUITests
- Subagent codex-review: findings 0
