### PR TITLE
Make async timeout tests deterministic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -173,7 +173,8 @@ let package = Package(
             dependencies: [
                 "WebInspectorCore",
                 "WebInspectorTransport",
-                "WebInspectorUI"
+                "WebInspectorUI",
+                "WebInspectorTestSupport"
             ],
             path: "Tests/WebInspectorUITests",
             swiftSettings: strictSwiftSettings

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -27,6 +27,9 @@ package final class DOMSession {
     @ObservationIgnored let documentRequests: DOMSessionDocumentRequestController
     @ObservationIgnored let styleHydration: DOMSessionElementStyleHydrationController
     @ObservationIgnored let deleteUndoController: DOMSessionDeleteUndoController
+    @ObservationIgnored var nextScheduledHighlightOperationIDForTesting: UInt64
+    @ObservationIgnored var scheduledHighlightOperationIDsForTesting: Set<UInt64>
+    @ObservationIgnored var scheduledHighlightOperationIdleWaitersForTesting: [CheckedContinuation<Void, Never>]
 
     package init(
         targetGraph: TargetGraph = TargetGraph(),
@@ -51,6 +54,9 @@ package final class DOMSession {
         documentRequests = DOMSessionDocumentRequestController()
         styleHydration = DOMSessionElementStyleHydrationController()
         deleteUndoController = DOMSessionDeleteUndoController()
+        nextScheduledHighlightOperationIDForTesting = 0
+        scheduledHighlightOperationIDsForTesting = []
+        scheduledHighlightOperationIdleWaitersForTesting = []
     }
 
     package var currentPageTargetID: ProtocolTarget.ID? {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -27,9 +27,11 @@ package final class DOMSession {
     @ObservationIgnored let documentRequests: DOMSessionDocumentRequestController
     @ObservationIgnored let styleHydration: DOMSessionElementStyleHydrationController
     @ObservationIgnored let deleteUndoController: DOMSessionDeleteUndoController
+    #if DEBUG
     @ObservationIgnored var nextScheduledHighlightOperationIDForTesting: UInt64
     @ObservationIgnored var scheduledHighlightOperationIDsForTesting: Set<UInt64>
     @ObservationIgnored var scheduledHighlightOperationIdleWaitersForTesting: [CheckedContinuation<Void, Never>]
+    #endif
 
     package init(
         targetGraph: TargetGraph = TargetGraph(),
@@ -54,9 +56,11 @@ package final class DOMSession {
         documentRequests = DOMSessionDocumentRequestController()
         styleHydration = DOMSessionElementStyleHydrationController()
         deleteUndoController = DOMSessionDeleteUndoController()
+        #if DEBUG
         nextScheduledHighlightOperationIDForTesting = 0
         scheduledHighlightOperationIDsForTesting = []
         scheduledHighlightOperationIdleWaitersForTesting = []
+        #endif
     }
 
     package var currentPageTargetID: ProtocolTarget.ID? {

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -278,6 +278,13 @@ final class DOMSessionDocumentRequestController {
         handlesByTargetID[handle.targetID] === handle
     }
 
+    func recordCoalescedWaiter(for handle: DOMSessionDocumentRequestHandle) {
+        guard isActive(handle) else {
+            return
+        }
+        handle.recordCoalescedWaiter()
+    }
+
     func finish(_ handle: DOMSessionDocumentRequestHandle) {
         guard isActive(handle) else {
             return
@@ -302,6 +309,17 @@ final class DOMSessionDocumentRequestController {
         while let handle = activeHandle(matching: targetID) {
             await handle.wait()
         }
+    }
+
+    func waitUntilCoalescedWaiterCount(
+        targetID: ProtocolTarget.ID,
+        minimumCount: Int
+    ) async {
+        precondition(minimumCount > 0, "minimumCount must be positive")
+        guard let handle = activeHandle(for: targetID) else {
+            return
+        }
+        await handle.waitUntilCoalescedWaiterCount(minimumCount)
     }
 
     private func activeHandle(matching targetID: ProtocolTarget.ID?) -> DOMSessionDocumentRequestHandle? {
@@ -649,9 +667,16 @@ final class DOMSessionDeleteUndoOperationQueue {
 
 @MainActor
 final class DOMSessionDocumentRequestHandle {
+    private struct CoalescedWaiterContinuation {
+        var minimumCount: Int
+        var continuation: CheckedContinuation<Void, Never>
+    }
+
     let targetID: ProtocolTarget.ID
     let targetKind: ProtocolTarget.Kind?
     var task: Task<Void, Error>?
+    private var coalescedWaiterCount = 0
+    private var coalescedWaiterContinuations: [CoalescedWaiterContinuation] = []
 
     init(targetID: ProtocolTarget.ID, targetKind: ProtocolTarget.Kind?) {
         self.targetID = targetID
@@ -665,5 +690,43 @@ final class DOMSessionDocumentRequestHandle {
     func cancel() {
         task?.cancel()
         task = nil
+    }
+
+    func recordCoalescedWaiter() {
+        coalescedWaiterCount += 1
+        resumeCoalescedWaiterContinuationsIfNeeded()
+    }
+
+    func waitUntilCoalescedWaiterCount(_ minimumCount: Int) async {
+        guard coalescedWaiterCount < minimumCount else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if coalescedWaiterCount >= minimumCount {
+                continuation.resume()
+            } else {
+                coalescedWaiterContinuations.append(
+                    CoalescedWaiterContinuation(
+                        minimumCount: minimumCount,
+                        continuation: continuation
+                    )
+                )
+            }
+        }
+    }
+
+    private func resumeCoalescedWaiterContinuationsIfNeeded() {
+        let readyContinuations = coalescedWaiterContinuations.filter {
+            coalescedWaiterCount >= $0.minimumCount
+        }
+        guard !readyContinuations.isEmpty else {
+            return
+        }
+        coalescedWaiterContinuations.removeAll {
+            coalescedWaiterCount >= $0.minimumCount
+        }
+        for readyContinuation in readyContinuations {
+            readyContinuation.continuation.resume()
+        }
     }
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -278,12 +278,14 @@ final class DOMSessionDocumentRequestController {
         handlesByTargetID[handle.targetID] === handle
     }
 
+    #if DEBUG
     func recordCoalescedWaiter(for handle: DOMSessionDocumentRequestHandle) {
         guard isActive(handle) else {
             return
         }
         handle.recordCoalescedWaiter()
     }
+    #endif
 
     func finish(_ handle: DOMSessionDocumentRequestHandle) {
         guard isActive(handle) else {
@@ -311,6 +313,7 @@ final class DOMSessionDocumentRequestController {
         }
     }
 
+    #if DEBUG
     func waitUntilCoalescedWaiterCount(
         targetID: ProtocolTarget.ID,
         minimumCount: Int
@@ -321,6 +324,7 @@ final class DOMSessionDocumentRequestController {
         }
         await handle.waitUntilCoalescedWaiterCount(minimumCount)
     }
+    #endif
 
     private func activeHandle(matching targetID: ProtocolTarget.ID?) -> DOMSessionDocumentRequestHandle? {
         if let targetID {
@@ -667,16 +671,20 @@ final class DOMSessionDeleteUndoOperationQueue {
 
 @MainActor
 final class DOMSessionDocumentRequestHandle {
+    #if DEBUG
     private struct CoalescedWaiterContinuation {
         var minimumCount: Int
         var continuation: CheckedContinuation<Void, Never>
     }
+    #endif
 
     let targetID: ProtocolTarget.ID
     let targetKind: ProtocolTarget.Kind?
     var task: Task<Void, Error>?
+    #if DEBUG
     private var coalescedWaiterCount = 0
     private var coalescedWaiterContinuations: [CoalescedWaiterContinuation] = []
+    #endif
 
     init(targetID: ProtocolTarget.ID, targetKind: ProtocolTarget.Kind?) {
         self.targetID = targetID
@@ -692,6 +700,7 @@ final class DOMSessionDocumentRequestHandle {
         task = nil
     }
 
+    #if DEBUG
     func recordCoalescedWaiter() {
         coalescedWaiterCount += 1
         resumeCoalescedWaiterContinuationsIfNeeded()
@@ -729,4 +738,5 @@ final class DOMSessionDocumentRequestHandle {
             readyContinuation.continuation.resume()
         }
     }
+    #endif
 }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -53,6 +53,7 @@ extension DOMSession {
         await documentRequests.waitUntilIdle(targetID: targetID)
     }
 
+    #if DEBUG
     package func waitUntilDocumentRequestCoalescedWaiterCountForTesting(
         targetID: ProtocolTarget.ID,
         minimumCount: Int
@@ -75,6 +76,7 @@ extension DOMSession {
             }
         }
     }
+    #endif
 
     package func waitUntilSelectedStyleRefreshIdle() async {
         await styleHydration.waitUntilIdle()
@@ -302,6 +304,7 @@ extension DOMSession {
     }
 
     package func scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) {
+        #if DEBUG
         let operationID = startScheduledHighlightOperationForTesting()
         Task { @MainActor [weak self] in
             defer {
@@ -309,6 +312,11 @@ extension DOMSession {
             }
             await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
         }
+        #else
+        Task { @MainActor [weak self] in
+            await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
+        }
+        #endif
     }
 
     package func scheduleNodeHighlightHideIfCurrent(
@@ -317,6 +325,7 @@ extension DOMSession {
         nodeID: DOMNode.ID? = nil,
         owner: DOMPageHighlightOwner? = nil
     ) {
+        #if DEBUG
         let operationID = startScheduledHighlightOperationForTesting()
         Task { @MainActor [weak self] in
             defer {
@@ -329,8 +338,19 @@ extension DOMSession {
                 owner: owner
             )
         }
+        #else
+        Task { @MainActor [weak self] in
+            await self?.hideNodeHighlightIfCurrent(
+                targetID: targetID,
+                generation: generation,
+                nodeID: nodeID,
+                owner: owner
+            )
+        }
+        #endif
     }
 
+    #if DEBUG
     private func startScheduledHighlightOperationForTesting() -> UInt64 {
         nextScheduledHighlightOperationIDForTesting &+= 1
         let operationID = nextScheduledHighlightOperationIDForTesting
@@ -349,6 +369,7 @@ extension DOMSession {
             waiter.resume()
         }
     }
+    #endif
 
     package func hideNodeHighlightIfCurrent(
         targetID: ProtocolTarget.ID,
@@ -1048,7 +1069,9 @@ extension DOMSession {
         if force {
             cancelDocumentRequest(targetID: targetID, reason: "force-\(reason)")
         } else if let activeHandle = documentRequests.activeHandle(for: targetID) {
+            #if DEBUG
             documentRequests.recordCoalescedWaiter(for: activeHandle)
+            #endif
             return activeHandle
         }
         guard let intent = getDocumentIntent(targetID: targetID) else {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -53,6 +53,29 @@ extension DOMSession {
         await documentRequests.waitUntilIdle(targetID: targetID)
     }
 
+    package func waitUntilDocumentRequestCoalescedWaiterCountForTesting(
+        targetID: ProtocolTarget.ID,
+        minimumCount: Int
+    ) async {
+        await documentRequests.waitUntilCoalescedWaiterCount(
+            targetID: targetID,
+            minimumCount: minimumCount
+        )
+    }
+
+    package func waitUntilScheduledHighlightOperationsIdleForTesting() async {
+        guard !scheduledHighlightOperationIDsForTesting.isEmpty else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if scheduledHighlightOperationIDsForTesting.isEmpty {
+                continuation.resume()
+            } else {
+                scheduledHighlightOperationIdleWaitersForTesting.append(continuation)
+            }
+        }
+    }
+
     package func waitUntilSelectedStyleRefreshIdle() async {
         await styleHydration.waitUntilIdle()
     }
@@ -279,7 +302,11 @@ extension DOMSession {
     }
 
     package func scheduleSelectedNodeHighlightRestoreOrHide(preferredHideTargetID: ProtocolTarget.ID? = nil) {
+        let operationID = startScheduledHighlightOperationForTesting()
         Task { @MainActor [weak self] in
+            defer {
+                self?.finishScheduledHighlightOperationForTesting(operationID)
+            }
             await self?.restoreSelectedNodeHighlightOrHide(preferredHideTargetID: preferredHideTargetID)
         }
     }
@@ -290,13 +317,36 @@ extension DOMSession {
         nodeID: DOMNode.ID? = nil,
         owner: DOMPageHighlightOwner? = nil
     ) {
+        let operationID = startScheduledHighlightOperationForTesting()
         Task { @MainActor [weak self] in
+            defer {
+                self?.finishScheduledHighlightOperationForTesting(operationID)
+            }
             await self?.hideNodeHighlightIfCurrent(
                 targetID: targetID,
                 generation: generation,
                 nodeID: nodeID,
                 owner: owner
             )
+        }
+    }
+
+    private func startScheduledHighlightOperationForTesting() -> UInt64 {
+        nextScheduledHighlightOperationIDForTesting &+= 1
+        let operationID = nextScheduledHighlightOperationIDForTesting
+        scheduledHighlightOperationIDsForTesting.insert(operationID)
+        return operationID
+    }
+
+    private func finishScheduledHighlightOperationForTesting(_ operationID: UInt64) {
+        scheduledHighlightOperationIDsForTesting.remove(operationID)
+        guard scheduledHighlightOperationIDsForTesting.isEmpty else {
+            return
+        }
+        let waiters = scheduledHighlightOperationIdleWaitersForTesting
+        scheduledHighlightOperationIdleWaitersForTesting.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 
@@ -998,6 +1048,7 @@ extension DOMSession {
         if force {
             cancelDocumentRequest(targetID: targetID, reason: "force-\(reason)")
         } else if let activeHandle = documentRequests.activeHandle(for: targetID) {
+            documentRequests.recordCoalescedWaiter(for: activeHandle)
             return activeHandle
         }
         guard let intent = getDocumentIntent(targetID: targetID) else {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2166,6 +2166,7 @@ func ensureDOMDocumentLoadedReloadsInvalidatedPageDocument() async throws {
     #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
 }
 
+#if DEBUG
 @Test("Regression: ensureDocumentLoaded coalesces pending page document requests")
 func ensureDOMDocumentLoadedCoalescesPendingPageDocumentRequest() async throws {
     let backend = FakeTransportBackend()
@@ -2219,6 +2220,7 @@ func ensureDOMDocumentLoadedCoalescesPendingPageDocumentRequest() async throws {
     #expect(finalSnapshot.currentPageDocumentID?.localDocumentLifetimeID == .init(2))
     #expect(finalSnapshot.currentNodeIDByKey[.init(targetID: .pageMain, nodeID: .init(40))] != nil)
 }
+#endif
 
 @Test("Regression: documentUpdated reopens document request gate while previous getDocument is pending")
 func documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending() async throws {
@@ -4464,6 +4466,7 @@ func staleSelectionClearDoesNotHideNewerSameTargetHighlight() async throws {
     await newerHighlightTask.value
 }
 
+#if DEBUG
 @Test
 func selectionClearDoesNotHideNewerTransientHighlightOnSameTarget() async throws {
     let backend = FakeTransportBackend()
@@ -4519,6 +4522,7 @@ func selectionClearDoesNotHideNewerTransientHighlightOnSameTarget() async throws
     )
     await transientHighlightTask.value
 }
+#endif
 
 @Test
 func staleSelectionClearRestoresCurrentSelectionHighlight() async throws {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2194,7 +2194,10 @@ func ensureDOMDocumentLoadedCoalescesPendingPageDocumentRequest() async throws {
     let secondEnsure = Task {
         await session.attachment.dom.ensureDocumentLoaded()
     }
-    await Task.yield()
+    await session.attachment.dom.waitUntilDocumentRequestCoalescedWaiterCountForTesting(
+        targetID: documentRequest.targetIdentifier,
+        minimumCount: 1
+    )
 
     #expect(
         await backend.sentTargetMessages().dropFirst(sentCount).compactMap { try? messageMethod($0.message) } == [
@@ -4502,7 +4505,7 @@ func selectionClearDoesNotHideNewerTransientHighlightOnSameTarget() async throws
 
     let countBeforeSelectionClear = await backend.sentTargetMessages().count
     await session.attachment.dom.selectNode(nil)
-    await Task.yield()
+    await session.attachment.dom.waitUntilScheduledHighlightOperationsIdleForTesting()
 
     #expect(await backend.sentTargetMessages().count == countBeforeSelectionClear)
     #expect(await session.attachment.dom.highlightController.possibleVisibleNodeID(targetID: .pageMain) == bodyID)
@@ -6667,7 +6670,14 @@ func detachDuringConnectKeepsSessionDetached() async throws {
 @Test
 func bootstrapFailureClearsSeededModelState() async throws {
     let backend = FakeTransportBackend()
-    let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
+    let responseTimeout = ManualResponseTimeout()
+    let transport = TransportSession(
+        backend: backend,
+        responseTimeout: .milliseconds(20),
+        timeoutSleep: { duration in
+            try await responseTimeout.sleep(for: duration)
+        }
+    )
     let session = await InspectorSession(
         configuration: .init(
             responseTimeout: .milliseconds(20),
@@ -6678,8 +6688,15 @@ func bootstrapFailureClearsSeededModelState() async throws {
         #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#
     )
 
-    await #expect(throws: TransportSession.Error.replyTimeout(method: "Inspector.enable", targetID: .pageMain)) {
+    let connectTask = Task {
         try await session.connect(transport: transport)
+    }
+    _ = try await waitForTargetMessage(backend, method: "Inspector.enable")
+    await responseTimeout.waitUntilSuspended()
+    await responseTimeout.fireNext()
+
+    await #expect(throws: TransportSession.Error.replyTimeout(method: "Inspector.enable", targetID: .pageMain)) {
+        try await connectTask.value
     }
 
     #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)

--- a/Tests/WebInspectorTestSupport/ManualResponseTimeout.swift
+++ b/Tests/WebInspectorTestSupport/ManualResponseTimeout.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+package actor ManualResponseTimeout {
+    private struct SuspensionContinuation {
+        var minimumSleeps: Int
+        var continuation: CheckedContinuation<Void, Never>
+    }
+
+    private var nextSleepID: UInt64 = 0
+    private var continuations: [UInt64: CheckedContinuation<Void, Error>] = [:]
+    private var nextSuspensionID: UInt64 = 0
+    private var suspensionContinuations: [UInt64: SuspensionContinuation] = [:]
+    private var handledTimeoutCount = 0
+    private var handledTimeoutContinuation: CheckedContinuation<Void, Never>?
+
+    package init() {}
+
+    package func sleep(for _: Duration) async throws {
+        nextSleepID &+= 1
+        let sleepID = nextSleepID
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                continuations[sleepID] = continuation
+                let suspensionContinuations = popReadySuspensionContinuations()
+                for suspensionContinuation in suspensionContinuations {
+                    suspensionContinuation.resume()
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancel(sleepID)
+            }
+        }
+    }
+
+    package func fireNext() {
+        guard let sleepID = continuations.keys.sorted().first,
+              let continuation = continuations.removeValue(forKey: sleepID) else {
+            return
+        }
+        continuation.resume()
+    }
+
+    package func waitUntilSuspended(by minimumSleeps: Int = 1) async {
+        precondition(minimumSleeps > 0, "minimumSleeps must be positive")
+        guard continuations.count < minimumSleeps else {
+            return
+        }
+
+        nextSuspensionID &+= 1
+        let suspensionID = nextSuspensionID
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if continuations.count >= minimumSleeps {
+                    continuation.resume()
+                } else {
+                    suspensionContinuations[suspensionID] = SuspensionContinuation(
+                        minimumSleeps: minimumSleeps,
+                        continuation: continuation
+                    )
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancelSuspension(suspensionID)
+            }
+        }
+    }
+
+    package func recordHandledTimeout() {
+        handledTimeoutCount += 1
+        handledTimeoutContinuation?.resume()
+        handledTimeoutContinuation = nil
+    }
+
+    package func waitUntilHandledTimeout() async {
+        guard handledTimeoutCount == 0 else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if handledTimeoutCount > 0 {
+                continuation.resume()
+            } else {
+                handledTimeoutContinuation = continuation
+            }
+        }
+    }
+
+    private func cancel(_ sleepID: UInt64) {
+        guard let continuation = continuations.removeValue(forKey: sleepID) else {
+            return
+        }
+        continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelSuspension(_ suspensionID: UInt64) {
+        guard let continuation = suspensionContinuations.removeValue(forKey: suspensionID)?.continuation else {
+            return
+        }
+        continuation.resume()
+    }
+
+    private func popReadySuspensionContinuations() -> [CheckedContinuation<Void, Never>] {
+        let readyIDs = suspensionContinuations.keys.sorted().filter { id in
+            guard let suspensionContinuation = suspensionContinuations[id] else {
+                return false
+            }
+            return continuations.count >= suspensionContinuation.minimumSleeps
+        }
+        return readyIDs.compactMap { id in
+            suspensionContinuations.removeValue(forKey: id)?.continuation
+        }
+    }
+}

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -706,7 +706,14 @@ func oldProvisionalTargetMessagesAreDispatchedAfterCommitTargetEvent() async thr
 @Test
 func retargetedPendingReplyStillTimesOutAfterCommit() async throws {
     let backend = FakeTransportBackend()
-    let session = TransportSession(backend: backend, responseTimeout: .milliseconds(20))
+    let responseTimeout = ManualResponseTimeout()
+    let session = TransportSession(
+        backend: backend,
+        responseTimeout: .milliseconds(20),
+        timeoutSleep: { duration in
+            try await responseTimeout.sleep(for: duration)
+        }
+    )
     await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-provisional","type":"frame","frameId":"ad-frame","isProvisional":true}}}"#)
 
     let sendTask = Task {
@@ -715,8 +722,10 @@ func retargetedPendingReplyStillTimesOutAfterCommit() async throws {
         )
     }
     _ = try await waitForTargetMessage(backend)
+    await responseTimeout.waitUntilSuspended()
 
     await session.receiveRootMessage(#"{"method":"Target.didCommitProvisionalTarget","params":{"oldTargetId":"frame-provisional","newTargetId":"frame-committed"}}"#)
+    await responseTimeout.fireNext()
 
     await #expect(throws: TransportSession.Error.replyTimeout(method: "DOM.getDocument", targetID: .init("frame-provisional"))) {
         try await sendTask.value
@@ -1968,114 +1977,6 @@ private func waitForBackendValue<Value: Sendable>(
             throw TransportSession.Error.replyTimeout(method: "test wait", targetID: nil)
         }
         return value
-    }
-}
-
-private actor ManualResponseTimeout {
-    private var nextSleepID: UInt64 = 0
-    private var continuations: [UInt64: CheckedContinuation<Void, Error>] = [:]
-    private var nextSuspensionID: UInt64 = 0
-    private var suspensionContinuations: [UInt64: SuspensionContinuation] = [:]
-    private var handledTimeoutCount: Int = 0
-    private var handledTimeoutContinuation: CheckedContinuation<Void, Never>?
-
-    private struct SuspensionContinuation {
-        var minimumSleeps: Int
-        var continuation: CheckedContinuation<Void, Never>
-    }
-
-    func sleep(for _: Duration) async throws {
-        nextSleepID &+= 1
-        let sleepID = nextSleepID
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                continuations[sleepID] = continuation
-                let suspensionContinuations = popReadySuspensionContinuations()
-                for suspensionContinuation in suspensionContinuations {
-                    suspensionContinuation.resume()
-                }
-            }
-        } onCancel: {
-            Task {
-                await self.cancel(sleepID)
-            }
-        }
-    }
-
-    func fireNext() {
-        guard let sleepID = continuations.keys.sorted().first,
-              let continuation = continuations.removeValue(forKey: sleepID) else {
-            return
-        }
-        continuation.resume()
-    }
-
-    func waitUntilSuspended(by minimumSleeps: Int = 1) async {
-        precondition(minimumSleeps > 0, "minimumSleeps must be positive")
-        guard continuations.count < minimumSleeps else {
-            return
-        }
-
-        nextSuspensionID &+= 1
-        let suspensionID = nextSuspensionID
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                if continuations.count >= minimumSleeps {
-                    continuation.resume()
-                } else {
-                    suspensionContinuations[suspensionID] = SuspensionContinuation(
-                        minimumSleeps: minimumSleeps,
-                        continuation: continuation
-                    )
-                }
-            }
-        } onCancel: {
-            Task {
-                await self.cancelSuspension(suspensionID)
-            }
-        }
-    }
-
-    func recordHandledTimeout() {
-        handledTimeoutCount += 1
-        handledTimeoutContinuation?.resume()
-        handledTimeoutContinuation = nil
-    }
-
-    func waitUntilHandledTimeout() async {
-        guard handledTimeoutCount == 0 else {
-            return
-        }
-        await withCheckedContinuation { continuation in
-            if handledTimeoutCount > 0 {
-                continuation.resume()
-            } else {
-                handledTimeoutContinuation = continuation
-            }
-        }
-    }
-
-    private func cancel(_ sleepID: UInt64) {
-        guard let continuation = continuations.removeValue(forKey: sleepID) else {
-            return
-        }
-        continuation.resume(throwing: CancellationError())
-    }
-
-    private func cancelSuspension(_ suspensionID: UInt64) {
-        guard let continuation = suspensionContinuations.removeValue(forKey: suspensionID)?.continuation else {
-            return
-        }
-        continuation.resume()
-    }
-
-    private func popReadySuspensionContinuations() -> [CheckedContinuation<Void, Never>] {
-        let readySuspensionIDs = suspensionContinuations.compactMap { suspensionID, suspensionContinuation in
-            continuations.count >= suspensionContinuation.minimumSleeps ? suspensionID : nil
-        }
-        return readySuspensionIDs.compactMap { suspensionID in
-            suspensionContinuations.removeValue(forKey: suspensionID)?.continuation
-        }
     }
 }
 

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit)
 import ObservationBridge
 import Testing
+import WebInspectorTestSupport
 import WebInspectorTransport
 import UIKit
 @testable import WebInspectorCore
@@ -955,9 +956,22 @@ struct DOMContainerTests {
     @Test
     func testBackendTargetMessageWaiterTimesOutWhenMethodIsMissing() async throws {
         let backend = RecordingTransportBackend()
+        let timeout = ManualResponseTimeout()
 
+        let waitTask = Task {
+            try await waitForTargetMessage(
+                backend,
+                method: "DOM.getDocument",
+                timeout: .milliseconds(20),
+                timeoutSleep: { duration in
+                    try await timeout.sleep(for: duration)
+                }
+            )
+        }
+        await timeout.waitUntilSuspended()
+        await timeout.fireNext()
         await #expect(throws: TransportSession.Error.replyTimeout(method: "DOM.getDocument", targetID: nil)) {
-            try await waitForTargetMessage(backend, method: "DOM.getDocument", timeout: .milliseconds(20))
+            try await waitTask.value
         }
     }
 
@@ -1302,7 +1316,10 @@ struct DOMContainerTests {
     private func waitForTargetMessage(
         _ backend: RecordingTransportBackend,
         method: String,
-        timeout: Duration = .seconds(5)
+        timeout: Duration = .seconds(5),
+        timeoutSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+            try await Task.sleep(for: duration)
+        }
     ) async throws -> RecordedTargetMessage {
         try await withThrowingTaskGroup(of: RecordedTargetMessage.self) { group in
             defer {
@@ -1313,7 +1330,7 @@ struct DOMContainerTests {
                 try await backend.waitForTargetMessage(method: method)
             }
             group.addTask {
-                try await Task.sleep(for: timeout)
+                try await timeoutSleep(timeout)
                 throw TransportSession.Error.replyTimeout(method: method, targetID: nil)
             }
 


### PR DESCRIPTION
## Purpose
Make flaky Core/Transport timeout and negative-assert tests deterministic by replacing scheduler yields and short wall-clock timeouts with owner signals and injected timeout control.

## Changes
- Added shared `ManualResponseTimeout` test support for injected timeout sleeps.
- Added DOM request coalescing and scheduled highlight idle test hooks.
- Updated Core, Transport, and UI tests to wait on explicit owner state or manually fired timeouts instead of `Task.yield()` or 20ms wall-clock waits.

## Testing
- `git diff --check`
- `xcodebuild test` via XcodeBuildMCP, `-only-testing:WebInspectorCoreTests` on iPhone 17 Simulator: 289 passed
- `xcodebuild test` via XcodeBuildMCP, `-only-testing:WebInspectorTransportTests` on iPhone 17 Simulator: 71 passed
- `xcodebuild test` via XcodeBuildMCP, `-only-testing:WebInspectorUITests` on iPhone 17 Simulator: 130 passed

Note: `swift test --filter ...` was attempted but the macOS SwiftPM test build hit an existing `WebKit.DOMNode` vs `WebInspectorCore.DOMNode` ambiguity in `InspectorSessionTests.swift`, so validation used the repository's iOS Simulator path.