### PR TITLE
[codex] Avoid DOM tree snapshots for row rendering

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeMarkup.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeMarkup.swift
@@ -121,6 +121,7 @@ private func domTreeDisplayColumnCount(for scalar: Unicode.Scalar) -> Int {
 }
 
 extension DOMTreeTextView {
+    @MainActor
     enum MarkupBuilder {
         private static let voidElementNames: Set<String> = [
             "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
@@ -132,7 +133,7 @@ extension DOMTreeTextView {
         ]
 
         static func markup(
-            for node: DOMNode.Snapshot,
+            for node: DOMNode,
             hasDisclosure: Bool,
             isOpen: Bool,
             isClosingTag: Bool,
@@ -164,7 +165,7 @@ extension DOMTreeTextView {
             }
         }
 
-        static func rendersClosingTagRow(for node: DOMNode.Snapshot) -> Bool {
+        static func rendersClosingTagRow(for node: DOMNode) -> Bool {
             guard inferredNodeType(for: node) == .element else {
                 return false
             }
@@ -174,7 +175,7 @@ extension DOMTreeTextView {
             return !voidElementNames.contains(elementName(for: node))
         }
 
-        static func canContainChildNodes(_ node: DOMNode.Snapshot) -> Bool {
+        static func canContainChildNodes(_ node: DOMNode) -> Bool {
             switch inferredNodeType(for: node) {
             case .document, .documentFragment:
                 return true
@@ -185,7 +186,7 @@ extension DOMTreeTextView {
             }
         }
 
-        private static func inferredNodeType(for node: DOMNode.Snapshot) -> DOMNode.Kind {
+        private static func inferredNodeType(for node: DOMNode) -> DOMNode.Kind {
             let name = (node.localName.isEmpty ? node.nodeName : node.localName).lowercased()
             if node.nodeType != .element || name.isEmpty {
                 return node.nodeType
@@ -211,7 +212,7 @@ extension DOMTreeTextView {
             }
         }
 
-        private static func elementMarkup(for node: DOMNode.Snapshot, hasDisclosure: Bool, isOpen: Bool) -> DOMTreeTextView.Markup {
+        private static func elementMarkup(for node: DOMNode, hasDisclosure: Bool, isOpen: Bool) -> DOMTreeTextView.Markup {
             if let pseudoType = node.pseudoType {
                 return fallbackMarkup("::\(pseudoType)")
             }
@@ -241,7 +242,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func closingElementMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func closingElementMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             let name = elementName(for: node)
             var markup = DOMTreeTextView.Markup()
             markup.append("</", kind: .punctuation)
@@ -250,7 +251,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func documentFragmentMarkup(for node: DOMNode.Snapshot, isTemplateContent: Bool) -> DOMTreeTextView.Markup {
+        private static func documentFragmentMarkup(for node: DOMNode, isTemplateContent: Bool) -> DOMTreeTextView.Markup {
             if let shadowRootType = node.shadowRootType {
                 return fallbackMarkup("Shadow Content (\(shadowRootTypeDisplayName(shadowRootType)))")
             }
@@ -287,7 +288,7 @@ extension DOMTreeTextView {
             markup.appendQuotedAttributeValue(escapedAttributeValue(attribute.value))
         }
 
-        private static func textMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func textMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             let text = escapedTextValue(normalizedValue(for: node))
             guard !text.isEmpty else {
                 return fallbackMarkup("#text")
@@ -297,7 +298,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func commentMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func commentMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<!--", kind: .punctuation)
             let text = escapedCommentValue(normalizedValue(for: node))
@@ -310,7 +311,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func documentTypeMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func documentTypeMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             let name = elementName(for: node, fallback: "html")
             markup.append("<!", kind: .punctuation)
@@ -321,7 +322,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func cdataMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func cdataMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<![CDATA[", kind: .punctuation)
             markup.append(lineSafeValue(normalizedValue(for: node)), kind: .text)
@@ -329,7 +330,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func processingInstructionMarkup(for node: DOMNode.Snapshot) -> DOMTreeTextView.Markup {
+        private static func processingInstructionMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<?", kind: .punctuation)
             markup.append(elementName(for: node, fallback: "instruction"), kind: .tagName)
@@ -352,7 +353,7 @@ extension DOMTreeTextView {
             attribute.value.isEmpty && booleanAttributeNames.contains(attribute.name.lowercased())
         }
 
-        private static func elementName(for node: DOMNode.Snapshot, fallback: String = "element") -> String {
+        private static func elementName(for node: DOMNode, fallback: String = "element") -> String {
             let rawName: String
             if !node.localName.isEmpty {
                 rawName = node.localName
@@ -365,7 +366,7 @@ extension DOMTreeTextView {
             return (name.isEmpty ? fallback : name).lowercased()
         }
 
-        private static func fallbackPreview(for node: DOMNode.Snapshot) -> String {
+        private static func fallbackPreview(for node: DOMNode) -> String {
             if !node.nodeValue.isEmpty {
                 return node.nodeValue
             }
@@ -375,7 +376,7 @@ extension DOMTreeTextView {
             return node.nodeName
         }
 
-        private static func normalizedValue(for node: DOMNode.Snapshot) -> String {
+        private static func normalizedValue(for node: DOMNode) -> String {
             let source = node.nodeValue.isEmpty ? node.nodeName : node.nodeValue
             return source
                 .split(whereSeparator: \.isWhitespace)

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeMarkup.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeMarkup.swift
@@ -121,7 +121,6 @@ private func domTreeDisplayColumnCount(for scalar: Unicode.Scalar) -> Int {
 }
 
 extension DOMTreeTextView {
-    @MainActor
     enum MarkupBuilder {
         private static let voidElementNames: Set<String> = [
             "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
@@ -133,7 +132,7 @@ extension DOMTreeTextView {
         ]
 
         static func markup(
-            for node: DOMNode,
+            for node: DOMTreeTextView.RenderedRowsBuildNode,
             hasDisclosure: Bool,
             isOpen: Bool,
             isClosingTag: Bool,
@@ -165,7 +164,7 @@ extension DOMTreeTextView {
             }
         }
 
-        static func rendersClosingTagRow(for node: DOMNode) -> Bool {
+        static func rendersClosingTagRow(for node: DOMTreeTextView.RenderedRowsBuildNode) -> Bool {
             guard inferredNodeType(for: node) == .element else {
                 return false
             }
@@ -175,7 +174,7 @@ extension DOMTreeTextView {
             return !voidElementNames.contains(elementName(for: node))
         }
 
-        static func canContainChildNodes(_ node: DOMNode) -> Bool {
+        static func canContainChildNodes(_ node: DOMTreeTextView.RenderedRowsBuildNode) -> Bool {
             switch inferredNodeType(for: node) {
             case .document, .documentFragment:
                 return true
@@ -186,7 +185,7 @@ extension DOMTreeTextView {
             }
         }
 
-        private static func inferredNodeType(for node: DOMNode) -> DOMNode.Kind {
+        private static func inferredNodeType(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMNode.Kind {
             let name = (node.localName.isEmpty ? node.nodeName : node.localName).lowercased()
             if node.nodeType != .element || name.isEmpty {
                 return node.nodeType
@@ -212,7 +211,7 @@ extension DOMTreeTextView {
             }
         }
 
-        private static func elementMarkup(for node: DOMNode, hasDisclosure: Bool, isOpen: Bool) -> DOMTreeTextView.Markup {
+        private static func elementMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode, hasDisclosure: Bool, isOpen: Bool) -> DOMTreeTextView.Markup {
             if let pseudoType = node.pseudoType {
                 return fallbackMarkup("::\(pseudoType)")
             }
@@ -242,7 +241,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func closingElementMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func closingElementMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             let name = elementName(for: node)
             var markup = DOMTreeTextView.Markup()
             markup.append("</", kind: .punctuation)
@@ -251,7 +250,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func documentFragmentMarkup(for node: DOMNode, isTemplateContent: Bool) -> DOMTreeTextView.Markup {
+        private static func documentFragmentMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode, isTemplateContent: Bool) -> DOMTreeTextView.Markup {
             if let shadowRootType = node.shadowRootType {
                 return fallbackMarkup("Shadow Content (\(shadowRootTypeDisplayName(shadowRootType)))")
             }
@@ -288,7 +287,7 @@ extension DOMTreeTextView {
             markup.appendQuotedAttributeValue(escapedAttributeValue(attribute.value))
         }
 
-        private static func textMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func textMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             let text = escapedTextValue(normalizedValue(for: node))
             guard !text.isEmpty else {
                 return fallbackMarkup("#text")
@@ -298,7 +297,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func commentMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func commentMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<!--", kind: .punctuation)
             let text = escapedCommentValue(normalizedValue(for: node))
@@ -311,7 +310,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func documentTypeMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func documentTypeMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             let name = elementName(for: node, fallback: "html")
             markup.append("<!", kind: .punctuation)
@@ -322,7 +321,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func cdataMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func cdataMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<![CDATA[", kind: .punctuation)
             markup.append(lineSafeValue(normalizedValue(for: node)), kind: .text)
@@ -330,7 +329,7 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private static func processingInstructionMarkup(for node: DOMNode) -> DOMTreeTextView.Markup {
+        private static func processingInstructionMarkup(for node: DOMTreeTextView.RenderedRowsBuildNode) -> DOMTreeTextView.Markup {
             var markup = DOMTreeTextView.Markup()
             markup.append("<?", kind: .punctuation)
             markup.append(elementName(for: node, fallback: "instruction"), kind: .tagName)
@@ -353,7 +352,7 @@ extension DOMTreeTextView {
             attribute.value.isEmpty && booleanAttributeNames.contains(attribute.name.lowercased())
         }
 
-        private static func elementName(for node: DOMNode, fallback: String = "element") -> String {
+        private static func elementName(for node: DOMTreeTextView.RenderedRowsBuildNode, fallback: String = "element") -> String {
             let rawName: String
             if !node.localName.isEmpty {
                 rawName = node.localName
@@ -366,7 +365,7 @@ extension DOMTreeTextView {
             return (name.isEmpty ? fallback : name).lowercased()
         }
 
-        private static func fallbackPreview(for node: DOMNode) -> String {
+        private static func fallbackPreview(for node: DOMTreeTextView.RenderedRowsBuildNode) -> String {
             if !node.nodeValue.isEmpty {
                 return node.nodeValue
             }
@@ -376,7 +375,7 @@ extension DOMTreeTextView {
             return node.nodeName
         }
 
-        private static func normalizedValue(for node: DOMNode) -> String {
+        private static func normalizedValue(for node: DOMTreeTextView.RenderedRowsBuildNode) -> String {
             let source = node.nodeValue.isEmpty ? node.nodeName : node.nodeValue
             return source
                 .split(whereSeparator: \.isWhitespace)

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -180,7 +180,6 @@ extension DOMTreeTextView {
             previousTextCapacity: Int
         ) -> DOMTreeTextView.RenderedRowsBuildRequest {
             DOMTreeTextView.RenderedRowsBuildRequest(
-                domSnapshot: dom.snapshot(),
                 treeRevision: dom.treeRevision,
                 expansionState: expansionState.snapshot,
                 previousRowCapacity: previousRowCapacity,
@@ -192,15 +191,7 @@ extension DOMTreeTextView {
         func build(
             _ request: DOMTreeTextView.RenderedRowsBuildRequest
         ) async throws -> DOMTreeTextView.RenderedRowsBuildResult {
-            let task = Task.detached(priority: .userInitiated) {
-                try Task.checkCancellation()
-                return try DOMTreeTextView.RenderedRowsWorker(request: request).build()
-            }
-            return try await withTaskCancellationHandler {
-                try await task.value
-            } onCancel: {
-                task.cancel()
-            }
+            try await DOMTreeTextView.RenderedRowsWorker(dom: dom, request: request).build()
         }
 
         func acceptCompletedBuild(_ result: DOMTreeTextView.RenderedRowsBuildResult) {
@@ -211,47 +202,24 @@ extension DOMTreeTextView {
 
 extension DOMTreeTextView {
     struct RenderedRowsBuildRequest: Sendable {
-        let domSnapshot: DOMSession.Snapshot
         let treeRevision: UInt64
         let expansionState: [DOMNode.ID: Bool]
         let previousRowCapacity: Int
         let previousTextCapacity: Int
         let markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
-        let frameDocumentRootIDByOwnerNodeID: [DOMNode.ID: DOMNode.ID]
 
         init(
-            domSnapshot: DOMSession.Snapshot,
             treeRevision: UInt64,
             expansionState: [DOMNode.ID: Bool],
             previousRowCapacity: Int,
             previousTextCapacity: Int,
             markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
         ) {
-            self.domSnapshot = domSnapshot
             self.treeRevision = treeRevision
             self.expansionState = expansionState
             self.previousRowCapacity = previousRowCapacity
             self.previousTextCapacity = previousTextCapacity
             self.markupCache = markupCache
-            self.frameDocumentRootIDByOwnerNodeID = Self.frameDocumentRootIDsByOwnerNodeID(
-                in: domSnapshot
-            )
-        }
-
-        private static func frameDocumentRootIDsByOwnerNodeID(
-            in snapshot: DOMSession.Snapshot
-        ) -> [DOMNode.ID: DOMNode.ID] {
-            var rootsByOwnerNodeID: [DOMNode.ID: DOMNode.ID] = [:]
-            for projection in snapshot.frameDocumentProjections.values
-                where projection.state == .attached {
-                guard let ownerNodeID = projection.ownerNodeID,
-                      let document = snapshot.documentsByID[projection.frameDocumentID],
-                      document.lifecycle == .loaded else {
-                    continue
-                }
-                rootsByOwnerNodeID[ownerNodeID] = document.rootNodeID
-            }
-            return rootsByOwnerNodeID
         }
     }
 
@@ -272,24 +240,33 @@ extension DOMTreeTextView {
 }
 
 extension DOMTreeTextView {
-    struct RenderedRowsWorker: Sendable {
+    @MainActor
+    struct RenderedRowsWorker {
+        private let dom: DOMSession
         private let request: DOMTreeTextView.RenderedRowsBuildRequest
         private var renderedLinePrefixCache: [Int: String] = [:]
         private var markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+#if DEBUG
+        private(set) static var lastVisitedNodeIDsForTesting: [DOMNode.ID] = []
+#endif
 
-        init(request: DOMTreeTextView.RenderedRowsBuildRequest) {
+        init(dom: DOMSession, request: DOMTreeTextView.RenderedRowsBuildRequest) {
+            self.dom = dom
             self.request = request
             self.markupCache = request.markupCache
         }
 
-        func build() throws -> DOMTreeTextView.RenderedRowsBuildResult {
+        func build() async throws -> DOMTreeTextView.RenderedRowsBuildResult {
             var worker = self
-            return try worker.buildRows()
+            return try await worker.buildRows()
         }
 
-        private mutating func buildRows() throws -> DOMTreeTextView.RenderedRowsBuildResult {
+        private mutating func buildRows() async throws -> DOMTreeTextView.RenderedRowsBuildResult {
             try Task.checkCancellation()
             guard let rootNode = currentPageRootNode() else {
+#if DEBUG
+                Self.lastVisitedNodeIDsForTesting = []
+#endif
                 return DOMTreeTextView.RenderedRowsBuildResult(
                     rows: [],
                     text: "",
@@ -305,14 +282,21 @@ extension DOMTreeTextView {
             var utf16Location = 0
             var maxLineDisplayColumnCount = 0
             var visitedNodeIDs = Set<DOMNode.ID>()
+#if DEBUG
+            var visitedNodeIDsForTesting: [DOMNode.ID] = []
+#endif
 
             func appendLine(
-                _ node: DOMNode.Snapshot,
+                _ node: DOMNode,
                 depth: Int,
                 isClosingTag: Bool
-            ) throws -> DOMTreeTextView.Line {
+            ) async throws -> DOMTreeTextView.Line {
                 try Task.checkCancellation()
                 let rowIndex = nextRows.count
+                if rowIndex > 0 && rowIndex.isMultiple(of: 128) {
+                    await Task.yield()
+                    try Task.checkCancellation()
+                }
                 let row = renderedRow(
                     for: node,
                     depth: depth,
@@ -331,34 +315,34 @@ extension DOMTreeTextView {
                 return row
             }
 
-            func append(_ node: DOMNode.Snapshot, depth: Int) throws {
+            func append(_ node: DOMNode, depth: Int) async throws {
                 try Task.checkCancellation()
                 guard visitedNodeIDs.insert(node.id).inserted else {
                     return
                 }
-                let row = try appendLine(node, depth: depth, isClosingTag: false)
+#if DEBUG
+                visitedNodeIDsForTesting.append(node.id)
+#endif
+                let row = try await appendLine(node, depth: depth, isClosingTag: false)
                 guard row.hasDisclosure, row.isOpen else {
                     return
                 }
-                for childID in visibleChildIDs(of: node) {
-                    guard let child = request.domSnapshot.nodesByID[childID] else {
-                        continue
-                    }
-                    try append(child, depth: depth + 1)
+                for child in visibleChildren(of: node) {
+                    try await append(child, depth: depth + 1)
                 }
                 if DOMTreeTextView.MarkupBuilder.rendersClosingTagRow(for: node) {
-                    _ = try appendLine(node, depth: depth, isClosingTag: true)
+                    _ = try await appendLine(node, depth: depth, isClosingTag: true)
                 }
             }
 
-            let displayRootIDs = rootNode.nodeType == .document ? visibleChildIDs(of: rootNode) : [rootNode.id]
-            for nodeID in displayRootIDs {
-                guard let node = request.domSnapshot.nodesByID[nodeID] else {
-                    continue
-                }
-                try append(node, depth: 0)
+            let displayRoots = rootNode.nodeType == .document ? visibleChildren(of: rootNode) : [rootNode]
+            for node in displayRoots {
+                try await append(node, depth: 0)
             }
 
+#if DEBUG
+            Self.lastVisitedNodeIDsForTesting = visitedNodeIDsForTesting
+#endif
             return DOMTreeTextView.RenderedRowsBuildResult(
                 rows: nextRows,
                 text: nextText,
@@ -368,7 +352,7 @@ extension DOMTreeTextView {
         }
 
         private mutating func renderedRow(
-            for node: DOMNode.Snapshot,
+            for node: DOMNode,
             depth: Int,
             rowIndex: Int,
             utf16Location: Int,
@@ -413,7 +397,7 @@ extension DOMTreeTextView {
         }
 
         private mutating func cachedMarkup(
-            for node: DOMNode.Snapshot,
+            for node: DOMNode,
             hasDisclosure: Bool,
             isOpen: Bool,
             isClosingTag: Bool
@@ -448,64 +432,19 @@ extension DOMTreeTextView {
             return markup
         }
 
-        private func currentPageRootNode() -> DOMNode.Snapshot? {
-            guard let targetID = request.domSnapshot.currentPageTargetID else {
-                return nil
-            }
-            let documentID = request.domSnapshot.targetStatesByID[targetID]?.currentDocumentID
-                ?? request.domSnapshot.targetsByID[targetID]?.currentDocumentID
-            guard let documentID,
-                  let document = request.domSnapshot.documentsByID[documentID],
-                  document.lifecycle == .loaded else {
-                return nil
-            }
-            return request.domSnapshot.nodesByID[document.rootNodeID]
+        private func currentPageRootNode() -> DOMNode? {
+            dom.currentPageRootNode
         }
 
-        private func visibleChildIDs(of node: DOMNode.Snapshot) -> [DOMNode.ID] {
-            guard isCurrentDocument(node.id.documentID) else {
-                return []
-            }
-
-            var children: [DOMNode.ID] = []
-            if let templateContentID = node.templateContentID {
-                children.append(templateContentID)
-            }
-            if let beforePseudoElementID = node.beforePseudoElementID {
-                children.append(beforePseudoElementID)
-            }
-            children.append(contentsOf: node.otherPseudoElementIDs)
-            children.append(contentsOf: effectiveChildIDs(of: node))
-            if let afterPseudoElementID = node.afterPseudoElementID {
-                children.append(afterPseudoElementID)
-            }
-            return children
+        private func visibleChildren(of node: DOMNode) -> [DOMNode] {
+            dom.visibleDOMTreeChildren(of: node)
         }
 
-        private func effectiveChildIDs(of node: DOMNode.Snapshot) -> [DOMNode.ID] {
-            if nodeName(for: node).lowercased() == "iframe" || nodeName(for: node).lowercased() == "frame",
-               let rootNodeID = projectedFrameDocumentRootID(forOwnerNodeID: node.id) {
-                return [rootNodeID]
-            }
-            if let contentDocumentID = node.contentDocumentID,
-               isCurrentDocument(contentDocumentID.documentID) {
-                return [contentDocumentID]
-            }
-            return node.shadowRootIDs + node.regularChildren.loadedChildren
+        private func nodeHasDisclosure(_ node: DOMNode) -> Bool {
+            dom.hasVisibleDOMTreeChildren(node)
         }
 
-        private func projectedFrameDocumentRootID(forOwnerNodeID ownerNodeID: DOMNode.ID) -> DOMNode.ID? {
-            request.frameDocumentRootIDByOwnerNodeID[ownerNodeID]
-        }
-
-        private func nodeHasDisclosure(_ node: DOMNode.Snapshot) -> Bool {
-            guard isCurrentDocument(node.id.documentID) else {
-                return node.regularChildren.knownCount > 0
-            }
-            return !visibleChildIDs(of: node).isEmpty || node.regularChildren.knownCount > 0
-        }
-
-        private func isNodeOpen(_ node: DOMNode.Snapshot) -> Bool {
+        private func isNodeOpen(_ node: DOMNode) -> Bool {
             if let explicitState = request.expansionState[node.id] {
                 return explicitState
             }
@@ -528,22 +467,11 @@ extension DOMTreeTextView {
             return prefix
         }
 
-        private func isCurrentDocument(_ documentID: DOMDocument.ID) -> Bool {
-            guard let document = request.domSnapshot.documentsByID[documentID] else {
-                return false
-            }
-            return document.lifecycle == .loaded
+        private func isTemplateContent(_ node: DOMNode) -> Bool {
+            dom.isTemplateContent(node)
         }
 
-        private func isTemplateContent(_ node: DOMNode.Snapshot) -> Bool {
-            guard let parentID = node.parentID,
-                  let parent = request.domSnapshot.nodesByID[parentID] else {
-                return false
-            }
-            return parent.templateContentID == node.id
-        }
-
-        private func nodeName(for node: DOMNode.Snapshot) -> String {
+        private func nodeName(for node: DOMNode) -> String {
             if !node.localName.isEmpty {
                 return node.localName
             }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -179,9 +179,11 @@ extension DOMTreeTextView {
             previousRowCapacity: Int,
             previousTextCapacity: Int
         ) -> DOMTreeTextView.RenderedRowsBuildRequest {
-            DOMTreeTextView.RenderedRowsBuildRequest(
+            let expansionSnapshot = expansionState.snapshot
+            return DOMTreeTextView.RenderedRowsBuildRequest(
                 treeRevision: dom.treeRevision,
-                expansionState: expansionState.snapshot,
+                expansionState: expansionSnapshot,
+                rows: collectVisibleRows(expansionState: expansionSnapshot),
                 previousRowCapacity: previousRowCapacity,
                 previousTextCapacity: previousTextCapacity,
                 markupCache: markupCache
@@ -191,19 +193,161 @@ extension DOMTreeTextView {
         func build(
             _ request: DOMTreeTextView.RenderedRowsBuildRequest
         ) async throws -> DOMTreeTextView.RenderedRowsBuildResult {
-            try await DOMTreeTextView.RenderedRowsWorker(dom: dom, request: request).build()
+            let task = Task.detached(priority: .userInitiated) {
+                try Task.checkCancellation()
+                return try await DOMTreeTextView.RenderedRowsWorker(request: request).build()
+            }
+            return try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
         }
 
         func acceptCompletedBuild(_ result: DOMTreeTextView.RenderedRowsBuildResult) {
             markupCache = result.markupCache
         }
+
+        private func collectVisibleRows(
+            expansionState: [DOMNode.ID: Bool]
+        ) -> [DOMTreeTextView.RenderedRowsBuildRow] {
+            guard let rootNode = dom.currentPageRootNode else {
+#if DEBUG
+                Self.lastCollectedNodeIDsForTesting = []
+#endif
+                return []
+            }
+
+            var rows: [DOMTreeTextView.RenderedRowsBuildRow] = []
+            rows.reserveCapacity(markupCache.count)
+            var visitedNodeIDs = Set<DOMNode.ID>()
+#if DEBUG
+            var visitedNodeIDsForTesting: [DOMNode.ID] = []
+#endif
+
+            func collect(_ node: DOMNode, depth: Int) {
+                guard visitedNodeIDs.insert(node.id).inserted else {
+                    return
+                }
+                let renderNode = DOMTreeTextView.RenderedRowsBuildNode(
+                    node: node,
+                    isTemplateContent: dom.isTemplateContent(node)
+                )
+                let hasDisclosure = dom.hasVisibleDOMTreeChildren(node)
+                let isOpen = Self.isNodeOpen(renderNode, expansionState: expansionState)
+                rows.append(
+                    DOMTreeTextView.RenderedRowsBuildRow(
+                        node: renderNode,
+                        depth: depth,
+                        hasDisclosure: hasDisclosure,
+                        isOpen: isOpen,
+                        isClosingTag: false
+                    )
+                )
+#if DEBUG
+                visitedNodeIDsForTesting.append(node.id)
+#endif
+
+                guard hasDisclosure, isOpen else {
+                    return
+                }
+                for child in dom.visibleDOMTreeChildren(of: node) {
+                    collect(child, depth: depth + 1)
+                }
+                guard DOMTreeTextView.MarkupBuilder.rendersClosingTagRow(for: renderNode) else {
+                    return
+                }
+                rows.append(
+                    DOMTreeTextView.RenderedRowsBuildRow(
+                        node: renderNode,
+                        depth: depth,
+                        hasDisclosure: false,
+                        isOpen: false,
+                        isClosingTag: true
+                    )
+                )
+            }
+
+            let displayRoots = rootNode.nodeType == .document ? dom.visibleDOMTreeChildren(of: rootNode) : [rootNode]
+            for node in displayRoots {
+                collect(node, depth: 0)
+            }
+#if DEBUG
+            Self.lastCollectedNodeIDsForTesting = visitedNodeIDsForTesting
+#endif
+            return rows
+        }
+
+        private static func isNodeOpen(
+            _ node: DOMTreeTextView.RenderedRowsBuildNode,
+            expansionState: [DOMNode.ID: Bool]
+        ) -> Bool {
+            if let explicitState = expansionState[node.id] {
+                return explicitState
+            }
+            let name = node.displayName.lowercased()
+            if name == "head" {
+                return false
+            }
+            return name == "html" || name == "body"
+        }
+
+#if DEBUG
+        private(set) static var lastCollectedNodeIDsForTesting: [DOMNode.ID] = []
+#endif
     }
 }
 
 extension DOMTreeTextView {
+    struct RenderedRowsBuildNode: Sendable {
+        let id: DOMNode.ID
+        let nodeType: DOMNode.Kind
+        let nodeName: String
+        let localName: String
+        let nodeValue: String
+        let attributes: [DOMNode.Attribute]
+        let pseudoType: String?
+        let shadowRootType: String?
+        let regularChildKnownCount: Int
+        let isTemplateContent: Bool
+
+        @MainActor
+        init(node: DOMNode, isTemplateContent: Bool) {
+            id = node.id
+            nodeType = node.nodeType
+            nodeName = node.nodeName
+            localName = node.localName
+            nodeValue = node.nodeValue
+            attributes = node.attributes
+            pseudoType = node.pseudoType
+            shadowRootType = node.shadowRootType
+            regularChildKnownCount = node.regularChildren.knownCount
+            self.isTemplateContent = isTemplateContent
+        }
+
+        var displayName: String {
+            if !localName.isEmpty {
+                return localName
+            }
+            if !nodeName.isEmpty {
+                return nodeName
+            }
+            return nodeValue.isEmpty ? nodeName : nodeValue
+        }
+    }
+
+    struct RenderedRowsBuildRow: Sendable {
+        let node: DOMTreeTextView.RenderedRowsBuildNode
+        let depth: Int
+        let hasDisclosure: Bool
+        let isOpen: Bool
+        let isClosingTag: Bool
+    }
+
     struct RenderedRowsBuildRequest: Sendable {
         let treeRevision: UInt64
         let expansionState: [DOMNode.ID: Bool]
+        let rows: [DOMTreeTextView.RenderedRowsBuildRow]
         let previousRowCapacity: Int
         let previousTextCapacity: Int
         let markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
@@ -211,12 +355,14 @@ extension DOMTreeTextView {
         init(
             treeRevision: UInt64,
             expansionState: [DOMNode.ID: Bool],
+            rows: [DOMTreeTextView.RenderedRowsBuildRow],
             previousRowCapacity: Int,
             previousTextCapacity: Int,
             markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
         ) {
             self.treeRevision = treeRevision
             self.expansionState = expansionState
+            self.rows = rows
             self.previousRowCapacity = previousRowCapacity
             self.previousTextCapacity = previousTextCapacity
             self.markupCache = markupCache
@@ -240,18 +386,12 @@ extension DOMTreeTextView {
 }
 
 extension DOMTreeTextView {
-    @MainActor
-    struct RenderedRowsWorker {
-        private let dom: DOMSession
+    struct RenderedRowsWorker: Sendable {
         private let request: DOMTreeTextView.RenderedRowsBuildRequest
         private var renderedLinePrefixCache: [Int: String] = [:]
         private var markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
-#if DEBUG
-        private(set) static var lastVisitedNodeIDsForTesting: [DOMNode.ID] = []
-#endif
 
-        init(dom: DOMSession, request: DOMTreeTextView.RenderedRowsBuildRequest) {
-            self.dom = dom
+        init(request: DOMTreeTextView.RenderedRowsBuildRequest) {
             self.request = request
             self.markupCache = request.markupCache
         }
@@ -263,17 +403,6 @@ extension DOMTreeTextView {
 
         private mutating func buildRows() async throws -> DOMTreeTextView.RenderedRowsBuildResult {
             try Task.checkCancellation()
-            guard let rootNode = currentPageRootNode() else {
-#if DEBUG
-                Self.lastVisitedNodeIDsForTesting = []
-#endif
-                return DOMTreeTextView.RenderedRowsBuildResult(
-                    rows: [],
-                    text: "",
-                    maxLineDisplayColumnCount: 0,
-                    markupCache: markupCache
-                )
-            }
 
             var nextRows: [DOMTreeTextView.Line] = []
             nextRows.reserveCapacity(request.previousRowCapacity)
@@ -281,15 +410,9 @@ extension DOMTreeTextView {
             nextText.reserveCapacity(request.previousTextCapacity)
             var utf16Location = 0
             var maxLineDisplayColumnCount = 0
-            var visitedNodeIDs = Set<DOMNode.ID>()
-#if DEBUG
-            var visitedNodeIDsForTesting: [DOMNode.ID] = []
-#endif
 
             func appendLine(
-                _ node: DOMNode,
-                depth: Int,
-                isClosingTag: Bool
+                _ rowInput: DOMTreeTextView.RenderedRowsBuildRow
             ) async throws -> DOMTreeTextView.Line {
                 try Task.checkCancellation()
                 let rowIndex = nextRows.count
@@ -298,11 +421,9 @@ extension DOMTreeTextView {
                     try Task.checkCancellation()
                 }
                 let row = renderedRow(
-                    for: node,
-                    depth: depth,
+                    for: rowInput,
                     rowIndex: rowIndex,
-                    utf16Location: utf16Location,
-                    isClosingTag: isClosingTag
+                    utf16Location: utf16Location
                 )
 
                 maxLineDisplayColumnCount = max(maxLineDisplayColumnCount, row.displayColumnCount)
@@ -315,34 +436,10 @@ extension DOMTreeTextView {
                 return row
             }
 
-            func append(_ node: DOMNode, depth: Int) async throws {
-                try Task.checkCancellation()
-                guard visitedNodeIDs.insert(node.id).inserted else {
-                    return
-                }
-#if DEBUG
-                visitedNodeIDsForTesting.append(node.id)
-#endif
-                let row = try await appendLine(node, depth: depth, isClosingTag: false)
-                guard row.hasDisclosure, row.isOpen else {
-                    return
-                }
-                for child in visibleChildren(of: node) {
-                    try await append(child, depth: depth + 1)
-                }
-                if DOMTreeTextView.MarkupBuilder.rendersClosingTagRow(for: node) {
-                    _ = try await appendLine(node, depth: depth, isClosingTag: true)
-                }
+            for rowInput in request.rows {
+                _ = try await appendLine(rowInput)
             }
 
-            let displayRoots = rootNode.nodeType == .document ? visibleChildren(of: rootNode) : [rootNode]
-            for node in displayRoots {
-                try await append(node, depth: 0)
-            }
-
-#if DEBUG
-            Self.lastVisitedNodeIDsForTesting = visitedNodeIDsForTesting
-#endif
             return DOMTreeTextView.RenderedRowsBuildResult(
                 rows: nextRows,
                 text: nextText,
@@ -352,23 +449,19 @@ extension DOMTreeTextView {
         }
 
         private mutating func renderedRow(
-            for node: DOMNode,
-            depth: Int,
+            for rowInput: DOMTreeTextView.RenderedRowsBuildRow,
             rowIndex: Int,
-            utf16Location: Int,
-            isClosingTag: Bool = false
+            utf16Location: Int
         ) -> DOMTreeTextView.Line {
-            let hasDisclosure = !isClosingTag && nodeHasDisclosure(node)
-            let isOpen = !isClosingTag && isNodeOpen(node)
             let markup = cachedMarkup(
-                for: node,
-                hasDisclosure: hasDisclosure,
-                isOpen: isOpen,
-                isClosingTag: isClosingTag
+                for: rowInput.node,
+                hasDisclosure: rowInput.hasDisclosure,
+                isOpen: rowInput.isOpen,
+                isClosingTag: rowInput.isClosingTag
             )
-            let prefix = renderedLinePrefix(depth: depth)
+            let prefix = renderedLinePrefix(depth: rowInput.depth)
             let line = prefix + markup.text
-            let prefixLength = depth * DOMTreeTextView.IndentMetrics.indentSpacesPerDepth + DOMTreeTextView.IndentMetrics.disclosureSlotSpaces
+            let prefixLength = rowInput.depth * DOMTreeTextView.IndentMetrics.indentSpacesPerDepth + DOMTreeTextView.IndentMetrics.disclosureSlotSpaces
             let lineLength = prefixLength + markup.utf16Length
             var tokens: [DOMTreeTextView.Token] = []
             tokens.reserveCapacity(markup.tokens.count)
@@ -382,27 +475,26 @@ extension DOMTreeTextView {
             }
 
             return DOMTreeTextView.Line(
-                nodeID: node.id,
-                depth: depth,
+                nodeID: rowInput.node.id,
+                depth: rowInput.depth,
                 rowIndex: rowIndex,
                 text: line,
                 textRange: NSRange(location: utf16Location, length: lineLength),
                 markupRange: NSRange(location: prefixLength, length: markup.utf16Length),
                 tokens: tokens,
                 displayColumnCount: prefixLength + markup.displayColumnCount,
-                hasDisclosure: hasDisclosure,
-                isOpen: isOpen,
-                isClosingTag: isClosingTag
+                hasDisclosure: rowInput.hasDisclosure,
+                isOpen: rowInput.isOpen,
+                isClosingTag: rowInput.isClosingTag
             )
         }
 
         private mutating func cachedMarkup(
-            for node: DOMNode,
+            for node: DOMTreeTextView.RenderedRowsBuildNode,
             hasDisclosure: Bool,
             isOpen: Bool,
             isClosingTag: Bool
         ) -> DOMTreeTextView.Markup {
-            let isTemplateContent = isTemplateContent(node)
             let signature = DOMTreeTextView.MarkupSignature(
                 nodeType: node.nodeType,
                 nodeName: node.nodeName,
@@ -410,9 +502,9 @@ extension DOMTreeTextView {
                 nodeValue: node.nodeValue,
                 pseudoType: node.pseudoType,
                 shadowRootType: node.shadowRootType,
-                isTemplateContent: isTemplateContent,
+                isTemplateContent: node.isTemplateContent,
                 attributes: node.attributes,
-                childCount: node.regularChildren.knownCount,
+                childCount: node.regularChildKnownCount,
                 hasDisclosure: hasDisclosure,
                 isOpen: isOpen,
                 isClosingTag: isClosingTag
@@ -426,33 +518,10 @@ extension DOMTreeTextView {
                 hasDisclosure: hasDisclosure,
                 isOpen: isOpen,
                 isClosingTag: isClosingTag,
-                isTemplateContent: isTemplateContent
+                isTemplateContent: node.isTemplateContent
             )
             markupCache[node.id] = DOMTreeTextView.CachedMarkup(signature: signature, markup: markup)
             return markup
-        }
-
-        private func currentPageRootNode() -> DOMNode? {
-            dom.currentPageRootNode
-        }
-
-        private func visibleChildren(of node: DOMNode) -> [DOMNode] {
-            dom.visibleDOMTreeChildren(of: node)
-        }
-
-        private func nodeHasDisclosure(_ node: DOMNode) -> Bool {
-            dom.hasVisibleDOMTreeChildren(node)
-        }
-
-        private func isNodeOpen(_ node: DOMNode) -> Bool {
-            if let explicitState = request.expansionState[node.id] {
-                return explicitState
-            }
-            let name = nodeName(for: node).lowercased()
-            if name == "head" {
-                return false
-            }
-            return name == "html" || name == "body"
         }
 
         private mutating func renderedLinePrefix(depth: Int) -> String {
@@ -465,20 +534,6 @@ extension DOMTreeTextView {
             )
             renderedLinePrefixCache[depth] = prefix
             return prefix
-        }
-
-        private func isTemplateContent(_ node: DOMNode) -> Bool {
-            dom.isTemplateContent(node)
-        }
-
-        private func nodeName(for node: DOMNode) -> String {
-            if !node.localName.isEmpty {
-                return node.localName
-            }
-            if !node.nodeName.isEmpty {
-                return node.nodeName
-            }
-            return node.nodeValue.isEmpty ? node.nodeName : node.nodeValue
         }
     }
 }

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -507,31 +507,37 @@ struct DOMTreeTextViewTests {
         #expect(session.hasPendingSelectionRequest)
         #expect(view.contentOffset.y < view.bounds.height)
 
-        let result = session.applyRequestNodeResult(
-            selectionRequestID: selectionRequestID,
-            targetID: protocolTargetID,
-            nodeID: .init(4)
+        var requestNodeResult: DOMNode.RequestResolution?
+        let revealedSelectionState = await waitForSelectionRenderedState(
+            in: view,
+            update: {
+                requestNodeResult = session.applyRequestNodeResult(
+                    selectionRequestID: selectionRequestID,
+                    targetID: protocolTargetID,
+                    nodeID: .init(4)
+                )
+            },
+            sample: {
+                renderedSelectionRevealState(
+                    in: view,
+                    containing: "id=\"selected-target\""
+                )
+            },
+            until: {
+                $0.isSelectedRowRevealed
+            }
         )
+        let result = try #require(requestNodeResult)
         guard case let .resolved(resolvedNodeID) = result else {
             Issue.record("Expected pending DOM.requestNode selection to resolve")
             return
         }
-        await Task.yield()
-
-        let selectedLine = try #require(
-            view.renderedLineSnapshotsForTesting.first { snapshot in
-                snapshot.text.contains("id=\"selected-target\"")
-            }
-        )
-        let selectedRowY = CGFloat(selectedLine.rowIndex) * view.rowHeightForTesting
-        let visibleMinY = view.contentOffset.y
-        let visibleMaxY = view.contentOffset.y + view.bounds.height
+        let revealState = try #require(revealedSelectionState)
 
         #expect(resolvedNodeID == oldSelectedNodeID)
         #expect(!session.hasPendingSelectionRequest)
-        #expect(view.contentOffset.y > view.bounds.height)
-        #expect(selectedRowY >= visibleMinY - view.rowHeightForTesting)
-        #expect(selectedRowY + view.rowHeightForTesting <= visibleMaxY + view.rowHeightForTesting)
+        #expect(revealState.contentOffsetY > revealState.boundsHeight)
+        #expect(revealState.isSelectedRowVisible)
     }
 
     @Test
@@ -645,6 +651,27 @@ private struct RenderedDOMTreeState: Equatable, Sendable {
         text.contains("#document")
             && text.contains("<img id=\"ad-node\">")
             && selectedRowCount == 1
+    }
+}
+
+private struct RenderedSelectionRevealState: Equatable, Sendable {
+    var contentOffsetY: Double
+    var boundsHeight: Double
+    var selectedRowY: Double?
+    var rowHeight: Double
+
+    var isSelectedRowRevealed: Bool {
+        contentOffsetY > boundsHeight && isSelectedRowVisible
+    }
+
+    var isSelectedRowVisible: Bool {
+        guard let selectedRowY else {
+            return false
+        }
+        let visibleMinY = contentOffsetY
+        let visibleMaxY = contentOffsetY + boundsHeight
+        return selectedRowY >= visibleMinY - rowHeight
+            && selectedRowY + rowHeight <= visibleMaxY + rowHeight
     }
 }
 
@@ -833,6 +860,49 @@ private func waitForSelectionObservationRender(
     await view.waitForRenderedRowsForTesting()
     view.layoutIfNeeded()
     return condition()
+}
+
+@MainActor
+private func waitForSelectionRenderedState<State: Sendable>(
+    in view: DOMTreeTextView,
+    timeout: Duration = .seconds(1),
+    update: @MainActor () -> Void,
+    sample: @escaping @MainActor @Sendable () -> State,
+    until condition: @escaping @Sendable (State) -> Bool
+) async -> State? {
+    let observedStates = await view.selectionObservationDeliveryForTesting.values {
+        sample()
+    }
+    defer {
+        observedStates.cancel()
+    }
+
+    update()
+    if let latestState = observedStates.latestValue, condition(latestState) {
+        return latestState
+    }
+    if let renderedState = await observedStates.waitUntil(timeout: timeout, condition) {
+        return renderedState
+    }
+    let fallbackState = sample()
+    return condition(fallbackState) ? fallbackState : nil
+}
+
+@MainActor
+private func renderedSelectionRevealState(
+    in view: DOMTreeTextView,
+    containing selectedText: String
+) -> RenderedSelectionRevealState {
+    view.layoutIfNeeded()
+    let selectedLine = view.renderedLineSnapshotsForTesting.first { snapshot in
+        snapshot.text.contains(selectedText)
+    }
+    return RenderedSelectionRevealState(
+        contentOffsetY: Double(view.contentOffset.y),
+        boundsHeight: Double(view.bounds.height),
+        selectedRowY: selectedLine.map { Double(CGFloat($0.rowIndex) * view.rowHeightForTesting) },
+        rowHeight: Double(view.rowHeightForTesting)
+    )
 }
 
 @MainActor

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -69,8 +69,8 @@ struct DOMTreeTextViewTests {
         await view.waitForRenderedRowsForTesting()
 
         #expect(didRouteBuild)
-        #expect(DOMTreeTextView.RenderedRowsWorker.lastVisitedNodeIDsForTesting.contains(articleID))
-        #expect(!DOMTreeTextView.RenderedRowsWorker.lastVisitedNodeIDsForTesting.contains(nestedChildID))
+        #expect(DOMTreeTextView.RenderedRowsBuilder.lastCollectedNodeIDsForTesting.contains(articleID))
+        #expect(!DOMTreeTextView.RenderedRowsBuilder.lastCollectedNodeIDsForTesting.contains(nestedChildID))
         #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
         #expect(view.renderedRowsAppliedTreeRevisionForTesting == baselineAppliedTreeRevision)
         #expect(!view.renderedTextForTesting.contains("data-state=\"ready\""))

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -27,6 +27,56 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func renderedRowsBuildDoesNotSnapshotDOMSession() async throws {
+        let session = makeDOMSession()
+        let baselineSnapshotBuildCount = session.snapshotBuildCountForTesting
+
+        let view = await makeTreeView(session: session)
+        #expect(view.renderedTextForTesting.contains("<html lang=\"en\">"))
+        #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
+
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
+        #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
+    }
+
+    @Test
+    func collapsedDescendantMutationDoesNotTraverseOrApplyCollapsedSubtree() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let documentID = try #require(session.currentPageRootNode?.id.documentID)
+        let articleID = DOMNode.ID(documentID: documentID, nodeID: .init(8))
+        let nestedChildID = DOMNode.ID(documentID: documentID, nodeID: .init(9))
+        let observedBuildCounts = await view.documentObservationDeliveryForTesting.values {
+            view.buildRenderedRowsCallCountForTesting
+        }
+        defer {
+            observedBuildCounts.cancel()
+        }
+        let baselineSnapshotBuildCount = session.snapshotBuildCountForTesting
+        let baselineAppliedTreeRevision = view.renderedRowsAppliedTreeRevisionForTesting
+        let baselineBuildCount = view.buildRenderedRowsCallCountForTesting
+
+        #expect(view.renderedTextForTesting.contains("<article>…</article>"))
+        #expect(!view.renderedTextForTesting.contains("data-state=\"ready\""))
+
+        session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
+        let didRouteBuild = await observedBuildCounts.waitUntil {
+            $0 > baselineBuildCount
+        } != nil
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(didRouteBuild)
+        #expect(DOMTreeTextView.RenderedRowsWorker.lastVisitedNodeIDsForTesting.contains(articleID))
+        #expect(!DOMTreeTextView.RenderedRowsWorker.lastVisitedNodeIDsForTesting.contains(nestedChildID))
+        #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
+        #expect(view.renderedRowsAppliedTreeRevisionForTesting == baselineAppliedTreeRevision)
+        #expect(!view.renderedTextForTesting.contains("data-state=\"ready\""))
+    }
+
+    @Test
     func textStorageKeepsTokenForegroundAsBaseAttributes() async throws {
         let view = await makeTreeView()
 


### PR DESCRIPTION
## Purpose

Reduce DOM tree row rendering work on the main actor by avoiding full `DOMSession.Snapshot` and `DOMNode.Snapshot` copies for the rendered rows build path.

## Changes

- Removed `DOMSession.Snapshot` / `DOMNode.Snapshot` from the DOM tree rendered rows build request.
- Collect a minimal `Sendable` visible-row render payload from live `DOMSession` / `DOMNode` state on the main actor.
- Keep payload collection scoped to visible/expanded rows and closing-tag rows, without traversing collapsed descendants or adding persistent row model state.
- Run markup escaping, token construction, and `nextText` assembly in a detached rendering task using the transient payload.
- Kept markup caching as a local rendered artifact with the existing invalidation signature behavior.
- Updated selection reveal test synchronization to wait on the production selection observation token and rendered scroll state instead of a bare `Task.yield()`.
- Added tests that verify the production rendering path does not call `DOMSession.snapshot()` and that collapsed descendant mutations are not collected, traversed, or applied by row builds.

## Validation

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' '-only-testing:WebInspectorUITests/DOMTreeTextViewTests/selectionRevealSkipsStaleSelectedNodeDuringPendingInspectSelection()' -test-iterations 5`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/DOMTreeTextViewTests`

## Codex Review

- Branch-wide review against pinned `main` base `refs/pr-fix/base/192/7655180ee803315ee8e0cba21cc4734e43076c38`: clean, finding count 0
- Job ID: `B57A7E1C-9A2B-4520-A89E-6C060A617FA0`
