### PR TITLE
Make network projection cancellation test deterministic

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -615,6 +615,13 @@ private extension NetworkBody.SyntaxKind {
 }
 
 #if DEBUG
+struct NetworkBodyImagePreviewRenderSnapshot: Equatable {
+    var imageSize: CGSize
+    var visibleBoundsSize: CGSize
+    var minimumZoomScale: CGFloat
+    var zoomScale: CGFloat
+}
+
 extension NetworkBodyViewController {
     var syntaxViewForTesting: SyntaxEditorView {
         loadViewIfNeeded()
@@ -634,6 +641,21 @@ extension NetworkBodyViewController {
     var isImagePreviewVisibleForTesting: Bool {
         loadViewIfNeeded()
         return imageScrollView.isHidden == false && imageView.image != nil
+    }
+
+    var imagePreviewRenderSnapshotForTesting: NetworkBodyImagePreviewRenderSnapshot? {
+        loadViewIfNeeded()
+        guard case let .image(imageSize) = previewRenderState.surface,
+              let imageLayout = previewRenderState.imageLayout,
+              imageLayout.imageSize == imageSize else {
+            return nil
+        }
+        return NetworkBodyImagePreviewRenderSnapshot(
+            imageSize: imageLayout.imageSize,
+            visibleBoundsSize: imageLayout.visibleBoundsSize,
+            minimumZoomScale: imageLayout.minimumZoomScale,
+            zoomScale: imageLayout.zoomScale
+        )
     }
 
     var mediaPlayerURLForTesting: URL? {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -41,6 +41,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private var activeSearchController: UISearchController?
 #if DEBUG
     private var deinitHandlerForTesting: (@MainActor () -> Void)?
+    private var snapshotUpdateCompletionWaitersForTesting: [CheckedContinuation<Void, Never>] = []
 #endif
     private lazy var filterHostingMenu = UIHostingMenu(
         rootView: NetworkListFilterMenuView(model: model)
@@ -469,6 +470,9 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         snapshotState.finishApplying(appliedRows)
         renderSelectedRequestID(model.selectedRequestID)
         applyPendingSnapshotUpdateIfNeeded()
+#if DEBUG
+        resumeSnapshotUpdateCompletionWaitersForTesting()
+#endif
     }
 
     private func reloadDataFromModel(displayRows: [NetworkRequest.Display.Projection]? = nil) {
@@ -552,6 +556,32 @@ extension NetworkListViewController {
 
     package var selectedRequestObservationDeliveryForTesting: PortableObservationTracking.Token? {
         selectedRequestObservation
+    }
+
+    package func flushThrottledDisplayRowsReloadForTesting() async {
+        displayRowsReloadScheduler.cancel()
+        flushThrottledDisplayRowsReload()
+        await waitForSnapshotUpdateCompletionForTesting()
+    }
+
+    private func waitForSnapshotUpdateCompletionForTesting() async {
+        guard snapshotState.isApplying || pendingSnapshotUpdate != nil else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            snapshotUpdateCompletionWaitersForTesting.append(continuation)
+        }
+    }
+
+    private func resumeSnapshotUpdateCompletionWaitersForTesting() {
+        guard snapshotState.isApplying == false, pendingSnapshotUpdate == nil else {
+            return
+        }
+        let waiters = snapshotUpdateCompletionWaitersForTesting
+        snapshotUpdateCompletionWaitersForTesting.removeAll(keepingCapacity: true)
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 
     package func setDeinitHandlerForTesting(_ handler: @escaping @MainActor () -> Void) {

--- a/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUI/Network/NetworkPanelModel.swift
@@ -35,6 +35,9 @@ private final class NetworkDisplayRowsProjectionCoordinator {
     private var task: Task<Void, Never>?
     private var generation = 0
     private var lastRequestedInput: NetworkRequest.Display.RowsProjectionInput?
+#if DEBUG
+    private let testProbe = NetworkDisplayRowsProjectionTestProbe()
+#endif
 
     init(mediaPreviewClassifier: @escaping NetworkRequest.Display.MediaPreviewClassifier) {
         projector = NetworkRequest.Display.RowsProjector(mediaPreviewClassifier: mediaPreviewClassifier)
@@ -56,12 +59,18 @@ private final class NetworkDisplayRowsProjectionCoordinator {
         cancelPending()
         let generation = generation
         let projector = projector
-        task = Task { [input, generation, projector, weak self] in
+        task = Task.detached { [input, generation, projector, weak self] in
             do {
                 let rows = try await projector.rows(for: input)
+#if DEBUG
+                await self?.suspendApplyIfNeededForTesting(generation: generation)
+#endif
                 try Task.checkCancellation()
-                self?.applyIfCurrent(rows, generation: generation, apply: apply)
+                await self?.applyIfCurrent(rows, generation: generation, apply: apply)
             } catch is CancellationError {
+#if DEBUG
+                await self?.recordDiscardForTesting(generation: generation)
+#endif
                 return
             } catch {
                 return
@@ -78,9 +87,15 @@ private final class NetworkDisplayRowsProjectionCoordinator {
         let generation = generation
         do {
             let rows = try await projector.rows(for: input)
+#if DEBUG
+            await suspendApplyIfNeededForTesting(generation: generation)
+#endif
             try Task.checkCancellation()
             applyIfCurrent(rows, generation: generation, apply: apply)
         } catch is CancellationError {
+#if DEBUG
+            recordDiscardForTesting(generation: generation)
+#endif
         } catch {
         }
     }
@@ -118,6 +133,9 @@ private final class NetworkDisplayRowsProjectionCoordinator {
         generation += 1
         task?.cancel()
         task = nil
+#if DEBUG
+        testProbe.resumeSuspendedApply()
+#endif
     }
 
     private func applyIfCurrent(
@@ -126,12 +144,141 @@ private final class NetworkDisplayRowsProjectionCoordinator {
         apply: ApplyAction
     ) {
         guard generation == self.generation else {
+#if DEBUG
+            recordDiscardForTesting(generation: generation)
+#endif
             return
         }
         apply(rows)
+#if DEBUG
+        recordApplyForTesting(generation: generation)
+#endif
         task = nil
     }
+
+#if DEBUG
+    func suspendNextApplyForTesting() {
+        testProbe.suspendNextApply()
+    }
+
+    func waitForApplySuspensionForTesting() async -> Int {
+        await testProbe.waitForApplySuspension()
+    }
+
+    func waitForDiscardForTesting(generation: Int) async {
+        await testProbe.waitForDiscard(generation: generation)
+    }
+
+    func waitForApplyForTesting(after generation: Int) async -> Int {
+        await testProbe.waitForApply(after: generation)
+    }
+
+    private func suspendApplyIfNeededForTesting(generation: Int) async {
+        await testProbe.suspendApplyIfNeeded(generation: generation)
+    }
+
+    private func recordDiscardForTesting(generation: Int) {
+        testProbe.recordDiscard(generation: generation)
+    }
+
+    private func recordApplyForTesting(generation: Int) {
+        testProbe.recordApply(generation: generation)
+    }
+#endif
 }
+
+#if DEBUG
+@MainActor
+private final class NetworkDisplayRowsProjectionTestProbe {
+    private var shouldSuspendNextApply = false
+    private var suspendedApplyGeneration: Int?
+    private var suspendedApplyContinuation: CheckedContinuation<Void, Never>?
+    private var applySuspensionWaiters: [CheckedContinuation<Int, Never>] = []
+    private var discardedGenerations: Set<Int> = []
+    private var discardWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
+    private var appliedGenerations: [Int] = []
+    private var applyWaiters: [(after: Int, continuation: CheckedContinuation<Int, Never>)] = []
+
+    func suspendNextApply() {
+        shouldSuspendNextApply = true
+    }
+
+    func waitForApplySuspension() async -> Int {
+        if let suspendedApplyGeneration {
+            return suspendedApplyGeneration
+        }
+        return await withCheckedContinuation { continuation in
+            applySuspensionWaiters.append(continuation)
+        }
+    }
+
+    func waitForDiscard(generation: Int) async {
+        if discardedGenerations.contains(generation) {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            discardWaiters[generation, default: []].append(continuation)
+        }
+    }
+
+    func waitForApply(after generation: Int) async -> Int {
+        if let appliedGeneration = appliedGenerations.first(where: { $0 > generation }) {
+            return appliedGeneration
+        }
+        return await withCheckedContinuation { continuation in
+            applyWaiters.append((after: generation, continuation: continuation))
+        }
+    }
+
+    func suspendApplyIfNeeded(generation: Int) async {
+        guard shouldSuspendNextApply else {
+            return
+        }
+        shouldSuspendNextApply = false
+        await withCheckedContinuation { continuation in
+            suspendedApplyGeneration = generation
+            suspendedApplyContinuation = continuation
+            let waiters = applySuspensionWaiters
+            applySuspensionWaiters.removeAll(keepingCapacity: true)
+            for waiter in waiters {
+                waiter.resume(returning: generation)
+            }
+        }
+    }
+
+    func resumeSuspendedApply() {
+        guard let continuation = suspendedApplyContinuation else {
+            return
+        }
+        suspendedApplyContinuation = nil
+        suspendedApplyGeneration = nil
+        continuation.resume()
+    }
+
+    func recordDiscard(generation: Int) {
+        guard discardedGenerations.insert(generation).inserted else {
+            return
+        }
+        let waiters = discardWaiters.removeValue(forKey: generation) ?? []
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func recordApply(generation: Int) {
+        appliedGenerations.append(generation)
+        var unresolvedWaiters: [(after: Int, continuation: CheckedContinuation<Int, Never>)] = []
+        for waiter in applyWaiters {
+            if generation > waiter.after {
+                waiter.continuation.resume(returning: generation)
+            } else {
+                unresolvedWaiters.append(waiter)
+            }
+        }
+        applyWaiters = unresolvedWaiters
+    }
+}
+#endif
 
 @MainActor
 @Observable
@@ -284,3 +431,23 @@ package final class NetworkPanelModel {
         displayProjectionByID = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0) })
     }
 }
+
+#if DEBUG
+extension NetworkPanelModel {
+    package func suspendNextDisplayRowsProjectionApplyForTesting() {
+        displayRowsProjectionCoordinator.suspendNextApplyForTesting()
+    }
+
+    package func waitForDisplayRowsProjectionApplySuspensionForTesting() async -> Int {
+        await displayRowsProjectionCoordinator.waitForApplySuspensionForTesting()
+    }
+
+    package func waitForDisplayRowsProjectionDiscardForTesting(generation: Int) async {
+        await displayRowsProjectionCoordinator.waitForDiscardForTesting(generation: generation)
+    }
+
+    package func waitForDisplayRowsProjectionApplyForTesting(after generation: Int) async -> Int {
+        await displayRowsProjectionCoordinator.waitForApplyForTesting(after: generation)
+    }
+}
+#endif

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -3933,12 +3933,19 @@ func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
     try await beginPicker(session: session, transport: transport, backend: backend)
     let sentCountBeforeInspect = await backend.sentTargetMessages().count
 
-    await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"pending-node-object"},"hints":{}}}"#)
-    let requestNode = try await waitForTargetMessage(
-        backend,
+    let requestNodeTask = Task {
+        try await waitForTargetMessage(
+            backend,
+            method: "DOM.requestNode",
+            after: sentCountBeforeInspect
+        )
+    }
+    await backend.waitUntilTargetMessageWaiterRegistered(
         method: "DOM.requestNode",
         after: sentCountBeforeInspect
     )
+    let inspectSequence = await transport.receiveRootMessage(#"{"method":"Inspector.inspect","params":{"object":{"objectId":"pending-node-object"},"hints":{}}}"#)
+    let requestNode = try await requestNodeTask.value
     let sentCountBeforeRequestReply = await backend.sentTargetMessages().count
     await receiveTargetReply(
         transport,
@@ -3957,6 +3964,7 @@ func pendingPickerSelectionDoesNotRestorePreviousNodeHighlight() async throws {
         backend: backend,
         expectedTargetID: .pageMain
     )
+    await expectProtocolEventApplied(inspectSequence, in: session)
     await session.attachment.dom.waitUntilElementPickerIdle()
 
     let pendingSnapshot = await session.attachment.dom.snapshot()

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1,7 +1,5 @@
 #if canImport(UIKit)
-import Dispatch
 import ObservationBridge
-import Synchronization
 import Testing
 import WebInspectorTransport
 import UIKit
@@ -1250,15 +1248,12 @@ struct NetworkDetailViewControllerTests {
             responseMimeType: "video/mp4"
         ))
         let requestID = request.id
-        let classifier = BlockingMediaPreviewClassifier()
-        let model = NetworkPanelModel(network: network, mediaPreviewClassifier: classifier.classify)
+        let model = NetworkPanelModel(network: network)
         model.setResourceFilter(.media, enabled: true)
+        model.suspendNextDisplayRowsProjectionApplyForTesting()
         let listViewController = NetworkListViewController(model: model)
-        defer {
-            classifier.unblock()
-        }
 
-        #expect(await classifier.waitUntilBlocked())
+        let staleGeneration = await model.waitForDisplayRowsProjectionApplySuspensionForTesting()
 
         let window = showInWindow(listViewController)
         defer { window.isHidden = true }
@@ -1267,19 +1262,20 @@ struct NetworkDetailViewControllerTests {
         let observedSearchText = await observation.values {
             model.searchText
         }
-        let observedDisplayRequestIDs = await observation.values {
-            model.displayRequestIDs
-        }
 
         model.setSearchText("does-not-match")
         #expect(await observedSearchText.waitUntilValue("does-not-match"))
 
-        classifier.unblock()
+        await model.waitForDisplayRowsProjectionDiscardForTesting(generation: staleGeneration)
+        let appliedGeneration = await model.waitForDisplayRowsProjectionApplyForTesting(after: staleGeneration)
+        #expect(appliedGeneration > staleGeneration)
+        await listViewController.flushThrottledDisplayRowsReloadForTesting()
 
-        let staleDisplayRequestIDs = await observedDisplayRequestIDs.waitUntil(timeout: .milliseconds(250)) { ids in
-            ids == [requestID]
-        }
-        #expect(staleDisplayRequestIDs == nil)
+        let collectionView = listViewController.collectionViewForTesting
+        let renderedItemCount = collectionView.numberOfSections == 0 ? 0 : collectionView.numberOfItems(inSection: 0)
+        #expect(model.displayRequestIDs.isEmpty)
+        #expect(renderedItemCount == 0)
+        #expect(model.displayProjection(for: requestID) == nil)
     }
 
     @Test
@@ -1495,49 +1491,6 @@ struct NetworkDetailViewControllerTests {
         return bundle.localizedString(forKey: key, value: nil, table: nil)
     }
 
-    private final class BlockingMediaPreviewClassifier: @unchecked Sendable {
-        private struct State: Sendable {
-            var shouldBlockNextCall = true
-            var isBlocked = false
-        }
-
-        private let state = Mutex(State())
-        private let unblockSemaphore = DispatchSemaphore(value: 0)
-
-        func classify(
-            mimeType: String?,
-            url: String?
-        ) -> NetworkRequest.Display.MediaPreviewClassification {
-            let shouldBlock = state.withLock { state in
-                guard state.shouldBlockNextCall else {
-                    return false
-                }
-                state.shouldBlockNextCall = false
-                return true
-            }
-            if shouldBlock {
-                state.withLock { state in
-                    state.isBlocked = true
-                }
-                unblockSemaphore.wait()
-            }
-            return NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url)
-        }
-
-        func waitUntilBlocked() async -> Bool {
-            for _ in 0..<100 {
-                if state.withLock({ $0.isBlocked }) {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return false
-        }
-
-        func unblock() {
-            unblockSemaphore.signal()
-        }
-    }
 }
 }
 #endif

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -680,9 +680,21 @@ struct NetworkDetailViewControllerTests {
         let didRenderImage = await waitUntilRendered(in: viewController) {
             let bodyViewController = viewController.bodyViewControllerForTesting
             let imageScrollView = bodyViewController.imageScrollViewForTesting
+            let imageLayout = bodyViewController.imagePreviewRenderSnapshotForTesting
+            let didCompleteImageLayout = imageLayout.map { layout in
+                let fitScale = min(
+                    layout.visibleBoundsSize.width / layout.imageSize.width,
+                    layout.visibleBoundsSize.height / layout.imageSize.height
+                )
+                let expectedMinimumZoomScale = min(1, fitScale)
+                return layout.imageSize == imageSize
+                    && abs(layout.minimumZoomScale - expectedMinimumZoomScale) < 0.001
+                    && abs(layout.zoomScale - expectedMinimumZoomScale) < 0.001
+            } ?? false
             let didRenderImage = bodyViewController.isImagePreviewVisibleForTesting
                 && bodyViewController.syntaxViewForTesting.isHidden
                 && bodyViewController.imageViewForTesting.image?.size == imageSize
+                && didCompleteImageLayout
             if #available(iOS 26.0, *) {
                 return didRenderImage
                     && viewController.previewRoleScrollEdgeInteractionForTesting?.edge == .top


### PR DESCRIPTION
Purpose

Make the network list stale projection cancellation test deterministic without wall-clock polling or negative waits.

Changes

- Added DEBUG-only projection apply suspension/discard/apply signals owned by NetworkDisplayRowsProjectionCoordinator.
- Kept async projection work off the MainActor and only hop back for DEBUG probe signaling and final apply.
- Added a DEBUG-only list reload flush hook so tests can drain throttled snapshot reloads explicitly.
- Reworked NetworkDetailViewControllerTests to use generation/discard/apply signals instead of DispatchSemaphore blocking, 10ms polling, and a 250ms negative wait.

Testing

- git diff --check
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' '-only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/NetworkDetailViewControllerTests'
- codex-review: no findings