### PR TITLE
Replace HLS playback UI tests with deterministic preview tests

### DIFF
--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -454,103 +454,94 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
-    func hlsResponsePreviewUsesOriginalPlaylistURLForPlayer() async throws {
-        let network = NetworkSession()
+    func hlsResponsePreviewCoordinatorUsesOriginalPlaylistURL() throws {
         let playlistURL = "https://media.example.com/live/master.m3u8"
-        let request = try #require(
-            applyRequest(
-                to: network,
-                requestID: "1",
-                url: playlistURL,
-                responseHeaders: ["content-type": "application/vnd.apple.mpegurl"],
-                responseMimeType: "application/vnd.apple.mpegurl"
-            )
+        let body = NetworkBody(
+            role: .response,
+            kind: .binary,
+            full: """
+            #EXTM3U
+            #EXT-X-STREAM-INF:BANDWIDTH=1280000
+            media/playlist.m3u8
+            """,
+            sourceSyntaxKind: .plainText,
+            phase: .loaded
         )
-        request.applyResponseBody(
-            NetworkBody.Payload(
-                body: """
-                #EXTM3U
-                #EXT-X-STREAM-INF:BANDWIDTH=1280000
-                media/playlist.m3u8
-                """,
-                base64Encoded: false
-            )
-        )
-        let model = NetworkPanelModel(network: network)
-        model.selectRequest(request)
-        let viewController = NetworkDetailViewController(model: model)
-        let window = showInWindow(viewController)
-        defer { window.isHidden = true }
-        viewController.setModeForTesting(.preview)
+        let coordinator = NetworkMediaPreviewCoordinator()
 
-        let didRenderHLSPreview = await waitUntilRendered(in: viewController) {
-            viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.absoluteString == playlistURL
+        let action = coordinator.preparePreview(
+            for: body,
+            metadata: NetworkMediaPreviewMetadata(
+                mimeType: "application/vnd.apple.mpegurl",
+                url: playlistURL
+            )
+        ) { _ in
+            Issue.record("HLS response preview should not require body payload preparation")
         }
-        #expect(didRenderHLSPreview)
+
+        guard case .remoteMovie(let url) = action else {
+            Issue.record("Expected HLS response preview to use the remote playlist URL")
+            return
+        }
+        #expect(url.absoluteString == playlistURL)
     }
 
     @Test
-    func hlsResponsePreviewUsesPlaylistURLBeforeBodyLoads() async throws {
-        let network = NetworkSession()
+    func hlsResponsePreviewCoordinatorUsesPlaylistURLBeforeBodyLoads() throws {
         let playlistURL = "https://media.example.com/live/master.m3u8"
-        let request = try #require(
-            applyRequest(
-                to: network,
-                requestID: "1",
-                url: playlistURL,
-                responseHeaders: ["content-type": "application/vnd.apple.mpegurl"],
-                responseMimeType: "application/vnd.apple.mpegurl"
-            )
+        let body = NetworkBody(
+            role: .response,
+            kind: .binary,
+            sourceSyntaxKind: .plainText,
+            phase: .available
         )
-        let model = NetworkPanelModel(network: network)
-        model.selectRequest(request)
-        let viewController = NetworkDetailViewController(model: model)
-        let window = showInWindow(viewController)
-        defer { window.isHidden = true }
-        viewController.setModeForTesting(.preview)
+        let coordinator = NetworkMediaPreviewCoordinator()
 
-        let didRenderHLSPreview = await waitUntilRendered(in: viewController) {
-            viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.absoluteString == playlistURL
+        let action = coordinator.preparePreview(
+            for: body,
+            metadata: NetworkMediaPreviewMetadata(
+                mimeType: "application/vnd.apple.mpegurl",
+                url: playlistURL
+            )
+        ) { _ in
+            Issue.record("HLS response preview should not fetch or prepare body payloads")
         }
-        #expect(didRenderHLSPreview)
+
+        guard case .remoteMovie(let url) = action else {
+            Issue.record("Expected HLS response preview to use the remote playlist URL before the body loads")
+            return
+        }
+        #expect(url.absoluteString == playlistURL)
     }
 
     @Test
-    func hlsRequestBodyRendersSubmittedTextInsteadOfRemotePlaylist() async throws {
-        let network = NetworkSession()
-        let request = try #require(
-            applyRequest(
-                to: network,
-                requestID: "1",
-                url: "https://media.example.com/upload.m3u8",
-                postData: """
-                #EXTM3U
-                #EXT-X-VERSION:3
-                """,
-                responseHeaders: ["content-type": "application/json"],
-                responseMimeType: "application/json"
-            )
+    func hlsRequestBodyPreviewCoordinatorDoesNotUseRemotePlaylist() throws {
+        let body = NetworkBody(
+            role: .request,
+            kind: .text,
+            full: """
+            #EXTM3U
+            #EXT-X-VERSION:3
+            """,
+            sourceSyntaxKind: .plainText,
+            phase: .loaded
         )
-        let model = NetworkPanelModel(network: network)
-        model.selectRequest(request)
-        let viewController = NetworkDetailViewController(model: model)
-        let window = showInWindow(viewController)
-        defer { window.isHidden = true }
-        viewController.setModeForTesting(.preview)
+        let coordinator = NetworkMediaPreviewCoordinator()
 
-        let didRenderPreviewRoles = await waitUntilRendered(in: viewController) {
-            viewController.isPreviewRoleControlHiddenForTesting == false
+        let action = coordinator.preparePreview(
+            for: body,
+            metadata: NetworkMediaPreviewMetadata(
+                mimeType: nil,
+                url: "https://media.example.com/upload.m3u8"
+            )
+        ) { _ in
+            Issue.record("HLS request bodies should stay on the syntax preview path")
         }
-        #expect(didRenderPreviewRoles)
 
-        viewController.selectPreviewRoleForTesting(.request)
-
-        let didRenderRequestBody = await waitUntilRendered(in: viewController) {
-            viewController.currentPreviewRoleForTesting == .request
-                && viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == nil
-                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains("#EXTM3U")
+        guard case .unavailable = action else {
+            Issue.record("Expected HLS request bodies to avoid remote movie preview")
+            return
         }
-        #expect(didRenderRequestBody)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -303,6 +303,30 @@ func mediaPreviewSupportClassifiesAVIFAndExcludesSVG() {
 }
 
 @Test
+func mediaPreviewSupportClassifiesHLSPlaylists() {
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(
+        mimeType: "application/vnd.apple.mpegurl",
+        url: nil
+    ) == .hlsPlaylist)
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(
+        mimeType: "application/x-mpegurl; charset=utf-8",
+        url: nil
+    ) == .hlsPlaylist)
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(
+        mimeType: "audio/mpegurl",
+        url: nil
+    ) == .hlsPlaylist)
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(
+        mimeType: nil,
+        url: "https://media.example.com/live/master.m3u8?token=abc"
+    ) == .hlsPlaylist)
+    #expect(NetworkRequest.Display.MediaPreviewSupport.previewKind(
+        mimeType: "application/octet-stream",
+        url: "https://media.example.com/live/master.m3u8"
+    ) == .hlsPlaylist)
+}
+
+@Test
 @MainActor
 func displayProjectionCacheInvalidatesWhenResponseMIMEBecomesPreviewable() async throws {
     let network = NetworkSession()


### PR DESCRIPTION
## Summary
- Replace HLS response preview UI tests that exercised `AVPlayer(url:)` with deterministic coordinator-level assertions.
- Add explicit media preview support coverage for HLS MIME types and `.m3u8` URL inference.
- Keep request-side HLS behavior covered by asserting the coordinator does not return a remote movie preview for request bodies.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests`
- `codex-review` on uncommitted changes: no findings

## Notes
- This PR is intentionally separate from #178 and only changes tests.
