### PR TITLE
Stabilize DOM tree render waits after observation delivery

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -97,6 +97,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     weak var inputDelegate: UITextInputDelegate?
 #if DEBUG
     private let performanceCounters = DOMTreeTextView.PerformanceCounters()
+    private var renderedRowsAppliedTreeRevisionForTestingStorage: UInt64 = 0
+    private var renderedRowsAppliedTreeRevisionWaitersForTesting: [UInt64: RenderedRowsAppliedTreeRevisionWaiter] = [:]
+    private var nextRenderedRowsAppliedTreeRevisionWaiterIDForTesting: UInt64 = 0
 #endif
 
     private var textStorage: NSTextStorage {
@@ -127,6 +130,14 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             }
         }
     }
+
+#if DEBUG
+    private struct RenderedRowsAppliedTreeRevisionWaiter {
+        var minimumRevision: UInt64
+        var continuation: CheckedContinuation<Bool, Never>
+        var timeoutTask: Task<Void, Never>
+    }
+#endif
 
     init(
         dom: DOMSession,
@@ -166,6 +177,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         renderedRowsBuildCoordinator.cancel()
         documentObservation?.cancel()
         selectionObservation?.cancel()
+#if DEBUG
+        cancelRenderedRowsAppliedTreeRevisionWaitersForTesting()
+#endif
     }
 
     override var canBecomeFirstResponder: Bool {
@@ -641,6 +655,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         updateTextLayoutGeometry()
         updateContentDecorations()
         setNeedsLayout()
+#if DEBUG
+        recordRenderedRowsAppliedTreeRevisionForTesting(dom.treeRevision)
+#endif
     }
 
     private func resetLocalDocumentStateIfNeeded() {
@@ -2230,8 +2247,66 @@ extension DOMTreeTextView {
         performanceCounters.resetTextFragmentViewsCallCount
     }
 
+    var renderedRowsAppliedTreeRevisionForTesting: UInt64 {
+        renderedRowsAppliedTreeRevisionForTestingStorage
+    }
+
     func resetPerformanceCountersForTesting() {
         performanceCounters.reset()
+    }
+
+    func waitForRenderedRowsAppliedTreeRevisionForTesting(
+        _ minimumRevision: UInt64,
+        timeout: Duration = .seconds(1)
+    ) async -> Bool {
+        if renderedRowsAppliedTreeRevisionForTestingStorage >= minimumRevision {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            let waiterID = nextRenderedRowsAppliedTreeRevisionWaiterIDForTesting
+            nextRenderedRowsAppliedTreeRevisionWaiterIDForTesting &+= 1
+            let timeoutTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: timeout)
+                self?.resolveRenderedRowsAppliedTreeRevisionWaiterForTesting(
+                    id: waiterID,
+                    result: false
+                )
+            }
+            renderedRowsAppliedTreeRevisionWaitersForTesting[waiterID] = RenderedRowsAppliedTreeRevisionWaiter(
+                minimumRevision: minimumRevision,
+                continuation: continuation,
+                timeoutTask: timeoutTask
+            )
+        }
+    }
+
+    private func recordRenderedRowsAppliedTreeRevisionForTesting(_ revision: UInt64) {
+        renderedRowsAppliedTreeRevisionForTestingStorage = revision
+        let completedWaiterIDs = renderedRowsAppliedTreeRevisionWaitersForTesting.compactMap { id, waiter in
+            waiter.minimumRevision <= revision ? id : nil
+        }
+        for waiterID in completedWaiterIDs {
+            resolveRenderedRowsAppliedTreeRevisionWaiterForTesting(id: waiterID, result: true)
+        }
+    }
+
+    private func resolveRenderedRowsAppliedTreeRevisionWaiterForTesting(
+        id: UInt64,
+        result: Bool
+    ) {
+        guard let waiter = renderedRowsAppliedTreeRevisionWaitersForTesting.removeValue(forKey: id) else {
+            return
+        }
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(returning: result)
+    }
+
+    private func cancelRenderedRowsAppliedTreeRevisionWaitersForTesting() {
+        let waiterIDs = Array(renderedRowsAppliedTreeRevisionWaitersForTesting.keys)
+        for waiterID in waiterIDs {
+            resolveRenderedRowsAppliedTreeRevisionWaiterForTesting(id: waiterID, result: false)
+        }
     }
 
     var findFoundRangesForTesting: [NSRange] {

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import ObservationBridge
 import Testing
 import WebInspectorTransport
 import UIKit
@@ -313,7 +314,6 @@ struct DOMTreeTextViewTests {
         let view = await makeTreeView(session: session)
 
         view.toggleRowForTesting(containing: "<article")
-        await Task.yield()
         await view.waitForRenderedRowsForTesting()
         #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
 
@@ -325,9 +325,17 @@ struct DOMTreeTextViewTests {
             }?.key
         )
 
-        session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
-        await Task.yield()
-        await view.waitForRenderedRowsForTesting()
+        let didRenderAttribute = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
+            },
+            until: {
+                view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>")
+            }
+        )
+        #expect(didRenderAttribute)
         #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>"))
     }
 
@@ -482,23 +490,32 @@ struct DOMTreeTextViewTests {
         let view = await makeTreeView(session: session)
 
         view.toggleRowForTesting(containing: "<article")
-        await Task.yield()
         await view.waitForRenderedRowsForTesting()
         #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
 
         let targetID = ProtocolTarget.ID("page-main")
-        session.reset()
-        session.applyTargetCreated(
-            ProtocolTarget.Record(
-                id: targetID,
-                kind: .page,
-                frameID: DOMFrame.ID("main-frame")
-            ),
-            makeCurrentMainPage: true
+        let didRenderResetDocument = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.reset()
+                session.applyTargetCreated(
+                    ProtocolTarget.Record(
+                        id: targetID,
+                        kind: .page,
+                        frameID: DOMFrame.ID("main-frame")
+                    ),
+                    makeCurrentMainPage: true
+                )
+                _ = session.replaceDocumentRoot(documentNode(), targetID: targetID)
+            },
+            until: {
+                let text = view.renderedTextForTesting
+                return text.contains("<article>…</article>")
+                    && !text.contains("<span id=\"nested-child\"></span>")
+            }
         )
-        _ = session.replaceDocumentRoot(documentNode(), targetID: targetID)
-        await Task.yield()
-        await view.waitForRenderedRowsForTesting()
+        #expect(didRenderResetDocument)
 
         #expect(view.renderedTextForTesting.contains("<article>…</article>"))
         #expect(!view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
@@ -552,10 +569,16 @@ struct DOMTreeTextViewTests {
                 selectedRowCount: view.selectedRowRectsForTesting().count
             )
         }
-        fixture.session.selectNode(fixture.selectedNodeID)
-        await Task.yield()
-        await view.waitForRenderedRowsForTesting()
-        let didRenderSelection = sampleRenderedState().hasProjectedFrameSelection
+        let didRenderSelection = await waitForRenderedSelectionTreeUpdate(
+            in: view,
+            session: fixture.session,
+            update: {
+                fixture.session.selectNode(fixture.selectedNodeID)
+            },
+            until: {
+                sampleRenderedState().hasProjectedFrameSelection
+            }
+        )
 
         let projection = fixture.session.treeProjection(rootTargetID: fixture.pageTargetID)
         #expect(fixture.session.snapshot().nodesByID[fixture.frameRootID]?.parentID == nil)
@@ -707,6 +730,94 @@ private func makeTreeView(session: DOMSession) async -> DOMTreeTextView {
     view.layoutIfNeeded()
     await view.waitForRenderedRowsForTesting()
     return view
+}
+
+@MainActor
+private func waitForRenderedDocumentTreeUpdate(
+    in view: DOMTreeTextView,
+    session: DOMSession,
+    timeout: Duration = .seconds(1),
+    update: @MainActor () -> Void,
+    until condition: @escaping @MainActor @Sendable () -> Bool
+) async -> Bool {
+    await waitForRenderedTreeUpdate(
+        in: view,
+        observing: view.documentObservationDeliveryForTesting,
+        revision: { session.treeRevision },
+        timeout: timeout,
+        update: update,
+        until: condition
+    )
+}
+
+@MainActor
+private func waitForRenderedSelectionTreeUpdate(
+    in view: DOMTreeTextView,
+    session: DOMSession,
+    timeout: Duration = .seconds(1),
+    update: @MainActor () -> Void,
+    until condition: @escaping @MainActor @Sendable () -> Bool
+) async -> Bool {
+    await waitForRenderedTreeUpdate(
+        in: view,
+        observing: view.selectionObservationDeliveryForTesting,
+        revision: { session.selectionRevision },
+        timeout: timeout,
+        update: update,
+        until: condition
+    )
+}
+
+@MainActor
+private func waitForRenderedTreeUpdate(
+    in view: DOMTreeTextView,
+    observing observation: PortableObservationTracking.Token,
+    revision: @escaping @MainActor @Sendable () -> UInt64,
+    timeout: Duration,
+    update: @MainActor () -> Void,
+    until condition: @escaping @MainActor @Sendable () -> Bool
+) async -> Bool {
+    let observedRevisions = await observation.values {
+        revision()
+    }
+    defer {
+        observedRevisions.cancel()
+    }
+
+    update()
+    return await waitForRenderedTreeUpdate(
+        in: view,
+        observedRevisions: observedRevisions,
+        expectedRevision: revision(),
+        timeout: timeout,
+        until: condition
+    )
+}
+
+@MainActor
+private func waitForRenderedTreeUpdate(
+    in view: DOMTreeTextView,
+    observedRevisions: ObservedValues<UInt64>,
+    expectedRevision: UInt64,
+    timeout: Duration,
+    until condition: @escaping @MainActor @Sendable () -> Bool
+) async -> Bool {
+    let didAlreadyObserveRevision = observedRevisions.latestValue.map { $0 >= expectedRevision } ?? false
+    let didObserveRevision: Bool
+    if didAlreadyObserveRevision {
+        didObserveRevision = true
+    } else {
+        didObserveRevision = await observedRevisions.waitUntil(timeout: timeout) { $0 >= expectedRevision } != nil
+    }
+    guard didObserveRevision else {
+        await view.waitForRenderedRowsForTesting()
+        view.layoutIfNeeded()
+        return condition()
+    }
+
+    await view.waitForRenderedRowsForTesting()
+    view.layoutIfNeeded()
+    return condition()
 }
 
 @MainActor

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -569,7 +569,7 @@ struct DOMTreeTextViewTests {
                 selectedRowCount: view.selectedRowRectsForTesting().count
             )
         }
-        let didRenderSelection = await waitForRenderedSelectionTreeUpdate(
+        let didRenderSelection = await waitForSelectionObservationRender(
             in: view,
             session: fixture.session,
             update: {
@@ -740,79 +740,44 @@ private func waitForRenderedDocumentTreeUpdate(
     update: @MainActor () -> Void,
     until condition: @escaping @MainActor @Sendable () -> Bool
 ) async -> Bool {
-    await waitForRenderedTreeUpdate(
-        in: view,
-        observing: view.documentObservationDeliveryForTesting,
-        revision: { session.treeRevision },
-        timeout: timeout,
-        update: update,
-        until: condition
+    update()
+    let expectedTreeRevision = session.treeRevision
+    let didApplyTreeRevision = await view.waitForRenderedRowsAppliedTreeRevisionForTesting(
+        expectedTreeRevision,
+        timeout: timeout
     )
+    view.layoutIfNeeded()
+    return didApplyTreeRevision && condition()
 }
 
 @MainActor
-private func waitForRenderedSelectionTreeUpdate(
+private func waitForSelectionObservationRender(
     in view: DOMTreeTextView,
     session: DOMSession,
     timeout: Duration = .seconds(1),
     update: @MainActor () -> Void,
     until condition: @escaping @MainActor @Sendable () -> Bool
 ) async -> Bool {
-    await waitForRenderedTreeUpdate(
-        in: view,
-        observing: view.selectionObservationDeliveryForTesting,
-        revision: { session.selectionRevision },
-        timeout: timeout,
-        update: update,
-        until: condition
-    )
-}
-
-@MainActor
-private func waitForRenderedTreeUpdate(
-    in view: DOMTreeTextView,
-    observing observation: PortableObservationTracking.Token,
-    revision: @escaping @MainActor @Sendable () -> UInt64,
-    timeout: Duration,
-    update: @MainActor () -> Void,
-    until condition: @escaping @MainActor @Sendable () -> Bool
-) async -> Bool {
-    let observedRevisions = await observation.values {
-        revision()
+    let observedSelectionRevisions = await view.selectionObservationDeliveryForTesting.values {
+        session.selectionRevision
     }
     defer {
-        observedRevisions.cancel()
+        observedSelectionRevisions.cancel()
     }
 
     update()
-    return await waitForRenderedTreeUpdate(
-        in: view,
-        observedRevisions: observedRevisions,
-        expectedRevision: revision(),
-        timeout: timeout,
-        until: condition
-    )
-}
-
-@MainActor
-private func waitForRenderedTreeUpdate(
-    in view: DOMTreeTextView,
-    observedRevisions: ObservedValues<UInt64>,
-    expectedRevision: UInt64,
-    timeout: Duration,
-    until condition: @escaping @MainActor @Sendable () -> Bool
-) async -> Bool {
-    let didAlreadyObserveRevision = observedRevisions.latestValue.map { $0 >= expectedRevision } ?? false
-    let didObserveRevision: Bool
-    if didAlreadyObserveRevision {
-        didObserveRevision = true
-    } else {
-        didObserveRevision = await observedRevisions.waitUntil(timeout: timeout) { $0 >= expectedRevision } != nil
-    }
-    guard didObserveRevision else {
-        await view.waitForRenderedRowsForTesting()
-        view.layoutIfNeeded()
-        return condition()
+    let expectedSelectionRevision = session.selectionRevision
+    let didAlreadyObserveRevision = observedSelectionRevisions.latestValue.map {
+        $0 >= expectedSelectionRevision
+    } ?? false
+    if !didAlreadyObserveRevision {
+        let didObserveSelectionRevision = await observedSelectionRevisions.waitUntil(timeout: timeout) {
+            $0 >= expectedSelectionRevision
+        } != nil
+        guard didObserveSelectionRevision else {
+            view.layoutIfNeeded()
+            return condition()
+        }
     }
 
     await view.waitForRenderedRowsForTesting()


### PR DESCRIPTION
## Purpose

Fix the CI race from run 27682371449 / job 81872759697 where `DOMTreeTextViewTests.documentResetClearsLocalExpansionStateEvenWhenNodeIDsRepeat()` could assert before the view had actually applied the replacement-document render.

CI failure: https://github.com/lynnswap/WebInspectorKit/actions/runs/27682371449/job/81872759697

## Changes

- Added a DEBUG-only `DOMTreeTextView` testing signal for the latest applied rendered-row tree revision, plus an async waiter for tests.
- Updated document-mutation test waits to wait for the view-owned applied tree revision before checking rendered text.
- Kept selection-only synchronization separate from applied tree revision; it still waits on selection observation delivery and then rendered-row completion where that test opens ancestors.
- Removed `Task.yield()` plus rendered-row wait usage from the DOM mutation wait paths covered by this PR.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' '-only-testing:WebInspectorUITests/DOMTreeTextViewTests/documentResetClearsLocalExpansionStateEvenWhenNodeIDsRepeat()'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' '-only-testing:WebInspectorUITests/DOMTreeTextViewTests'`
- `codex-review` reported 0 findings after the initial patch and again after the applied-revision follow-up.