### PR TITLE
Optimize DOM tree rendering invalidation

### DIFF
--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -10,6 +10,7 @@ package final class DOMSession {
     package private(set) var treeRenderInvalidation: DOMTreeRenderInvalidation
     package private(set) var selectionRevision: UInt64
     package private(set) var commandAvailabilityRevision: UInt64
+    @ObservationIgnored private var treeRenderInvalidationHistory: [DOMTreeRenderInvalidation]
     #if DEBUG
     @ObservationIgnored package private(set) var snapshotBuildCountForTesting: UInt64 = 0
     #endif
@@ -41,7 +42,9 @@ package final class DOMSession {
         self.elementStyles = elementStyles
         isSelectingElement = false
         treeRevision = 0
-        treeRenderInvalidation = DOMTreeRenderInvalidation(revision: 0, kind: .root)
+        let initialTreeRenderInvalidation = DOMTreeRenderInvalidation(revision: 0, kind: .root)
+        treeRenderInvalidation = initialTreeRenderInvalidation
+        treeRenderInvalidationHistory = [initialTreeRenderInvalidation]
         selectionRevision = 0
         commandAvailabilityRevision = 0
         self.targetGraph = targetGraph
@@ -118,12 +121,36 @@ package final class DOMSession {
         parentNodeID: DOMNode.ID? = nil
     ) {
         treeRevision &+= 1
-        treeRenderInvalidation = DOMTreeRenderInvalidation(
+        let invalidation = DOMTreeRenderInvalidation(
             revision: treeRevision,
             kind: kind,
             affectedNodeID: affectedNodeID,
             parentNodeID: parentNodeID
         )
+        treeRenderInvalidation = invalidation
+        treeRenderInvalidationHistory.append(invalidation)
+        if treeRenderInvalidationHistory.count > 512 {
+            treeRenderInvalidationHistory.removeFirst(treeRenderInvalidationHistory.count - 512)
+        }
+    }
+
+    package func treeRenderInvalidation(since routedRevision: UInt64?) -> DOMTreeRenderInvalidation {
+        guard let routedRevision,
+              routedRevision < treeRevision else {
+            return treeRenderInvalidation
+        }
+
+        let pendingInvalidations = treeRenderInvalidationHistory.filter { $0.revision > routedRevision }
+        guard var mergedInvalidation = pendingInvalidations.first else {
+            return DOMTreeRenderInvalidation(revision: treeRevision, kind: .root)
+        }
+        guard mergedInvalidation.revision == routedRevision &+ 1 else {
+            return DOMTreeRenderInvalidation(revision: treeRevision, kind: .root)
+        }
+        for invalidation in pendingInvalidations.dropFirst() {
+            mergedInvalidation = mergedInvalidation.merging(with: invalidation)
+        }
+        return mergedInvalidation
     }
 
     private func recordSelectionMutation() {

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -7,6 +7,7 @@ package final class DOMSession {
     package private(set) var elementStyles: CSSSession
     package var isSelectingElement: Bool
     package private(set) var treeRevision: UInt64
+    package private(set) var treeRenderInvalidation: DOMTreeRenderInvalidation
     package private(set) var selectionRevision: UInt64
     package private(set) var commandAvailabilityRevision: UInt64
     #if DEBUG
@@ -40,6 +41,7 @@ package final class DOMSession {
         self.elementStyles = elementStyles
         isSelectingElement = false
         treeRevision = 0
+        treeRenderInvalidation = DOMTreeRenderInvalidation(revision: 0, kind: .root)
         selectionRevision = 0
         commandAvailabilityRevision = 0
         self.targetGraph = targetGraph
@@ -110,8 +112,18 @@ package final class DOMSession {
         targetGraph.attachKnownFrameTargets(mainFrameID: currentPage.mainFrameID)
     }
 
-    private func recordTreeMutation() {
+    private func recordTreeMutation(
+        kind: DOMTreeRenderInvalidation.Kind = .structure,
+        affectedNodeID: DOMNode.ID? = nil,
+        parentNodeID: DOMNode.ID? = nil
+    ) {
         treeRevision &+= 1
+        treeRenderInvalidation = DOMTreeRenderInvalidation(
+            revision: treeRevision,
+            kind: kind,
+            affectedNodeID: affectedNodeID,
+            parentNodeID: parentNodeID
+        )
     }
 
     private func recordSelectionMutation() {
@@ -131,7 +143,7 @@ package final class DOMSession {
         elementStyles.reset()
         nextSelectionRequestRawID = 0
         isSelectingElement = false
-        recordTreeMutation()
+        recordTreeMutation(kind: .root)
         recordSelectionMutation()
         recordCommandAvailabilityMutation()
     }
@@ -146,7 +158,7 @@ package final class DOMSession {
         if record.kind == .frame {
             targetGraph.attachFrameTarget(record.id)
         }
-        recordTreeMutation()
+        recordTreeMutation(kind: .root)
 
         guard makeCurrentMainPage, record.kind == .page else {
             return
@@ -170,12 +182,12 @@ package final class DOMSession {
         _ = state(for: targetID)
         targetGraph.assignMainFrame(resolvedMainFrameID, to: targetID)
         attachKnownFrameTargets()
-        recordTreeMutation()
+        recordTreeMutation(kind: .root)
     }
 
     package func applyTargetCommitted(targetID: ProtocolTarget.ID) {
         if targetGraph.markTargetCommitted(targetID) {
-            recordTreeMutation()
+            recordTreeMutation(kind: .root)
         }
     }
 
@@ -226,7 +238,7 @@ package final class DOMSession {
             }
         }
 
-        recordTreeMutation()
+        recordTreeMutation(kind: .root)
         reconcileSelection()
     }
 
@@ -252,7 +264,7 @@ package final class DOMSession {
             scheduleHighlightClearAfterSelectionCleared(previousSelectedNodeID: previousSelectedNodeID)
         }
         documentStore.removeState(for: targetID)
-        recordTreeMutation()
+        recordTreeMutation(kind: .root)
         reconcileSelection()
     }
 
@@ -317,7 +329,7 @@ package final class DOMSession {
         }
         updateAllFrameDocumentProjectionStates()
 
-        recordTreeMutation()
+        recordTreeMutation(kind: .root, affectedNodeID: rootNodeID)
         reconcileSelection()
         return rootNodeID
     }
@@ -342,7 +354,7 @@ package final class DOMSession {
             frameTargetID: targetID,
             documentID: documentID
         )
-        recordTreeMutation()
+        recordTreeMutation(kind: .root, affectedNodeID: document.rootNodeID)
         reconcileSelection()
     }
 
@@ -383,8 +395,8 @@ package final class DOMSession {
         if document.nodesByID[nodeID] != nil {
             removeNodeSubtree(nodeID, detachFromParent: true)
         }
-        buildSubtree(payload, document: document, parentID: nil)
-        recordTreeMutation()
+        let detachedRootID = buildSubtree(payload, document: document, parentID: nil)
+        recordTreeMutation(kind: .structure, affectedNodeID: detachedRootID)
         completePendingSelectionIfPossible(in: document)
     }
 
@@ -425,7 +437,7 @@ package final class DOMSession {
         document.removeOwnerHydrationTransactions()
         splicePendingTransactionFragments(parentRawNodeID: parent.protocolNodeID, into: document)
         if affectsVisibleTree {
-            recordTreeMutation()
+            recordTreeMutation(kind: .structure, affectedNodeID: nodeID)
             updateAllFrameDocumentProjectionStates()
             reconcileSelection()
         } else {
@@ -460,7 +472,7 @@ package final class DOMSession {
         parent.regularChildren = .loaded(children)
         relinkProtocolEffectiveChildren(of: parent)
         if affectsVisibleTree {
-            recordTreeMutation()
+            recordTreeMutation(kind: .structure, affectedNodeID: childID, parentNodeID: parentID)
             reattachFrameDocumentProjections(using: replacementOwnerKeys)
             updateAllFrameDocumentProjectionStates()
             reconcileSelection()
@@ -475,10 +487,11 @@ package final class DOMSession {
               canApplyDOMEvent(to: nodeID) else {
             return
         }
+        let parentID = document.nodesByID[nodeID]?.parentID
         let affectsVisibleTree = document.containsConnectedNode(nodeID)
         removeNodeSubtree(nodeID, detachFromParent: true)
         if affectsVisibleTree {
-            recordTreeMutation()
+            recordTreeMutation(kind: .structure, affectedNodeID: nodeID, parentNodeID: parentID)
             updateAllFrameDocumentProjectionStates()
             reconcileSelection()
         }
@@ -497,7 +510,7 @@ package final class DOMSession {
             }
             node.regularChildren = .unrequested(count: nextCount)
             if document.containsConnectedNode(nodeID) {
-                recordTreeMutation()
+                recordTreeMutation(kind: .structure, affectedNodeID: nodeID, parentNodeID: node.parentID)
             }
         }
     }
@@ -516,9 +529,13 @@ package final class DOMSession {
         } else {
             node.attributes.append(.init(name: name, value: value))
         }
-        recordTreeMutation()
-        if node.isFrameOwner,
-           name.caseInsensitiveCompare("src") == .orderedSame {
+        let changesFrameProjection = node.isFrameOwner && name.caseInsensitiveCompare("src") == .orderedSame
+        recordTreeMutation(
+            kind: changesFrameProjection ? .structure : .content,
+            affectedNodeID: nodeID,
+            parentNodeID: node.parentID
+        )
+        if changesFrameProjection {
             updateAllFrameDocumentProjectionStates()
         }
     }
@@ -531,9 +548,13 @@ package final class DOMSession {
             return
         }
         node.attributes.remove(at: index)
-        recordTreeMutation()
-        if node.isFrameOwner,
-           name.caseInsensitiveCompare("src") == .orderedSame {
+        let changesFrameProjection = node.isFrameOwner && name.caseInsensitiveCompare("src") == .orderedSame
+        recordTreeMutation(
+            kind: changesFrameProjection ? .structure : .content,
+            affectedNodeID: nodeID,
+            parentNodeID: node.parentID
+        )
+        if changesFrameProjection {
             updateAllFrameDocumentProjectionStates()
         }
     }
@@ -632,6 +653,48 @@ package final class DOMSession {
         return document.nodesByID[document.rootNodeID]
     }
 
+    package var currentDOMTreeRenderRootNodeID: DOMNode.ID? {
+        guard let targetID = currentPageTargetID,
+              let document = documentStore.currentDocument(forTargetID: targetID),
+              document.lifecycle == .loaded
+        else {
+            return nil
+        }
+        return document.rootNodeID
+    }
+
+    package func domTreeRenderSnapshot() -> DOMTreeRenderSnapshot {
+        guard currentPageTargetID != nil else {
+            return DOMTreeRenderSnapshot(
+                treeRevision: treeRevision,
+                rootNodeID: nil,
+                nodesByID: [:],
+                projectedFrameDocumentRootIDByOwnerNodeID: [:],
+                invalidation: treeRenderInvalidation
+            )
+        }
+
+        var nodesByID: [DOMNode.ID: DOMTreeRenderNodeSnapshot] = [:]
+        var projectedFrameDocumentRootIDByOwnerNodeID: [DOMNode.ID: DOMNode.ID] = [:]
+        for document in documentStore.currentDocuments where document.lifecycle == .loaded {
+            for node in document.nodesByID.values {
+                let snapshot = node.domTreeRenderSnapshot
+                nodesByID[snapshot.id] = snapshot
+                if snapshot.isFrameOwner,
+                   let projectedRootID = projectedFrameDocumentRootID(for: snapshot.id) {
+                    projectedFrameDocumentRootIDByOwnerNodeID[snapshot.id] = projectedRootID
+                }
+            }
+        }
+        return DOMTreeRenderSnapshot(
+            treeRevision: treeRevision,
+            rootNodeID: currentDOMTreeRenderRootNodeID,
+            nodesByID: nodesByID,
+            projectedFrameDocumentRootIDByOwnerNodeID: projectedFrameDocumentRootIDByOwnerNodeID,
+            invalidation: treeRenderInvalidation
+        )
+    }
+
     package func node(for id: DOMNode.ID) -> DOMNode? {
         documentStore.node(for: id)
     }
@@ -698,7 +761,7 @@ package final class DOMSession {
         return .success(resolvedNodeID)
     }
 
-    package func requestChildNodesIntent(for nodeID: DOMNode.ID, depth: Int = 3, issuedSequence: UInt64 = 0) -> DOMCommand.Intent? {
+    package func requestChildNodesIntent(for nodeID: DOMNode.ID, depth: Int = 1, issuedSequence: UInt64 = 0) -> DOMCommand.Intent? {
         guard let document = currentDocument(for: nodeID.documentID),
               let node = document.nodesByID[nodeID],
               hasUnloadedRegularChildren(node),

--- a/Sources/WebInspectorCore/DOM/DOMModelTypes.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModelTypes.swift
@@ -366,26 +366,57 @@ package extension DOMNode {
 package final class DOMNode: Identifiable {
     package let id: ID
     package let protocolNodeID: DOMNode.ProtocolID
-    package var nodeType: DOMNode.Kind
-    package var nodeName: String
-    package var localName: String
-    package var nodeValue: String
+    package var nodeType: DOMNode.Kind {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var nodeName: String {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var localName: String {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var nodeValue: String {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
     package var ownerFrameID: DOMFrame.ID?
     package var documentURL: String?
     package var baseURL: String?
-    package var attributes: [DOMNode.Attribute]
-    package var parentID: ID?
+    package var attributes: [DOMNode.Attribute] {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var parentID: ID? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
     package var previousSiblingID: ID?
     package var nextSiblingID: ID?
-    package var regularChildren: DOMNode.ChildrenState
-    package var contentDocumentID: ID?
-    package var shadowRootIDs: [ID]
-    package var templateContentID: ID?
-    package var beforePseudoElementID: ID?
-    package var otherPseudoElementIDs: [ID]
-    package var afterPseudoElementID: ID?
-    package var pseudoType: String?
-    package var shadowRootType: String?
+    package var regularChildren: DOMNode.ChildrenState {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var contentDocumentID: ID? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var shadowRootIDs: [ID] {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var templateContentID: ID? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var beforePseudoElementID: ID? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var otherPseudoElementIDs: [ID] {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var afterPseudoElementID: ID? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var pseudoType: String? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    package var shadowRootType: String? {
+        didSet { refreshDOMTreeRenderSnapshot() }
+    }
+    @ObservationIgnored package private(set) var domTreeRenderSnapshot: DOMTreeRenderNodeSnapshot
 
     package init(id: ID, payload: DOMNode.Payload, parentID: ID?) {
         self.id = id
@@ -410,6 +441,25 @@ package final class DOMNode: Identifiable {
         self.afterPseudoElementID = nil
         self.pseudoType = payload.pseudoType
         self.shadowRootType = payload.shadowRootType
+        self.domTreeRenderSnapshot = DOMTreeRenderNodeSnapshot(
+            id: id,
+            protocolNodeID: payload.nodeID,
+            nodeType: payload.nodeType,
+            nodeName: payload.nodeName,
+            localName: payload.localName,
+            nodeValue: payload.nodeValue,
+            attributes: payload.attributes,
+            parentID: parentID,
+            regularChildren: .unrequested(count: 0),
+            contentDocumentID: nil,
+            shadowRootIDs: [],
+            templateContentID: nil,
+            beforePseudoElementID: nil,
+            otherPseudoElementIDs: [],
+            afterPseudoElementID: nil,
+            pseudoType: payload.pseudoType,
+            shadowRootType: payload.shadowRootType
+        )
     }
 
     package func update(from payload: DOMNode.Payload, parentID: ID?) {
@@ -424,6 +474,28 @@ package final class DOMNode: Identifiable {
         self.parentID = parentID
         pseudoType = payload.pseudoType
         shadowRootType = payload.shadowRootType
+    }
+
+    private func refreshDOMTreeRenderSnapshot() {
+        domTreeRenderSnapshot = DOMTreeRenderNodeSnapshot(
+            id: id,
+            protocolNodeID: protocolNodeID,
+            nodeType: nodeType,
+            nodeName: nodeName,
+            localName: localName,
+            nodeValue: nodeValue,
+            attributes: attributes,
+            parentID: parentID,
+            regularChildren: regularChildren.snapshot,
+            contentDocumentID: contentDocumentID,
+            shadowRootIDs: shadowRootIDs,
+            templateContentID: templateContentID,
+            beforePseudoElementID: beforePseudoElementID,
+            otherPseudoElementIDs: otherPseudoElementIDs,
+            afterPseudoElementID: afterPseudoElementID,
+            pseudoType: pseudoType,
+            shadowRootType: shadowRootType
+        )
     }
 
     package var isFrameOwner: Bool {
@@ -455,6 +527,17 @@ package final class DOMNode: Identifiable {
             children.append(afterPseudoElementID)
         }
         return children
+    }
+}
+
+private extension DOMNode.ChildrenState {
+    var snapshot: DOMNode.ChildrenSnapshot {
+        switch self {
+        case let .unrequested(count):
+            return .unrequested(count: count)
+        case let .loaded(children):
+            return .loaded(children)
+        }
     }
 }
 

--- a/Sources/WebInspectorCore/DOM/DOMProjection.swift
+++ b/Sources/WebInspectorCore/DOM/DOMProjection.swift
@@ -122,6 +122,233 @@ package struct DOMTreeProjection: Equatable, Sendable {
     }
 }
 
+package struct DOMTreeRenderInvalidation: Equatable, Sendable {
+    package enum Kind: Equatable, Sendable {
+        case root
+        case structure
+        case content
+    }
+
+    package var revision: UInt64
+    package var kind: Kind
+    package var affectedNodeID: DOMNode.ID?
+    package var parentNodeID: DOMNode.ID?
+
+    package init(
+        revision: UInt64,
+        kind: Kind,
+        affectedNodeID: DOMNode.ID? = nil,
+        parentNodeID: DOMNode.ID? = nil
+    ) {
+        self.revision = revision
+        self.kind = kind
+        self.affectedNodeID = affectedNodeID
+        self.parentNodeID = parentNodeID
+    }
+
+    package var requiresFragmentReset: Bool {
+        kind == .root
+    }
+
+    package func merging(with newer: DOMTreeRenderInvalidation) -> DOMTreeRenderInvalidation {
+        let mergedKind: Kind
+        if kind == .root || newer.kind == .root {
+            mergedKind = .root
+        } else if kind == .structure || newer.kind == .structure {
+            mergedKind = .structure
+        } else {
+            mergedKind = .content
+        }
+        return DOMTreeRenderInvalidation(
+            revision: newer.revision,
+            kind: mergedKind,
+            affectedNodeID: affectedNodeID == newer.affectedNodeID ? affectedNodeID : nil,
+            parentNodeID: parentNodeID == newer.parentNodeID ? parentNodeID : nil
+        )
+    }
+}
+
+package struct DOMVisibleChildrenProjection: Equatable, Sendable {
+    package var children: [DOMNode.ID]
+    package var hasUnloadedChildren: Bool
+    package var hasRenderableChildren: Bool
+
+    package init(
+        children: [DOMNode.ID] = [],
+        hasUnloadedChildren: Bool = false,
+        hasRenderableChildren: Bool = false
+    ) {
+        self.children = children
+        self.hasUnloadedChildren = hasUnloadedChildren
+        self.hasRenderableChildren = hasRenderableChildren
+    }
+}
+
+package struct DOMTreeRenderNodeSnapshot: Equatable, Sendable, Identifiable {
+    package var id: DOMNode.ID
+    package var protocolNodeID: DOMNode.ProtocolID
+    package var nodeType: DOMNode.Kind
+    package var nodeName: String
+    package var localName: String
+    package var nodeValue: String
+    package var attributes: [DOMNode.Attribute]
+    package var parentID: DOMNode.ID?
+    package var regularChildren: DOMNode.ChildrenSnapshot
+    package var contentDocumentID: DOMNode.ID?
+    package var shadowRootIDs: [DOMNode.ID]
+    package var templateContentID: DOMNode.ID?
+    package var beforePseudoElementID: DOMNode.ID?
+    package var otherPseudoElementIDs: [DOMNode.ID]
+    package var afterPseudoElementID: DOMNode.ID?
+    package var pseudoType: String?
+    package var shadowRootType: String?
+
+    package init(
+        id: DOMNode.ID,
+        protocolNodeID: DOMNode.ProtocolID,
+        nodeType: DOMNode.Kind,
+        nodeName: String,
+        localName: String,
+        nodeValue: String,
+        attributes: [DOMNode.Attribute],
+        parentID: DOMNode.ID?,
+        regularChildren: DOMNode.ChildrenSnapshot,
+        contentDocumentID: DOMNode.ID?,
+        shadowRootIDs: [DOMNode.ID],
+        templateContentID: DOMNode.ID?,
+        beforePseudoElementID: DOMNode.ID?,
+        otherPseudoElementIDs: [DOMNode.ID],
+        afterPseudoElementID: DOMNode.ID?,
+        pseudoType: String?,
+        shadowRootType: String?
+    ) {
+        self.id = id
+        self.protocolNodeID = protocolNodeID
+        self.nodeType = nodeType
+        self.nodeName = nodeName
+        self.localName = localName
+        self.nodeValue = nodeValue
+        self.attributes = attributes
+        self.parentID = parentID
+        self.regularChildren = regularChildren
+        self.contentDocumentID = contentDocumentID
+        self.shadowRootIDs = shadowRootIDs
+        self.templateContentID = templateContentID
+        self.beforePseudoElementID = beforePseudoElementID
+        self.otherPseudoElementIDs = otherPseudoElementIDs
+        self.afterPseudoElementID = afterPseudoElementID
+        self.pseudoType = pseudoType
+        self.shadowRootType = shadowRootType
+    }
+
+    package var regularChildKnownCount: Int {
+        regularChildren.knownCount
+    }
+
+    package var hasUnloadedRegularChildren: Bool {
+        if case let .unrequested(count) = regularChildren {
+            return count > 0
+        }
+        return false
+    }
+
+    package var isFrameOwner: Bool {
+        let lowercasedName = nodeName.lowercased()
+        return lowercasedName == "iframe" || lowercasedName == "frame"
+    }
+
+    package var displayName: String {
+        if !localName.isEmpty {
+            return localName
+        }
+        if !nodeName.isEmpty {
+            return nodeName
+        }
+        return nodeValue.isEmpty ? nodeName : nodeValue
+    }
+}
+
+package struct DOMTreeRenderSnapshot: Equatable, Sendable {
+    package var treeRevision: UInt64
+    package var rootNodeID: DOMNode.ID?
+    package var nodesByID: [DOMNode.ID: DOMTreeRenderNodeSnapshot]
+    package var projectedFrameDocumentRootIDByOwnerNodeID: [DOMNode.ID: DOMNode.ID]
+    package var invalidation: DOMTreeRenderInvalidation
+
+    package init(
+        treeRevision: UInt64,
+        rootNodeID: DOMNode.ID?,
+        nodesByID: [DOMNode.ID: DOMTreeRenderNodeSnapshot],
+        projectedFrameDocumentRootIDByOwnerNodeID: [DOMNode.ID: DOMNode.ID],
+        invalidation: DOMTreeRenderInvalidation
+    ) {
+        self.treeRevision = treeRevision
+        self.rootNodeID = rootNodeID
+        self.nodesByID = nodesByID
+        self.projectedFrameDocumentRootIDByOwnerNodeID = projectedFrameDocumentRootIDByOwnerNodeID
+        self.invalidation = invalidation
+    }
+
+    package func node(for nodeID: DOMNode.ID) -> DOMTreeRenderNodeSnapshot? {
+        nodesByID[nodeID]
+    }
+
+    package func isTemplateContent(_ nodeID: DOMNode.ID) -> Bool {
+        guard let parentID = nodesByID[nodeID]?.parentID,
+              let parent = nodesByID[parentID] else {
+            return false
+        }
+        return parent.templateContentID == nodeID
+    }
+
+    package func displayRootIDs() -> [DOMNode.ID] {
+        guard let rootNodeID,
+              let rootNode = nodesByID[rootNodeID] else {
+            return []
+        }
+        if rootNode.nodeType == .document {
+            return visibleChildrenProjection(of: rootNodeID).children
+        }
+        return [rootNodeID]
+    }
+
+    package func visibleChildrenProjection(of nodeID: DOMNode.ID) -> DOMVisibleChildrenProjection {
+        guard let node = nodesByID[nodeID] else {
+            return DOMVisibleChildrenProjection()
+        }
+
+        var children: [DOMNode.ID] = []
+        if let templateContentID = node.templateContentID {
+            children.append(templateContentID)
+        }
+        if let beforePseudoElementID = node.beforePseudoElementID {
+            children.append(beforePseudoElementID)
+        }
+        children.append(contentsOf: node.otherPseudoElementIDs)
+        children.append(contentsOf: effectiveChildIDs(of: node))
+        if let afterPseudoElementID = node.afterPseudoElementID {
+            children.append(afterPseudoElementID)
+        }
+
+        return DOMVisibleChildrenProjection(
+            children: children,
+            hasUnloadedChildren: node.hasUnloadedRegularChildren,
+            hasRenderableChildren: !children.isEmpty || node.regularChildKnownCount > 0
+        )
+    }
+
+    private func effectiveChildIDs(of node: DOMTreeRenderNodeSnapshot) -> [DOMNode.ID] {
+        if node.isFrameOwner,
+           let projectedRootID = projectedFrameDocumentRootIDByOwnerNodeID[node.id] {
+            return [projectedRootID]
+        }
+        if let contentDocumentID = node.contentDocumentID {
+            return [contentDocumentID]
+        }
+        return node.shadowRootIDs + node.regularChildren.loadedChildren
+    }
+}
+
 package extension DOMTarget {
     struct Snapshot: Equatable, Sendable, Identifiable {
         package var id: ProtocolTarget.ID

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -193,7 +193,7 @@ extension DOMSession {
     }
 
     @discardableResult
-    package func requestChildNodes(for nodeID: DOMNode.ID, depth: Int = 3) async -> Bool {
+    package func requestChildNodes(for nodeID: DOMNode.ID, depth: Int = 1) async -> Bool {
         guard let intent = requestChildNodesIntent(
             for: nodeID,
             depth: depth,

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -129,6 +129,10 @@ extension DOMTreeTextView {
             }
         }
 
+        func cachedMarkupKeysForTesting() -> Set<DOMTreeTextView.MarkupCacheKey> {
+            builder.cachedMarkupKeysForTesting
+        }
+
         func resumeSuspendedBuildForTesting() {
             guard let continuation = suspendedBuildContinuationForTesting else {
                 return
@@ -160,7 +164,7 @@ extension DOMTreeTextView {
     final class RenderedRowsBuilder {
         private let dom: DOMSession
         private let expansionState: DOMTreeTextView.ExpansionState
-        private var markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup] = [:]
+        private var markupCache: [DOMTreeTextView.MarkupCacheKey: DOMTreeTextView.CachedMarkup] = [:]
 
         init(dom: DOMSession, expansionState: DOMTreeTextView.ExpansionState) {
             self.dom = dom
@@ -172,7 +176,7 @@ extension DOMTreeTextView {
         }
 
         func pruneCachedMarkup(keeping nodeIDs: Set<DOMNode.ID>) {
-            markupCache = markupCache.filter { nodeIDs.contains($0.key) }
+            markupCache = markupCache.filter { nodeIDs.contains($0.key.nodeID) }
         }
 
         func makeBuildRequest(
@@ -181,9 +185,8 @@ extension DOMTreeTextView {
         ) -> DOMTreeTextView.RenderedRowsBuildRequest {
             let expansionSnapshot = expansionState.snapshot
             return DOMTreeTextView.RenderedRowsBuildRequest(
-                treeRevision: dom.treeRevision,
+                snapshot: dom.domTreeRenderSnapshot(),
                 expansionState: expansionSnapshot,
-                rows: collectVisibleRows(expansionState: expansionSnapshot),
                 previousRowCapacity: previousRowCapacity,
                 previousTextCapacity: previousTextCapacity,
                 markupCache: markupCache
@@ -206,94 +209,17 @@ extension DOMTreeTextView {
 
         func acceptCompletedBuild(_ result: DOMTreeTextView.RenderedRowsBuildResult) {
             markupCache = result.markupCache
-        }
-
-        private func collectVisibleRows(
-            expansionState: [DOMNode.ID: Bool]
-        ) -> [DOMTreeTextView.RenderedRowsBuildRow] {
-            guard let rootNode = dom.currentPageRootNode else {
 #if DEBUG
-                Self.lastCollectedNodeIDsForTesting = []
+            Self.lastCollectedNodeIDsForTesting = result.collectedNodeIDsForTesting
 #endif
-                return []
-            }
-
-            var rows: [DOMTreeTextView.RenderedRowsBuildRow] = []
-            rows.reserveCapacity(markupCache.count)
-            var visitedNodeIDs = Set<DOMNode.ID>()
-#if DEBUG
-            var visitedNodeIDsForTesting: [DOMNode.ID] = []
-#endif
-
-            func collect(_ node: DOMNode, depth: Int) {
-                guard visitedNodeIDs.insert(node.id).inserted else {
-                    return
-                }
-                let renderNode = DOMTreeTextView.RenderedRowsBuildNode(
-                    node: node,
-                    isTemplateContent: dom.isTemplateContent(node)
-                )
-                let hasDisclosure = dom.hasVisibleDOMTreeChildren(node)
-                let isOpen = Self.isNodeOpen(renderNode, expansionState: expansionState)
-                rows.append(
-                    DOMTreeTextView.RenderedRowsBuildRow(
-                        node: renderNode,
-                        depth: depth,
-                        hasDisclosure: hasDisclosure,
-                        isOpen: isOpen,
-                        isClosingTag: false
-                    )
-                )
-#if DEBUG
-                visitedNodeIDsForTesting.append(node.id)
-#endif
-
-                guard hasDisclosure, isOpen else {
-                    return
-                }
-                for child in dom.visibleDOMTreeChildren(of: node) {
-                    collect(child, depth: depth + 1)
-                }
-                guard DOMTreeTextView.MarkupBuilder.rendersClosingTagRow(for: renderNode) else {
-                    return
-                }
-                rows.append(
-                    DOMTreeTextView.RenderedRowsBuildRow(
-                        node: renderNode,
-                        depth: depth,
-                        hasDisclosure: false,
-                        isOpen: false,
-                        isClosingTag: true
-                    )
-                )
-            }
-
-            let displayRoots = rootNode.nodeType == .document ? dom.visibleDOMTreeChildren(of: rootNode) : [rootNode]
-            for node in displayRoots {
-                collect(node, depth: 0)
-            }
-#if DEBUG
-            Self.lastCollectedNodeIDsForTesting = visitedNodeIDsForTesting
-#endif
-            return rows
-        }
-
-        private static func isNodeOpen(
-            _ node: DOMTreeTextView.RenderedRowsBuildNode,
-            expansionState: [DOMNode.ID: Bool]
-        ) -> Bool {
-            if let explicitState = expansionState[node.id] {
-                return explicitState
-            }
-            let name = node.displayName.lowercased()
-            if name == "head" {
-                return false
-            }
-            return name == "html" || name == "body"
         }
 
 #if DEBUG
         private(set) static var lastCollectedNodeIDsForTesting: [DOMNode.ID] = []
+
+        var cachedMarkupKeysForTesting: Set<DOMTreeTextView.MarkupCacheKey> {
+            Set(markupCache.keys)
+        }
 #endif
     }
 }
@@ -311,8 +237,7 @@ extension DOMTreeTextView {
         let regularChildKnownCount: Int
         let isTemplateContent: Bool
 
-        @MainActor
-        init(node: DOMNode, isTemplateContent: Bool) {
+        init(node: DOMTreeRenderNodeSnapshot, isTemplateContent: Bool) {
             id = node.id
             nodeType = node.nodeType
             nodeName = node.nodeName
@@ -321,7 +246,7 @@ extension DOMTreeTextView {
             attributes = node.attributes
             pseudoType = node.pseudoType
             shadowRootType = node.shadowRootType
-            regularChildKnownCount = node.regularChildren.knownCount
+            regularChildKnownCount = node.regularChildKnownCount
             self.isTemplateContent = isTemplateContent
         }
 
@@ -345,27 +270,28 @@ extension DOMTreeTextView {
     }
 
     struct RenderedRowsBuildRequest: Sendable {
-        let treeRevision: UInt64
+        let snapshot: DOMTreeRenderSnapshot
         let expansionState: [DOMNode.ID: Bool]
-        let rows: [DOMTreeTextView.RenderedRowsBuildRow]
         let previousRowCapacity: Int
         let previousTextCapacity: Int
-        let markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+        let markupCache: [DOMTreeTextView.MarkupCacheKey: DOMTreeTextView.CachedMarkup]
 
         init(
-            treeRevision: UInt64,
+            snapshot: DOMTreeRenderSnapshot,
             expansionState: [DOMNode.ID: Bool],
-            rows: [DOMTreeTextView.RenderedRowsBuildRow],
             previousRowCapacity: Int,
             previousTextCapacity: Int,
-            markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+            markupCache: [DOMTreeTextView.MarkupCacheKey: DOMTreeTextView.CachedMarkup]
         ) {
-            self.treeRevision = treeRevision
+            self.snapshot = snapshot
             self.expansionState = expansionState
-            self.rows = rows
             self.previousRowCapacity = previousRowCapacity
             self.previousTextCapacity = previousTextCapacity
             self.markupCache = markupCache
+        }
+
+        var treeRevision: UInt64 {
+            snapshot.treeRevision
         }
     }
 
@@ -373,7 +299,10 @@ extension DOMTreeTextView {
         let rows: [DOMTreeTextView.Line]
         let text: String
         let maxLineDisplayColumnCount: Int
-        let markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+        let markupCache: [DOMTreeTextView.MarkupCacheKey: DOMTreeTextView.CachedMarkup]
+#if DEBUG
+        let collectedNodeIDsForTesting: [DOMNode.ID]
+#endif
 
         var observedContent: DOMTreeTextView.ObservedContent {
             DOMTreeTextView.ObservedContent((
@@ -389,7 +318,7 @@ extension DOMTreeTextView {
     struct RenderedRowsWorker: Sendable {
         private let request: DOMTreeTextView.RenderedRowsBuildRequest
         private var renderedLinePrefixCache: [Int: String] = [:]
-        private var markupCache: [DOMNode.ID: DOMTreeTextView.CachedMarkup]
+        private var markupCache: [DOMTreeTextView.MarkupCacheKey: DOMTreeTextView.CachedMarkup]
 
         init(request: DOMTreeTextView.RenderedRowsBuildRequest) {
             self.request = request
@@ -404,6 +333,7 @@ extension DOMTreeTextView {
         private mutating func buildRows() async throws -> DOMTreeTextView.RenderedRowsBuildResult {
             try Task.checkCancellation()
 
+            let buildRows = try await collectVisibleRows()
             var nextRows: [DOMTreeTextView.Line] = []
             nextRows.reserveCapacity(request.previousRowCapacity)
             var nextText = ""
@@ -436,16 +366,102 @@ extension DOMTreeTextView {
                 return row
             }
 
-            for rowInput in request.rows {
+            for rowInput in buildRows.rows {
                 _ = try await appendLine(rowInput)
             }
 
+#if DEBUG
+            return DOMTreeTextView.RenderedRowsBuildResult(
+                rows: nextRows,
+                text: nextText,
+                maxLineDisplayColumnCount: maxLineDisplayColumnCount,
+                markupCache: markupCache,
+                collectedNodeIDsForTesting: buildRows.collectedNodeIDsForTesting
+            )
+#else
             return DOMTreeTextView.RenderedRowsBuildResult(
                 rows: nextRows,
                 text: nextText,
                 maxLineDisplayColumnCount: maxLineDisplayColumnCount,
                 markupCache: markupCache
             )
+#endif
+        }
+
+        private func collectVisibleRows() async throws -> (
+            rows: [DOMTreeTextView.RenderedRowsBuildRow],
+            collectedNodeIDsForTesting: [DOMNode.ID]
+        ) {
+            var rows: [DOMTreeTextView.RenderedRowsBuildRow] = []
+            rows.reserveCapacity(request.previousRowCapacity)
+            var visitedNodeIDs = Set<DOMNode.ID>()
+            var visitedNodeIDsForTesting: [DOMNode.ID] = []
+
+            func collect(_ nodeID: DOMNode.ID, depth: Int) throws {
+                try Task.checkCancellation()
+                guard visitedNodeIDs.insert(nodeID).inserted,
+                      let node = request.snapshot.node(for: nodeID) else {
+                    return
+                }
+                let visibleChildren = request.snapshot.visibleChildrenProjection(of: nodeID)
+                let renderNode = DOMTreeTextView.RenderedRowsBuildNode(
+                    node: node,
+                    isTemplateContent: request.snapshot.isTemplateContent(nodeID)
+                )
+                let hasDisclosure = visibleChildren.hasRenderableChildren
+                let isOpen = Self.isNodeOpen(renderNode, expansionState: request.expansionState)
+                rows.append(
+                    DOMTreeTextView.RenderedRowsBuildRow(
+                        node: renderNode,
+                        depth: depth,
+                        hasDisclosure: hasDisclosure,
+                        isOpen: isOpen,
+                        isClosingTag: false
+                    )
+                )
+                visitedNodeIDsForTesting.append(nodeID)
+
+                guard hasDisclosure, isOpen else {
+                    return
+                }
+                for childID in visibleChildren.children {
+                    try collect(childID, depth: depth + 1)
+                }
+                guard DOMTreeTextView.MarkupBuilder.rendersClosingTagRow(for: renderNode) else {
+                    return
+                }
+                rows.append(
+                    DOMTreeTextView.RenderedRowsBuildRow(
+                        node: renderNode,
+                        depth: depth,
+                        hasDisclosure: false,
+                        isOpen: false,
+                        isClosingTag: true
+                    )
+                )
+            }
+
+            for nodeID in request.snapshot.displayRootIDs() {
+                if rows.count > 0, rows.count.isMultiple(of: 128) {
+                    await Task.yield()
+                }
+                try collect(nodeID, depth: 0)
+            }
+            return (rows, visitedNodeIDsForTesting)
+        }
+
+        private static func isNodeOpen(
+            _ node: DOMTreeTextView.RenderedRowsBuildNode,
+            expansionState: [DOMNode.ID: Bool]
+        ) -> Bool {
+            if let explicitState = expansionState[node.id] {
+                return explicitState
+            }
+            let name = node.displayName.lowercased()
+            if name == "head" {
+                return false
+            }
+            return name == "html" || name == "body"
         }
 
         private mutating func renderedRow(
@@ -509,7 +525,11 @@ extension DOMTreeTextView {
                 isOpen: isOpen,
                 isClosingTag: isClosingTag
             )
-            if let cached = markupCache[node.id],
+            let cacheKey = DOMTreeTextView.MarkupCacheKey(
+                nodeID: node.id,
+                isClosingTag: isClosingTag
+            )
+            if let cached = markupCache[cacheKey],
                cached.signature == signature {
                 return cached.markup
             }
@@ -520,7 +540,7 @@ extension DOMTreeTextView {
                 isClosingTag: isClosingTag,
                 isTemplateContent: node.isTemplateContent
             )
-            markupCache[node.id] = DOMTreeTextView.CachedMarkup(signature: signature, markup: markup)
+            markupCache[cacheKey] = DOMTreeTextView.CachedMarkup(signature: signature, markup: markup)
             return markup
         }
 

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeRenderedRowsBuilder.swift
@@ -12,6 +12,7 @@ extension DOMTreeTextView {
 
         private let builder: DOMTreeTextView.RenderedRowsBuilder
         private var task: Task<Void, Never>?
+        private var currentRequest: DOMTreeTextView.RenderedRowsBuildRequest?
         private var generation: UInt64 = 0
 #if DEBUG
         private var shouldSuspendNextBuildForTesting = false
@@ -38,9 +39,14 @@ extension DOMTreeTextView {
         func cancel() {
             task?.cancel()
             task = nil
+            currentRequest = nil
 #if DEBUG
             resumeSuspendedBuildForTesting()
 #endif
+        }
+
+        func currentBuildRenders(nodeID: DOMNode.ID) -> Bool {
+            currentRequest?.rendersNode(nodeID) ?? false
         }
 
         func waitForCurrentBuild() async {
@@ -68,6 +74,7 @@ extension DOMTreeTextView {
             generation &+= 1
             let buildGeneration = generation
             task?.cancel()
+            currentRequest = request
 #if DEBUG
             resumeSuspendedBuildForTesting()
 #endif
@@ -79,6 +86,7 @@ extension DOMTreeTextView {
                 defer {
                     if generation == buildGeneration {
                         task = nil
+                        currentRequest = nil
                         if shouldNotifyFinish {
                             didFinish?()
                         }
@@ -293,6 +301,45 @@ extension DOMTreeTextView {
         var treeRevision: UInt64 {
             snapshot.treeRevision
         }
+
+        func rendersNode(_ targetNodeID: DOMNode.ID) -> Bool {
+            var visitedNodeIDs = Set<DOMNode.ID>()
+
+            func renders(_ nodeID: DOMNode.ID) -> Bool {
+                guard visitedNodeIDs.insert(nodeID).inserted,
+                      let node = snapshot.node(for: nodeID) else {
+                    return false
+                }
+                if nodeID == targetNodeID {
+                    return true
+                }
+                let visibleChildren = snapshot.visibleChildrenProjection(of: nodeID)
+                guard visibleChildren.hasRenderableChildren,
+                      isNodeOpen(nodeID: node.id, displayName: node.displayName) else {
+                    return false
+                }
+                for childID in visibleChildren.children where renders(childID) {
+                    return true
+                }
+                return false
+            }
+
+            for rootNodeID in snapshot.displayRootIDs() where renders(rootNodeID) {
+                return true
+            }
+            return false
+        }
+
+        func isNodeOpen(nodeID: DOMNode.ID, displayName: String) -> Bool {
+            if let explicitState = expansionState[nodeID] {
+                return explicitState
+            }
+            let name = displayName.lowercased()
+            if name == "head" {
+                return false
+            }
+            return name == "html" || name == "body"
+        }
     }
 
     struct RenderedRowsBuildResult: Sendable {
@@ -409,7 +456,7 @@ extension DOMTreeTextView {
                     isTemplateContent: request.snapshot.isTemplateContent(nodeID)
                 )
                 let hasDisclosure = visibleChildren.hasRenderableChildren
-                let isOpen = Self.isNodeOpen(renderNode, expansionState: request.expansionState)
+                let isOpen = request.isNodeOpen(nodeID: renderNode.id, displayName: renderNode.displayName)
                 rows.append(
                     DOMTreeTextView.RenderedRowsBuildRow(
                         node: renderNode,
@@ -448,20 +495,6 @@ extension DOMTreeTextView {
                 try collect(nodeID, depth: 0)
             }
             return (rows, visitedNodeIDsForTesting)
-        }
-
-        private static func isNodeOpen(
-            _ node: DOMTreeTextView.RenderedRowsBuildNode,
-            expansionState: [DOMNode.ID: Bool]
-        ) -> Bool {
-            if let explicitState = expansionState[node.id] {
-                return explicitState
-            }
-            let name = node.displayName.lowercased()
-            if name == "head" {
-                return false
-            }
-            return name == "html" || name == "body"
         }
 
         private mutating func renderedRow(

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -80,6 +80,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var lastBoundsSize: CGSize = .zero
     private var lastRenderedDocumentRootID: DOMNode.ID?
     private var lastRoutedTreeRevision: UInt64?
+    private var pendingDOMTreeRenderInvalidation: DOMTreeRenderInvalidation?
+    private var pendingDOMTreeRenderInvalidationIsInitial = false
+    private var domTreeRenderInvalidationTask: Task<Void, Never>?
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
     private let selectionRevealState = DOMTreeTextView.SelectionRevealState()
@@ -174,6 +177,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
     isolated deinit {
         pageHighlightTask?.cancel()
+        domTreeRenderInvalidationTask?.cancel()
         renderedRowsBuildCoordinator.cancel()
         documentObservation?.cancel()
         selectionObservation?.cancel()
@@ -496,13 +500,14 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func startObservingDocument() {
         documentObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
-            let treeRevision = dom.treeRevision
+            let invalidation = dom.treeRenderInvalidation
+            let treeRevision = invalidation.revision
             let shouldRouteDOMInvalidation = event.kind == .initial || lastRoutedTreeRevision != treeRevision
             lastRoutedTreeRevision = treeRevision
             guard shouldRouteDOMInvalidation else {
                 return
             }
-            routeDOMInvalidation(from: dom, isInitial: event.kind == .initial)
+            scheduleDOMInvalidation(invalidation, isInitial: event.kind == .initial)
         }
         selectionObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
@@ -511,14 +516,46 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
     }
 
-    private func routeDOMInvalidation(from dom: DOMSession, isInitial: Bool) {
+    private func scheduleDOMInvalidation(
+        _ invalidation: DOMTreeRenderInvalidation,
+        isInitial: Bool
+    ) {
+        pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: invalidation) ?? invalidation
+        pendingDOMTreeRenderInvalidationIsInitial = pendingDOMTreeRenderInvalidationIsInitial || isInitial
+        guard domTreeRenderInvalidationTask == nil else {
+            return
+        }
+        domTreeRenderInvalidationTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self else {
+                return
+            }
+            let pendingInvalidation = pendingDOMTreeRenderInvalidation
+            let pendingIsInitial = pendingDOMTreeRenderInvalidationIsInitial
+            pendingDOMTreeRenderInvalidation = nil
+            pendingDOMTreeRenderInvalidationIsInitial = false
+            domTreeRenderInvalidationTask = nil
+            guard let pendingInvalidation else {
+                return
+            }
+            routeDOMInvalidation(pendingInvalidation, isInitial: pendingIsInitial)
+        }
+    }
+
+    private func routeDOMInvalidation(
+        _ invalidation: DOMTreeRenderInvalidation,
+        isInitial: Bool
+    ) {
+        guard shouldRouteDOMInvalidation(invalidation, isInitial: isInitial) else {
+            return
+        }
 #if DEBUG
         performanceCounters.buildRenderedRowsCallCount += 1
 #endif
-        resetLocalDocumentStateIfNeeded()
+        let didResetLocalDocumentState = resetLocalDocumentStateIfNeeded(rootID: dom.currentDOMTreeRenderRootNodeID)
         prepareSelectionForRendering()
         startRenderedRowsBuild(
-            resetFragments: true,
+            resetFragments: isInitial || invalidation.requiresFragmentReset || didResetLocalDocumentState,
             previousRows: rows,
             previousText: renderedText,
             shouldApply: { [weak self] result in
@@ -531,6 +568,35 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 return treeChanged
             }
         )
+    }
+
+    private func shouldRouteDOMInvalidation(
+        _ invalidation: DOMTreeRenderInvalidation,
+        isInitial: Bool
+    ) -> Bool {
+        guard !isInitial, !invalidation.requiresFragmentReset else {
+            return true
+        }
+
+        switch invalidation.kind {
+        case .root:
+            return true
+        case .content:
+            guard let affectedNodeID = invalidation.affectedNodeID else {
+                return true
+            }
+            return renderedRows.contains(nodeID: affectedNodeID)
+        case .structure:
+            if let affectedNodeID = invalidation.affectedNodeID,
+               renderedRows.contains(nodeID: affectedNodeID) {
+                return true
+            }
+            if let parentNodeID = invalidation.parentNodeID,
+               renderedRows.contains(nodeID: parentNodeID) {
+                return true
+            }
+            return invalidation.affectedNodeID == nil && invalidation.parentNodeID == nil
+        }
     }
 
     private func routeSelectionInvalidation(from dom: DOMSession) {
@@ -571,10 +637,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             performanceCounters.reloadTreeCallCount += 1
         }
 #endif
-        resetLocalDocumentStateIfNeeded()
+        let didResetLocalDocumentState = resetLocalDocumentStateIfNeeded()
         let previousRows = rows
         let previousText = renderedText
-        if resetFragments {
+        let shouldResetFragments = resetFragments || didResetLocalDocumentState
+        if shouldResetFragments {
             renderedRowsBuildCoordinator.removeCachedMarkup(keepingCapacity: true)
         }
         prepareSelectionForRendering()
@@ -582,7 +649,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         performanceCounters.buildRenderedRowsCallCount += 1
 #endif
         startRenderedRowsBuild(
-            resetFragments: resetFragments,
+            resetFragments: shouldResetFragments,
             previousRows: previousRows,
             previousText: previousText
         )
@@ -601,7 +668,10 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 guard let self else {
                     return false
                 }
-                return dom.treeRevision == request.treeRevision
+                let currentInvalidation = dom.treeRenderInvalidation
+                let isCurrentTreeRevision = currentInvalidation.revision == request.treeRevision
+                    || !shouldRouteDOMInvalidation(currentInvalidation, isInitial: false)
+                return isCurrentTreeRevision
                     && expansionState.snapshot == request.expansionState
             },
             shouldApply: shouldApply,
@@ -660,14 +730,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 #endif
     }
 
-    private func resetLocalDocumentStateIfNeeded() {
-        let rootID = dom.currentPageRootNode?.id
+    @discardableResult
+    private func resetLocalDocumentStateIfNeeded(rootID: DOMNode.ID? = nil) -> Bool {
+        let rootID = rootID ?? dom.currentDOMTreeRenderRootNodeID
         defer {
             lastRenderedDocumentRootID = rootID
         }
         guard rootID == nil
                 || (lastRenderedDocumentRootID != nil && lastRenderedDocumentRootID != rootID) else {
-            return
+            return false
         }
 
         expansionState.removeAll()
@@ -680,6 +751,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         multiSelection.reset()
         dismissDOMMenuAnchor()
         clearTextSelection()
+        return true
     }
 
     private func prepareSelectionForRendering(clearsMultiSelectionForDocumentSelection: Bool = false) {
@@ -1236,6 +1308,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         performanceCounters.incrementalTextStorageEditCallCount += 1
 #endif
 
+        let editedLength = max(edit.range.length, (edit.replacement as NSString).length)
+        invalidateTextLayout(for: NSRange(location: edit.range.location, length: editedLength))
         let changedRows = Array(nextRows[diff.nextStart..<diff.nextEnd])
         applyTextAttributes(to: changedRows)
         invalidateTokenRenderingAttributes(for: changedRows.map(\.textRange))
@@ -1445,6 +1519,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
     private func invalidateTextLayout() {
         layoutManager.invalidateLayout(for: textContentStorage.documentRange)
+        layoutManager.textSelectionNavigation.flushLayoutCache()
+    }
+
+    private func invalidateTextLayout(for range: NSRange) {
+        guard range.length > 0,
+              let textRange = textRange(for: range) else {
+            return
+        }
+        layoutManager.invalidateLayout(for: textRange)
         layoutManager.textSelectionNavigation.flushLayoutCache()
     }
 
@@ -2247,6 +2330,10 @@ extension DOMTreeTextView {
         performanceCounters.resetTextFragmentViewsCallCount
     }
 
+    var cachedMarkupKeysForTesting: Set<DOMTreeTextView.MarkupCacheKey> {
+        renderedRowsBuildCoordinator.cachedMarkupKeysForTesting()
+    }
+
     var renderedRowsAppliedTreeRevisionForTesting: UInt64 {
         renderedRowsAppliedTreeRevisionForTestingStorage
     }
@@ -2378,7 +2465,16 @@ extension DOMTreeTextView {
     }
 
     func waitForRenderedRowsForTesting() async {
-        await renderedRowsBuildCoordinator.waitForCurrentBuild()
+        while true {
+            if let domTreeRenderInvalidationTask {
+                await domTreeRenderInvalidationTask.value
+                continue
+            }
+            await renderedRowsBuildCoordinator.waitForCurrentBuild()
+            if domTreeRenderInvalidationTask == nil {
+                return
+            }
+        }
     }
 
     func suspendNextRenderedRowsBuildForTesting() {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -500,13 +500,17 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func startObservingDocument() {
         documentObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
-            let invalidation = dom.treeRenderInvalidation
-            let treeRevision = invalidation.revision
-            let shouldRouteDOMInvalidation = event.kind == .initial || lastRoutedTreeRevision != treeRevision
+            let latestInvalidation = dom.treeRenderInvalidation
+            let treeRevision = latestInvalidation.revision
+            let previousRoutedTreeRevision = lastRoutedTreeRevision
+            let shouldRouteDOMInvalidation = event.kind == .initial || previousRoutedTreeRevision != treeRevision
             lastRoutedTreeRevision = treeRevision
             guard shouldRouteDOMInvalidation else {
                 return
             }
+            let invalidation = event.kind == .initial
+                ? latestInvalidation
+                : dom.treeRenderInvalidation(since: previousRoutedTreeRevision)
             scheduleDOMInvalidation(invalidation, isInitial: event.kind == .initial)
         }
         selectionObservation = withPortableContinuousObservation { [weak self] _ in
@@ -668,7 +672,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 guard let self else {
                     return false
                 }
-                let currentInvalidation = dom.treeRenderInvalidation
+                let currentInvalidation = dom.treeRenderInvalidation(since: request.treeRevision)
                 let isCurrentTreeRevision = currentInvalidation.revision == request.treeRevision
                     || !shouldRouteDOMInvalidation(currentInvalidation, isInitial: false)
                 return isCurrentTreeRevision

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -82,6 +82,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var lastRoutedTreeRevision: UInt64?
     private var pendingDOMTreeRenderInvalidation: DOMTreeRenderInvalidation?
     private var pendingDOMTreeRenderInvalidationIsInitial = false
+    private var pendingDOMTreeRenderInvalidationRequiresRoute = false
     private var domTreeRenderInvalidationTask: Task<Void, Never>?
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
@@ -526,6 +527,14 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     ) {
         pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: invalidation) ?? invalidation
         pendingDOMTreeRenderInvalidationIsInitial = pendingDOMTreeRenderInvalidationIsInitial || isInitial
+        pendingDOMTreeRenderInvalidationRequiresRoute = pendingDOMTreeRenderInvalidationRequiresRoute
+            || shouldRouteDOMInvalidation(
+                invalidation,
+                isInitial: isInitial,
+                includesNode: { [renderedRowsBuildCoordinator] nodeID in
+                    renderedRowsBuildCoordinator.currentBuildRenders(nodeID: nodeID)
+                }
+            )
         guard domTreeRenderInvalidationTask == nil else {
             return
         }
@@ -536,21 +545,28 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             }
             let pendingInvalidation = pendingDOMTreeRenderInvalidation
             let pendingIsInitial = pendingDOMTreeRenderInvalidationIsInitial
+            let pendingRequiresRoute = pendingDOMTreeRenderInvalidationRequiresRoute
             pendingDOMTreeRenderInvalidation = nil
             pendingDOMTreeRenderInvalidationIsInitial = false
+            pendingDOMTreeRenderInvalidationRequiresRoute = false
             domTreeRenderInvalidationTask = nil
             guard let pendingInvalidation else {
                 return
             }
-            routeDOMInvalidation(pendingInvalidation, isInitial: pendingIsInitial)
+            routeDOMInvalidation(
+                pendingInvalidation,
+                isInitial: pendingIsInitial,
+                forceRoute: pendingRequiresRoute
+            )
         }
     }
 
     private func routeDOMInvalidation(
         _ invalidation: DOMTreeRenderInvalidation,
-        isInitial: Bool
+        isInitial: Bool,
+        forceRoute: Bool = false
     ) {
-        guard shouldRouteDOMInvalidation(invalidation, isInitial: isInitial) else {
+        guard forceRoute || shouldRouteDOMInvalidation(invalidation, isInitial: isInitial) else {
             return
         }
 #if DEBUG
@@ -576,10 +592,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
     private func shouldRouteDOMInvalidation(
         _ invalidation: DOMTreeRenderInvalidation,
-        isInitial: Bool
+        isInitial: Bool,
+        includesNode: ((DOMNode.ID) -> Bool)? = nil
     ) -> Bool {
         guard !isInitial, !invalidation.requiresFragmentReset else {
             return true
+        }
+
+        func isVisible(_ nodeID: DOMNode.ID) -> Bool {
+            renderedRows.contains(nodeID: nodeID) || includesNode?(nodeID) == true
         }
 
         switch invalidation.kind {
@@ -589,7 +610,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             guard let affectedNodeID = invalidation.affectedNodeID else {
                 return true
             }
-            return renderedRows.contains(nodeID: affectedNodeID)
+            return isVisible(affectedNodeID)
         case .structure:
             let renderRootNodeID = dom.currentDOMTreeRenderRootNodeID
             if invalidation.affectedNodeID == renderRootNodeID
@@ -597,11 +618,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 return true
             }
             if let affectedNodeID = invalidation.affectedNodeID,
-               renderedRows.contains(nodeID: affectedNodeID) {
+               isVisible(affectedNodeID) {
                 return true
             }
             if let parentNodeID = invalidation.parentNodeID,
-               renderedRows.contains(nodeID: parentNodeID) {
+               isVisible(parentNodeID) {
                 return true
             }
             return invalidation.affectedNodeID == nil && invalidation.parentNodeID == nil
@@ -679,7 +700,13 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 }
                 let currentInvalidation = dom.treeRenderInvalidation(since: request.treeRevision)
                 let isCurrentTreeRevision = currentInvalidation.revision == request.treeRevision
-                    || !shouldRouteDOMInvalidation(currentInvalidation, isInitial: false)
+                    || !shouldRouteDOMInvalidation(
+                        currentInvalidation,
+                        isInitial: false,
+                        includesNode: { nodeID in
+                            request.rendersNode(nodeID)
+                        }
+                    )
                 return isCurrentTreeRevision
                     && expansionState.snapshot == request.expansionState
             },

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -591,6 +591,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             }
             return renderedRows.contains(nodeID: affectedNodeID)
         case .structure:
+            let renderRootNodeID = dom.currentDOMTreeRenderRootNodeID
+            if invalidation.affectedNodeID == renderRootNodeID
+                || invalidation.parentNodeID == renderRootNodeID {
+                return true
+            }
             if let affectedNodeID = invalidation.affectedNodeID,
                renderedRows.contains(nodeID: affectedNodeID) {
                 return true

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextViewTypes.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextViewTypes.swift
@@ -422,6 +422,13 @@ extension DOMTreeTextView {
 }
 
 extension DOMTreeTextView {
+    struct MarkupCacheKey: Hashable, Sendable {
+        let nodeID: DOMNode.ID
+        let isClosingTag: Bool
+    }
+}
+
+extension DOMTreeTextView {
     struct CachedMarkup: Sendable {
         let signature: DOMTreeTextView.MarkupSignature
         let markup: DOMTreeTextView.Markup

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -856,6 +856,153 @@ func setChildNodesPreservesProtocolChildOrderAndSiblingLinks() async throws {
     #expect(snapshot.nodesByID[childIDs[2]]?.nextSiblingID == nil)
 }
 
+@Test
+func domTreeRenderSnapshotPreservesVisibleChildProjectionOrdering() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                DOMNode.Payload(
+                    nodeID: .init(2),
+                    nodeType: .element,
+                    nodeName: "host",
+                    localName: "host",
+                    regularChildren: .loaded([
+                        .element(nodeID: 6, name: "regular"),
+                    ]),
+                    shadowRoots: [
+                        DOMNode.Payload(
+                            nodeID: .init(5),
+                            nodeType: .documentFragment,
+                            nodeName: "#shadow-root",
+                            shadowRootType: "open"
+                        ),
+                    ],
+                    templateContent: DOMNode.Payload(
+                        nodeID: .init(3),
+                        nodeType: .documentFragment,
+                        nodeName: "#document-fragment"
+                    ),
+                    beforePseudoElement: .element(nodeID: 4, name: "::before", pseudoType: "before"),
+                    otherPseudoElements: [
+                        .element(nodeID: 7, name: "::marker", pseudoType: "marker"),
+                    ],
+                    afterPseudoElement: .element(nodeID: 8, name: "::after", pseudoType: "after")
+                ),
+                DOMNode.Payload(
+                    nodeID: .init(20),
+                    nodeType: .element,
+                    nodeName: "iframe",
+                    localName: "iframe",
+                    contentDocument: document(nodeID: 21)
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+
+    let snapshot = await session.domTreeRenderSnapshot()
+    let hostID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(2)))
+    let iframeID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(20)))
+    var expectedHostChildren: [DOMNode.ID] = []
+    for rawNodeID in [3, 4, 7, 5, 6, 8] {
+        let nodeID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(rawNodeID)))
+        expectedHostChildren.append(nodeID)
+    }
+    let iframeDocumentID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(21)))
+
+    #expect(snapshot.visibleChildrenProjection(of: hostID).children == expectedHostChildren)
+    #expect(snapshot.visibleChildrenProjection(of: hostID).hasRenderableChildren)
+    #expect(snapshot.visibleChildrenProjection(of: iframeID).children == [iframeDocumentID])
+}
+
+@Test
+func domTreeRenderInvalidationRecordsContentAndStructureMutations() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                .element(
+                    nodeID: 2,
+                    name: "body",
+                    children: [
+                        .element(nodeID: 3, name: "span"),
+                    ]
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+    let bodyID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(2)))
+    let spanID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(3)))
+
+    await session.applyAttributeModified(spanID, name: "data-state", value: "ready")
+    var invalidation = await session.treeRenderInvalidation
+    #expect(invalidation.kind == .content)
+    #expect(invalidation.affectedNodeID == spanID)
+    #expect(invalidation.parentNodeID == bodyID)
+
+    let insertedID = try #require(await session.applyChildInserted(
+        parent: bodyID,
+        previousSibling: spanID,
+        child: .element(nodeID: 4, name: "em")
+    ))
+    invalidation = await session.treeRenderInvalidation
+    #expect(invalidation.kind == .structure)
+    #expect(invalidation.affectedNodeID == insertedID)
+    #expect(invalidation.parentNodeID == bodyID)
+}
+
+@Test
+func domTreeRenderInvalidationMergesConservatively() {
+    let documentID = DOMDocument.ID(
+        targetID: ProtocolTarget.ID("page-main"),
+        localDocumentLifetimeID: .init(1)
+    )
+    let parentID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+    let firstNodeID = DOMNode.ID(documentID: documentID, nodeID: .init(2))
+    let secondNodeID = DOMNode.ID(documentID: documentID, nodeID: .init(3))
+
+    let first = DOMTreeRenderInvalidation(
+        revision: 1,
+        kind: .content,
+        affectedNodeID: firstNodeID,
+        parentNodeID: parentID
+    )
+    let second = DOMTreeRenderInvalidation(
+        revision: 2,
+        kind: .content,
+        affectedNodeID: secondNodeID,
+        parentNodeID: parentID
+    )
+    let mergedContent = first.merging(with: second)
+    #expect(mergedContent.revision == 2)
+    #expect(mergedContent.kind == .content)
+    #expect(mergedContent.affectedNodeID == nil)
+    #expect(mergedContent.parentNodeID == parentID)
+
+    let mergedStructure = first.merging(
+        with: DOMTreeRenderInvalidation(
+            revision: 3,
+            kind: .structure,
+            affectedNodeID: secondNodeID,
+            parentNodeID: parentID
+        )
+    )
+    #expect(mergedStructure.revision == 3)
+    #expect(mergedStructure.kind == .structure)
+    #expect(mergedStructure.affectedNodeID == nil)
+    #expect(mergedStructure.parentNodeID == parentID)
+}
+
 @Test("Regression: detached root cannot overwrite connected page document nodes")
 func detachedRootCannotOverwriteConnectedPageDocumentNodes() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")

--- a/Tests/WebInspectorCoreTests/DOMModelTests.swift
+++ b/Tests/WebInspectorCoreTests/DOMModelTests.swift
@@ -1003,6 +1003,50 @@ func domTreeRenderInvalidationMergesConservatively() {
     #expect(mergedStructure.parentNodeID == parentID)
 }
 
+@Test
+func domTreeRenderInvalidationSinceRevisionMergesRecordedMutations() async throws {
+    let pageTargetID = ProtocolTarget.ID("page-main")
+    let session = await DOMSession()
+
+    await session.applyTargetCreated(.init(id: pageTargetID, kind: .page), makeCurrentMainPage: true)
+    _ = await session.replaceDocumentRoot(
+        document(
+            nodeID: 1,
+            children: [
+                .element(
+                    nodeID: 2,
+                    name: "body",
+                    children: [
+                        .element(nodeID: 3, name: "div"),
+                        .element(
+                            nodeID: 4,
+                            name: "article",
+                            children: [
+                                .element(nodeID: 5, name: "span"),
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        ),
+        targetID: pageTargetID
+    )
+    let routedRevision = await session.treeRevision
+    let divID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(3)))
+    let spanID = try #require(await session.currentNodeID(targetID: pageTargetID, rawNodeID: .init(5)))
+
+    await session.applyAttributeModified(divID, name: "data-visible", value: "ready")
+    await session.applyAttributeModified(spanID, name: "data-hidden", value: "ready")
+
+    let latestInvalidation = await session.treeRenderInvalidation
+    let mergedInvalidation = await session.treeRenderInvalidation(since: routedRevision)
+    #expect(latestInvalidation.affectedNodeID == spanID)
+    #expect(mergedInvalidation.revision == latestInvalidation.revision)
+    #expect(mergedInvalidation.kind == .content)
+    #expect(mergedInvalidation.affectedNodeID == nil)
+    #expect(mergedInvalidation.parentNodeID == nil)
+}
+
 @Test("Regression: detached root cannot overwrite connected page document nodes")
 func detachedRootCannotOverwriteConnectedPageDocumentNodes() async throws {
     let pageTargetID = ProtocolTarget.ID("page-main")

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -2073,10 +2073,11 @@ func frameDocumentRequestDoesNotBlockPageDOMEvents() async throws {
     )
     #expect(frameDocumentRequest.targetIdentifier == ProtocolTarget.ID.frameAd)
 
-    await receiveTargetDispatch(
+    await receiveAndApplyTargetDispatch(
         transport,
         targetID: .pageMain,
-        message: pageHTMLChildrenSetChildNodesMessage
+        message: pageHTMLChildrenSetChildNodesMessage,
+        in: session
     )
     let bodyID = try await waitForCurrentNode(
         in: session,
@@ -7202,10 +7203,11 @@ private func hydratePageHTMLChildren(
         await session.attachment.dom.requestChildNodes(for: htmlID)
     }
     let request = try await waitForTargetMessage(backend, method: "DOM.requestChildNodes", after: sentCount)
-    await receiveTargetDispatch(
+    await receiveAndApplyTargetDispatch(
         transport,
         targetID: .pageMain,
-        message: pageHTMLChildrenSetChildNodesMessage
+        message: pageHTMLChildrenSetChildNodesMessage,
+        in: session
     )
     await receiveTargetReply(
         transport,

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -108,6 +108,47 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func documentRootStructureMutationRoutesHiddenRenderRoot() async throws {
+        let session = makeDOMSession(
+            root: DOMNode.Payload(
+                nodeID: .init(1),
+                nodeType: .document,
+                nodeName: "#document",
+                regularChildren: .unrequested(count: 1)
+            )
+        )
+        let view = await makeTreeView(session: session)
+        let rootID = try #require(session.currentPageRootNode?.id)
+
+        #expect(view.renderedTextForTesting.isEmpty)
+
+        let didRenderDocumentElement = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.applySetChildNodes(
+                    parent: rootID,
+                    children: [
+                        DOMNode.Payload(
+                            nodeID: .init(2),
+                            nodeType: .element,
+                            nodeName: "HTML",
+                            localName: "html"
+                        ),
+                    ],
+                    eventSequence: 1
+                )
+            },
+            until: {
+                view.renderedTextForTesting.contains("<html")
+            }
+        )
+
+        #expect(didRenderDocumentElement)
+        #expect(view.renderedTextForTesting.contains("<html"))
+    }
+
+    @Test
     func textStorageKeepsTokenForegroundAsBaseAttributes() async throws {
         let view = await makeTreeView()
 

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -43,17 +43,17 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
-    func collapsedDescendantMutationDoesNotTraverseOrApplyCollapsedSubtree() async throws {
+    func collapsedDescendantMutationDoesNotRouteCollapsedSubtreeBuild() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)
         let documentID = try #require(session.currentPageRootNode?.id.documentID)
         let articleID = DOMNode.ID(documentID: documentID, nodeID: .init(8))
         let nestedChildID = DOMNode.ID(documentID: documentID, nodeID: .init(9))
-        let observedBuildCounts = await view.documentObservationDeliveryForTesting.values {
-            view.buildRenderedRowsCallCountForTesting
+        let observedTreeRenderRevisions = await view.documentObservationDeliveryForTesting.values {
+            session.treeRenderInvalidation.revision
         }
         defer {
-            observedBuildCounts.cancel()
+            observedTreeRenderRevisions.cancel()
         }
         let baselineSnapshotBuildCount = session.snapshotBuildCountForTesting
         let baselineAppliedTreeRevision = view.renderedRowsAppliedTreeRevisionForTesting
@@ -63,12 +63,14 @@ struct DOMTreeTextViewTests {
         #expect(!view.renderedTextForTesting.contains("data-state=\"ready\""))
 
         session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
-        let didRouteBuild = await observedBuildCounts.waitUntil {
-            $0 > baselineBuildCount
+        let expectedTreeRevision = session.treeRevision
+        let didObserveTreeRevision = await observedTreeRenderRevisions.waitUntil {
+            $0 >= expectedTreeRevision
         } != nil
         await view.waitForRenderedRowsForTesting()
 
-        #expect(didRouteBuild)
+        #expect(didObserveTreeRevision)
+        #expect(view.buildRenderedRowsCallCountForTesting == baselineBuildCount)
         #expect(DOMTreeTextView.RenderedRowsBuilder.lastCollectedNodeIDsForTesting.contains(articleID))
         #expect(!DOMTreeTextView.RenderedRowsBuilder.lastCollectedNodeIDsForTesting.contains(nestedChildID))
         #expect(session.snapshotBuildCountForTesting == baselineSnapshotBuildCount)
@@ -342,6 +344,25 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func markupCacheSeparatesOpeningAndClosingRowsForSameNode() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsForTesting()
+
+        let articleID = try #require(
+            session.snapshot().nodesByID.first { entry in
+                entry.value.localName == "article"
+            }?.key
+        )
+        let cachedKeys = view.cachedMarkupKeysForTesting
+
+        #expect(cachedKeys.contains(DOMTreeTextView.MarkupCacheKey(nodeID: articleID, isClosingTag: false)))
+        #expect(cachedKeys.contains(DOMTreeTextView.MarkupCacheKey(nodeID: articleID, isClosingTag: true)))
+    }
+
+    @Test
     func multiSelectionDisplayOrderUsesRenderedRowIndexes() async throws {
         let view = await makeTreeView()
 
@@ -387,6 +408,40 @@ struct DOMTreeTextViewTests {
         )
         #expect(didRenderAttribute)
         #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>"))
+    }
+
+    @Test
+    func visibleContentMutationUsesIncrementalTextStorageUpdate() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsForTesting()
+        view.resetPerformanceCountersForTesting()
+
+        let nestedChildID = try #require(
+            session.snapshot().nodesByID.first { entry in
+                entry.value.attributes.contains { attribute in
+                    attribute.name == "id" && attribute.value == "nested-child"
+                }
+            }?.key
+        )
+
+        let didRenderAttribute = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
+            },
+            until: {
+                view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>")
+            }
+        )
+
+        #expect(didRenderAttribute)
+        #expect(view.incrementalTextStorageEditCallCountForTesting == 1)
+        #expect(view.rebuildTextStorageCallCountForTesting == 0)
+        #expect(view.resetTextFragmentViewsCallCountForTesting == 0)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -79,6 +79,35 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func coalescedVisibleThenCollapsedMutationStillRoutesVisibleUpdate() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let documentID = try #require(session.currentPageRootNode?.id.documentID)
+        let visibleDivID = DOMNode.ID(documentID: documentID, nodeID: .init(7))
+        let nestedChildID = DOMNode.ID(documentID: documentID, nodeID: .init(9))
+
+        #expect(view.renderedTextForTesting.contains("<div id=\"start-of-content\" data-testid=\"cellInnerDiv\"></div>"))
+        #expect(view.renderedTextForTesting.contains("<article>…</article>"))
+        #expect(!view.renderedTextForTesting.contains("data-hidden=\"ready\""))
+
+        let didRenderVisibleAttribute = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.applyAttributeModified(visibleDivID, name: "data-visible", value: "ready")
+                session.applyAttributeModified(nestedChildID, name: "data-hidden", value: "ready")
+            },
+            until: {
+                view.renderedTextForTesting.contains("data-visible=\"ready\"")
+            }
+        )
+
+        #expect(didRenderVisibleAttribute)
+        #expect(view.renderedTextForTesting.contains("data-visible=\"ready\""))
+        #expect(!view.renderedTextForTesting.contains("data-hidden=\"ready\""))
+    }
+
+    @Test
     func textStorageKeepsTokenForegroundAsBaseAttributes() async throws {
         let view = await makeTreeView()
 

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -515,6 +515,37 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func inFlightExpansionMutationRebuildsAgainstNewSnapshot() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let nestedChildID = try #require(
+            session.snapshot().nodesByID.first { entry in
+                entry.value.attributes.contains { attribute in
+                    attribute.name == "id" && attribute.value == "nested-child"
+                }
+            }?.key
+        )
+
+        view.suspendNextRenderedRowsBuildForTesting()
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsBuildSuspensionForTesting()
+
+        let didRenderAttribute = await waitForRenderedDocumentTreeUpdate(
+            in: view,
+            session: session,
+            update: {
+                session.applyAttributeModified(nestedChildID, name: "data-state", value: "ready")
+            },
+            until: {
+                view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>")
+            }
+        )
+
+        #expect(didRenderAttribute)
+        #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\" data-state=\"ready\"></span>"))
+    }
+
+    @Test
     func selectionChangeUpdatesDecorationsWithoutRebuildingRenderedRows() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)


### PR DESCRIPTION
## Purpose
Improve DOM tree rendering responsiveness by narrowing Observation dependencies and avoiding full TextKit fragment resets for ordinary DOM updates.

## Changes
- Add immutable DOM tree render snapshots, visible child projections, and lightweight render invalidations.
- Build rendered rows from snapshot input outside the tracked Observation read path.
- Coalesce and merge DOM invalidations, including hidden document root changes and in-flight expansion builds.
- Use incremental TextKit storage updates with range-limited invalidation, and separate markup cache keys for opening and closing rows.
- Add regression coverage for projection ordering, coalesced invalidations, hidden root updates, in-flight build mutations, and incremental rendering behavior.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` against `origin/main` returned no findings.