### PR TITLE
Make media preview player tests deterministic

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -12,6 +12,8 @@ extension NetworkBodyViewController {
 
 @MainActor
 final class NetworkBodyViewController: UIViewController {
+    typealias MoviePreviewPlayerFactory = @MainActor (URL) -> AVPlayer
+
     private let syntaxModel = SyntaxEditorModel(
         text: "",
         language: .json,
@@ -51,6 +53,8 @@ final class NetworkBodyViewController: UIViewController {
     private var metadata: NetworkBodyViewController.PreviewMetadata?
     private var hasDisplayedBody = false
     private var mediaPlayerViewController: AVPlayerViewController?
+    private var mediaPlayerURL: URL?
+    private var moviePreviewPlayerFactory: MoviePreviewPlayerFactory
     private var mediaPreviewCoordinator = NetworkMediaPreviewCoordinator()
     private let previewRenderState = NetworkBodyPreviewRenderState()
     private var imageWidthConstraint: NSLayoutConstraint?
@@ -62,8 +66,14 @@ final class NetworkBodyViewController: UIViewController {
     private var previewRenderObservationDelivery: PortableObservationTracking.Token?
 #endif
 
-    init(scrollEdgeSink: (any NetworkBodyScrollEdgeSink)? = nil) {
+    init(
+        scrollEdgeSink: (any NetworkBodyScrollEdgeSink)? = nil,
+        moviePreviewPlayerFactory: @escaping MoviePreviewPlayerFactory = { url in
+            AVPlayer(url: url)
+        }
+    ) {
         self.scrollEdgeSink = scrollEdgeSink
+        self.moviePreviewPlayerFactory = moviePreviewPlayerFactory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -384,10 +394,11 @@ final class NetworkBodyViewController: UIViewController {
             playerViewController.didMove(toParent: self)
             mediaPlayerViewController = playerViewController
         }
-        if currentMediaURL(in: playerViewController) == url {
+        if mediaPlayerURL == url {
             return
         }
-        playerViewController.player = AVPlayer(url: url)
+        playerViewController.player = moviePreviewPlayerFactory(url)
+        mediaPlayerURL = url
         previewRenderState.showMovie(url)
     }
 
@@ -480,6 +491,7 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func removeMediaPlayerViewController() {
+        mediaPlayerURL = nil
         guard let mediaPlayerViewController else {
             return
         }
@@ -488,10 +500,6 @@ final class NetworkBodyViewController: UIViewController {
         mediaPlayerViewController.removeFromParent()
         mediaPlayerViewController.player = nil
         self.mediaPlayerViewController = nil
-    }
-
-    private func currentMediaURL(in playerViewController: AVPlayerViewController) -> URL? {
-        (playerViewController.player?.currentItem?.asset as? AVURLAsset)?.url
     }
 }
 
@@ -638,10 +646,10 @@ extension NetworkBodyViewController {
 
     var mediaPlayerURLForTesting: URL? {
         loadViewIfNeeded()
-        guard let mediaPlayerViewController else {
+        guard mediaPlayerViewController != nil else {
             return nil
         }
-        return currentMediaURL(in: mediaPlayerViewController)
+        return mediaPlayerURL
     }
 
     var mediaPlayerIdentityForTesting: ObjectIdentifier? {
@@ -650,6 +658,12 @@ extension NetworkBodyViewController {
             return nil
         }
         return ObjectIdentifier(player)
+    }
+
+    func setMoviePreviewPlayerFactoryForTesting(
+        _ factory: @escaping MoviePreviewPlayerFactory
+    ) {
+        moviePreviewPlayerFactory = factory
     }
 
     var bodyObservationDeliveryForTesting: PortableObservationTracking.Token? {

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import AVFoundation
 import Dispatch
 import ObservationBridge
 import Synchronization
@@ -565,6 +566,10 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(network: network)
         model.selectRequest(request)
         let viewController = NetworkDetailViewController(model: model)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        viewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
@@ -574,6 +579,7 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didRenderMediaPreview)
         let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
         #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
 
         viewController.setModeForTesting(.headers)
@@ -584,6 +590,7 @@ struct NetworkDetailViewControllerTests {
                 && FileManager.default.fileExists(atPath: temporaryFileURL.path) == false
         }
         #expect(didReleaseMediaPreview)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
 
         viewController.setModeForTesting(.preview)
 
@@ -592,6 +599,8 @@ struct NetworkDetailViewControllerTests {
                 && viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
         }
         #expect(didRestoreMediaPreview)
+        #expect(playerFactory.requestedURLs.count == 2)
+        #expect(playerFactory.requestedURLs.allSatisfy { $0.pathExtension == "mp4" })
     }
 
     @Test
@@ -616,6 +625,10 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(network: network)
         model.selectRequest(request)
         let viewController = NetworkDetailViewController(model: model)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        viewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
@@ -628,6 +641,7 @@ struct NetworkDetailViewControllerTests {
         let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
         let playerIdentity = try #require(viewController.bodyViewControllerForTesting.mediaPlayerIdentityForTesting)
         let delivery = try #require(viewController.selectedRequestRenderObservationDeliveryForTesting)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
 
         network.applyDataReceived(
             targetID: request.id.targetID,
@@ -644,6 +658,7 @@ struct NetworkDetailViewControllerTests {
                 && FileManager.default.fileExists(atPath: temporaryFileURL.path)
         }
         #expect(observedValues.latestValue == true)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
     }
 
     @Test
@@ -1538,6 +1553,18 @@ struct NetworkDetailViewControllerTests {
             unblockSemaphore.signal()
         }
     }
+
+    @MainActor
+    private final class MoviePreviewPlayerFactorySpy {
+        private(set) var requestedURLs: [URL] = []
+
+        func makePlayer(for url: URL) -> AVPlayer {
+            requestedURLs.append(url)
+            return StubMoviePreviewPlayer()
+        }
+    }
+
+    private final class StubMoviePreviewPlayer: AVPlayer {}
 }
 }
 #endif


### PR DESCRIPTION
## Purpose
Make media preview UI tests deterministic by avoiding URL-backed AVPlayer construction during test media previews. This removes CI exposure to media playback/player-process runtime noise while preserving temporary-file lifecycle coverage.

## Changes
- Add an injectable movie preview player factory to `NetworkBodyViewController`, with production still using `AVPlayer(url:)`.
- Track the displayed media preview URL in the view controller instead of reading it back from `AVURLAsset`.
- Update media preview UI tests to inject a lightweight `AVPlayer` stub and assert factory reuse plus temporary-file creation/removal.

## Testing
- `git diff --check`
- XcodeBuildMCP `test_sim` with `-only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/NetworkDetailViewControllerTests` (34 passed)
- Checked the test log for `FigFilePlayer` / `FFR_Common` matches; none found.
- `codex-review` on uncommitted changes: no findings.