### PR TITLE
[codex] Index DOM tree row lookups

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -818,7 +818,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func multiSelectedNodesInDisplayOrder() -> [DOMNode] {
-        multiSelection.selectedNodeIDsInDisplayOrder(rows: rows).compactMap { dom.node(for: $0) }
+        multiSelection.selectedNodeIDsInDisplayOrder(renderedRows: renderedRows).compactMap { dom.node(for: $0) }
     }
 
     private func scrollRowToVisible(_ row: DOMTreeTextView.Line) {
@@ -1035,7 +1035,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func localMarkupText(for nodeID: DOMNode.ID) -> String? {
-        rows.first { !$0.isClosingTag && $0.nodeID == nodeID }?.text
+        renderedRows.row(for: nodeID)?.text
     }
 
     private func uniqueNodeIDsInDisplayOrder(for nodes: [DOMNode]) -> [DOMNode.ID] {
@@ -1504,9 +1504,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func multiSelectionContentRowRects() -> [CGRect] {
-        rows.flatMap { row in
-            !row.isClosingTag && multiSelection.contains(row.nodeID) ? contentRowRects(for: row) : []
-        }
+        multiSelection.selectedRowsInDisplayOrder(renderedRows: renderedRows).flatMap(contentRowRects(for:))
     }
 
     private func hoverContentRowRects() -> [CGRect] {
@@ -2149,22 +2147,11 @@ extension DOMTreeTextView {
     }
 
     var renderedLineSnapshotsForTesting: [LineSnapshot] {
-        rows.map { row in
-            let line = row.text as NSString
-            return LineSnapshot(
-                text: row.text,
-                depth: row.depth,
-                rowIndex: row.rowIndex,
-                textRange: row.textRange,
-                markupRange: row.markupRange,
-                markupStartX: markupStartRect(for: row)?.minX ?? 0,
-                hasDisclosure: row.hasDisclosure,
-                isOpen: row.isOpen,
-                isClosingTag: row.isClosingTag,
-                tokenKinds: row.tokens.map(\.kind.rawValue),
-                tokenTexts: row.tokens.map { line.substring(with: $0.range) }
-            )
-        }
+        rows.map { lineSnapshot(for: $0) }
+    }
+
+    var multiSelectedLineSnapshotsInDisplayOrderForTesting: [LineSnapshot] {
+        multiSelection.selectedRowsInDisplayOrder(renderedRows: renderedRows).map { lineSnapshot(for: $0) }
     }
 
     func removeRowIndexForTesting(containing text: String) {
@@ -2172,6 +2159,27 @@ extension DOMTreeTextView {
             return
         }
         renderedRows.removeRowIndex(for: row.nodeID)
+    }
+
+    func localMarkupTextByNodeIDForTesting(_ nodeIDs: [DOMNode.ID]) -> [DOMNode.ID: String] {
+        localMarkupTextByNodeID(for: nodeIDs)
+    }
+
+    private func lineSnapshot(for row: DOMTreeTextView.Line) -> LineSnapshot {
+        let line = row.text as NSString
+        return LineSnapshot(
+            text: row.text,
+            depth: row.depth,
+            rowIndex: row.rowIndex,
+            textRange: row.textRange,
+            markupRange: row.markupRange,
+            markupStartX: markupStartRect(for: row)?.minX ?? 0,
+            hasDisclosure: row.hasDisclosure,
+            isOpen: row.isOpen,
+            isClosingTag: row.isClosingTag,
+            tokenKinds: row.tokens.map(\.kind.rawValue),
+            tokenTexts: row.tokens.map { line.substring(with: $0.range) }
+        )
     }
 
     var disclosureAttachmentSnapshotsForTesting: [DisclosureAttachmentSnapshot] {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextViewTypes.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextViewTypes.swift
@@ -110,6 +110,18 @@ extension DOMTreeTextView {
             return rows[rowIndex]
         }
 
+        func rowsInDisplayOrder(for nodeIDs: Set<DOMNode.ID>) -> [DOMTreeTextView.Line] {
+            var rowIndexes = IndexSet()
+            for nodeID in nodeIDs {
+                guard let rowIndex = rowIndexByNodeID[nodeID],
+                      rows.indices.contains(rowIndex) else {
+                    continue
+                }
+                rowIndexes.insert(rowIndex)
+            }
+            return rowIndexes.map { rows[$0] }
+        }
+
         func rowsBetween(_ firstNodeID: DOMNode.ID, _ secondNodeID: DOMNode.ID) -> ArraySlice<DOMTreeTextView.Line> {
             guard let firstIndex = rowIndexByNodeID[firstNodeID],
                   let secondIndex = rowIndexByNodeID[secondNodeID]
@@ -313,10 +325,12 @@ extension DOMTreeTextView {
             return false
         }
 
-        func selectedNodeIDsInDisplayOrder(rows: [DOMTreeTextView.Line]) -> [DOMNode.ID] {
-            rows.compactMap { row in
-                !row.isClosingTag && selectedNodeIDs.contains(row.nodeID) ? row.nodeID : nil
-            }
+        func selectedRowsInDisplayOrder(renderedRows: DOMTreeTextView.RenderedRows) -> [DOMTreeTextView.Line] {
+            renderedRows.rowsInDisplayOrder(for: selectedNodeIDs)
+        }
+
+        func selectedNodeIDsInDisplayOrder(renderedRows: DOMTreeTextView.RenderedRows) -> [DOMNode.ID] {
+            selectedRowsInDisplayOrder(renderedRows: renderedRows).map(\.nodeID)
         }
 
         private func anchorNodeID(

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -269,6 +269,45 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func localMarkupLookupUsesIndexedOpeningRow() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsForTesting()
+
+        let articleID = try #require(
+            session.snapshot().nodesByID.first { entry in
+                entry.value.localName == "article"
+            }?.key
+        )
+
+        let markupByNodeID = view.localMarkupTextByNodeIDForTesting([articleID])
+        #expect(markupByNodeID[articleID] == "      <article>")
+        #expect(view.renderedTextForTesting.contains("</article>"))
+
+        view.removeRowIndexForTesting(containing: "<article>")
+        #expect(view.localMarkupTextByNodeIDForTesting([articleID]).isEmpty)
+    }
+
+    @Test
+    func multiSelectionDisplayOrderUsesRenderedRowIndexes() async throws {
+        let view = await makeTreeView()
+
+        view.primaryClickRowForTesting(containing: "<article", modifiers: .command)
+        view.primaryClickRowForTesting(containing: "<div id=\"start-of-content\"", modifiers: .command)
+        view.primaryClickRowForTesting(containing: "<input disabled>", modifiers: .command)
+
+        let selectedRows = view.multiSelectedLineSnapshotsInDisplayOrderForTesting
+        #expect(selectedRows.map(\.text) == [
+            "      <div id=\"start-of-content\" data-testid=\"cellInnerDiv\"></div>",
+            "      <input disabled>",
+            "      <article>…</article>",
+        ])
+        #expect(selectedRows.map(\.rowIndex) == selectedRows.map(\.rowIndex).sorted())
+    }
+
+    @Test
     func expandedDescendantMutationRerendersAfterExpansionDependencyRefresh() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)


### PR DESCRIPTION
## Summary
- Use `RenderedRows` opening-row indexes for DOM local markup lookup instead of scanning rendered rows per node.
- Route multi-selection display order and selection decoration rect collection through row-indexed rendered rows.
- Add DOM tree text view coverage for indexed local markup lookup and rowIndex-ordered multi-selection output.

## Root Cause
DOM tree context menu and multi-selection paths already operate from selected node IDs, but they were deriving row data by scanning all rendered rows. `RenderedRows` owns the opening-row index, so the lookup responsibility belongs there rather than in view-level full-row scans.

## Validation
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeTextViewTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- `codex-review` self-review: no findings