### PR TITLE
[codex] Stabilize style hydration cancellation test

### DIFF
--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -642,14 +642,23 @@ func selectedElementStyleHydrationCancellationDoesNotPublishFailure() async thro
     let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
     let bodyID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(4))
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
-    session.attachment.dom.selectNode(bodyID)
-
     let firstSentCount = await backend.sentTargetMessages().count
-    _ = try await waitForCSSRefreshMessages(backend, after: firstSentCount)
+    session.attachment.dom.selectNode(bodyID)
+    let firstMessages = try await waitForCSSRefreshMessages(
+        backend,
+        after: firstSentCount,
+        protocolNodeID: .init(4)
+    )
+    #expect(try messageParameters(firstMessages.matched.message)["nodeId"] as? Int == 4)
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.selectNode(htmlID)
-    let secondMessages = try await waitForCSSRefreshMessages(backend, after: secondSentCount)
+    let secondMessages = try await waitForCSSRefreshMessages(
+        backend,
+        after: secondSentCount,
+        protocolNodeID: .init(2)
+    )
+    #expect(try messageParameters(secondMessages.matched.message)["nodeId"] as? Int == 2)
     try await replyCSSRefresh(
         transport: transport,
         messages: secondMessages,


### PR DESCRIPTION
## Summary
- Move the first CSS refresh sent-message boundary before selecting the body node while style hydration is active.
- Filter the first and second CSS refresh waits by protocol node ID and assert body/html node IDs explicitly.

## Root Cause
`selectedElementStyleHydrationCancellationDoesNotPublishFailure()` sampled `sentTargetMessages()` after `selectNode(bodyID)`, but selection can synchronously start style hydration. When that happened, the test skipped the actual body refresh messages and waited for a non-existent next refresh until timeout.

## Validation
- `git diff --check origin/main...HEAD`
- `xcodebuild -quiet test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorCoreTests/selectedElementStyleHydrationCancellationDoesNotPublishFailure` (passed on latest `origin/main`; also passed 3 successful runs before rebase, with one intermediate simulator bootstrap failure rerun cleanly)
- `codex-review --base origin/main`: findings 0
