### PR TITLE
Make CSS style refresh retry deterministic

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSStyleRefreshCoordinator.swift
+++ b/Sources/WebInspectorCore/CSS/CSSStyleRefreshCoordinator.swift
@@ -7,22 +7,23 @@ extension CSSSession {
     private enum RefreshCommandResult: Sendable {
         case success(ProtocolCommand.Result)
         case failure(RefreshCommandFailure)
+    }
 
-        var failure: RefreshCommandFailure? {
-            guard case let .failure(failure) = self else {
-                return nil
-            }
-            return failure
-        }
+    private enum RefreshCommandKind: Sendable {
+        case matched
+        case inline
+        case computed
+    }
 
-        func requireSuccess() throws -> ProtocolCommand.Result {
-            switch self {
-            case let .success(result):
-                return result
-            case let .failure(failure):
-                throw failure.error
-            }
-        }
+    private struct RefreshCommandOutput: Sendable {
+        var kind: RefreshCommandKind
+        var result: RefreshCommandResult
+    }
+
+    private struct RefreshCommandResults: Sendable {
+        var matched: ProtocolCommand.Result?
+        var inline: ProtocolCommand.Result?
+        var computed: ProtocolCommand.Result?
     }
 
     private enum RefreshCommandFailure: Error, Sendable {
@@ -104,28 +105,79 @@ extension CSSSession {
     private func fetchRefreshResultsWithoutCompatibilityRetry(
         for id: CSSNodeStyles.ID
     ) async throws -> CSSSession.RefreshResults {
-        async let matched = performRefreshCommand(.getMatchedStyles(id: id))
-        async let inline = performRefreshCommand(.getInlineStyles(id: id))
-        async let computed = performRefreshCommand(.getComputedStyle(id: id))
-        let results = await (matched, inline, computed)
-        let failures = [results.0, results.1, results.2].compactMap(\.failure)
-        if failures.contains(where: \.isCancellation) {
-            throw CancellationError()
+        let results = try await collectRefreshCommandResults(for: id)
+        guard let matchedResult = results.matched,
+              let inlineResult = results.inline,
+              let computedResult = results.computed else {
+            throw InspectorSession.Error("CSS style refresh did not produce all required results.")
         }
-        if let retryFailure = failures.first(where: { shouldRetryAfterEnablingCSSAgent($0.error) }) {
-            throw retryFailure.error
-        }
-        if let failure = failures.first {
-            throw failure.error
-        }
-        let matchedResult = try results.0.requireSuccess()
-        let inlineResult = try results.1.requireSuccess()
-        let computedResult = try results.2.requireSuccess()
         return CSSSession.RefreshResults(
             matched: try protocolCommands.matchedStyles(from: matchedResult),
             inline: try protocolCommands.inlineStyles(from: inlineResult),
             computed: try protocolCommands.computedStyles(from: computedResult)
         )
+    }
+
+    private func collectRefreshCommandResults(
+        for id: CSSNodeStyles.ID
+    ) async throws -> RefreshCommandResults {
+        try await withThrowingTaskGroup(of: RefreshCommandOutput.self) { group in
+            group.addTask {
+                await RefreshCommandOutput(
+                    kind: .matched,
+                    result: self.performRefreshCommand(.getMatchedStyles(id: id))
+                )
+            }
+            group.addTask {
+                await RefreshCommandOutput(
+                    kind: .inline,
+                    result: self.performRefreshCommand(.getInlineStyles(id: id))
+                )
+            }
+            group.addTask {
+                await RefreshCommandOutput(
+                    kind: .computed,
+                    result: self.performRefreshCommand(.getComputedStyle(id: id))
+                )
+            }
+
+            var collected = RefreshCommandResults()
+            var firstNonRetryFailure: RefreshCommandFailure?
+            while let output = try await group.next() {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    throw CancellationError()
+                }
+                switch output.result {
+                case let .success(result):
+                    switch output.kind {
+                    case .matched:
+                        collected.matched = result
+                    case .inline:
+                        collected.inline = result
+                    case .computed:
+                        collected.computed = result
+                    }
+                case let .failure(failure):
+                    if failure.isCancellation {
+                        group.cancelAll()
+                        throw CancellationError()
+                    }
+                    if shouldRetryAfterEnablingCSSAgent(failure.error) {
+                        group.cancelAll()
+                        throw failure.error
+                    }
+                    if firstNonRetryFailure == nil {
+                        firstNonRetryFailure = failure
+                    }
+                }
+            }
+
+            if let firstNonRetryFailure {
+                throw firstNonRetryFailure.error
+            }
+            return collected
+        }
     }
 
     private func performRefreshCommand(_ intent: CSSCommand.Intent) async -> RefreshCommandResult {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -688,6 +688,10 @@ extension NetworkBodyViewController {
         moviePreviewPlayerFactory = factory
     }
 
+    func waitUntilMediaPreviewPreparationFinishedForTesting() async {
+        await mediaPreviewCoordinator.waitUntilPreparationFinishedForTesting()
+    }
+
     var bodyObservationDeliveryForTesting: PortableObservationTracking.Token? {
         bodyObservationDelivery
     }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
@@ -68,6 +68,14 @@ final class NetworkMediaPreviewCoordinator {
         removeCachedTemporaryFile()
     }
 
+#if DEBUG
+    func waitUntilPreparationFinishedForTesting() async {
+        while let task {
+            await task.value
+        }
+    }
+#endif
+
     private func mediaPreviewSource(
         for body: NetworkBody,
         metadata: NetworkMediaPreviewMetadata?

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -955,6 +955,7 @@ func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() asyn
         await session.attachment.dom.refreshStylesForSelectedNode()
     }
     let firstMessages = try await waitForCSSRefreshMessages(backend, after: sentCount)
+    #expect(await targetMessageMethods(backend).dropFirst(sentCount).contains("CSS.enable") == false)
     let cssEnableTask = Task {
         try await waitForTargetMessage(backend, method: "CSS.enable", after: sentCount)
     }
@@ -963,18 +964,6 @@ func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() asyn
         transport,
         targetID: firstMessages.matched.targetIdentifier,
         messageID: try messageID(firstMessages.matched.message),
-        message: "CSS agent is not enabled"
-    )
-    await receiveTargetErrorReply(
-        transport,
-        targetID: firstMessages.inline.targetIdentifier,
-        messageID: try messageID(firstMessages.inline.message),
-        message: "CSS agent is not enabled"
-    )
-    await receiveTargetErrorReply(
-        transport,
-        targetID: firstMessages.computed.targetIdentifier,
-        messageID: try messageID(firstMessages.computed.message),
         message: "CSS agent is not enabled"
     )
 
@@ -7332,7 +7321,7 @@ private func hydrateSelectedBodyStyles(
     return bodyID
 }
 
-private struct CSSRefreshMessages {
+private struct CSSRefreshMessages: Sendable {
     var matched: SentTargetMessage
     var inline: SentTargetMessage
     var computed: SentTargetMessage
@@ -7343,49 +7332,92 @@ private func waitForCSSRefreshMessages(
     after count: Int,
     protocolNodeID: DOMNode.ProtocolID? = nil
 ) async throws -> CSSRefreshMessages {
-    let matched = try await waitForTargetMessage(
-        backend,
+    try await withThrowingTaskGroup(of: CSSRefreshMessages.self) { group in
+        defer {
+            group.cancelAll()
+        }
+
+        group.addTask {
+            try await waitForCSSRefreshMessageBatch(
+                backend,
+                after: count,
+                protocolNodeID: protocolNodeID
+            )
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(5))
+            throw TransportSession.Error.replyTimeout(method: "CSS refresh messages", targetID: nil)
+        }
+
+        guard let messages = try await group.next() else {
+            throw TransportSession.Error.replyTimeout(method: "CSS refresh messages", targetID: nil)
+        }
+        return messages
+    }
+}
+
+private func waitForCSSRefreshMessageBatch(
+    _ backend: FakeTransportBackend,
+    after count: Int,
+    protocolNodeID: DOMNode.ProtocolID?
+) async throws -> CSSRefreshMessages {
+    var observedTargetMessageCount = 0
+    while true {
+        let messages = await backend.sentTargetMessages()
+        let messagesAfterCursor = Array(messages.dropFirst(count))
+        if let refreshMessages = try cssRefreshMessages(
+            in: messagesAfterCursor,
+            protocolNodeID: protocolNodeID
+        ) {
+            return refreshMessages
+        }
+
+        observedTargetMessageCount = messagesAfterCursor.count
+        _ = try await waitForBackendTargetMessage(
+            backend,
+            method: nil,
+            ordinal: observedTargetMessageCount,
+            after: count
+        )
+    }
+}
+
+private func cssRefreshMessages(
+    in messages: [SentTargetMessage],
+    protocolNodeID: DOMNode.ProtocolID?
+) throws -> CSSRefreshMessages? {
+    guard let matched = try cssRefreshMessage(
+        in: messages,
         method: "CSS.getMatchedStylesForNode",
-        after: count,
         protocolNodeID: protocolNodeID
-    )
-    let inline = try await waitForTargetMessage(
-        backend,
+    ), let inline = try cssRefreshMessage(
+        in: messages,
         method: "CSS.getInlineStylesForNode",
-        after: count,
         protocolNodeID: protocolNodeID
-    )
-    let computed = try await waitForTargetMessage(
-        backend,
+    ), let computed = try cssRefreshMessage(
+        in: messages,
         method: "CSS.getComputedStyleForNode",
-        after: count,
         protocolNodeID: protocolNodeID
-    )
+    ) else {
+        return nil
+    }
+
     return CSSRefreshMessages(matched: matched, inline: inline, computed: computed)
 }
 
-private func waitForTargetMessage(
-    _ backend: FakeTransportBackend,
+private func cssRefreshMessage(
+    in messages: [SentTargetMessage],
     method: String,
-    after count: Int,
     protocolNodeID: DOMNode.ProtocolID?
-) async throws -> SentTargetMessage {
-    guard let protocolNodeID else {
-        return try await waitForTargetMessage(backend, method: method, after: count)
-    }
-
-    var ordinal = 0
-    while true {
-        let message = try await waitForTargetMessage(
-            backend,
-            method: method,
-            ordinal: ordinal,
-            after: count
-        )
-        if try messageParameters(message.message)["nodeId"] as? Int == protocolNodeID.rawValue {
-            return message
+) throws -> SentTargetMessage? {
+    try messages.first { message in
+        guard try messageMethod(message.message) == method else {
+            return false
         }
-        ordinal += 1
+        guard let protocolNodeID else {
+            return true
+        }
+        return try messageParameters(message.message)["nodeId"] as? Int == protocolNodeID.rawValue
     }
 }
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -573,6 +573,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRenderMediaPreview = await waitUntilRendered(in: viewController) {
             viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
@@ -593,6 +594,7 @@ struct NetworkDetailViewControllerTests {
         #expect(playerFactory.requestedURLs == [temporaryFileURL])
 
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRestoreMediaPreview = await waitUntilRendered(in: viewController) {
             viewController.currentModeForTesting == .preview
@@ -632,6 +634,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRenderMediaPreview = await waitUntilRendered(in: viewController) {
             viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
@@ -693,6 +696,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRenderImage = await waitUntilRendered(in: viewController) {
             let bodyViewController = viewController.bodyViewControllerForTesting
@@ -760,6 +764,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController, makeVisible: true)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRenderImage = await waitUntilRendered(in: viewController) {
             viewController.bodyViewControllerForTesting.isImagePreviewVisibleForTesting
@@ -808,6 +813,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
 
         let didRenderImage = await waitUntilRendered(in: viewController) {
             viewController.bodyViewControllerForTesting.isImagePreviewVisibleForTesting
@@ -1447,6 +1453,13 @@ struct NetworkDetailViewControllerTests {
                 sampleRenderedCondition(in: viewController, condition: condition)
             }
         )
+    }
+
+    private func waitUntilMediaPreviewPrepared(
+        in viewController: NetworkDetailViewController
+    ) async {
+        await viewController.bodyViewControllerForTesting.waitUntilMediaPreviewPreparationFinishedForTesting()
+        viewController.view.layoutIfNeeded()
     }
 
     private func waitUntilNavigationStackSynced(


### PR DESCRIPTION
## Purpose

Fix iOS 26 CI flakes caused by nondeterministic asynchronous work in inspector refresh and media preview rendering tests.

## Changes

- Collect CSS refresh read commands with a task group so cancellation and CSS-enable-required remote errors are handled as soon as one command reports them.
- Cancel sibling CSS refresh reads before starting the compatibility `CSS.enable` retry.
- Make the CSS refresh test helper observe a batch of refresh messages from a single cursor instead of waiting for matched/inline/computed sequentially.
- Add a DEBUG-only media preview preparation waiter so UI rendering tests wait for the preview coordinator's async image/movie payload work instead of racing a 1-second render timeout.
- Update media/image preview tests to wait for preparation completion before asserting scroll/zoom layout.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:'WebInspectorCoreTests/selectedElementStyleHydrationSelectionChangeStartsReplacementRefresh()' -only-testing:'WebInspectorCoreTests/selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt()' -test-iterations 10 -run-tests-until-failure -test-repetition-relaunch-enabled NO`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:WebInspectorCoreTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:'WebInspectorUITests/WebInspectorUIRenderingTests/NetworkDetailViewControllerTests/imageResponsePreviewUsesScrollViewAndFitsLargeImage()' -test-iterations 10 -run-tests-until-failure -test-repetition-relaunch-enabled NO`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:'WebInspectorUITests/WebInspectorUIRenderingTests/NetworkDetailViewControllerTests'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -only-testing:'WebInspectorUITests/WebInspectorUIRenderingTests'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1`