### PR TITLE
Suspend hidden inspector UI rendering by view lifecycle

### DIFF
--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -121,6 +121,12 @@ extension NetworkBody {
             job?.preparation
         }
 
+#if DEBUG
+        var hasCurrentPreparation: Bool {
+            job != nil
+        }
+#endif
+
         func withInvalidationBatch(_ updates: () -> Void, invalidate: () -> Void) {
             isBatchingInvalidation = true
             updates()
@@ -320,6 +326,12 @@ package final class NetworkBody {
     package func cancelTextRepresentationPreparation() {
         textRepresentationPreparation.cancelPreparation()
     }
+
+#if DEBUG
+    package var hasActiveTextRepresentationPreparationForTesting: Bool {
+        textRepresentationPreparation.hasCurrentPreparation
+    }
+#endif
 
     package static func makeRequestBody(for request: NetworkRequest.Payload) -> NetworkBody? {
         guard let postData = request.postData else {

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -266,6 +266,10 @@ package final class NetworkBody {
         return NetworkBody.TextPreparation(task: task)
     }
 
+    package func cancelTextRepresentationPreparation() {
+        textRepresentationPreparation.cancelPreparation()
+    }
+
     package static func makeRequestBody(for request: NetworkRequest.Payload) -> NetworkBody? {
         guard let postData = request.postData else {
             return nil

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -606,9 +606,12 @@ private enum CancellableJSONPrettyPrinter {
                 return try consumeLiteral("false") ? "false" : nil
             case "n":
                 return try consumeLiteral("null") ? "null" : nil
-            case "-", "0"..."9":
+            case "-":
                 return try parseNumber()
             default:
+                if isASCIIDigit(character) {
+                    return try parseNumber()
+                }
                 return nil
             }
         }
@@ -689,7 +692,7 @@ private enum CancellableJSONPrettyPrinter {
                     if escaped == "u" {
                         for _ in 0..<4 {
                             guard let scalar = currentCharacter,
-                                  scalar.isHexDigit else {
+                                  isASCIIHexDigit(scalar) else {
                                 return nil
                             }
                             advance()
@@ -710,25 +713,25 @@ private enum CancellableJSONPrettyPrinter {
                 try checkpoint()
             }
             guard let firstDigit = currentCharacter,
-                  firstDigit.isNumber else {
+                  isASCIIDigit(firstDigit) else {
                 return nil
             }
             if firstDigit == "0" {
                 advance()
             } else {
                 while let character = currentCharacter,
-                      character.isNumber {
+                      isASCIIDigit(character) {
                     try checkpoint()
                     advance()
                 }
             }
             if try consumeIfPresent(".") {
                 guard let digit = currentCharacter,
-                      digit.isNumber else {
+                      isASCIIDigit(digit) else {
                     return nil
                 }
                 while let character = currentCharacter,
-                      character.isNumber {
+                      isASCIIDigit(character) {
                     try checkpoint()
                     advance()
                 }
@@ -741,11 +744,11 @@ private enum CancellableJSONPrettyPrinter {
                     advance()
                 }
                 guard let digit = currentCharacter,
-                      digit.isNumber else {
+                      isASCIIDigit(digit) else {
                     return nil
                 }
                 while let character = currentCharacter,
-                      character.isNumber {
+                      isASCIIDigit(character) {
                     try checkpoint()
                     advance()
                 }
@@ -807,6 +810,24 @@ private enum CancellableJSONPrettyPrinter {
 
         private func indent(_ depth: Int) -> String {
             String(repeating: "  ", count: depth)
+        }
+
+        private func isASCIIDigit(_ character: Character) -> Bool {
+            guard character.unicodeScalars.count == 1,
+                  let scalar = character.unicodeScalars.first else {
+                return false
+            }
+            return (0x30...0x39).contains(scalar.value)
+        }
+
+        private func isASCIIHexDigit(_ character: Character) -> Bool {
+            guard character.unicodeScalars.count == 1,
+                  let scalar = character.unicodeScalars.first else {
+                return false
+            }
+            return (0x30...0x39).contains(scalar.value)
+                || (0x41...0x46).contains(scalar.value)
+                || (0x61...0x66).contains(scalar.value)
         }
     }
 }

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -75,9 +75,41 @@ extension NetworkBody {
 
 extension NetworkBody {
     @MainActor
+    fileprivate final class TextRepresentationPreparationJob {
+        let id: Int
+        let generation: Int
+        private let worker: Task<NetworkBody.PreparedTextRepresentation.Result?, Error>
+        private let completion: Task<Void, Never>
+
+        init(
+            id: Int,
+            generation: Int,
+            worker: Task<NetworkBody.PreparedTextRepresentation.Result?, Error>,
+            completion: Task<Void, Never>
+        ) {
+            self.id = id
+            self.generation = generation
+            self.worker = worker
+            self.completion = completion
+        }
+
+        var preparation: NetworkBody.TextPreparation {
+            NetworkBody.TextPreparation(task: completion)
+        }
+
+        func cancel() {
+            worker.cancel()
+            completion.cancel()
+        }
+    }
+}
+
+extension NetworkBody {
+    @MainActor
     fileprivate final class TextRepresentationPreparationState {        private(set) var generation = 0
         private var preparedGeneration: Int?
-        private var task: Task<Void, Never>?
+        private var job: NetworkBody.TextRepresentationPreparationJob?
+        private var nextJobID = 0
         private var isBatchingInvalidation = false
         private var needsInvalidation = false
 
@@ -86,7 +118,7 @@ extension NetworkBody {
         }
 
         var currentPreparation: NetworkBody.TextPreparation? {
-            task.map(NetworkBody.TextPreparation.init(task:))
+            job?.preparation
         }
 
         func withInvalidationBatch(_ updates: () -> Void, invalidate: () -> Void) {
@@ -116,25 +148,30 @@ extension NetworkBody {
             preparedGeneration = generation
         }
 
-        func startPreparation(_ task: Task<Void, Never>) {
-            self.task = task
+        func makeJobID() -> Int {
+            nextJobID += 1
+            return nextJobID
         }
 
-        func isCurrent(generation: Int) -> Bool {
-            generation == self.generation
+        func startPreparation(_ job: NetworkBody.TextRepresentationPreparationJob) {
+            self.job = job
         }
 
-        func finishPreparation(generation: Int) {
-            guard generation == self.generation else {
+        func isCurrent(generation: Int, jobID: Int) -> Bool {
+            generation == self.generation && job?.id == jobID
+        }
+
+        func finishPreparation(generation: Int, jobID: Int) {
+            guard isCurrent(generation: generation, jobID: jobID) else {
                 return
             }
             preparedGeneration = generation
-            task = nil
+            job = nil
         }
 
         func cancelPreparation() {
-            task?.cancel()
-            task = nil
+            job?.cancel()
+            job = nil
         }
     }
 }
@@ -248,22 +285,36 @@ package final class NetworkBody {
         }
 
         let generation = textRepresentationPreparation.generation
+        let jobID = textRepresentationPreparation.makeJobID()
         let worker = Task.detached(priority: .utility) {
-            NetworkBody.PreparedTextRepresentation.make(from: input)
+            try NetworkBody.PreparedTextRepresentation.make(from: input)
         }
-        let task = Task { @MainActor [weak self, worker] in
-            let result = await withTaskCancellationHandler {
-                await worker.value
-            } onCancel: {
-                worker.cancel()
+        let completion = Task { @MainActor [weak self, worker] in
+            let result: NetworkBody.PreparedTextRepresentation.Result?
+            do {
+                result = try await withTaskCancellationHandler {
+                    try await worker.value
+                } onCancel: {
+                    worker.cancel()
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                return
             }
             guard Task.isCancelled == false else {
                 return
             }
-            self?.applyPreparedTextRepresentation(result, generation: generation)
+            self?.applyPreparedTextRepresentation(result, generation: generation, jobID: jobID)
         }
-        textRepresentationPreparation.startPreparation(task)
-        return NetworkBody.TextPreparation(task: task)
+        let job = NetworkBody.TextRepresentationPreparationJob(
+            id: jobID,
+            generation: generation,
+            worker: worker,
+            completion: completion
+        )
+        textRepresentationPreparation.startPreparation(job)
+        return job.preparation
     }
 
     package func cancelTextRepresentationPreparation() {
@@ -409,9 +460,10 @@ package final class NetworkBody {
 
     private func applyPreparedTextRepresentation(
         _ result: NetworkBody.PreparedTextRepresentation.Result?,
-        generation: Int
+        generation: Int,
+        jobID: Int
     ) {
-        guard textRepresentationPreparation.isCurrent(generation: generation) else {
+        guard textRepresentationPreparation.isCurrent(generation: generation, jobID: jobID) else {
             return
         }
         if let result {
@@ -422,7 +474,7 @@ package final class NetworkBody {
                 textRepresentationSyntaxKind = result.syntaxKind
             }
         }
-        textRepresentationPreparation.finishPreparation(generation: generation)
+        textRepresentationPreparation.finishPreparation(generation: generation, jobID: jobID)
     }
 
     private func decodedContentText() -> String? {
@@ -487,7 +539,8 @@ package final class NetworkBody {
 }
 
 extension NetworkBody {
-    fileprivate enum PreparedTextRepresentation {        struct Input: Sendable {
+    fileprivate enum PreparedTextRepresentation {
+        struct Input: Sendable {
             let text: String
         }
 
@@ -496,30 +549,264 @@ extension NetworkBody {
             let syntaxKind: NetworkBody.SyntaxKind
         }
 
-        static func make(from input: Input) -> Result? {
-            guard let prettyJSON = prettyPrintedJSON(from: input.text) else {
+        static func make(from input: Input) throws -> Result? {
+            guard let prettyJSON = try CancellableJSONPrettyPrinter.prettyPrintedJSON(from: input.text) else {
                 return nil
             }
             return Result(text: prettyJSON, syntaxKind: .json)
         }
+    }
+}
 
-        private static func prettyPrintedJSON(from text: String) -> String? {
-            guard let data = text.data(using: .utf8) else {
+private enum CancellableJSONPrettyPrinter {
+    static func prettyPrintedJSON(from text: String) throws -> String? {
+        var parser = Parser(text: text)
+        return try parser.prettyPrintedJSON()
+    }
+
+    private struct Parser {
+        private let text: String
+        private var index: String.Index
+        private var checkpointCounter = 0
+
+        init(text: String) {
+            self.text = text
+            self.index = text.startIndex
+        }
+
+        mutating func prettyPrintedJSON() throws -> String? {
+            try skipWhitespace()
+            guard let first = currentCharacter,
+                  first == "{" || first == "[" else {
                 return nil
             }
-            guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            let result = try parseValue(depth: 0)
+            try skipWhitespace()
+            guard index == text.endIndex else {
                 return nil
             }
-            guard JSONSerialization.isValidJSONObject(object) else {
+            return result
+        }
+
+        private mutating func parseValue(depth: Int) throws -> String? {
+            try skipWhitespace()
+            guard let character = currentCharacter else {
                 return nil
             }
-            guard
-                let prettyData = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
-                let pretty = String(data: prettyData, encoding: .utf8)
-            else {
+            switch character {
+            case "{":
+                return try parseObject(depth: depth)
+            case "[":
+                return try parseArray(depth: depth)
+            case "\"":
+                return try parseString()
+            case "t":
+                return try consumeLiteral("true") ? "true" : nil
+            case "f":
+                return try consumeLiteral("false") ? "false" : nil
+            case "n":
+                return try consumeLiteral("null") ? "null" : nil
+            case "-", "0"..."9":
+                return try parseNumber()
+            default:
                 return nil
             }
-            return pretty
+        }
+
+        private mutating func parseObject(depth: Int) throws -> String? {
+            try consumeExpected("{")
+            try skipWhitespace()
+            if try consumeIfPresent("}") {
+                return "{}"
+            }
+
+            var members: [String] = []
+            while true {
+                try skipWhitespace()
+                guard currentCharacter == "\"" else {
+                    return nil
+                }
+                guard let key = try parseString() else {
+                    return nil
+                }
+                try skipWhitespace()
+                guard try consumeIfPresent(":") else {
+                    return nil
+                }
+                guard let value = try parseValue(depth: depth + 1) else {
+                    return nil
+                }
+                members.append("\(indent(depth + 1))\(key) : \(value)")
+                try skipWhitespace()
+                if try consumeIfPresent("}") {
+                    break
+                }
+                guard try consumeIfPresent(",") else {
+                    return nil
+                }
+            }
+            return "{\n" + members.joined(separator: ",\n") + "\n" + indent(depth) + "}"
+        }
+
+        private mutating func parseArray(depth: Int) throws -> String? {
+            try consumeExpected("[")
+            try skipWhitespace()
+            if try consumeIfPresent("]") {
+                return "[]"
+            }
+
+            var values: [String] = []
+            while true {
+                guard let value = try parseValue(depth: depth + 1) else {
+                    return nil
+                }
+                values.append("\(indent(depth + 1))\(value)")
+                try skipWhitespace()
+                if try consumeIfPresent("]") {
+                    break
+                }
+                guard try consumeIfPresent(",") else {
+                    return nil
+                }
+            }
+            return "[\n" + values.joined(separator: ",\n") + "\n" + indent(depth) + "]"
+        }
+
+        private mutating func parseString() throws -> String? {
+            let start = index
+            try consumeExpected("\"")
+            while let character = currentCharacter {
+                try checkpoint()
+                advance()
+                if character == "\"" {
+                    return String(text[start..<index])
+                }
+                if character == "\\" {
+                    guard let escaped = currentCharacter else {
+                        return nil
+                    }
+                    advance()
+                    if escaped == "u" {
+                        for _ in 0..<4 {
+                            guard let scalar = currentCharacter,
+                                  scalar.isHexDigit else {
+                                return nil
+                            }
+                            advance()
+                        }
+                    } else if "\"\\/bfnrt".contains(escaped) == false {
+                        return nil
+                    }
+                } else if character.unicodeScalars.contains(where: { $0.value < 0x20 }) {
+                    return nil
+                }
+            }
+            return nil
+        }
+
+        private mutating func parseNumber() throws -> String? {
+            let start = index
+            if try consumeIfPresent("-") == false {
+                try checkpoint()
+            }
+            guard let firstDigit = currentCharacter,
+                  firstDigit.isNumber else {
+                return nil
+            }
+            if firstDigit == "0" {
+                advance()
+            } else {
+                while let character = currentCharacter,
+                      character.isNumber {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            if try consumeIfPresent(".") {
+                guard let digit = currentCharacter,
+                      digit.isNumber else {
+                    return nil
+                }
+                while let character = currentCharacter,
+                      character.isNumber {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            if let character = currentCharacter,
+               character == "e" || character == "E" {
+                advance()
+                if let sign = currentCharacter,
+                   sign == "+" || sign == "-" {
+                    advance()
+                }
+                guard let digit = currentCharacter,
+                      digit.isNumber else {
+                    return nil
+                }
+                while let character = currentCharacter,
+                      character.isNumber {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            return String(text[start..<index])
+        }
+
+        private mutating func consumeLiteral(_ literal: String) throws -> Bool {
+            for expected in literal {
+                try checkpoint()
+                guard currentCharacter == expected else {
+                    return false
+                }
+                advance()
+            }
+            return true
+        }
+
+        private mutating func skipWhitespace() throws {
+            while let character = currentCharacter,
+                  character == " " || character == "\n" || character == "\r" || character == "\t" {
+                try checkpoint()
+                advance()
+            }
+        }
+
+        private mutating func consumeExpected(_ expected: Character) throws {
+            guard currentCharacter == expected else {
+                return
+            }
+            try checkpoint()
+            advance()
+        }
+
+        private mutating func consumeIfPresent(_ expected: Character) throws -> Bool {
+            guard currentCharacter == expected else {
+                return false
+            }
+            try checkpoint()
+            advance()
+            return true
+        }
+
+        private mutating func checkpoint() throws {
+            checkpointCounter += 1
+            if checkpointCounter >= 128 {
+                checkpointCounter = 0
+                try Task.checkCancellation()
+            }
+        }
+
+        private mutating func advance() {
+            index = text.index(after: index)
+        }
+
+        private var currentCharacter: Character? {
+            index == text.endIndex ? nil : text[index]
+        }
+
+        private func indent(_ depth: Int) -> String {
+            String(repeating: "  ", count: depth)
         }
     }
 }

--- a/Sources/WebInspectorCore/Network/NetworkBody.swift
+++ b/Sources/WebInspectorCore/Network/NetworkBody.swift
@@ -60,158 +60,37 @@ extension NetworkBody {
     }
 }
 
-extension NetworkBody {
-    package struct TextPreparation: Sendable {        private let task: Task<Void, Never>
-
-        fileprivate init(task: Task<Void, Never>) {
-            self.task = task
-        }
-
-        package func wait() async {
-            await task.value
-        }
-    }
-}
-
-extension NetworkBody {
-    @MainActor
-    fileprivate final class TextRepresentationPreparationJob {
-        let id: Int
-        let generation: Int
-        private let worker: Task<NetworkBody.PreparedTextRepresentation.Result?, Error>
-        private let completion: Task<Void, Never>
-
-        init(
-            id: Int,
-            generation: Int,
-            worker: Task<NetworkBody.PreparedTextRepresentation.Result?, Error>,
-            completion: Task<Void, Never>
-        ) {
-            self.id = id
-            self.generation = generation
-            self.worker = worker
-            self.completion = completion
-        }
-
-        var preparation: NetworkBody.TextPreparation {
-            NetworkBody.TextPreparation(task: completion)
-        }
-
-        func cancel() {
-            worker.cancel()
-            completion.cancel()
-        }
-    }
-}
-
-extension NetworkBody {
-    @MainActor
-    fileprivate final class TextRepresentationPreparationState {        private(set) var generation = 0
-        private var preparedGeneration: Int?
-        private var job: NetworkBody.TextRepresentationPreparationJob?
-        private var nextJobID = 0
-        private var isBatchingInvalidation = false
-        private var needsInvalidation = false
-
-        var needsPreparation: Bool {
-            preparedGeneration != generation
-        }
-
-        var currentPreparation: NetworkBody.TextPreparation? {
-            job?.preparation
-        }
-
-#if DEBUG
-        var hasCurrentPreparation: Bool {
-            job != nil
-        }
-#endif
-
-        func withInvalidationBatch(_ updates: () -> Void, invalidate: () -> Void) {
-            isBatchingInvalidation = true
-            updates()
-            isBatchingInvalidation = false
-
-            if needsInvalidation {
-                needsInvalidation = false
-                invalidate()
-            }
-        }
-
-        @discardableResult
-        func invalidate() -> Bool {
-            guard isBatchingInvalidation == false else {
-                needsInvalidation = true
-                return false
-            }
-            generation += 1
-            preparedGeneration = nil
-            cancelPreparation()
-            return true
-        }
-
-        func markCurrentGenerationPrepared() {
-            preparedGeneration = generation
-        }
-
-        func makeJobID() -> Int {
-            nextJobID += 1
-            return nextJobID
-        }
-
-        func startPreparation(_ job: NetworkBody.TextRepresentationPreparationJob) {
-            self.job = job
-        }
-
-        func isCurrent(generation: Int, jobID: Int) -> Bool {
-            generation == self.generation && job?.id == jobID
-        }
-
-        func finishPreparation(generation: Int, jobID: Int) {
-            guard isCurrent(generation: generation, jobID: jobID) else {
-                return
-            }
-            preparedGeneration = generation
-            job = nil
-        }
-
-        func cancelPreparation() {
-            job?.cancel()
-            job = nil
-        }
-    }
-}
-
 @MainActor
 @Observable
 package final class NetworkBody {
     package let role: NetworkBody.Role
     package var kind: NetworkBody.Kind {
         didSet {
-            invalidatePreparedTextRepresentation()
+            invalidateTextRepresentation()
         }
     }
     package private(set) var full: String? {
         didSet {
-            invalidatePreparedTextRepresentation()
+            invalidateTextRepresentation()
         }
     }
     package private(set) var size: Int?
     package private(set) var isBase64Encoded: Bool {
         didSet {
-            invalidatePreparedTextRepresentation()
+            invalidateTextRepresentation()
         }
     }
     package private(set) var isTruncated: Bool
     package var phase: NetworkBody.Phase
     package private(set) var sourceSyntaxKind: NetworkBody.SyntaxKind {
         didSet {
-            invalidatePreparedTextRepresentation()
+            invalidateTextRepresentation()
         }
     }
     package private(set) var textRepresentation: String?
     package private(set) var textRepresentationSyntaxKind: NetworkBody.SyntaxKind
-    @ObservationIgnored private let textRepresentationPreparation = NetworkBody.TextRepresentationPreparationState()
+    @ObservationIgnored private var isBatchingTextRepresentationInvalidation = false
+    @ObservationIgnored private var needsTextRepresentationInvalidation = false
 
     package init(
         role: NetworkBody.Role,
@@ -234,10 +113,6 @@ package final class NetworkBody {
         self.textRepresentation = nil
         self.textRepresentationSyntaxKind = .plainText
         refreshTextRepresentation()
-    }
-
-    isolated deinit {
-        textRepresentationPreparation.cancelPreparation()
     }
 
     package var needsFetch: Bool {
@@ -273,65 +148,6 @@ package final class NetworkBody {
         size = payload.size ?? payload.body.utf8.count
         phase = .loaded
     }
-
-    @discardableResult
-    package func prepareTextRepresentation() -> NetworkBody.TextPreparation? {
-        guard case .loaded = phase else {
-            return nil
-        }
-        guard textRepresentationPreparation.needsPreparation else {
-            return nil
-        }
-        if let currentPreparation = textRepresentationPreparation.currentPreparation {
-            return currentPreparation
-        }
-        guard let input = preparedTextRepresentationInput() else {
-            textRepresentationPreparation.markCurrentGenerationPrepared()
-            return nil
-        }
-
-        let generation = textRepresentationPreparation.generation
-        let jobID = textRepresentationPreparation.makeJobID()
-        let worker = Task.detached(priority: .utility) {
-            try NetworkBody.PreparedTextRepresentation.make(from: input)
-        }
-        let completion = Task { @MainActor [weak self, worker] in
-            let result: NetworkBody.PreparedTextRepresentation.Result?
-            do {
-                result = try await withTaskCancellationHandler {
-                    try await worker.value
-                } onCancel: {
-                    worker.cancel()
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                return
-            }
-            guard Task.isCancelled == false else {
-                return
-            }
-            self?.applyPreparedTextRepresentation(result, generation: generation, jobID: jobID)
-        }
-        let job = NetworkBody.TextRepresentationPreparationJob(
-            id: jobID,
-            generation: generation,
-            worker: worker,
-            completion: completion
-        )
-        textRepresentationPreparation.startPreparation(job)
-        return job.preparation
-    }
-
-    package func cancelTextRepresentationPreparation() {
-        textRepresentationPreparation.cancelPreparation()
-    }
-
-#if DEBUG
-    package var hasActiveTextRepresentationPreparationForTesting: Bool {
-        textRepresentationPreparation.hasCurrentPreparation
-    }
-#endif
 
     package static func makeRequestBody(for request: NetworkRequest.Payload) -> NetworkBody? {
         guard let postData = request.postData else {
@@ -425,13 +241,19 @@ package final class NetworkBody {
     }
 
     private func withTextRepresentationInvalidationBatch(_ updates: () -> Void) {
-        textRepresentationPreparation.withInvalidationBatch(updates) {
-            invalidatePreparedTextRepresentation()
+        isBatchingTextRepresentationInvalidation = true
+        updates()
+        isBatchingTextRepresentationInvalidation = false
+
+        if needsTextRepresentationInvalidation {
+            needsTextRepresentationInvalidation = false
+            refreshTextRepresentation()
         }
     }
 
-    private func invalidatePreparedTextRepresentation() {
-        guard textRepresentationPreparation.invalidate() else {
+    private func invalidateTextRepresentation() {
+        guard isBatchingTextRepresentationInvalidation == false else {
+            needsTextRepresentationInvalidation = true
             return
         }
         refreshTextRepresentation()
@@ -454,39 +276,6 @@ package final class NetworkBody {
         if textRepresentationSyntaxKind != syntaxKind {
             textRepresentationSyntaxKind = syntaxKind
         }
-    }
-
-    private func preparedTextRepresentationInput() -> NetworkBody.PreparedTextRepresentation.Input? {
-        guard kind != .binary, kind != .form else {
-            return nil
-        }
-        guard let contentText = decodedContentText() else {
-            return nil
-        }
-        let isJSONCandidate = sourceSyntaxKind == .json || Self.looksLikeJSON(contentText)
-        guard isJSONCandidate else {
-            return nil
-        }
-        return NetworkBody.PreparedTextRepresentation.Input(text: contentText)
-    }
-
-    private func applyPreparedTextRepresentation(
-        _ result: NetworkBody.PreparedTextRepresentation.Result?,
-        generation: Int,
-        jobID: Int
-    ) {
-        guard textRepresentationPreparation.isCurrent(generation: generation, jobID: jobID) else {
-            return
-        }
-        if let result {
-            if textRepresentation != result.text {
-                textRepresentation = result.text
-            }
-            if textRepresentationSyntaxKind != result.syntaxKind {
-                textRepresentationSyntaxKind = result.syntaxKind
-            }
-        }
-        textRepresentationPreparation.finishPreparation(generation: generation, jobID: jobID)
     }
 
     private func decodedContentText() -> String? {
@@ -542,304 +331,4 @@ package final class NetworkBody {
             .removingPercentEncoding
     }
 
-    private static func looksLikeJSON(_ text: String?) -> Bool {
-        guard let firstNonWhitespace = text?.first(where: { $0.isWhitespace == false }) else {
-            return false
-        }
-        return firstNonWhitespace == "{" || firstNonWhitespace == "["
-    }
-}
-
-extension NetworkBody {
-    fileprivate enum PreparedTextRepresentation {
-        struct Input: Sendable {
-            let text: String
-        }
-
-        struct Result: Sendable {
-            let text: String
-            let syntaxKind: NetworkBody.SyntaxKind
-        }
-
-        static func make(from input: Input) throws -> Result? {
-            guard let prettyJSON = try CancellableJSONPrettyPrinter.prettyPrintedJSON(from: input.text) else {
-                return nil
-            }
-            return Result(text: prettyJSON, syntaxKind: .json)
-        }
-    }
-}
-
-private enum CancellableJSONPrettyPrinter {
-    static func prettyPrintedJSON(from text: String) throws -> String? {
-        var parser = Parser(text: text)
-        return try parser.prettyPrintedJSON()
-    }
-
-    private struct Parser {
-        private let text: String
-        private var index: String.Index
-        private var checkpointCounter = 0
-
-        init(text: String) {
-            self.text = text
-            self.index = text.startIndex
-        }
-
-        mutating func prettyPrintedJSON() throws -> String? {
-            try skipWhitespace()
-            guard let first = currentCharacter,
-                  first == "{" || first == "[" else {
-                return nil
-            }
-            let result = try parseValue(depth: 0)
-            try skipWhitespace()
-            guard index == text.endIndex else {
-                return nil
-            }
-            return result
-        }
-
-        private mutating func parseValue(depth: Int) throws -> String? {
-            try skipWhitespace()
-            guard let character = currentCharacter else {
-                return nil
-            }
-            switch character {
-            case "{":
-                return try parseObject(depth: depth)
-            case "[":
-                return try parseArray(depth: depth)
-            case "\"":
-                return try parseString()
-            case "t":
-                return try consumeLiteral("true") ? "true" : nil
-            case "f":
-                return try consumeLiteral("false") ? "false" : nil
-            case "n":
-                return try consumeLiteral("null") ? "null" : nil
-            case "-":
-                return try parseNumber()
-            default:
-                if isASCIIDigit(character) {
-                    return try parseNumber()
-                }
-                return nil
-            }
-        }
-
-        private mutating func parseObject(depth: Int) throws -> String? {
-            try consumeExpected("{")
-            try skipWhitespace()
-            if try consumeIfPresent("}") {
-                return "{}"
-            }
-
-            var members: [String] = []
-            while true {
-                try skipWhitespace()
-                guard currentCharacter == "\"" else {
-                    return nil
-                }
-                guard let key = try parseString() else {
-                    return nil
-                }
-                try skipWhitespace()
-                guard try consumeIfPresent(":") else {
-                    return nil
-                }
-                guard let value = try parseValue(depth: depth + 1) else {
-                    return nil
-                }
-                members.append("\(indent(depth + 1))\(key) : \(value)")
-                try skipWhitespace()
-                if try consumeIfPresent("}") {
-                    break
-                }
-                guard try consumeIfPresent(",") else {
-                    return nil
-                }
-            }
-            return "{\n" + members.joined(separator: ",\n") + "\n" + indent(depth) + "}"
-        }
-
-        private mutating func parseArray(depth: Int) throws -> String? {
-            try consumeExpected("[")
-            try skipWhitespace()
-            if try consumeIfPresent("]") {
-                return "[]"
-            }
-
-            var values: [String] = []
-            while true {
-                guard let value = try parseValue(depth: depth + 1) else {
-                    return nil
-                }
-                values.append("\(indent(depth + 1))\(value)")
-                try skipWhitespace()
-                if try consumeIfPresent("]") {
-                    break
-                }
-                guard try consumeIfPresent(",") else {
-                    return nil
-                }
-            }
-            return "[\n" + values.joined(separator: ",\n") + "\n" + indent(depth) + "]"
-        }
-
-        private mutating func parseString() throws -> String? {
-            let start = index
-            try consumeExpected("\"")
-            while let character = currentCharacter {
-                try checkpoint()
-                advance()
-                if character == "\"" {
-                    return String(text[start..<index])
-                }
-                if character == "\\" {
-                    guard let escaped = currentCharacter else {
-                        return nil
-                    }
-                    advance()
-                    if escaped == "u" {
-                        for _ in 0..<4 {
-                            guard let scalar = currentCharacter,
-                                  isASCIIHexDigit(scalar) else {
-                                return nil
-                            }
-                            advance()
-                        }
-                    } else if "\"\\/bfnrt".contains(escaped) == false {
-                        return nil
-                    }
-                } else if character.unicodeScalars.contains(where: { $0.value < 0x20 }) {
-                    return nil
-                }
-            }
-            return nil
-        }
-
-        private mutating func parseNumber() throws -> String? {
-            let start = index
-            if try consumeIfPresent("-") == false {
-                try checkpoint()
-            }
-            guard let firstDigit = currentCharacter,
-                  isASCIIDigit(firstDigit) else {
-                return nil
-            }
-            if firstDigit == "0" {
-                advance()
-            } else {
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
-                    try checkpoint()
-                    advance()
-                }
-            }
-            if try consumeIfPresent(".") {
-                guard let digit = currentCharacter,
-                      isASCIIDigit(digit) else {
-                    return nil
-                }
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
-                    try checkpoint()
-                    advance()
-                }
-            }
-            if let character = currentCharacter,
-               character == "e" || character == "E" {
-                advance()
-                if let sign = currentCharacter,
-                   sign == "+" || sign == "-" {
-                    advance()
-                }
-                guard let digit = currentCharacter,
-                      isASCIIDigit(digit) else {
-                    return nil
-                }
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
-                    try checkpoint()
-                    advance()
-                }
-            }
-            return String(text[start..<index])
-        }
-
-        private mutating func consumeLiteral(_ literal: String) throws -> Bool {
-            for expected in literal {
-                try checkpoint()
-                guard currentCharacter == expected else {
-                    return false
-                }
-                advance()
-            }
-            return true
-        }
-
-        private mutating func skipWhitespace() throws {
-            while let character = currentCharacter,
-                  character == " " || character == "\n" || character == "\r" || character == "\t" {
-                try checkpoint()
-                advance()
-            }
-        }
-
-        private mutating func consumeExpected(_ expected: Character) throws {
-            guard currentCharacter == expected else {
-                return
-            }
-            try checkpoint()
-            advance()
-        }
-
-        private mutating func consumeIfPresent(_ expected: Character) throws -> Bool {
-            guard currentCharacter == expected else {
-                return false
-            }
-            try checkpoint()
-            advance()
-            return true
-        }
-
-        private mutating func checkpoint() throws {
-            checkpointCounter += 1
-            if checkpointCounter >= 128 {
-                checkpointCounter = 0
-                try Task.checkCancellation()
-            }
-        }
-
-        private mutating func advance() {
-            index = text.index(after: index)
-        }
-
-        private var currentCharacter: Character? {
-            index == text.endIndex ? nil : text[index]
-        }
-
-        private func indent(_ depth: Int) -> String {
-            String(repeating: "  ", count: depth)
-        }
-
-        private func isASCIIDigit(_ character: Character) -> Bool {
-            guard character.unicodeScalars.count == 1,
-                  let scalar = character.unicodeScalars.first else {
-                return false
-            }
-            return (0x30...0x39).contains(scalar.value)
-        }
-
-        private func isASCIIHexDigit(_ character: Character) -> Bool {
-            guard character.unicodeScalars.count == 1,
-                  let scalar = character.unicodeScalars.first else {
-                return false
-            }
-            return (0x30...0x39).contains(scalar.value)
-                || (0x41...0x46).contains(scalar.value)
-                || (0x61...0x66).contains(scalar.value)
-        }
-    }
 }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -71,6 +71,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private let renderedRowsBuildCoordinator: DOMTreeTextView.RenderedRowsBuildCoordinator
     private var hoveredNodeID: DOMNode.ID?
     private var pageHighlightTask: Task<Void, Never>?
+    private var isPageHighlightRestoreTaskQueued = false
     private var requestedChildNodeIDs: Set<DOMNode.ID> = []
     private let findDecorationState = DOMTreeTextView.FindDecorationState()
     private var hoverRowRects: [CGRect] = []
@@ -555,9 +556,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
         if needsHoveredPageHighlightRestore {
             clearHoveredRowAndRestoreSelectionHighlight()
-        } else {
-            pageHighlightTask?.cancel()
-            pageHighlightTask = nil
+        } else if isPageHighlightRestoreTaskQueued == false {
+            cancelPageHighlightTask()
         }
     }
 
@@ -1148,7 +1148,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         guard isRenderingActive else {
             return
         }
-        pageHighlightTask?.cancel()
+        cancelPageHighlightTask()
         pageHighlightTask = Task { @MainActor [weak self, highlightNodeAction] in
             await Task.yield()
             guard !Task.isCancelled,
@@ -1176,18 +1176,29 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func clearHoveredRowAndRestoreSelectionHighlight() {
-        pageHighlightTask?.cancel()
+        cancelPageHighlightTask()
         clearHoveredRow()
+        isPageHighlightRestoreTaskQueued = true
         pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard !Task.isCancelled,
-                  let self,
-                  self.hoveredNodeID == nil,
+                  let self else {
+                return
+            }
+            guard self.hoveredNodeID == nil,
                   !self.dom.isSelectingElement else {
+                self.isPageHighlightRestoreTaskQueued = false
                 return
             }
             await restoreHighlightAction?()
+            self.isPageHighlightRestoreTaskQueued = false
         }
+    }
+
+    private func cancelPageHighlightTask() {
+        pageHighlightTask?.cancel()
+        pageHighlightTask = nil
+        isPageHighlightRestoreTaskQueued = false
     }
 
     private func presentDOMMenu(for nodes: [DOMNode], at location: CGPoint) {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -71,7 +71,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private let renderedRowsBuildCoordinator: DOMTreeTextView.RenderedRowsBuildCoordinator
     private var hoveredNodeID: DOMNode.ID?
     private var pageHighlightTask: Task<Void, Never>?
-    private var isPageHighlightRestoreTaskQueued = false
+    private var pageHighlightIntent: PageHighlightIntent?
     private var requestedChildNodeIDs: Set<DOMNode.ID> = []
     private let findDecorationState = DOMTreeTextView.FindDecorationState()
     private var hoverRowRects: [CGRect] = []
@@ -88,7 +88,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
     private var isRenderingActive = false
-    private var hasPendingSelectionInvalidation = false
+    private var selectionReconciliationState = SelectionReconciliationState()
     private let selectionRevealState = DOMTreeTextView.SelectionRevealState()
     private var resolvedTextAttributesCache: DOMTreeTextView.ResolvedTextAttributes?
     private var disclosureSymbolImageCache: [DisclosureSymbolImageCacheKey: UIImage] = [:]
@@ -124,7 +124,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         Self.paragraphLineHeight
     }
 
-    private enum PageHighlightReason {
+    private enum PageHighlightReason: Equatable {
         case selection
         case hover
 
@@ -134,6 +134,35 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 .selection
             case .hover:
                 .transient
+            }
+        }
+    }
+
+    private enum PageHighlightIntent: Equatable {
+        case selection(DOMNode.ID)
+        case restoreSelectionAfterHover
+    }
+
+    private struct SelectionReconciliationState {
+        private var lastReconciledSelectionRevision: UInt64?
+        private(set) var pendingSelectionRevision: UInt64?
+
+        mutating func recordSelectionObservation(revision: UInt64) {
+            pendingSelectionRevision = max(pendingSelectionRevision ?? revision, revision)
+        }
+
+        func needsReconcile(currentRevision: UInt64) -> Bool {
+            guard let lastReconciledSelectionRevision else {
+                return true
+            }
+            return currentRevision != lastReconciledSelectionRevision
+        }
+
+        mutating func markReconciled(revision: UInt64) {
+            lastReconciledSelectionRevision = revision
+            if let pendingSelectionRevision,
+               pendingSelectionRevision <= revision {
+                self.pendingSelectionRevision = nil
             }
         }
     }
@@ -539,8 +568,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
         selectionObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            _ = dom.selectionRevision
-            routeSelectionInvalidation(from: dom)
+            let selectionRevision = dom.selectionRevision
+            routeSelectionInvalidation(from: dom, selectionRevision: selectionRevision)
         }
     }
 
@@ -556,8 +585,10 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
         if needsHoveredPageHighlightRestore {
             clearHoveredRowAndRestoreSelectionHighlight()
-        } else if isPageHighlightRestoreTaskQueued == false {
-            cancelPageHighlightTask()
+        } else if pageHighlightIntent == .restoreSelectionAfterHover {
+            return
+        } else {
+            cancelPageHighlightTask(preservingIntent: true)
         }
     }
 
@@ -711,37 +742,44 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
     }
 
-    private func routeSelectionInvalidation(from dom: DOMSession) {
+    private func routeSelectionInvalidation(
+        from dom: DOMSession,
+        selectionRevision: UInt64
+    ) {
         guard isRenderingActive else {
-            hasPendingSelectionInvalidation = true
+            selectionReconciliationState.recordSelectionObservation(revision: selectionRevision)
             return
         }
 
         let nextSelectedNodeID = dom.selectedNodeID
-        guard lastRoutedSelectedNodeID != nextSelectedNodeID else {
+        let shouldReconcileSelection = lastRoutedSelectedNodeID != nextSelectedNodeID
+            || selectionReconciliationState.needsReconcile(currentRevision: selectionRevision)
+        guard shouldReconcileSelection else {
             revealPendingSelectedNodeIfPossible()
+            reconcilePageSelectionHighlightIntentIfNeeded()
             return
         }
-        handleSelectedNodeChange()
+        handleSelectedNodeChange(selectionRevision: selectionRevision)
     }
 
     private func flushPendingSelectionInvalidationIfNeeded() {
         guard isRenderingActive else {
             return
         }
-        hasPendingSelectionInvalidation = false
-        routeSelectionInvalidation(from: dom)
+        routeSelectionInvalidation(from: dom, selectionRevision: dom.selectionRevision)
     }
 
-    private func handleSelectedNodeChange() {
+    private func handleSelectedNodeChange(selectionRevision: UInt64) {
         let previousOpenState = expansionState.snapshot
         prepareSelectionForRendering(clearsMultiSelectionForDocumentSelection: true)
+        selectionReconciliationState.markReconciled(revision: selectionRevision)
         if previousOpenState != expansionState.snapshot || selectedNodeNeedsRowReload() {
             reloadTree(resetFragments: false)
             return
         }
         updateContentDecorations()
         revealPendingSelectedNodeIfPossible()
+        reconcilePageSelectionHighlightIntentIfNeeded()
     }
 
     private func reloadTree(resetFragments: Bool, countsCall: Bool = true) {
@@ -833,6 +871,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             },
             didFinish: { [weak self] in
                 self?.revealPendingSelectedNodeIfPossible()
+                self?.reconcilePageSelectionHighlightIntentIfNeeded()
             }
         )
     }
@@ -999,7 +1038,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func select(_ nodeID: DOMNode.ID) {
         multiSelection.notePrimarySelection(nodeID)
         dom.selectNode(nodeID)
-        highlightPageNode(nodeID, reason: .selection)
+        queuePageSelectionHighlight(for: nodeID)
     }
 
     private func toggleMultiSelection(row: DOMTreeTextView.Line) {
@@ -1144,11 +1183,30 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         highlightPageNode(row.nodeID, reason: .hover)
     }
 
+    private func queuePageSelectionHighlight(for nodeID: DOMNode.ID) {
+        pageHighlightIntent = .selection(nodeID)
+        reconcilePageSelectionHighlightIntentIfNeeded()
+    }
+
+    private func reconcilePageSelectionHighlightIntentIfNeeded() {
+        guard case .selection(let nodeID) = pageHighlightIntent,
+              dom.selectedNodeID == nodeID else {
+            return
+        }
+        highlightPageNode(nodeID, reason: .selection)
+    }
+
     private func highlightPageNode(_ nodeID: DOMNode.ID, reason: PageHighlightReason) {
         guard isRenderingActive else {
             return
         }
-        cancelPageHighlightTask()
+        switch reason {
+        case .selection:
+            pageHighlightIntent = .selection(nodeID)
+            cancelPageHighlightTask(preservingIntent: true)
+        case .hover:
+            cancelPageHighlightTask()
+        }
         pageHighlightTask = Task { @MainActor [weak self, highlightNodeAction] in
             await Task.yield()
             guard !Task.isCancelled,
@@ -1172,13 +1230,17 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                 return
             }
             await highlightNodeAction?(nodeID, reason.owner)
+            if reason == .selection,
+               self.pageHighlightIntent == .selection(nodeID) {
+                self.pageHighlightIntent = nil
+            }
         }
     }
 
     private func clearHoveredRowAndRestoreSelectionHighlight() {
         cancelPageHighlightTask()
         clearHoveredRow()
-        isPageHighlightRestoreTaskQueued = true
+        pageHighlightIntent = .restoreSelectionAfterHover
         pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard !Task.isCancelled,
@@ -1187,18 +1249,24 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             }
             guard self.hoveredNodeID == nil,
                   !self.dom.isSelectingElement else {
-                self.isPageHighlightRestoreTaskQueued = false
+                if self.pageHighlightIntent == .restoreSelectionAfterHover {
+                    self.pageHighlightIntent = nil
+                }
                 return
             }
             await restoreHighlightAction?()
-            self.isPageHighlightRestoreTaskQueued = false
+            if self.pageHighlightIntent == .restoreSelectionAfterHover {
+                self.pageHighlightIntent = nil
+            }
         }
     }
 
-    private func cancelPageHighlightTask() {
+    private func cancelPageHighlightTask(preservingIntent: Bool = false) {
         pageHighlightTask?.cancel()
         pageHighlightTask = nil
-        isPageHighlightRestoreTaskQueued = false
+        if !preservingIntent {
+            pageHighlightIntent = nil
+        }
     }
 
     private func presentDOMMenu(for nodes: [DOMNode], at location: CGPoint) {

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -306,18 +306,18 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     func setRenderingActive(_ isActive: Bool) {
         guard isRenderingActive != isActive else {
             if isActive {
+                flushPendingSelectionInvalidationIfNeeded()
                 reconcileCurrentDOMInvalidationForActiveRendering()
                 flushPendingDOMInvalidationIfNeeded()
-                flushPendingSelectionInvalidationIfNeeded()
             }
             return
         }
 
         isRenderingActive = isActive
         if isActive {
+            flushPendingSelectionInvalidationIfNeeded()
             reconcileCurrentDOMInvalidationForActiveRendering()
             flushPendingDOMInvalidationIfNeeded()
-            flushPendingSelectionInvalidationIfNeeded()
         } else {
             suspendRenderingWork()
         }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -545,6 +545,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
 
     private func suspendRenderingWork() {
         let hadCurrentRenderedRowsBuild = renderedRowsBuildCoordinator.hasCurrentBuild
+        let needsHoveredPageHighlightRestore = hoveredNodeID != nil
         domTreeRenderInvalidationTask?.cancel()
         domTreeRenderInvalidationTask = nil
         renderedRowsBuildCoordinator.cancel()
@@ -552,8 +553,12 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: dom.treeRenderInvalidation) ?? dom.treeRenderInvalidation
             pendingDOMTreeRenderInvalidationRequiresRoute = true
         }
-        pageHighlightTask?.cancel()
-        pageHighlightTask = nil
+        if needsHoveredPageHighlightRestore {
+            clearHoveredRowAndRestoreSelectionHighlight()
+        } else {
+            pageHighlightTask?.cancel()
+            pageHighlightTask = nil
+        }
     }
 
     private func reconcileCurrentDOMInvalidationForActiveRendering() {
@@ -1173,9 +1178,6 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func clearHoveredRowAndRestoreSelectionHighlight() {
         pageHighlightTask?.cancel()
         clearHoveredRow()
-        guard isRenderingActive else {
-            return
-        }
         pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard !Task.isCancelled,

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -86,6 +86,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private var domTreeRenderInvalidationTask: Task<Void, Never>?
     private var lastObservedTreeContent: DOMTreeTextView.ObservedContent?
     private var lastRoutedSelectedNodeID: DOMNode.ID?
+    private var isRenderingActive = false
+    private var hasPendingSelectionInvalidation = false
     private let selectionRevealState = DOMTreeTextView.SelectionRevealState()
     private var resolvedTextAttributesCache: DOMTreeTextView.ResolvedTextAttributes?
     private var disclosureSymbolImageCache: [DisclosureSymbolImageCacheKey: UIImage] = [:]
@@ -298,6 +300,26 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         } else {
             clearMultiSelection(keepingLast: row.nodeID)
             select(row.nodeID)
+        }
+    }
+
+    func setRenderingActive(_ isActive: Bool) {
+        guard isRenderingActive != isActive else {
+            if isActive {
+                reconcileCurrentDOMInvalidationForActiveRendering()
+                flushPendingDOMInvalidationIfNeeded()
+                flushPendingSelectionInvalidationIfNeeded()
+            }
+            return
+        }
+
+        isRenderingActive = isActive
+        if isActive {
+            reconcileCurrentDOMInvalidationForActiveRendering()
+            flushPendingDOMInvalidationIfNeeded()
+            flushPendingSelectionInvalidationIfNeeded()
+        } else {
+            suspendRenderingWork()
         }
     }
 
@@ -521,6 +543,38 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         }
     }
 
+    private func suspendRenderingWork() {
+        let hadCurrentRenderedRowsBuild = renderedRowsBuildCoordinator.hasCurrentBuild
+        domTreeRenderInvalidationTask?.cancel()
+        domTreeRenderInvalidationTask = nil
+        renderedRowsBuildCoordinator.cancel()
+        if hadCurrentRenderedRowsBuild {
+            pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: dom.treeRenderInvalidation) ?? dom.treeRenderInvalidation
+            pendingDOMTreeRenderInvalidationRequiresRoute = true
+        }
+        pageHighlightTask?.cancel()
+        pageHighlightTask = nil
+    }
+
+    private func reconcileCurrentDOMInvalidationForActiveRendering() {
+        guard isRenderingActive else {
+            return
+        }
+
+        let latestInvalidation = dom.treeRenderInvalidation
+        let treeRevision = latestInvalidation.revision
+        let previousRoutedTreeRevision = lastRoutedTreeRevision
+        guard previousRoutedTreeRevision != treeRevision else {
+            return
+        }
+
+        lastRoutedTreeRevision = treeRevision
+        let invalidation = previousRoutedTreeRevision.map {
+            dom.treeRenderInvalidation(since: $0)
+        } ?? latestInvalidation
+        scheduleDOMInvalidation(invalidation, isInitial: previousRoutedTreeRevision == nil)
+    }
+
     private func scheduleDOMInvalidation(
         _ invalidation: DOMTreeRenderInvalidation,
         isInitial: Bool
@@ -535,7 +589,15 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
                     renderedRowsBuildCoordinator.currentBuildRenders(nodeID: nodeID)
                 }
             )
-        guard domTreeRenderInvalidationTask == nil else {
+        guard isRenderingActive else {
+            return
+        }
+        schedulePendingDOMInvalidationFlush()
+    }
+
+    private func schedulePendingDOMInvalidationFlush() {
+        guard isRenderingActive,
+              domTreeRenderInvalidationTask == nil else {
             return
         }
         domTreeRenderInvalidationTask = Task { @MainActor [weak self] in
@@ -543,22 +605,31 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             guard let self else {
                 return
             }
-            let pendingInvalidation = pendingDOMTreeRenderInvalidation
-            let pendingIsInitial = pendingDOMTreeRenderInvalidationIsInitial
-            let pendingRequiresRoute = pendingDOMTreeRenderInvalidationRequiresRoute
-            pendingDOMTreeRenderInvalidation = nil
-            pendingDOMTreeRenderInvalidationIsInitial = false
-            pendingDOMTreeRenderInvalidationRequiresRoute = false
             domTreeRenderInvalidationTask = nil
-            guard let pendingInvalidation else {
-                return
-            }
-            routeDOMInvalidation(
-                pendingInvalidation,
-                isInitial: pendingIsInitial,
-                forceRoute: pendingRequiresRoute
-            )
+            flushPendingDOMInvalidationIfNeeded()
         }
+    }
+
+    private func flushPendingDOMInvalidationIfNeeded() {
+        guard isRenderingActive else {
+            return
+        }
+        domTreeRenderInvalidationTask?.cancel()
+        domTreeRenderInvalidationTask = nil
+        let pendingInvalidation = pendingDOMTreeRenderInvalidation
+        let pendingIsInitial = pendingDOMTreeRenderInvalidationIsInitial
+        let pendingRequiresRoute = pendingDOMTreeRenderInvalidationRequiresRoute
+        pendingDOMTreeRenderInvalidation = nil
+        pendingDOMTreeRenderInvalidationIsInitial = false
+        pendingDOMTreeRenderInvalidationRequiresRoute = false
+        guard let pendingInvalidation else {
+            return
+        }
+        routeDOMInvalidation(
+            pendingInvalidation,
+            isInitial: pendingIsInitial,
+            forceRoute: pendingRequiresRoute
+        )
     }
 
     private func routeDOMInvalidation(
@@ -566,6 +637,12 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         isInitial: Bool,
         forceRoute: Bool = false
     ) {
+        guard isRenderingActive else {
+            pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: invalidation) ?? invalidation
+            pendingDOMTreeRenderInvalidationIsInitial = pendingDOMTreeRenderInvalidationIsInitial || isInitial
+            pendingDOMTreeRenderInvalidationRequiresRoute = pendingDOMTreeRenderInvalidationRequiresRoute || forceRoute
+            return
+        }
         guard forceRoute || shouldRouteDOMInvalidation(invalidation, isInitial: isInitial) else {
             return
         }
@@ -630,12 +707,25 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func routeSelectionInvalidation(from dom: DOMSession) {
+        guard isRenderingActive else {
+            hasPendingSelectionInvalidation = true
+            return
+        }
+
         let nextSelectedNodeID = dom.selectedNodeID
         guard lastRoutedSelectedNodeID != nextSelectedNodeID else {
             revealPendingSelectedNodeIfPossible()
             return
         }
         handleSelectedNodeChange()
+    }
+
+    private func flushPendingSelectionInvalidationIfNeeded() {
+        guard isRenderingActive else {
+            return
+        }
+        hasPendingSelectionInvalidation = false
+        routeSelectionInvalidation(from: dom)
     }
 
     private func handleSelectedNodeChange() {
@@ -662,6 +752,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         resetFragments: Bool,
         countsCall: Bool = true
     ) {
+        guard isRenderingActive else {
+            pendingDOMTreeRenderInvalidation = pendingDOMTreeRenderInvalidation?.merging(with: dom.treeRenderInvalidation) ?? dom.treeRenderInvalidation
+            pendingDOMTreeRenderInvalidationRequiresRoute = true
+            return
+        }
 #if DEBUG
         if countsCall {
             performanceCounters.reloadTreeCallCount += 1
@@ -691,11 +786,17 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         previousText: String,
         shouldApply: (@MainActor (DOMTreeTextView.RenderedRowsBuildResult) -> Bool)? = nil
     ) {
+        guard isRenderingActive else {
+            return
+        }
         renderedRowsBuildCoordinator.startBuild(
             previousRowCapacity: rows.count,
             previousTextCapacity: renderedText.count,
             isCurrentBuild: { [weak self] request in
                 guard let self else {
+                    return false
+                }
+                guard isRenderingActive else {
                     return false
                 }
                 let currentInvalidation = dom.treeRenderInvalidation(since: request.treeRevision)
@@ -713,6 +814,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
             shouldApply: shouldApply,
             apply: { [weak self] buildResult in
                 guard let self else {
+                    return
+                }
+                guard isRenderingActive else {
                     return
                 }
                 applyRenderedRowsBuildResult(
@@ -852,7 +956,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func requestChildrenForOpenRowsIfNeeded() {
-        guard dom.currentPageRootNode != nil else {
+        guard isRenderingActive,
+              dom.currentPageRootNode != nil else {
             return
         }
         for row in rows where row.hasDisclosure && row.isOpen {
@@ -864,7 +969,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func requestChildrenIfNeeded(for node: DOMNode) {
-        guard dom.hasUnloadedRegularChildren(node),
+        guard isRenderingActive,
+              dom.hasUnloadedRegularChildren(node),
               requestedChildNodeIDs.insert(node.id).inserted
         else {
             return
@@ -1034,6 +1140,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func highlightPageNode(_ nodeID: DOMNode.ID, reason: PageHighlightReason) {
+        guard isRenderingActive else {
+            return
+        }
         pageHighlightTask?.cancel()
         pageHighlightTask = Task { @MainActor [weak self, highlightNodeAction] in
             await Task.yield()
@@ -1064,6 +1173,9 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func clearHoveredRowAndRestoreSelectionHighlight() {
         pageHighlightTask?.cancel()
         clearHoveredRow()
+        guard isRenderingActive else {
+            return
+        }
         pageHighlightTask = Task { @MainActor [weak self, restoreHighlightAction] in
             await Task.yield()
             guard !Task.isCancelled,
@@ -1929,7 +2041,8 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     }
 
     private func revealPendingSelectedNodeIfPossible() {
-        guard let selectedNodeID = selectionRevealState.pendingSelectedNodeID,
+        guard isRenderingActive,
+              let selectedNodeID = selectionRevealState.pendingSelectedNodeID,
               !dom.hasPendingSelectionRequest,
               !renderedRowsBuildCoordinator.hasCurrentBuild,
               let row = renderedRows.row(for: selectedNodeID),
@@ -1949,7 +2062,7 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
         )
         scrollRectToVisible(
             targetRect.insetBy(dx: 0, dy: -rowRect.height * 2),
-            animated: window != nil
+            animated: isRenderingActive
         )
         selectionRevealState.consumePendingSelection()
     }

--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeViewController.swift
@@ -8,6 +8,7 @@ package final class DOMTreeViewController: UIViewController {
     private let treeView: DOMTreeTextView
     private weak var inspection: AttachedInspection?
     private var domRootObservation: PortableObservationTracking.Token?
+    private var isRenderingLifecycleActive = false
 
     package var domTreeUndoManager: UndoManager? {
         treeView.undoManager
@@ -87,7 +88,15 @@ package final class DOMTreeViewController: UIViewController {
 
     override package func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
+        isRenderingLifecycleActive = true
+        treeView.setRenderingActive(true)
         ensureDOMDocumentLoadedIfNeeded()
+    }
+
+    override package func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        isRenderingLifecycleActive = false
+        treeView.setRenderingActive(false)
     }
 
     private func startObservingDOMRoot(inspection: AttachedInspection) {
@@ -123,7 +132,7 @@ package final class DOMTreeViewController: UIViewController {
         guard let inspection else {
             return
         }
-        guard viewIfLoaded?.window != nil,
+        guard isRenderingLifecycleActive,
               !hasRoot,
               canReloadDocument else {
             return

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -74,6 +74,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
             return
         }
         model.selectRequest(nil)
+        detailViewController.clearSelectionPresentationAfterContainerDeselection()
     }
 
     private func startObservingSelection() {
@@ -127,6 +128,9 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
         guard viewControllers.count != 1 || viewControllers.first !== listViewController else {
             return
+        }
+        if viewControllers.contains(where: { $0 === detailViewController }) {
+            detailViewController.clearSelectionPresentationAfterContainerDeselection()
         }
         setViewControllers([listViewController], animated: animated)
     }

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -5,14 +5,46 @@ import UIKit
 
 @MainActor
 package final class NetworkCompactNavigationController: UINavigationController, UINavigationControllerDelegate {
+    private enum StackTarget {
+        case list
+        case detail
+    }
+
+    private enum SelectionCommit {
+        case none
+        case clearIfStillSelected(NetworkRequest.ID)
+
+        @MainActor
+        func apply(to model: NetworkPanelModel) {
+            switch self {
+            case .none:
+                return
+            case .clearIfStillSelected(let requestID):
+                guard model.selectedRequestID == requestID else {
+                    return
+                }
+                model.selectRequest(nil)
+            }
+        }
+    }
+
+    private struct StackTransition {
+        var target: StackTarget
+        var removesDetail: Bool
+        var selectionCommit: SelectionCommit
+    }
+
+    private struct DeferredStackSync {
+        var target: StackTarget
+        var animated: Bool
+    }
+
     private let model: NetworkPanelModel
     private let listViewController: NetworkListViewController
     private let detailViewController: NetworkDetailViewController
     private var selectionObservation: PortableObservationTracking.Token?
-    private var isSyncingStack = false
-    private var isStackSyncScheduledAfterTransition = false
-    private var pendingStackSyncAnimates = false
-    private var pendingDetailSurfaceDiscardAfterProgrammaticPop = false
+    private var activeTransition: StackTransition?
+    private var deferredStackSync: DeferredStackSync?
 
     package init(
         model: NetworkPanelModel,
@@ -45,7 +77,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     override package func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        syncStack(hasSelection: model.selectedRequest != nil, animated: false)
+        syncStack(to: desiredStackTarget(), animated: false)
         startObservingSelection()
     }
 
@@ -66,23 +98,31 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     package func navigationController(
         _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        guard viewController === listViewController,
+              activeTransition == nil,
+              transitionCoordinator?.viewController(forKey: .from) === detailViewController else {
+            return
+        }
+        activeTransition = StackTransition(
+            target: .list,
+            removesDetail: true,
+            selectionCommit: userPopSelectionCommit()
+        )
+    }
+
+    package func navigationController(
+        _ navigationController: UINavigationController,
         didShow viewController: UIViewController,
         animated: Bool
     ) {
-        guard viewController === listViewController else {
-            return
+        let shownTarget = stackTarget(for: viewController)
+        if finishActiveTransitionIfNeeded(shownTarget: shownTarget) == false {
+            finishUntrackedDetailRemovalIfNeeded(shownTarget: shownTarget)
         }
-        if pendingDetailSurfaceDiscardAfterProgrammaticPop {
-            pendingDetailSurfaceDiscardAfterProgrammaticPop = false
-            detailViewController.discardDetailSurfaceAfterCompactRemoval()
-            return
-        }
-        guard isSyncingStack == false,
-              model.selectedRequest != nil else {
-            return
-        }
-        model.selectRequest(nil)
-        detailViewController.discardDetailSurfaceAfterCompactRemoval()
+        performDeferredStackSyncIfNeeded()
     }
 
     private func startObservingSelection() {
@@ -90,7 +130,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         selectionObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
             syncStack(
-                hasSelection: model.selectedRequest != nil,
+                to: desiredStackTarget(),
                 animated: event.kind != .initial
             )
         }
@@ -101,80 +141,162 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         selectionObservation = nil
     }
 
-    private func syncStack(hasSelection: Bool, animated: Bool) {
-        guard scheduleStackSyncAfterCurrentTransitionIfNeeded(animated: animated) == false else {
+    private func syncStack(to target: StackTarget, animated: Bool) {
+        guard scheduleStackSyncAfterCurrentTransitionIfNeeded(to: target, animated: animated) == false else {
             return
         }
 
-        guard hasSelection else {
+        guard currentStackTarget() != target else {
+            return
+        }
+
+        switch target {
+        case .list:
             popRequestDetailIfNeeded(animated: animated)
-            return
+        case .detail:
+            pushRequestDetailIfNeeded(animated: animated)
         }
+    }
 
-        isSyncingStack = true
-        defer {
-            isSyncingStack = false
-        }
-
+    private func pushRequestDetailIfNeeded(animated: Bool) {
         guard viewControllers.last !== detailViewController else {
             return
         }
         detailViewController.webInspectorDetachFromContainerForReuse()
         let shouldAnimate = animated && viewControllers.first === listViewController
+        activeTransition = StackTransition(
+            target: .detail,
+            removesDetail: false,
+            selectionCommit: .none
+        )
         if viewControllers.first === listViewController {
             setViewControllers([listViewController, detailViewController], animated: shouldAnimate)
         } else {
             setViewControllers([listViewController, detailViewController], animated: false)
         }
+        finishActiveTransitionIfNoCoordinator()
     }
 
     private func popRequestDetailIfNeeded(animated: Bool) {
-        isSyncingStack = true
-        defer {
-            isSyncingStack = false
-        }
-
         guard viewControllers.count != 1 || viewControllers.first !== listViewController else {
             return
         }
-        if viewControllers.contains(where: { $0 === detailViewController }) {
-            pendingDetailSurfaceDiscardAfterProgrammaticPop = true
-        }
+        activeTransition = StackTransition(
+            target: .list,
+            removesDetail: viewControllers.contains { $0 === detailViewController },
+            selectionCommit: .none
+        )
         setViewControllers([listViewController], animated: animated)
+        finishActiveTransitionIfNoCoordinator()
     }
 
-    private func scheduleStackSyncAfterCurrentTransitionIfNeeded(animated: Bool) -> Bool {
+    private func scheduleStackSyncAfterCurrentTransitionIfNeeded(to target: StackTarget, animated: Bool) -> Bool {
+        if let activeTransition {
+            if activeTransition.target != target {
+                mergeDeferredStackSync(to: target, animated: animated)
+            }
+            return true
+        }
         guard let transitionCoordinator else {
             return false
         }
 
-        pendingStackSyncAnimates = pendingStackSyncAnimates || animated
-        guard isStackSyncScheduledAfterTransition == false else {
+        let hadDeferredSync = deferredStackSync != nil
+        mergeDeferredStackSync(to: target, animated: animated)
+        guard hadDeferredSync == false else {
             return true
         }
 
-        isStackSyncScheduledAfterTransition = true
         let didSchedule = transitionCoordinator.animate(alongsideTransition: nil) { [weak self] _ in
-            self?.performPendingStackSyncAfterTransition()
+            self?.performDeferredStackSyncIfNeeded()
         }
         if didSchedule {
             return true
         }
 
-        isStackSyncScheduledAfterTransition = false
-        pendingStackSyncAnimates = false
+        deferredStackSync = nil
         return false
     }
 
-    private func performPendingStackSyncAfterTransition() {
-        guard isStackSyncScheduledAfterTransition else {
+    private func mergeDeferredStackSync(to target: StackTarget, animated: Bool) {
+        let shouldAnimate = (deferredStackSync?.animated ?? false) || animated
+        deferredStackSync = DeferredStackSync(target: target, animated: shouldAnimate)
+    }
+
+    private func performDeferredStackSyncIfNeeded() {
+        guard let deferredStackSync else {
             return
         }
+        self.deferredStackSync = nil
+        syncStack(to: deferredStackSync.target, animated: deferredStackSync.animated)
+    }
 
-        isStackSyncScheduledAfterTransition = false
-        let shouldAnimate = pendingStackSyncAnimates
-        pendingStackSyncAnimates = false
-        syncStack(hasSelection: model.selectedRequest != nil, animated: shouldAnimate)
+    private func finishActiveTransitionIfNoCoordinator() {
+        guard transitionCoordinator == nil else {
+            return
+        }
+        _ = finishActiveTransitionIfNeeded(shownTarget: currentStackTarget())
+    }
+
+    @discardableResult
+    private func finishActiveTransitionIfNeeded(shownTarget: StackTarget?) -> Bool {
+        guard let transition = activeTransition else {
+            return false
+        }
+        activeTransition = nil
+        guard shownTarget == transition.target else {
+            return true
+        }
+
+        commit(transition)
+        return true
+    }
+
+    private func finishUntrackedDetailRemovalIfNeeded(shownTarget: StackTarget?) {
+        guard shownTarget == .list,
+              model.selectedRequestID != nil else {
+            return
+        }
+        commit(
+            StackTransition(
+                target: .list,
+                removesDetail: true,
+                selectionCommit: userPopSelectionCommit()
+            )
+        )
+    }
+
+    private func commit(_ transition: StackTransition) {
+        transition.selectionCommit.apply(to: model)
+        guard transition.removesDetail else {
+            return
+        }
+        detailViewController.discardDetailSurfaceAfterCompactRemoval()
+    }
+
+    private func desiredStackTarget() -> StackTarget {
+        model.selectedRequest == nil ? .list : .detail
+    }
+
+    private func currentStackTarget() -> StackTarget {
+        stackTarget(for: viewControllers.last) ?? .list
+    }
+
+    private func stackTarget(for viewController: UIViewController?) -> StackTarget? {
+        if viewController === detailViewController {
+            return .detail
+        }
+        if viewController === listViewController {
+            return .list
+        }
+        return nil
+    }
+
+    private func userPopSelectionCommit() -> SelectionCommit {
+        guard let selectedRequestID = model.selectedRequestID else {
+            return .none
+        }
+        return .clearIfStillSelected(selectedRequestID)
     }
 
     private func applyBackgroundFromTraits() {

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -191,10 +191,8 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func scheduleStackSyncAfterCurrentTransitionIfNeeded(to target: StackTarget, animated: Bool) -> Bool {
-        if let activeTransition {
-            if activeTransition.target != target {
-                mergeDeferredStackSync(to: target, animated: animated)
-            }
+        if activeTransition != nil {
+            mergeDeferredStackSync(to: target, animated: animated)
             return true
         }
         guard let transitionCoordinator else {

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -12,6 +12,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     private var isSyncingStack = false
     private var isStackSyncScheduledAfterTransition = false
     private var pendingStackSyncAnimates = false
+    private var pendingDetailSurfaceDiscardAfterProgrammaticPop = false
 
     package init(
         model: NetworkPanelModel,
@@ -68,8 +69,15 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         didShow viewController: UIViewController,
         animated: Bool
     ) {
+        guard viewController === listViewController else {
+            return
+        }
+        if pendingDetailSurfaceDiscardAfterProgrammaticPop {
+            pendingDetailSurfaceDiscardAfterProgrammaticPop = false
+            detailViewController.discardDetailSurfaceAfterCompactRemoval()
+            return
+        }
         guard isSyncingStack == false,
-              viewController === listViewController,
               model.selectedRequest != nil else {
             return
         }
@@ -130,7 +138,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
             return
         }
         if viewControllers.contains(where: { $0 === detailViewController }) {
-            detailViewController.discardDetailSurfaceAfterCompactRemoval()
+            pendingDetailSurfaceDiscardAfterProgrammaticPop = true
         }
         setViewControllers([listViewController], animated: animated)
     }

--- a/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkCompactNavigationController.swift
@@ -74,7 +74,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
             return
         }
         model.selectRequest(nil)
-        detailViewController.clearSelectionPresentationAfterContainerDeselection()
+        detailViewController.discardDetailSurfaceAfterCompactRemoval()
     }
 
     private func startObservingSelection() {
@@ -130,7 +130,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
             return
         }
         if viewControllers.contains(where: { $0 === detailViewController }) {
-            detailViewController.clearSelectionPresentationAfterContainerDeselection()
+            detailViewController.discardDetailSurfaceAfterCompactRemoval()
         }
         setViewControllers([listViewController], animated: animated)
     }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -52,6 +52,7 @@ final class NetworkBodyViewController: UIViewController {
     private weak var body: NetworkBody?
     private var metadata: NetworkBodyViewController.PreviewMetadata?
     private var hasDisplayedBody = false
+    private var isRenderingActive = false
     private var mediaPlayerViewController: AVPlayerViewController?
     private var mediaPlayerURL: URL?
     private var moviePreviewPlayerFactory: MoviePreviewPlayerFactory
@@ -119,14 +120,18 @@ final class NetworkBodyViewController: UIViewController {
                 return
             }
             self.metadata = metadata
-            renderBody(body)
+            if isRenderingActive {
+                renderBody(body)
+            }
             return
         }
         hasDisplayedBody = true
         self.body = body
         self.metadata = metadata
         startObserving(body: body)
-        renderBody(body)
+        if isRenderingActive {
+            renderBody(body)
+        }
     }
 
     func releasePreviewResources() {
@@ -136,6 +141,31 @@ final class NetworkBodyViewController: UIViewController {
         startObserving(body: nil)
         hideMediaPreview()
         scrollEdgeSink?.contentScrollView = nil
+    }
+
+    func setRenderingActive(_ isActive: Bool) {
+        guard isRenderingActive != isActive else {
+            if isActive, hasDisplayedBody {
+                renderBody(body)
+            }
+            return
+        }
+
+        isRenderingActive = isActive
+        if isActive {
+            startObserving(body: body)
+            if hasDisplayedBody {
+                renderBody(body)
+            }
+        } else {
+            bodyObservation?.cancel()
+            bodyObservation = nil
+#if DEBUG
+            bodyObservationDelivery = nil
+#endif
+            body?.cancelTextRepresentationPreparation()
+            mediaPreviewCoordinator.suspendPreparation()
+        }
     }
 
     private func configureSyntaxView() {
@@ -202,7 +232,8 @@ final class NetworkBodyViewController: UIViewController {
 #if DEBUG
         bodyObservationDelivery = nil
 #endif
-        guard let body else {
+        guard isRenderingActive,
+              let body else {
             return
         }
         let token = withPortableContinuousObservation { [weak self, weak body] _ in
@@ -232,6 +263,9 @@ final class NetworkBodyViewController: UIViewController {
 #endif
 
     private func renderBody(_ body: NetworkBody?) {
+        guard isRenderingActive else {
+            return
+        }
         let displayText: String
         let syntaxKind: NetworkBody.SyntaxKind
         guard let body else {
@@ -321,6 +355,9 @@ final class NetworkBodyViewController: UIViewController {
     private func applyMediaPreviewResult(
         _ result: NetworkMediaPreviewResultAction
     ) {
+        guard isRenderingActive else {
+            return
+        }
         switch result {
         case .ignore:
             return

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -14,42 +14,43 @@ extension NetworkBodyViewController {
 final class NetworkBodyViewController: UIViewController {
     typealias MoviePreviewPlayerFactory = @MainActor (URL) -> AVPlayer
 
-    enum SurfaceDiscardReason {
-        case emptySelection
-        case headersMode
-        case missingPreviewBody
-        case compactRemoval
-    }
+    enum Surface {
+        case none
+        case unavailableBodyPlaceholder
+        case body(NetworkBody, metadata: NetworkBodyViewController.PreviewMetadata?)
 
-    private struct SurfaceBinding {
-        enum Kind {
-            case none
-            case unavailableBodyPlaceholder
-            case body
+        var body: NetworkBody? {
+            if case .body(let body, _) = self {
+                return body
+            }
+            return nil
         }
 
-        var kind: Kind
-        weak var body: NetworkBody?
-        var metadata: NetworkBodyViewController.PreviewMetadata?
-
-        static let none = SurfaceBinding(kind: .none, body: nil, metadata: nil)
-        static let unavailableBodyPlaceholder = SurfaceBinding(kind: .unavailableBodyPlaceholder, body: nil, metadata: nil)
-
-        static func body(
-            _ body: NetworkBody,
-            metadata: NetworkBodyViewController.PreviewMetadata?
-        ) -> SurfaceBinding {
-            SurfaceBinding(kind: .body, body: body, metadata: metadata)
+        var metadata: NetworkBodyViewController.PreviewMetadata? {
+            if case .body(_, let metadata) = self {
+                return metadata
+            }
+            return nil
         }
 
-        var hasRenderableSurface: Bool {
-            kind != .none
+        var isRenderable: Bool {
+            switch self {
+            case .none:
+                false
+            case .unavailableBodyPlaceholder, .body:
+                true
+            }
         }
 
-        func isEquivalent(to other: SurfaceBinding) -> Bool {
-            kind == other.kind
-                && body === other.body
-                && metadata == other.metadata
+        func isEquivalent(to other: NetworkBodyViewController.Surface) -> Bool {
+            switch (self, other) {
+            case (.none, .none), (.unavailableBodyPlaceholder, .unavailableBodyPlaceholder):
+                return true
+            case (.body(let body, let metadata), .body(let otherBody, let otherMetadata)):
+                return body === otherBody && metadata == otherMetadata
+            default:
+                return false
+            }
         }
     }
 
@@ -88,11 +89,12 @@ final class NetworkBodyViewController: UIViewController {
     }()
     private var bodyObservation: PortableObservationTracking.Token?
     private weak var scrollEdgeSink: (any NetworkBodyScrollEdgeSink)?
-    private var surfaceBinding = SurfaceBinding.none
+    private var surface = Surface.none
     private var isRenderingActive = false
     private var mediaPlayerViewController: AVPlayerViewController?
     private var mediaPlayerURL: URL?
     private var moviePreviewPlayerFactory: MoviePreviewPlayerFactory
+    private var textPreviewCoordinator = NetworkTextPreviewCoordinator()
     private var mediaPreviewCoordinator = NetworkMediaPreviewCoordinator()
     private let previewRenderState = NetworkBodyPreviewRenderState()
     private var imageWidthConstraint: NSLayoutConstraint?
@@ -145,42 +147,24 @@ final class NetworkBodyViewController: UIViewController {
         previewRenderObservationDelivery?.cancel()
 #endif
         mediaPreviewCoordinator.cancel()
+        textPreviewCoordinator.cancel()
     }
 
-    func bindSurface(body: NetworkBody?) {
-        bindSurface(body: body, metadata: nil)
-    }
-
-    func bindSurface(body: NetworkBody?, metadata: NetworkBodyViewController.PreviewMetadata?) {
-        let nextBinding: SurfaceBinding
-        if let body {
-            nextBinding = .body(body, metadata: metadata)
-        } else {
-            nextBinding = .unavailableBodyPlaceholder
-        }
-        setSurfaceBinding(nextBinding, discardsVisibleResources: false)
-    }
-
-    func discardSurface(reason: SurfaceDiscardReason) {
-        switch reason {
-        case .missingPreviewBody:
-            setSurfaceBinding(.unavailableBodyPlaceholder, discardsVisibleResources: true)
-        case .emptySelection, .headersMode, .compactRemoval:
-            setSurfaceBinding(.none, discardsVisibleResources: true)
-        }
+    func setSurface(_ nextSurface: Surface) {
+        setSurface(nextSurface, discardsVisibleResources: nextSurface.isRenderable == false)
     }
 
     func resumeRendering() {
         guard isRenderingActive == false else {
-            if surfaceBinding.hasRenderableSurface {
+            if surface.isRenderable {
                 renderCurrentSurface()
             }
             return
         }
 
         isRenderingActive = true
-        startObserving(body: surfaceBinding.body)
-        if surfaceBinding.hasRenderableSurface {
+        startObserving(body: surface.body)
+        if surface.isRenderable {
             renderCurrentSurface()
         }
     }
@@ -196,34 +180,34 @@ final class NetworkBodyViewController: UIViewController {
 #if DEBUG
         bodyObservationDelivery = nil
 #endif
-        surfaceBinding.body?.cancelTextRepresentationPreparation()
+        textPreviewCoordinator.suspendPreparation()
         mediaPreviewCoordinator.suspendPreparation()
         pauseMediaPreviewPlayback()
     }
 
-    private func setSurfaceBinding(
-        _ nextBinding: SurfaceBinding,
+    private func setSurface(
+        _ nextSurface: Surface,
         discardsVisibleResources: Bool
     ) {
-        guard surfaceBinding.isEquivalent(to: nextBinding) == false else {
-            if isRenderingActive, nextBinding.hasRenderableSurface {
+        guard surface.isEquivalent(to: nextSurface) == false else {
+            if isRenderingActive, nextSurface.isRenderable {
                 renderCurrentSurface()
             }
             return
         }
 
-        let previousBody = surfaceBinding.body
-        let nextBody = nextBinding.body
-        if previousBody !== nextBody {
-            previousBody?.cancelTextRepresentationPreparation()
+        if surface.body !== nextSurface.body || surface.metadata != nextSurface.metadata {
+            textPreviewCoordinator.cancel()
+            mediaPreviewCoordinator.cancel()
         }
 
-        surfaceBinding = nextBinding
-        startObserving(body: nextBody)
+        surface = nextSurface
+        startObserving(body: nextSurface.body)
 
-        if isRenderingActive, nextBinding.hasRenderableSurface {
+        if isRenderingActive, nextSurface.isRenderable {
             renderCurrentSurface()
         } else if discardsVisibleResources {
+            textPreviewCoordinator.cancel()
             mediaPreviewCoordinator.cancel()
             hideMediaPreview()
             scrollEdgeSink?.contentScrollView = nil
@@ -301,7 +285,7 @@ final class NetworkBodyViewController: UIViewController {
         let token = withPortableContinuousObservation { [weak self, weak body] _ in
             guard let self,
                   let body,
-                  body === self.surfaceBinding.body else {
+                  body === self.surface.body else {
                 return
             }
             self.renderBody(body)
@@ -325,13 +309,13 @@ final class NetworkBodyViewController: UIViewController {
 #endif
 
     private func renderCurrentSurface() {
-        switch surfaceBinding.kind {
+        switch surface {
         case .none:
             return
         case .unavailableBodyPlaceholder:
             renderBody(nil)
-        case .body:
-            renderBody(surfaceBinding.body)
+        case .body(let body, _):
+            renderBody(body)
         }
     }
 
@@ -342,6 +326,7 @@ final class NetworkBodyViewController: UIViewController {
         let displayText: String
         let syntaxKind: NetworkBody.SyntaxKind
         guard let body else {
+            textPreviewCoordinator.cancel()
             hideMediaPreview()
             applyBodyDisplay(
                 text: String(localized: "network.body.unavailable", bundle: .module),
@@ -351,20 +336,30 @@ final class NetworkBodyViewController: UIViewController {
         }
 
         if renderMediaPreviewIfPossible(for: body) {
+            textPreviewCoordinator.cancel()
             return
         }
 
         switch body.phase {
         case .available, .fetching:
+            textPreviewCoordinator.cancel()
             hideMediaPreview()
             displayText = ""
             syntaxKind = body.textRepresentationSyntaxKind
         case .loaded:
-            body.prepareTextRepresentation()
-            displayText = body.textRepresentation
-                ?? String(localized: "network.body.unavailable", bundle: .module)
-            syntaxKind = body.textRepresentationSyntaxKind
+            let textAction = textPreviewCoordinator.preparePreview(for: body) { [weak self] result in
+                self?.applyTextPreviewResult(result)
+            }
+            switch textAction {
+            case .unavailable:
+                displayText = String(localized: "network.body.unavailable", bundle: .module)
+                syntaxKind = .plainText
+            case .active(let text, let preparedSyntaxKind), .ready(let text, let preparedSyntaxKind):
+                displayText = text
+                syntaxKind = preparedSyntaxKind
+            }
         case .failed(let error):
+            textPreviewCoordinator.cancel()
             hideMediaPreview()
             let text = body.textRepresentation
                 ?? String(localized: "network.body.unavailable", bundle: .module)
@@ -373,6 +368,18 @@ final class NetworkBodyViewController: UIViewController {
         }
 
         applyBodyDisplay(text: displayText, syntaxKind: syntaxKind)
+    }
+
+    private func applyTextPreviewResult(_ result: NetworkTextPreviewResultAction) {
+        guard isRenderingActive else {
+            return
+        }
+        switch result {
+        case .ignore:
+            return
+        case .show(let text, let syntaxKind):
+            applyBodyDisplay(text: text, syntaxKind: syntaxKind)
+        }
     }
 
     private func localizedDescription(for error: NetworkBody.FetchError) -> String {
@@ -401,7 +408,7 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func renderMediaPreviewIfPossible(for body: NetworkBody) -> Bool {
-        let action = mediaPreviewCoordinator.preparePreview(for: body, metadata: surfaceBinding.metadata) { [weak self] result in
+        let action = mediaPreviewCoordinator.preparePreview(for: body, metadata: surface.metadata) { [weak self] result in
             self?.applyMediaPreviewResult(result)
         }
         switch action {
@@ -805,6 +812,18 @@ extension NetworkBodyViewController {
 
     func waitUntilMediaPreviewPreparationFinishedForTesting() async {
         await mediaPreviewCoordinator.waitUntilPreparationFinishedForTesting()
+    }
+
+    var hasActiveTextPreviewPreparationForTesting: Bool {
+        textPreviewCoordinator.hasActivePreparationForTesting
+    }
+
+    var activeTextPreviewPreparationBodyIDForTesting: ObjectIdentifier? {
+        textPreviewCoordinator.activePreparationBodyIDForTesting
+    }
+
+    func waitUntilTextPreviewPreparationFinishedForTesting() async {
+        await textPreviewCoordinator.waitUntilPreparationFinishedForTesting()
     }
 
     var bodyObservationDeliveryForTesting: PortableObservationTracking.Token? {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -142,14 +142,20 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     func discardSurface(reason: SurfaceDiscardReason) {
-        hasDisplayedBody = false
+        let shouldRenderUnavailableBodyPlaceholder = reason == .missingPreviewBody
+        hasDisplayedBody = shouldRenderUnavailableBodyPlaceholder
         body = nil
         metadata = nil
         startObserving(body: nil)
         mediaPreviewCoordinator.cancel()
         switch reason {
         case .missingPreviewBody:
-            renderUnavailableBodyPlaceholder()
+            if isRenderingActive {
+                renderBody(nil)
+            } else {
+                hideMediaPreview()
+                scrollEdgeSink?.contentScrollView = nil
+            }
         case .emptySelection, .headersMode, .compactRemoval:
             hideMediaPreview()
             scrollEdgeSink?.contentScrollView = nil
@@ -409,19 +415,6 @@ final class NetworkBodyViewController: UIViewController {
         applyScrollEdgeObservedBackgrounds()
         scrollEdgeSink?.contentScrollView = syntaxView
         previewRenderState.showSyntax()
-    }
-
-    private func renderUnavailableBodyPlaceholder() {
-        guard isRenderingActive else {
-            hideMediaPreview()
-            scrollEdgeSink?.contentScrollView = nil
-            return
-        }
-        hideMediaPreview()
-        applyBodyDisplay(
-            text: String(localized: "network.body.unavailable", bundle: .module),
-            syntaxKind: .plainText
-        )
     }
 
     private func showImagePreview(_ image: UIImage) {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -14,6 +14,13 @@ extension NetworkBodyViewController {
 final class NetworkBodyViewController: UIViewController {
     typealias MoviePreviewPlayerFactory = @MainActor (URL) -> AVPlayer
 
+    enum SurfaceDiscardReason {
+        case emptySelection
+        case headersMode
+        case missingPreviewBody
+        case compactRemoval
+    }
+
     private let syntaxModel = SyntaxEditorModel(
         text: "",
         language: .json,
@@ -110,11 +117,11 @@ final class NetworkBodyViewController: UIViewController {
         mediaPreviewCoordinator.cancel()
     }
 
-    func display(body: NetworkBody?) {
-        display(body: body, metadata: nil)
+    func bindSurface(body: NetworkBody?) {
+        bindSurface(body: body, metadata: nil)
     }
 
-    func display(body: NetworkBody?, metadata: NetworkBodyViewController.PreviewMetadata?) {
+    func bindSurface(body: NetworkBody?, metadata: NetworkBodyViewController.PreviewMetadata?) {
         guard hasDisplayedBody == false || self.body !== body else {
             guard self.metadata != metadata else {
                 return
@@ -134,39 +141,45 @@ final class NetworkBodyViewController: UIViewController {
         }
     }
 
-    func releasePreviewResources() {
+    func discardSurface(reason: SurfaceDiscardReason) {
         hasDisplayedBody = false
         body = nil
         metadata = nil
         startObserving(body: nil)
+        mediaPreviewCoordinator.cancel()
         hideMediaPreview()
         scrollEdgeSink?.contentScrollView = nil
     }
 
-    func setRenderingActive(_ isActive: Bool) {
-        guard isRenderingActive != isActive else {
-            if isActive, hasDisplayedBody {
+    func resumeRendering() {
+        guard isRenderingActive == false else {
+            if hasDisplayedBody {
                 renderBody(body)
             }
             return
         }
 
-        isRenderingActive = isActive
-        if isActive {
-            startObserving(body: body)
-            if hasDisplayedBody {
-                renderBody(body)
-            }
-        } else {
-            bodyObservation?.cancel()
-            bodyObservation = nil
-#if DEBUG
-            bodyObservationDelivery = nil
-#endif
-            body?.cancelTextRepresentationPreparation()
-            mediaPreviewCoordinator.suspendPreparation()
-            pauseMediaPreviewPlayback()
+        isRenderingActive = true
+        startObserving(body: body)
+        if hasDisplayedBody {
+            renderBody(body)
         }
+    }
+
+    func suspendKeepingSurface() {
+        guard isRenderingActive else {
+            return
+        }
+
+        isRenderingActive = false
+        bodyObservation?.cancel()
+        bodyObservation = nil
+#if DEBUG
+        bodyObservationDelivery = nil
+#endif
+        body?.cancelTextRepresentationPreparation()
+        mediaPreviewCoordinator.suspendPreparation()
+        pauseMediaPreviewPlayback()
     }
 
     private func configureSyntaxView() {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -165,6 +165,7 @@ final class NetworkBodyViewController: UIViewController {
 #endif
             body?.cancelTextRepresentationPreparation()
             mediaPreviewCoordinator.suspendPreparation()
+            pauseMediaPreviewPlayback()
         }
     }
 
@@ -447,6 +448,10 @@ final class NetworkBodyViewController: UIViewController {
         previewRenderState.showSyntax()
     }
 
+    private func pauseMediaPreviewPlayback() {
+        mediaPlayerViewController?.player?.pause()
+    }
+
     private func hideImagePreview() {
         imageScrollView.isHidden = true
         imageView.image = nil
@@ -532,6 +537,7 @@ final class NetworkBodyViewController: UIViewController {
         guard let mediaPlayerViewController else {
             return
         }
+        pauseMediaPreviewPlayback()
         mediaPlayerViewController.willMove(toParent: nil)
         mediaPlayerViewController.view.removeFromSuperview()
         mediaPlayerViewController.removeFromParent()

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -21,6 +21,38 @@ final class NetworkBodyViewController: UIViewController {
         case compactRemoval
     }
 
+    private struct SurfaceBinding {
+        enum Kind {
+            case none
+            case unavailableBodyPlaceholder
+            case body
+        }
+
+        var kind: Kind
+        weak var body: NetworkBody?
+        var metadata: NetworkBodyViewController.PreviewMetadata?
+
+        static let none = SurfaceBinding(kind: .none, body: nil, metadata: nil)
+        static let unavailableBodyPlaceholder = SurfaceBinding(kind: .unavailableBodyPlaceholder, body: nil, metadata: nil)
+
+        static func body(
+            _ body: NetworkBody,
+            metadata: NetworkBodyViewController.PreviewMetadata?
+        ) -> SurfaceBinding {
+            SurfaceBinding(kind: .body, body: body, metadata: metadata)
+        }
+
+        var hasRenderableSurface: Bool {
+            kind != .none
+        }
+
+        func isEquivalent(to other: SurfaceBinding) -> Bool {
+            kind == other.kind
+                && body === other.body
+                && metadata == other.metadata
+        }
+    }
+
     private let syntaxModel = SyntaxEditorModel(
         text: "",
         language: .json,
@@ -56,9 +88,7 @@ final class NetworkBodyViewController: UIViewController {
     }()
     private var bodyObservation: PortableObservationTracking.Token?
     private weak var scrollEdgeSink: (any NetworkBodyScrollEdgeSink)?
-    private weak var body: NetworkBody?
-    private var metadata: NetworkBodyViewController.PreviewMetadata?
-    private var hasDisplayedBody = false
+    private var surfaceBinding = SurfaceBinding.none
     private var isRenderingActive = false
     private var mediaPlayerViewController: AVPlayerViewController?
     private var mediaPlayerURL: URL?
@@ -122,58 +152,36 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     func bindSurface(body: NetworkBody?, metadata: NetworkBodyViewController.PreviewMetadata?) {
-        guard hasDisplayedBody == false || self.body !== body else {
-            guard self.metadata != metadata else {
-                return
-            }
-            self.metadata = metadata
-            if isRenderingActive {
-                renderBody(body)
-            }
-            return
+        let nextBinding: SurfaceBinding
+        if let body {
+            nextBinding = .body(body, metadata: metadata)
+        } else {
+            nextBinding = .unavailableBodyPlaceholder
         }
-        hasDisplayedBody = true
-        self.body = body
-        self.metadata = metadata
-        startObserving(body: body)
-        if isRenderingActive {
-            renderBody(body)
-        }
+        setSurfaceBinding(nextBinding, discardsVisibleResources: false)
     }
 
     func discardSurface(reason: SurfaceDiscardReason) {
-        let shouldRenderUnavailableBodyPlaceholder = reason == .missingPreviewBody
-        hasDisplayedBody = shouldRenderUnavailableBodyPlaceholder
-        body = nil
-        metadata = nil
-        startObserving(body: nil)
-        mediaPreviewCoordinator.cancel()
         switch reason {
         case .missingPreviewBody:
-            if isRenderingActive {
-                renderBody(nil)
-            } else {
-                hideMediaPreview()
-                scrollEdgeSink?.contentScrollView = nil
-            }
+            setSurfaceBinding(.unavailableBodyPlaceholder, discardsVisibleResources: true)
         case .emptySelection, .headersMode, .compactRemoval:
-            hideMediaPreview()
-            scrollEdgeSink?.contentScrollView = nil
+            setSurfaceBinding(.none, discardsVisibleResources: true)
         }
     }
 
     func resumeRendering() {
         guard isRenderingActive == false else {
-            if hasDisplayedBody {
-                renderBody(body)
+            if surfaceBinding.hasRenderableSurface {
+                renderCurrentSurface()
             }
             return
         }
 
         isRenderingActive = true
-        startObserving(body: body)
-        if hasDisplayedBody {
-            renderBody(body)
+        startObserving(body: surfaceBinding.body)
+        if surfaceBinding.hasRenderableSurface {
+            renderCurrentSurface()
         }
     }
 
@@ -188,9 +196,38 @@ final class NetworkBodyViewController: UIViewController {
 #if DEBUG
         bodyObservationDelivery = nil
 #endif
-        body?.cancelTextRepresentationPreparation()
+        surfaceBinding.body?.cancelTextRepresentationPreparation()
         mediaPreviewCoordinator.suspendPreparation()
         pauseMediaPreviewPlayback()
+    }
+
+    private func setSurfaceBinding(
+        _ nextBinding: SurfaceBinding,
+        discardsVisibleResources: Bool
+    ) {
+        guard surfaceBinding.isEquivalent(to: nextBinding) == false else {
+            if isRenderingActive, nextBinding.hasRenderableSurface {
+                renderCurrentSurface()
+            }
+            return
+        }
+
+        let previousBody = surfaceBinding.body
+        let nextBody = nextBinding.body
+        if previousBody !== nextBody {
+            previousBody?.cancelTextRepresentationPreparation()
+        }
+
+        surfaceBinding = nextBinding
+        startObserving(body: nextBody)
+
+        if isRenderingActive, nextBinding.hasRenderableSurface {
+            renderCurrentSurface()
+        } else if discardsVisibleResources {
+            mediaPreviewCoordinator.cancel()
+            hideMediaPreview()
+            scrollEdgeSink?.contentScrollView = nil
+        }
     }
 
     private func configureSyntaxView() {
@@ -264,7 +301,7 @@ final class NetworkBodyViewController: UIViewController {
         let token = withPortableContinuousObservation { [weak self, weak body] _ in
             guard let self,
                   let body,
-                  body === self.body else {
+                  body === self.surfaceBinding.body else {
                 return
             }
             self.renderBody(body)
@@ -286,6 +323,17 @@ final class NetworkBodyViewController: UIViewController {
         }
     }
 #endif
+
+    private func renderCurrentSurface() {
+        switch surfaceBinding.kind {
+        case .none:
+            return
+        case .unavailableBodyPlaceholder:
+            renderBody(nil)
+        case .body:
+            renderBody(surfaceBinding.body)
+        }
+    }
 
     private func renderBody(_ body: NetworkBody?) {
         guard isRenderingActive else {
@@ -353,7 +401,7 @@ final class NetworkBodyViewController: UIViewController {
     }
 
     private func renderMediaPreviewIfPossible(for body: NetworkBody) -> Bool {
-        let action = mediaPreviewCoordinator.preparePreview(for: body, metadata: metadata) { [weak self] result in
+        let action = mediaPreviewCoordinator.preparePreview(for: body, metadata: surfaceBinding.metadata) { [weak self] result in
             self?.applyMediaPreviewResult(result)
         }
         switch action {
@@ -387,7 +435,7 @@ final class NetworkBodyViewController: UIViewController {
         case .ignore:
             return
         case .fallback:
-            renderBody(body)
+            renderCurrentSurface()
         case .showImage(let image):
             showImagePreview(image)
         case .showMovie(let fileURL):

--- a/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkBodyViewController.swift
@@ -147,8 +147,13 @@ final class NetworkBodyViewController: UIViewController {
         metadata = nil
         startObserving(body: nil)
         mediaPreviewCoordinator.cancel()
-        hideMediaPreview()
-        scrollEdgeSink?.contentScrollView = nil
+        switch reason {
+        case .missingPreviewBody:
+            renderUnavailableBodyPlaceholder()
+        case .emptySelection, .headersMode, .compactRemoval:
+            hideMediaPreview()
+            scrollEdgeSink?.contentScrollView = nil
+        }
     }
 
     func resumeRendering() {
@@ -404,6 +409,19 @@ final class NetworkBodyViewController: UIViewController {
         applyScrollEdgeObservedBackgrounds()
         scrollEdgeSink?.contentScrollView = syntaxView
         previewRenderState.showSyntax()
+    }
+
+    private func renderUnavailableBodyPlaceholder() {
+        guard isRenderingActive else {
+            hideMediaPreview()
+            scrollEdgeSink?.contentScrollView = nil
+            return
+        }
+        hideMediaPreview()
+        applyBodyDisplay(
+            text: String(localized: "network.body.unavailable", bundle: .module),
+            syntaxKind: .plainText
+        )
     }
 
     private func showImagePreview(_ image: UIImage) {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -389,10 +389,10 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showEmptySelection() {
+        bodyViewController.display(body: nil)
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         headersTextView.isHidden = true
-        bodyViewController.display(body: nil)
         headersTextView.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
         scrollEdgeController.contentScrollView = nil

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -146,6 +146,10 @@ package final class NetworkDetailViewController: UIViewController {
         return super.contentScrollView(for: edge)
     }
 
+    package func clearSelectionPresentationAfterContainerDeselection() {
+        clearSelectedRequestPresentation()
+    }
+
     private func startObservingModel() {
         guard isRenderingActive else {
             return
@@ -274,6 +278,11 @@ package final class NetworkDetailViewController: UIViewController {
             return
         }
 
+        guard let request else {
+            clearSelectedRequestPresentation()
+            return
+        }
+
         hasBoundSelectedRequest = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
@@ -282,13 +291,6 @@ package final class NetworkDetailViewController: UIViewController {
 #if DEBUG
         selectedRequestRenderObservationDelivery = nil
 #endif
-
-        guard let request else {
-            title = nil
-            showEmptySelection()
-            renderModeControl(selectedRequest: nil)
-            return
-        }
 
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
@@ -386,6 +388,20 @@ package final class NetworkDetailViewController: UIViewController {
     private func renderModeControl(selectedRequest request: NetworkRequest? = nil) {
         let request = request ?? observedRequest
         modeControlController.render(mode: mode, isEnabled: request != nil)
+    }
+
+    private func clearSelectedRequestPresentation() {
+        hasBoundSelectedRequest = true
+        selectedRequestRenderObservation?.cancel()
+        selectedRequestRenderObservation = nil
+        unbindResponseBodyFetchObservation()
+        observedRequest = nil
+#if DEBUG
+        selectedRequestRenderObservationDelivery = nil
+#endif
+        title = nil
+        showEmptySelection()
+        renderModeControl(selectedRequest: nil)
     }
 
     private func showEmptySelection() {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -389,7 +389,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showEmptySelection() {
-        bodyViewController.display(body: nil)
+        bodyViewController.releasePreviewResources()
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         headersTextView.isHidden = true

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -146,8 +146,8 @@ package final class NetworkDetailViewController: UIViewController {
         return super.contentScrollView(for: edge)
     }
 
-    package func clearSelectionPresentationAfterContainerDeselection() {
-        clearSelectedRequestPresentation()
+    package func discardDetailSurfaceAfterCompactRemoval() {
+        clearSelectedRequestPresentation(discardReason: .compactRemoval)
     }
 
     private func startObservingModel() {
@@ -202,7 +202,11 @@ package final class NetworkDetailViewController: UIViewController {
             return
         }
         isBodyRenderingActive = isActive
-        bodyViewController.setRenderingActive(isActive)
+        if isActive {
+            bodyViewController.resumeRendering()
+        } else {
+            bodyViewController.suspendKeepingSurface()
+        }
     }
 
     private func updateBodyRenderingActiveForCurrentSurface() {
@@ -279,7 +283,7 @@ package final class NetworkDetailViewController: UIViewController {
         }
 
         guard let request else {
-            clearSelectedRequestPresentation()
+            clearSelectedRequestPresentation(discardReason: .emptySelection)
             return
         }
 
@@ -390,7 +394,7 @@ package final class NetworkDetailViewController: UIViewController {
         modeControlController.render(mode: mode, isEnabled: request != nil)
     }
 
-    private func clearSelectedRequestPresentation() {
+    private func clearSelectedRequestPresentation(discardReason: NetworkBodyViewController.SurfaceDiscardReason) {
         hasBoundSelectedRequest = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
@@ -400,12 +404,12 @@ package final class NetworkDetailViewController: UIViewController {
         selectedRequestRenderObservationDelivery = nil
 #endif
         title = nil
-        showEmptySelection()
+        showEmptySelection(discardReason: discardReason)
         renderModeControl(selectedRequest: nil)
     }
 
-    private func showEmptySelection() {
-        bodyViewController.releasePreviewResources()
+    private func showEmptySelection(discardReason: NetworkBodyViewController.SurfaceDiscardReason) {
+        bodyViewController.discardSurface(reason: discardReason)
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         headersTextView.isHidden = true
@@ -432,7 +436,7 @@ package final class NetworkDetailViewController: UIViewController {
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         scrollEdgeController.isPreviewRoleControlVisible = false
-        bodyViewController.releasePreviewResources()
+        bodyViewController.discardSurface(reason: .headersMode)
         headersTextView.isHidden = false
         scrollEdgeController.contentScrollView = headersTextView.contentScrollView
     }
@@ -446,11 +450,11 @@ package final class NetworkDetailViewController: UIViewController {
         renderPreviewRoleControl(roles: roles, selectedRole: selectedRole)
 
         guard let role = selectedRole else {
-            bodyViewController.display(body: nil)
+            bodyViewController.discardSurface(reason: .missingPreviewBody)
             unbindResponseBodyFetchObservation()
             return
         }
-        bodyViewController.display(
+        bodyViewController.bindSurface(
             body: body(in: request, for: role),
             metadata: previewMetadata(in: request, for: role)
         )

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -52,6 +52,8 @@ package final class NetworkDetailViewController: UIViewController {
     private var selectedRequestRenderObservation: PortableObservationTracking.Token?
     private let responseBodyFetchObservationBinding = NetworkResponseBodyFetchObservationBinding()
     private let scrollEdgeController = NetworkDetailScrollEdgeController()
+    private var isRenderingActive = false
+    private var isBodyRenderingActive = false
     private lazy var bodyViewController = NetworkBodyViewController(
         scrollEdgeSink: scrollEdgeController
     )
@@ -125,7 +127,16 @@ package final class NetworkDetailViewController: UIViewController {
         installContentViews()
         installModeTitleView()
         scrollEdgeController.install(previewRoleControlContainerView: previewRoleControlController.containerView)
-        startObservingModel()
+    }
+
+    override package func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        resumeRendering()
+    }
+
+    override package func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        suspendRendering()
     }
 
     override package func contentScrollView(for edge: NSDirectionalRectEdge) -> UIScrollView? {
@@ -136,14 +147,62 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func startObservingModel() {
+        guard isRenderingActive else {
+            return
+        }
+        modelObservation?.cancel()
         let token = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            bindSelectedRequest(model.selectedRequest)
+            bindSelectedRequest(
+                model.selectedRequest,
+                force: selectedRequestRenderObservation == nil
+            )
         }
         modelObservation = token
 #if DEBUG
         modelObservationDelivery = token
 #endif
+    }
+
+    private func resumeRendering() {
+        guard isRenderingActive == false else {
+            bindSelectedRequest(model.selectedRequest, force: selectedRequestRenderObservation == nil)
+            updateBodyRenderingActiveForCurrentSurface()
+            return
+        }
+        isRenderingActive = true
+        bindSelectedRequest(model.selectedRequest, force: true)
+        startObservingModel()
+        updateBodyRenderingActiveForCurrentSurface()
+    }
+
+    private func suspendRendering() {
+        guard isRenderingActive else {
+            return
+        }
+        isRenderingActive = false
+        modelObservation?.cancel()
+        modelObservation = nil
+        selectedRequestRenderObservation?.cancel()
+        selectedRequestRenderObservation = nil
+        unbindResponseBodyFetchObservation()
+        setBodyRenderingActive(false)
+#if DEBUG
+        modelObservationDelivery = nil
+        selectedRequestRenderObservationDelivery = nil
+#endif
+    }
+
+    private func setBodyRenderingActive(_ isActive: Bool) {
+        guard isBodyRenderingActive != isActive else {
+            return
+        }
+        isBodyRenderingActive = isActive
+        bodyViewController.setRenderingActive(isActive)
+    }
+
+    private func updateBodyRenderingActiveForCurrentSurface() {
+        setBodyRenderingActive(isRenderingActive && previewContainerView.isHidden == false)
     }
 
     private func applyBackgroundFromTraits() {
@@ -206,8 +265,11 @@ package final class NetworkDetailViewController: UIViewController {
         renderModeControl()
     }
 
-    private func bindSelectedRequest(_ request: NetworkRequest?) {
-        guard hasBoundSelectedRequest == false || observedRequest !== request else {
+    private func bindSelectedRequest(_ request: NetworkRequest?, force: Bool = false) {
+        guard isRenderingActive else {
+            return
+        }
+        guard force || hasBoundSelectedRequest == false || observedRequest !== request else {
             renderModeControl(selectedRequest: request)
             return
         }
@@ -242,6 +304,9 @@ package final class NetworkDetailViewController: UIViewController {
 #if DEBUG
         selectedRequestRenderObservationDelivery = nil
 #endif
+        guard isRenderingActive else {
+            return
+        }
         guard let observedRequest else {
             return
         }
@@ -249,6 +314,9 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func bindSelectedRequestRendering(_ request: NetworkRequest) {
+        guard isRenderingActive else {
+            return
+        }
         let token = withPortableContinuousObservation { [weak self, weak request] _ in
             guard let request,
                   self?.observedRequest === request else {
@@ -263,6 +331,9 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func renderSelectedRequest(_ request: NetworkRequest) {
+        guard isRenderingActive else {
+            return
+        }
         switch mode {
         case .preview:
             renderPreviewSurface(selectedRequest: request)
@@ -275,6 +346,7 @@ package final class NetworkDetailViewController: UIViewController {
         title = request.displayName
         showPreview()
         renderPreview(selectedRequest: request)
+        updateBodyRenderingActiveForCurrentSurface()
     }
 
     private func renderHeadersSurface(selectedRequest request: NetworkRequest) {
@@ -289,6 +361,9 @@ package final class NetworkDetailViewController: UIViewController {
             return
         }
         mode = nextMode
+        guard isRenderingActive else {
+            return
+        }
         renderModeControl()
         rebindSelectedRequestRendering()
     }
@@ -302,6 +377,9 @@ package final class NetworkDetailViewController: UIViewController {
             return
         }
         previewRole = nextRole
+        guard isRenderingActive else {
+            return
+        }
         rebindSelectedRequestRendering()
     }
 
@@ -311,6 +389,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showEmptySelection() {
+        setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         headersTextView.isHidden = true
         bodyViewController.display(body: nil)
@@ -334,6 +413,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showHeaders() {
+        setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         scrollEdgeController.isPreviewRoleControlVisible = false
         bodyViewController.releasePreviewResources()
@@ -400,6 +480,10 @@ package final class NetworkDetailViewController: UIViewController {
         for request: NetworkRequest,
         role: NetworkBody.Role
     ) {
+        guard isRenderingActive else {
+            unbindResponseBodyFetchObservation()
+            return
+        }
         guard role == .response else {
             unbindResponseBodyFetchObservation()
             return
@@ -414,7 +498,8 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func fetchResponseBodyIfNeededForVisibleResponse(_ request: NetworkRequest) {
-        guard mode == .preview,
+        guard isRenderingActive,
+              mode == .preview,
               observedRequest === request,
               selectedPreviewRole(from: availablePreviewRoles(in: request)) == .response,
               request.canFetchResponseBody else {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -147,7 +147,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     package func discardDetailSurfaceAfterCompactRemoval() {
-        clearSelectedRequestPresentation(discardReason: .compactRemoval)
+        clearSelectedRequestPresentation(bodySurface: .none)
     }
 
     private func startObservingModel() {
@@ -283,7 +283,7 @@ package final class NetworkDetailViewController: UIViewController {
         }
 
         guard let request else {
-            clearSelectedRequestPresentation(discardReason: .emptySelection)
+            clearSelectedRequestPresentation(bodySurface: .none)
             return
         }
 
@@ -394,7 +394,7 @@ package final class NetworkDetailViewController: UIViewController {
         modeControlController.render(mode: mode, isEnabled: request != nil)
     }
 
-    private func clearSelectedRequestPresentation(discardReason: NetworkBodyViewController.SurfaceDiscardReason) {
+    private func clearSelectedRequestPresentation(bodySurface: NetworkBodyViewController.Surface) {
         hasBoundSelectedRequest = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
@@ -404,12 +404,12 @@ package final class NetworkDetailViewController: UIViewController {
         selectedRequestRenderObservationDelivery = nil
 #endif
         title = nil
-        showEmptySelection(discardReason: discardReason)
+        showEmptySelection(bodySurface: bodySurface)
         renderModeControl(selectedRequest: nil)
     }
 
-    private func showEmptySelection(discardReason: NetworkBodyViewController.SurfaceDiscardReason) {
-        bodyViewController.discardSurface(reason: discardReason)
+    private func showEmptySelection(bodySurface: NetworkBodyViewController.Surface) {
+        bodyViewController.setSurface(bodySurface)
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         headersTextView.isHidden = true
@@ -436,7 +436,7 @@ package final class NetworkDetailViewController: UIViewController {
         setBodyRenderingActive(false)
         previewContainerView.isHidden = true
         scrollEdgeController.isPreviewRoleControlVisible = false
-        bodyViewController.discardSurface(reason: .headersMode)
+        bodyViewController.setSurface(.none)
         headersTextView.isHidden = false
         scrollEdgeController.contentScrollView = headersTextView.contentScrollView
     }
@@ -450,14 +450,11 @@ package final class NetworkDetailViewController: UIViewController {
         renderPreviewRoleControl(roles: roles, selectedRole: selectedRole)
 
         guard let role = selectedRole else {
-            bodyViewController.discardSurface(reason: .missingPreviewBody)
+            bodyViewController.setSurface(.unavailableBodyPlaceholder)
             unbindResponseBodyFetchObservation()
             return
         }
-        bodyViewController.bindSurface(
-            body: body(in: request, for: role),
-            metadata: previewMetadata(in: request, for: role)
-        )
+        bodyViewController.setSurface(bodySurface(in: request, for: role))
         bindResponseBodyFetchObservationIfNeeded(for: request, role: role)
     }
 
@@ -535,6 +532,19 @@ package final class NetworkDetailViewController: UIViewController {
         case .response:
             request.responseBody
         }
+    }
+
+    private func bodySurface(
+        in request: NetworkRequest,
+        for role: NetworkBody.Role
+    ) -> NetworkBodyViewController.Surface {
+        guard let body = body(in: request, for: role) else {
+            return .unavailableBodyPlaceholder
+        }
+        return .body(
+            body,
+            metadata: previewMetadata(in: request, for: role)
+        )
     }
 
     private func previewMetadata(

--- a/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkMediaPreviewCoordinator.swift
@@ -68,6 +68,10 @@ final class NetworkMediaPreviewCoordinator {
         removeCachedTemporaryFile()
     }
 
+    func suspendPreparation() {
+        cancelPending()
+    }
+
 #if DEBUG
     func waitUntilPreparationFinishedForTesting() async {
         while let task {

--- a/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
@@ -158,10 +158,15 @@ private struct NetworkTextPreviewInput: Equatable, Sendable {
     }
 
     private static func looksLikeJSON(_ text: String) -> Bool {
-        guard let firstNonWhitespace = text.first(where: { $0.isWhitespace == false }) else {
+        guard let firstNonWhitespace = text.unicodeScalars.first(where: { scalar in
+            scalar.value != 0x20
+                && scalar.value != 0x0A
+                && scalar.value != 0x0D
+                && scalar.value != 0x09
+        }) else {
             return false
         }
-        return firstNonWhitespace == "{" || firstNonWhitespace == "["
+        return firstNonWhitespace.value == 0x7B || firstNonWhitespace.value == 0x5B
     }
 }
 
@@ -186,24 +191,24 @@ private enum CancellableJSONPrettyPrinter {
     private struct Parser {
         private static let maximumNestingDepth = 128
 
-        private let text: String
-        private var index: String.Index
+        private let scalars: String.UnicodeScalarView
+        private var index: String.UnicodeScalarView.Index
         private var checkpointCounter = 0
 
         init(text: String) {
-            self.text = text
-            self.index = text.startIndex
+            self.scalars = text.unicodeScalars
+            self.index = scalars.startIndex
         }
 
         mutating func prettyPrintedJSON() throws -> String? {
             try skipWhitespace()
-            guard let first = currentCharacter,
-                  first == "{" || first == "[" else {
+            guard let first = currentScalar,
+                  first.value == 0x7B || first.value == 0x5B else {
                 return nil
             }
             let result = try parseValue(depth: 0)
             try skipWhitespace()
-            guard index == text.endIndex else {
+            guard index == scalars.endIndex else {
                 return nil
             }
             return result
@@ -214,26 +219,26 @@ private enum CancellableJSONPrettyPrinter {
                 return nil
             }
             try skipWhitespace()
-            guard let character = currentCharacter else {
+            guard let scalar = currentScalar else {
                 return nil
             }
-            switch character {
-            case "{":
+            switch scalar.value {
+            case 0x7B:
                 return try parseObject(depth: depth)
-            case "[":
+            case 0x5B:
                 return try parseArray(depth: depth)
-            case "\"":
+            case 0x22:
                 return try parseString()
-            case "t":
+            case 0x74:
                 return try consumeLiteral("true") ? "true" : nil
-            case "f":
+            case 0x66:
                 return try consumeLiteral("false") ? "false" : nil
-            case "n":
+            case 0x6E:
                 return try consumeLiteral("null") ? "null" : nil
-            case "-":
+            case 0x2D:
                 return try parseNumber()
             default:
-                if isASCIIDigit(character) {
+                if isASCIIDigit(scalar) {
                     return try parseNumber()
                 }
                 return nil
@@ -241,23 +246,23 @@ private enum CancellableJSONPrettyPrinter {
         }
 
         private mutating func parseObject(depth: Int) throws -> String? {
-            try consumeExpected("{")
+            try consumeExpected(0x7B)
             try skipWhitespace()
-            if try consumeIfPresent("}") {
+            if try consumeIfPresent(0x7D) {
                 return "{}"
             }
 
             var members: [String] = []
             while true {
                 try skipWhitespace()
-                guard currentCharacter == "\"" else {
+                guard currentScalar?.value == 0x22 else {
                     return nil
                 }
                 guard let key = try parseString() else {
                     return nil
                 }
                 try skipWhitespace()
-                guard try consumeIfPresent(":") else {
+                guard try consumeIfPresent(0x3A) else {
                     return nil
                 }
                 guard let value = try parseValue(depth: depth + 1) else {
@@ -265,10 +270,10 @@ private enum CancellableJSONPrettyPrinter {
                 }
                 members.append("\(indent(depth + 1))\(key) : \(value)")
                 try skipWhitespace()
-                if try consumeIfPresent("}") {
+                if try consumeIfPresent(0x7D) {
                     break
                 }
-                guard try consumeIfPresent(",") else {
+                guard try consumeIfPresent(0x2C) else {
                     return nil
                 }
             }
@@ -276,9 +281,9 @@ private enum CancellableJSONPrettyPrinter {
         }
 
         private mutating func parseArray(depth: Int) throws -> String? {
-            try consumeExpected("[")
+            try consumeExpected(0x5B)
             try skipWhitespace()
-            if try consumeIfPresent("]") {
+            if try consumeIfPresent(0x5D) {
                 return "[]"
             }
 
@@ -289,10 +294,10 @@ private enum CancellableJSONPrettyPrinter {
                 }
                 values.append("\(indent(depth + 1))\(value)")
                 try skipWhitespace()
-                if try consumeIfPresent("]") {
+                if try consumeIfPresent(0x5D) {
                     break
                 }
-                guard try consumeIfPresent(",") else {
+                guard try consumeIfPresent(0x2C) else {
                     return nil
                 }
             }
@@ -301,30 +306,30 @@ private enum CancellableJSONPrettyPrinter {
 
         private mutating func parseString() throws -> String? {
             let start = index
-            try consumeExpected("\"")
-            while let character = currentCharacter {
+            try consumeExpected(0x22)
+            while let scalar = currentScalar {
                 try checkpoint()
                 advance()
-                if character == "\"" {
-                    return String(text[start..<index])
+                if scalar.value == 0x22 {
+                    return String(scalars[start..<index])
                 }
-                if character == "\\" {
-                    guard let escaped = currentCharacter else {
+                if scalar.value == 0x5C {
+                    guard let escaped = currentScalar else {
                         return nil
                     }
                     advance()
-                    if escaped == "u" {
+                    if escaped.value == 0x75 {
                         for _ in 0..<4 {
-                            guard let scalar = currentCharacter,
+                            guard let scalar = currentScalar,
                                   isASCIIHexDigit(scalar) else {
                                 return nil
                             }
                             advance()
                         }
-                    } else if "\"\\/bfnrt".contains(escaped) == false {
+                    } else if isJSONEscapedCharacter(escaped) == false {
                         return nil
                     }
-                } else if character.unicodeScalars.contains(where: { $0.value < 0x20 }) {
+                } else if scalar.value < 0x20 {
                     return nil
                 }
             }
@@ -333,57 +338,57 @@ private enum CancellableJSONPrettyPrinter {
 
         private mutating func parseNumber() throws -> String? {
             let start = index
-            if try consumeIfPresent("-") == false {
+            if try consumeIfPresent(0x2D) == false {
                 try checkpoint()
             }
-            guard let firstDigit = currentCharacter,
+            guard let firstDigit = currentScalar,
                   isASCIIDigit(firstDigit) else {
                 return nil
             }
-            if firstDigit == "0" {
+            if firstDigit.value == 0x30 {
                 advance()
             } else {
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
+                while let scalar = currentScalar,
+                      isASCIIDigit(scalar) {
                     try checkpoint()
                     advance()
                 }
             }
-            if try consumeIfPresent(".") {
-                guard let digit = currentCharacter,
+            if try consumeIfPresent(0x2E) {
+                guard let digit = currentScalar,
                       isASCIIDigit(digit) else {
                     return nil
                 }
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
+                while let scalar = currentScalar,
+                      isASCIIDigit(scalar) {
                     try checkpoint()
                     advance()
                 }
             }
-            if let character = currentCharacter,
-               character == "e" || character == "E" {
+            if let scalar = currentScalar,
+               scalar.value == 0x65 || scalar.value == 0x45 {
                 advance()
-                if let sign = currentCharacter,
-                   sign == "+" || sign == "-" {
+                if let sign = currentScalar,
+                   sign.value == 0x2B || sign.value == 0x2D {
                     advance()
                 }
-                guard let digit = currentCharacter,
+                guard let digit = currentScalar,
                       isASCIIDigit(digit) else {
                     return nil
                 }
-                while let character = currentCharacter,
-                      isASCIIDigit(character) {
+                while let scalar = currentScalar,
+                      isASCIIDigit(scalar) {
                     try checkpoint()
                     advance()
                 }
             }
-            return String(text[start..<index])
+            return String(scalars[start..<index])
         }
 
         private mutating func consumeLiteral(_ literal: String) throws -> Bool {
-            for expected in literal {
+            for expected in literal.unicodeScalars {
                 try checkpoint()
-                guard currentCharacter == expected else {
+                guard currentScalar?.value == expected.value else {
                     return false
                 }
                 advance()
@@ -392,23 +397,26 @@ private enum CancellableJSONPrettyPrinter {
         }
 
         private mutating func skipWhitespace() throws {
-            while let character = currentCharacter,
-                  character == " " || character == "\n" || character == "\r" || character == "\t" {
+            while let scalar = currentScalar,
+                  scalar.value == 0x20
+                    || scalar.value == 0x0A
+                    || scalar.value == 0x0D
+                    || scalar.value == 0x09 {
                 try checkpoint()
                 advance()
             }
         }
 
-        private mutating func consumeExpected(_ expected: Character) throws {
-            guard currentCharacter == expected else {
+        private mutating func consumeExpected(_ expectedValue: UInt32) throws {
+            guard currentScalar?.value == expectedValue else {
                 return
             }
             try checkpoint()
             advance()
         }
 
-        private mutating func consumeIfPresent(_ expected: Character) throws -> Bool {
-            guard currentCharacter == expected else {
+        private mutating func consumeIfPresent(_ expectedValue: UInt32) throws -> Bool {
+            guard currentScalar?.value == expectedValue else {
                 return false
             }
             try checkpoint()
@@ -425,33 +433,34 @@ private enum CancellableJSONPrettyPrinter {
         }
 
         private mutating func advance() {
-            index = text.index(after: index)
+            index = scalars.index(after: index)
         }
 
-        private var currentCharacter: Character? {
-            index == text.endIndex ? nil : text[index]
+        private var currentScalar: Unicode.Scalar? {
+            index == scalars.endIndex ? nil : scalars[index]
         }
 
         private func indent(_ depth: Int) -> String {
             String(repeating: "  ", count: depth)
         }
 
-        private func isASCIIDigit(_ character: Character) -> Bool {
-            guard character.unicodeScalars.count == 1,
-                  let scalar = character.unicodeScalars.first else {
-                return false
-            }
+        private func isASCIIDigit(_ scalar: Unicode.Scalar) -> Bool {
             return (0x30...0x39).contains(scalar.value)
         }
 
-        private func isASCIIHexDigit(_ character: Character) -> Bool {
-            guard character.unicodeScalars.count == 1,
-                  let scalar = character.unicodeScalars.first else {
-                return false
-            }
+        private func isASCIIHexDigit(_ scalar: Unicode.Scalar) -> Bool {
             return (0x30...0x39).contains(scalar.value)
                 || (0x41...0x46).contains(scalar.value)
                 || (0x61...0x66).contains(scalar.value)
+        }
+
+        private func isJSONEscapedCharacter(_ scalar: Unicode.Scalar) -> Bool {
+            switch scalar.value {
+            case 0x22, 0x5C, 0x2F, 0x62, 0x66, 0x6E, 0x72, 0x74:
+                return true
+            default:
+                return false
+            }
         }
     }
 }

--- a/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
@@ -1,0 +1,453 @@
+#if canImport(UIKit)
+import Foundation
+import WebInspectorCore
+
+enum NetworkTextPreviewPreparationAction {
+    case unavailable
+    case active(text: String, syntaxKind: NetworkBody.SyntaxKind)
+    case ready(text: String, syntaxKind: NetworkBody.SyntaxKind)
+}
+
+enum NetworkTextPreviewResultAction {
+    case ignore
+    case show(text: String, syntaxKind: NetworkBody.SyntaxKind)
+}
+
+@MainActor
+final class NetworkTextPreviewCoordinator {
+    private var generation = 0
+    private var task: Task<Void, Never>?
+    private var pendingInput: NetworkTextPreviewInput?
+    private var displayedInput: NetworkTextPreviewInput?
+    private var displayedOutput: NetworkTextPreviewOutput?
+
+    func preparePreview(
+        for body: NetworkBody,
+        completion: @escaping @MainActor (NetworkTextPreviewResultAction) -> Void
+    ) -> NetworkTextPreviewPreparationAction {
+        guard let input = NetworkTextPreviewInput(body: body) else {
+            cancel()
+            return .unavailable
+        }
+
+        if displayedInput == input, let displayedOutput {
+            return .ready(text: displayedOutput.text, syntaxKind: displayedOutput.syntaxKind)
+        }
+        if pendingInput == input {
+            return .active(text: input.text, syntaxKind: input.syntaxKind)
+        }
+        guard input.requiresPreparation else {
+            cancelPending()
+            let output = input.rawOutput
+            displayedInput = input
+            displayedOutput = output
+            return .ready(text: output.text, syntaxKind: output.syntaxKind)
+        }
+
+        startPreparation(for: input, completion: completion)
+        return .active(text: input.text, syntaxKind: input.syntaxKind)
+    }
+
+    func suspendPreparation() {
+        cancelPending()
+    }
+
+    func cancel() {
+        cancelPending()
+        displayedInput = nil
+        displayedOutput = nil
+    }
+
+#if DEBUG
+    var hasActivePreparationForTesting: Bool {
+        task != nil
+    }
+
+    var activePreparationBodyIDForTesting: ObjectIdentifier? {
+        pendingInput?.bodyID
+    }
+
+    func waitUntilPreparationFinishedForTesting() async {
+        while let task {
+            await task.value
+        }
+    }
+#endif
+
+    private func startPreparation(
+        for input: NetworkTextPreviewInput,
+        completion: @escaping @MainActor (NetworkTextPreviewResultAction) -> Void
+    ) {
+        cancelPending()
+        displayedInput = nil
+        displayedOutput = nil
+        pendingInput = input
+        generation += 1
+        let generation = generation
+
+        let worker = Task.detached(priority: .utility) {
+            try NetworkTextPreviewOutput.prepared(from: input)
+        }
+        task = Task { @MainActor [worker, completion] in
+            let output: NetworkTextPreviewOutput?
+            do {
+                output = try await withTaskCancellationHandler {
+                    try await worker.value
+                } onCancel: {
+                    worker.cancel()
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                output = nil
+            }
+            guard Task.isCancelled == false else {
+                return
+            }
+            completion(consume(output: output, input: input, generation: generation))
+        }
+    }
+
+    private func consume(
+        output preparedOutput: NetworkTextPreviewOutput?,
+        input: NetworkTextPreviewInput,
+        generation: Int
+    ) -> NetworkTextPreviewResultAction {
+        guard generation == self.generation,
+              pendingInput == input else {
+            return .ignore
+        }
+        task = nil
+        pendingInput = nil
+
+        let output = preparedOutput ?? input.rawOutput
+        displayedInput = input
+        displayedOutput = output
+        return .show(text: output.text, syntaxKind: output.syntaxKind)
+    }
+
+    private func cancelPending() {
+        generation += 1
+        task?.cancel()
+        task = nil
+        pendingInput = nil
+    }
+}
+
+private struct NetworkTextPreviewInput: Equatable, Sendable {
+    var bodyID: ObjectIdentifier
+    var text: String
+    var syntaxKind: NetworkBody.SyntaxKind
+
+    @MainActor
+    init?(body: NetworkBody) {
+        guard let text = body.textRepresentation else {
+            return nil
+        }
+        self.bodyID = ObjectIdentifier(body)
+        self.text = text
+        self.syntaxKind = body.textRepresentationSyntaxKind
+    }
+
+    var rawOutput: NetworkTextPreviewOutput {
+        NetworkTextPreviewOutput(text: text, syntaxKind: syntaxKind)
+    }
+
+    var requiresPreparation: Bool {
+        syntaxKind == .json || Self.looksLikeJSON(text)
+    }
+
+    private static func looksLikeJSON(_ text: String) -> Bool {
+        guard let firstNonWhitespace = text.first(where: { $0.isWhitespace == false }) else {
+            return false
+        }
+        return firstNonWhitespace == "{" || firstNonWhitespace == "["
+    }
+}
+
+private struct NetworkTextPreviewOutput: Sendable {
+    var text: String
+    var syntaxKind: NetworkBody.SyntaxKind
+
+    static func prepared(from input: NetworkTextPreviewInput) throws -> NetworkTextPreviewOutput? {
+        guard let prettyJSON = try CancellableJSONPrettyPrinter.prettyPrintedJSON(from: input.text) else {
+            return nil
+        }
+        return NetworkTextPreviewOutput(text: prettyJSON, syntaxKind: .json)
+    }
+}
+
+private enum CancellableJSONPrettyPrinter {
+    static func prettyPrintedJSON(from text: String) throws -> String? {
+        var parser = Parser(text: text)
+        return try parser.prettyPrintedJSON()
+    }
+
+    private struct Parser {
+        private let text: String
+        private var index: String.Index
+        private var checkpointCounter = 0
+
+        init(text: String) {
+            self.text = text
+            self.index = text.startIndex
+        }
+
+        mutating func prettyPrintedJSON() throws -> String? {
+            try skipWhitespace()
+            guard let first = currentCharacter,
+                  first == "{" || first == "[" else {
+                return nil
+            }
+            let result = try parseValue(depth: 0)
+            try skipWhitespace()
+            guard index == text.endIndex else {
+                return nil
+            }
+            return result
+        }
+
+        private mutating func parseValue(depth: Int) throws -> String? {
+            try skipWhitespace()
+            guard let character = currentCharacter else {
+                return nil
+            }
+            switch character {
+            case "{":
+                return try parseObject(depth: depth)
+            case "[":
+                return try parseArray(depth: depth)
+            case "\"":
+                return try parseString()
+            case "t":
+                return try consumeLiteral("true") ? "true" : nil
+            case "f":
+                return try consumeLiteral("false") ? "false" : nil
+            case "n":
+                return try consumeLiteral("null") ? "null" : nil
+            case "-":
+                return try parseNumber()
+            default:
+                if isASCIIDigit(character) {
+                    return try parseNumber()
+                }
+                return nil
+            }
+        }
+
+        private mutating func parseObject(depth: Int) throws -> String? {
+            try consumeExpected("{")
+            try skipWhitespace()
+            if try consumeIfPresent("}") {
+                return "{}"
+            }
+
+            var members: [String] = []
+            while true {
+                try skipWhitespace()
+                guard currentCharacter == "\"" else {
+                    return nil
+                }
+                guard let key = try parseString() else {
+                    return nil
+                }
+                try skipWhitespace()
+                guard try consumeIfPresent(":") else {
+                    return nil
+                }
+                guard let value = try parseValue(depth: depth + 1) else {
+                    return nil
+                }
+                members.append("\(indent(depth + 1))\(key) : \(value)")
+                try skipWhitespace()
+                if try consumeIfPresent("}") {
+                    break
+                }
+                guard try consumeIfPresent(",") else {
+                    return nil
+                }
+            }
+            return "{\n" + members.joined(separator: ",\n") + "\n" + indent(depth) + "}"
+        }
+
+        private mutating func parseArray(depth: Int) throws -> String? {
+            try consumeExpected("[")
+            try skipWhitespace()
+            if try consumeIfPresent("]") {
+                return "[]"
+            }
+
+            var values: [String] = []
+            while true {
+                guard let value = try parseValue(depth: depth + 1) else {
+                    return nil
+                }
+                values.append("\(indent(depth + 1))\(value)")
+                try skipWhitespace()
+                if try consumeIfPresent("]") {
+                    break
+                }
+                guard try consumeIfPresent(",") else {
+                    return nil
+                }
+            }
+            return "[\n" + values.joined(separator: ",\n") + "\n" + indent(depth) + "]"
+        }
+
+        private mutating func parseString() throws -> String? {
+            let start = index
+            try consumeExpected("\"")
+            while let character = currentCharacter {
+                try checkpoint()
+                advance()
+                if character == "\"" {
+                    return String(text[start..<index])
+                }
+                if character == "\\" {
+                    guard let escaped = currentCharacter else {
+                        return nil
+                    }
+                    advance()
+                    if escaped == "u" {
+                        for _ in 0..<4 {
+                            guard let scalar = currentCharacter,
+                                  isASCIIHexDigit(scalar) else {
+                                return nil
+                            }
+                            advance()
+                        }
+                    } else if "\"\\/bfnrt".contains(escaped) == false {
+                        return nil
+                    }
+                } else if character.unicodeScalars.contains(where: { $0.value < 0x20 }) {
+                    return nil
+                }
+            }
+            return nil
+        }
+
+        private mutating func parseNumber() throws -> String? {
+            let start = index
+            if try consumeIfPresent("-") == false {
+                try checkpoint()
+            }
+            guard let firstDigit = currentCharacter,
+                  isASCIIDigit(firstDigit) else {
+                return nil
+            }
+            if firstDigit == "0" {
+                advance()
+            } else {
+                while let character = currentCharacter,
+                      isASCIIDigit(character) {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            if try consumeIfPresent(".") {
+                guard let digit = currentCharacter,
+                      isASCIIDigit(digit) else {
+                    return nil
+                }
+                while let character = currentCharacter,
+                      isASCIIDigit(character) {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            if let character = currentCharacter,
+               character == "e" || character == "E" {
+                advance()
+                if let sign = currentCharacter,
+                   sign == "+" || sign == "-" {
+                    advance()
+                }
+                guard let digit = currentCharacter,
+                      isASCIIDigit(digit) else {
+                    return nil
+                }
+                while let character = currentCharacter,
+                      isASCIIDigit(character) {
+                    try checkpoint()
+                    advance()
+                }
+            }
+            return String(text[start..<index])
+        }
+
+        private mutating func consumeLiteral(_ literal: String) throws -> Bool {
+            for expected in literal {
+                try checkpoint()
+                guard currentCharacter == expected else {
+                    return false
+                }
+                advance()
+            }
+            return true
+        }
+
+        private mutating func skipWhitespace() throws {
+            while let character = currentCharacter,
+                  character == " " || character == "\n" || character == "\r" || character == "\t" {
+                try checkpoint()
+                advance()
+            }
+        }
+
+        private mutating func consumeExpected(_ expected: Character) throws {
+            guard currentCharacter == expected else {
+                return
+            }
+            try checkpoint()
+            advance()
+        }
+
+        private mutating func consumeIfPresent(_ expected: Character) throws -> Bool {
+            guard currentCharacter == expected else {
+                return false
+            }
+            try checkpoint()
+            advance()
+            return true
+        }
+
+        private mutating func checkpoint() throws {
+            checkpointCounter += 1
+            if checkpointCounter >= 128 {
+                checkpointCounter = 0
+                try Task.checkCancellation()
+            }
+        }
+
+        private mutating func advance() {
+            index = text.index(after: index)
+        }
+
+        private var currentCharacter: Character? {
+            index == text.endIndex ? nil : text[index]
+        }
+
+        private func indent(_ depth: Int) -> String {
+            String(repeating: "  ", count: depth)
+        }
+
+        private func isASCIIDigit(_ character: Character) -> Bool {
+            guard character.unicodeScalars.count == 1,
+                  let scalar = character.unicodeScalars.first else {
+                return false
+            }
+            return (0x30...0x39).contains(scalar.value)
+        }
+
+        private func isASCIIHexDigit(_ character: Character) -> Bool {
+            guard character.unicodeScalars.count == 1,
+                  let scalar = character.unicodeScalars.first else {
+                return false
+            }
+            return (0x30...0x39).contains(scalar.value)
+                || (0x41...0x46).contains(scalar.value)
+                || (0x61...0x66).contains(scalar.value)
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkTextPreviewCoordinator.swift
@@ -184,6 +184,8 @@ private enum CancellableJSONPrettyPrinter {
     }
 
     private struct Parser {
+        private static let maximumNestingDepth = 128
+
         private let text: String
         private var index: String.Index
         private var checkpointCounter = 0
@@ -208,6 +210,9 @@ private enum CancellableJSONPrettyPrinter {
         }
 
         private mutating func parseValue(depth: Int) throws -> String? {
+            guard depth <= Self.maximumNestingDepth else {
+                return nil
+            }
             try skipWhitespace()
             guard let character = currentCharacter else {
                 return nil

--- a/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListCell.swift
@@ -9,6 +9,7 @@ package final class NetworkListCell: UICollectionViewListCell {
     private let fileTypeLabel = UILabel()
     private var requestObservation: PortableObservationTracking.Token?
     private weak var observedRequest: NetworkRequest?
+    private var isRenderingActive = true
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -26,32 +27,62 @@ package final class NetworkListCell: UICollectionViewListCell {
 
     override package func prepareForReuse() {
         super.prepareForReuse()
-        cancelRequestObservation()
+        unbind()
     }
 
-    package func bind(request: NetworkRequest) {
-        guard observedRequest !== request else {
+    package func bind(request: NetworkRequest, renderingActive: Bool) {
+        if observedRequest !== request {
+            cancelRequestObservation()
+            observedRequest = request
+        }
+        setRenderingActive(renderingActive)
+    }
+
+    package func setRenderingActive(_ isActive: Bool) {
+        guard isRenderingActive != isActive else {
+            if isActive {
+                renderObservedRequest()
+                startRequestObservationIfNeeded()
+            }
             return
         }
-        cancelRequestObservation()
-        observedRequest = request
-        requestObservation = withPortableContinuousObservation { [weak self, weak request] _ in
-            guard let self,
-                  let request,
-                  self.observedRequest === request else {
-                return
-            }
-            render(
-                displayName: request.displayName,
-                statusSeverity: request.statusSeverity,
-                fileTypeLabel: request.fileTypeLabel
-            )
+
+        isRenderingActive = isActive
+        if isActive {
+            renderObservedRequest()
+            startRequestObservationIfNeeded()
+        } else {
+            cancelRequestObservation()
         }
     }
 
     package func unbind() {
         cancelRequestObservation()
+        observedRequest = nil
         render(displayName: "", statusSeverity: .neutral, fileTypeLabel: "")
+    }
+
+    private func startRequestObservationIfNeeded() {
+        guard requestObservation == nil,
+              let observedRequest else {
+            return
+        }
+        requestObservation = withPortableContinuousObservation { [weak self, weak observedRequest] _ in
+            guard let self,
+                  let observedRequest,
+                  self.isRenderingActive,
+                  self.observedRequest === observedRequest else {
+                return
+            }
+            render(request: observedRequest)
+        }
+    }
+
+    private func renderObservedRequest() {
+        guard let observedRequest else {
+            return
+        }
+        render(request: observedRequest)
     }
 
     private func configureStaticViews() {
@@ -94,6 +125,14 @@ package final class NetworkListCell: UICollectionViewListCell {
         renderAccessories(statusSeverity: statusSeverity, fileTypeLabel: fileTypeLabel)
     }
 
+    private func render(request: NetworkRequest) {
+        render(
+            displayName: request.displayName,
+            statusSeverity: request.statusSeverity,
+            fileTypeLabel: request.fileTypeLabel
+        )
+    }
+
     private func render(displayName: String) {
         var content = (contentConfiguration as? UIListContentConfiguration) ?? Self.makeContentConfiguration()
         guard content.text != displayName else {
@@ -119,7 +158,6 @@ package final class NetworkListCell: UICollectionViewListCell {
     private func cancelRequestObservation() {
         requestObservation?.cancel()
         requestObservation = nil
-        observedRequest = nil
     }
 
     private static func makeContentConfiguration() -> UIListContentConfiguration {
@@ -136,4 +174,20 @@ package final class NetworkListCell: UICollectionViewListCell {
         return content
     }
 }
+
+#if DEBUG
+extension NetworkListCell {
+    package var displayNameForTesting: String? {
+        (contentConfiguration as? UIListContentConfiguration)?.text
+    }
+
+    package var fileTypeLabelForTesting: String? {
+        fileTypeLabel.text
+    }
+
+    package var hasActiveRequestObservationForTesting: Bool {
+        requestObservation != nil
+    }
+}
+#endif
 #endif

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -33,7 +33,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private let displayRowsReloadScheduler = MainActorDelayScheduler()
     private var hasPendingThrottledDisplayRowsReload = false
 
-    private var needsSnapshotReloadOnNextAppearance = false
+    private var isRenderingActive = false
+    private var needsSnapshotReloadOnNextAppearance = true
     private var pendingSnapshotUpdate: PendingSnapshotUpdate?
     private var snapshotState = NetworkListViewController.SnapshotState()
     private var isApplyingSearchPresentation = false
@@ -107,7 +108,6 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         applyBackgroundFromTraits()
 
         configureNavigationItem()
-        reloadDataFromModel()
     }
 
     override package func viewWillAppear(_ animated: Bool) {
@@ -118,7 +118,12 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     override package func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
-        flushPendingSnapshotUpdateIfNeeded()
+        resumeRendering()
+    }
+
+    override package func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        suspendRendering()
     }
 
     override package func willMove(toParent parent: UIViewController?) {
@@ -149,7 +154,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         displayRowsObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
             _ = model.displayRowsInvalidationRevision
-            guard isViewLoaded else {
+            guard isRenderingActive else {
                 needsSnapshotReloadOnNextAppearance = true
                 return
             }
@@ -163,23 +168,53 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         searchTextObservation?.cancel()
         searchTextObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            renderSearchText(model.searchText)
+            let searchText = model.searchText
+            guard isRenderingActive else { return }
+            renderSearchText(searchText)
         }
 
         resourceFilterObservation?.cancel()
         resourceFilterObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
+            let effectiveResourceFilters = model.effectiveResourceFilters
+            guard isRenderingActive else { return }
+            resourceFilterSelectionDidChange(effectiveResourceFilters: effectiveResourceFilters)
         }
 
         selectedRequestObservation?.cancel()
         selectedRequestObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            renderSelectedRequestID(model.selectedRequestID)
+            let selectedRequestID = model.selectedRequestID
+            guard isRenderingActive else { return }
+            renderSelectedRequestID(selectedRequestID)
         }
     }
 
+    private func resumeRendering() {
+        isRenderingActive = true
+        renderSearchText(model.searchText)
+        resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
+        renderSelectedRequestID(model.selectedRequestID)
+        flushPendingSnapshotUpdateIfNeeded()
+    }
+
+    private func suspendRendering() {
+        guard isRenderingActive else {
+            return
+        }
+        isRenderingActive = false
+        if hasPendingThrottledDisplayRowsReload {
+            needsSnapshotReloadOnNextAppearance = true
+        }
+        hasPendingThrottledDisplayRowsReload = false
+        displayRowsReloadScheduler.cancel()
+    }
+
     private func scheduleThrottledDisplayRowsReload() {
+        guard isRenderingActive else {
+            needsSnapshotReloadOnNextAppearance = true
+            return
+        }
         hasPendingThrottledDisplayRowsReload = true
         guard displayRowsReloadScheduler.hasScheduledDelay == false else {
             return
@@ -192,6 +227,11 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private func flushThrottledDisplayRowsReload() {
         guard hasPendingThrottledDisplayRowsReload else {
+            return
+        }
+        guard isRenderingActive else {
+            hasPendingThrottledDisplayRowsReload = false
+            needsSnapshotReloadOnNextAppearance = true
             return
         }
         hasPendingThrottledDisplayRowsReload = false
@@ -349,7 +389,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private var isCollectionViewVisible: Bool {
-        isViewLoaded && view.window != nil
+        isRenderingActive && isViewLoaded
     }
 
     private func requestSnapshotUpdate(requestIDs: [NetworkRequest.ID]) {
@@ -385,6 +425,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
         needsSnapshotReloadOnNextAppearance = false
         let requestIDs = displayRequestIDsFromModel()
+        renderEmptyState(isEmpty: requestIDs.isEmpty)
         enqueueSnapshotUpdate(
             rows: NetworkListViewController.SnapshotRows(requestIDs: requestIDs),
             mode: .reloadData
@@ -447,6 +488,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func reloadDataFromModel() {
+        guard isRenderingActive else {
+            needsSnapshotReloadOnNextAppearance = true
+            return
+        }
         let requestIDs = displayRequestIDsFromModel()
         requestSnapshotUpdate(requestIDs: requestIDs)
         renderEmptyState(isEmpty: requestIDs.isEmpty)

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -220,6 +220,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private func resumeRendering() {
         snapshotCoordinator.resumeRendering()
+        setVisibleCellRenderingActive(true)
         renderSearchText(model.searchText)
         resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
         renderSelectedRequestID(model.selectedRequestID)
@@ -233,6 +234,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         snapshotCoordinator.suspendRendering(hasPendingThrottledReload: hasPendingThrottledDisplayRowsReload)
         hasPendingThrottledDisplayRowsReload = false
         displayRowsReloadScheduler.cancel()
+        setVisibleCellRenderingActive(false)
     }
 
     private func scheduleThrottledDisplayRowsReload() {
@@ -386,7 +388,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
                 cell.unbind()
                 return
             }
-            cell.bind(request: request)
+            cell.bind(request: request, renderingActive: self?.snapshotCoordinator.isRenderingActive == true)
         }
         return UICollectionViewDiffableDataSource<SectionIdentifier, NetworkRequest.ID>(
             collectionView: collectionView
@@ -585,6 +587,15 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
     }
 
+    private func setVisibleCellRenderingActive(_ isActive: Bool) {
+        guard isViewLoaded else {
+            return
+        }
+        for cell in collectionView.visibleCells {
+            (cell as? NetworkListCell)?.setRenderingActive(isActive)
+        }
+    }
+
     override package func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard
             let requestID = dataSource.itemIdentifier(for: indexPath),
@@ -630,6 +641,10 @@ extension NetworkListViewController {
 
     package var displayedRequestIDsForTesting: [NetworkRequest.ID] {
         dataSource.snapshot().itemIdentifiers
+    }
+
+    package func networkListCellForTesting(at indexPath: IndexPath) -> NetworkListCell? {
+        collectionView.cellForItem(at: indexPath) as? NetworkListCell
     }
 
     package var hasPendingSnapshotUpdateForTesting: Bool {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -203,10 +203,11 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             return
         }
         isRenderingActive = false
-        if hasPendingThrottledDisplayRowsReload {
+        if hasPendingThrottledDisplayRowsReload || pendingSnapshotUpdate != nil {
             needsSnapshotReloadOnNextAppearance = true
         }
         hasPendingThrottledDisplayRowsReload = false
+        pendingSnapshotUpdate = nil
         displayRowsReloadScheduler.cancel()
     }
 
@@ -456,6 +457,13 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func applyPendingSnapshotUpdateIfNeeded() {
+        guard isRenderingActive else {
+            if pendingSnapshotUpdate != nil {
+                pendingSnapshotUpdate = nil
+                needsSnapshotReloadOnNextAppearance = true
+            }
+            return
+        }
         guard !snapshotState.isApplying, let update = pendingSnapshotUpdate else {
             return
         }
@@ -479,12 +487,21 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private func snapshotUpdateDidFinish(
         appliedRows: NetworkListViewController.SnapshotRows
     ) {
+#if DEBUG
+        defer {
+            resumeSnapshotUpdateCompletionWaitersForTesting()
+        }
+#endif
         snapshotState.finishApplying(appliedRows)
+        guard isRenderingActive else {
+            if pendingSnapshotUpdate != nil {
+                pendingSnapshotUpdate = nil
+                needsSnapshotReloadOnNextAppearance = true
+            }
+            return
+        }
         renderSelectedRequestID(model.selectedRequestID)
         applyPendingSnapshotUpdateIfNeeded()
-#if DEBUG
-        resumeSnapshotUpdateCompletionWaitersForTesting()
-#endif
     }
 
     private func reloadDataFromModel() {
@@ -587,6 +604,26 @@ extension NetworkListViewController {
 
     package var displayedRequestIDsForTesting: [NetworkRequest.ID] {
         dataSource.snapshot().itemIdentifiers
+    }
+
+    package var hasPendingSnapshotUpdateForTesting: Bool {
+        pendingSnapshotUpdate != nil
+    }
+
+    package func beginSnapshotApplyForTesting(requestIDs: [NetworkRequest.ID]) {
+        snapshotState.beginApplying(
+            NetworkListViewController.SnapshotRows(requestIDs: requestIDs)
+        )
+    }
+
+    package func queueSnapshotUpdateForTesting(requestIDs: [NetworkRequest.ID]) {
+        requestSnapshotUpdate(requestIDs: requestIDs)
+    }
+
+    package func finishSnapshotApplyForTesting(requestIDs: [NetworkRequest.ID]) {
+        snapshotUpdateDidFinish(
+            appliedRows: NetworkListViewController.SnapshotRows(requestIDs: requestIDs)
+        )
     }
 
     package func flushPendingSnapshotUpdateForTesting() async {

--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -22,6 +22,37 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         var mode: SnapshotApplyMode
     }
 
+    private struct SnapshotCoordinator {
+        var isRenderingActive = false
+        var needsReloadOnNextAppearance = true
+        var pendingUpdate: PendingSnapshotUpdate?
+        var state = NetworkListViewController.SnapshotState()
+
+        mutating func resumeRendering() {
+            isRenderingActive = true
+        }
+
+        mutating func suspendRendering(hasPendingThrottledReload: Bool) {
+            isRenderingActive = false
+            if hasPendingThrottledReload || pendingUpdate != nil {
+                needsReloadOnNextAppearance = true
+            }
+            pendingUpdate = nil
+        }
+
+        mutating func markNeedsReloadOnNextAppearance() {
+            needsReloadOnNextAppearance = true
+        }
+
+        mutating func consumeReloadOnNextAppearanceIfNeeded() -> Bool {
+            guard isRenderingActive, needsReloadOnNextAppearance else {
+                return false
+            }
+            needsReloadOnNextAppearance = false
+            return true
+        }
+    }
+
     private static let snapshotThrottleInterval: Duration = .milliseconds(80)
 
     private let model: NetworkPanelModel
@@ -33,10 +64,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private let displayRowsReloadScheduler = MainActorDelayScheduler()
     private var hasPendingThrottledDisplayRowsReload = false
 
-    private var isRenderingActive = false
-    private var needsSnapshotReloadOnNextAppearance = true
-    private var pendingSnapshotUpdate: PendingSnapshotUpdate?
-    private var snapshotState = NetworkListViewController.SnapshotState()
+    private var snapshotCoordinator = SnapshotCoordinator()
     private var isApplyingSearchPresentation = false
     private var activeSearchController: UISearchController?
 #if DEBUG
@@ -154,8 +182,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         displayRowsObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else { return }
             _ = model.displayRowsInvalidationRevision
-            guard isRenderingActive else {
-                needsSnapshotReloadOnNextAppearance = true
+            guard snapshotCoordinator.isRenderingActive else {
+                snapshotCoordinator.markNeedsReloadOnNextAppearance()
                 return
             }
             if event.kind == .initial {
@@ -169,7 +197,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         searchTextObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
             let searchText = model.searchText
-            guard isRenderingActive else { return }
+            guard snapshotCoordinator.isRenderingActive else { return }
             renderSearchText(searchText)
         }
 
@@ -177,7 +205,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         resourceFilterObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
             let effectiveResourceFilters = model.effectiveResourceFilters
-            guard isRenderingActive else { return }
+            guard snapshotCoordinator.isRenderingActive else { return }
             resourceFilterSelectionDidChange(effectiveResourceFilters: effectiveResourceFilters)
         }
 
@@ -185,13 +213,13 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         selectedRequestObservation = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
             let selectedRequestID = model.selectedRequestID
-            guard isRenderingActive else { return }
+            guard snapshotCoordinator.isRenderingActive else { return }
             renderSelectedRequestID(selectedRequestID)
         }
     }
 
     private func resumeRendering() {
-        isRenderingActive = true
+        snapshotCoordinator.resumeRendering()
         renderSearchText(model.searchText)
         resourceFilterSelectionDidChange(effectiveResourceFilters: model.effectiveResourceFilters)
         renderSelectedRequestID(model.selectedRequestID)
@@ -199,21 +227,17 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func suspendRendering() {
-        guard isRenderingActive else {
+        guard snapshotCoordinator.isRenderingActive else {
             return
         }
-        isRenderingActive = false
-        if hasPendingThrottledDisplayRowsReload || pendingSnapshotUpdate != nil {
-            needsSnapshotReloadOnNextAppearance = true
-        }
+        snapshotCoordinator.suspendRendering(hasPendingThrottledReload: hasPendingThrottledDisplayRowsReload)
         hasPendingThrottledDisplayRowsReload = false
-        pendingSnapshotUpdate = nil
         displayRowsReloadScheduler.cancel()
     }
 
     private func scheduleThrottledDisplayRowsReload() {
-        guard isRenderingActive else {
-            needsSnapshotReloadOnNextAppearance = true
+        guard snapshotCoordinator.isRenderingActive else {
+            snapshotCoordinator.markNeedsReloadOnNextAppearance()
             return
         }
         hasPendingThrottledDisplayRowsReload = true
@@ -230,9 +254,9 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         guard hasPendingThrottledDisplayRowsReload else {
             return
         }
-        guard isRenderingActive else {
+        guard snapshotCoordinator.isRenderingActive else {
             hasPendingThrottledDisplayRowsReload = false
-            needsSnapshotReloadOnNextAppearance = true
+            snapshotCoordinator.markNeedsReloadOnNextAppearance()
             return
         }
         hasPendingThrottledDisplayRowsReload = false
@@ -390,7 +414,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private var isCollectionViewVisible: Bool {
-        isRenderingActive && isViewLoaded
+        snapshotCoordinator.isRenderingActive && isViewLoaded
     }
 
     private func requestSnapshotUpdate(requestIDs: [NetworkRequest.ID]) {
@@ -400,20 +424,20 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private func requestSnapshotUpdate(
         rows: NetworkListViewController.SnapshotRows
     ) {
-        if let applyingRows = snapshotState.applyingRows {
+        if let applyingRows = snapshotCoordinator.state.applyingRows {
             if applyingRows.requestIDs == rows.requestIDs {
-                pendingSnapshotUpdate = nil
+                snapshotCoordinator.pendingUpdate = nil
                 return
             }
         } else if dataSource.snapshot().itemIdentifiers == rows.requestIDs {
-            pendingSnapshotUpdate = nil
+            snapshotCoordinator.pendingUpdate = nil
             return
         }
         guard isCollectionViewVisible else {
-            needsSnapshotReloadOnNextAppearance = true
+            snapshotCoordinator.markNeedsReloadOnNextAppearance()
             return
         }
-        needsSnapshotReloadOnNextAppearance = false
+        snapshotCoordinator.needsReloadOnNextAppearance = false
         enqueueSnapshotUpdate(
             rows: rows,
             mode: .apply
@@ -421,10 +445,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func flushPendingSnapshotUpdateIfNeeded() {
-        guard needsSnapshotReloadOnNextAppearance, isCollectionViewVisible else {
+        guard isCollectionViewVisible,
+              snapshotCoordinator.consumeReloadOnNextAppearanceIfNeeded() else {
             return
         }
-        needsSnapshotReloadOnNextAppearance = false
         let requestIDs = displayRequestIDsFromModel()
         renderEmptyState(isEmpty: requestIDs.isEmpty)
         enqueueSnapshotUpdate(
@@ -437,19 +461,20 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         rows: NetworkListViewController.SnapshotRows,
         mode: SnapshotApplyMode
     ) {
-        if let pendingSnapshotUpdate, pendingSnapshotUpdate.rows.requestIDs == rows.requestIDs {
-            self.pendingSnapshotUpdate = PendingSnapshotUpdate(
+        if let pendingSnapshotUpdate = snapshotCoordinator.pendingUpdate,
+           pendingSnapshotUpdate.rows.requestIDs == rows.requestIDs {
+            snapshotCoordinator.pendingUpdate = PendingSnapshotUpdate(
                 rows: rows,
                 mode: pendingSnapshotUpdate.mode == .reloadData || mode == .reloadData ? .reloadData : .apply
             )
             return
         }
-        guard snapshotState.isApplying
+        guard snapshotCoordinator.state.isApplying
             || dataSource.snapshot().itemIdentifiers != rows.requestIDs
             || mode == .reloadData else {
             return
         }
-        pendingSnapshotUpdate = PendingSnapshotUpdate(
+        snapshotCoordinator.pendingUpdate = PendingSnapshotUpdate(
             rows: rows,
             mode: mode
         )
@@ -457,18 +482,19 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func applyPendingSnapshotUpdateIfNeeded() {
-        guard isRenderingActive else {
-            if pendingSnapshotUpdate != nil {
-                pendingSnapshotUpdate = nil
-                needsSnapshotReloadOnNextAppearance = true
+        guard snapshotCoordinator.isRenderingActive else {
+            if snapshotCoordinator.pendingUpdate != nil {
+                snapshotCoordinator.pendingUpdate = nil
+                snapshotCoordinator.markNeedsReloadOnNextAppearance()
             }
             return
         }
-        guard !snapshotState.isApplying, let update = pendingSnapshotUpdate else {
+        guard !snapshotCoordinator.state.isApplying,
+              let update = snapshotCoordinator.pendingUpdate else {
             return
         }
-        pendingSnapshotUpdate = nil
-        snapshotState.beginApplying(update.rows)
+        snapshotCoordinator.pendingUpdate = nil
+        snapshotCoordinator.state.beginApplying(update.rows)
 
         let snapshot = makeSnapshot(
             requestIDs: update.rows.requestIDs
@@ -492,11 +518,11 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             resumeSnapshotUpdateCompletionWaitersForTesting()
         }
 #endif
-        snapshotState.finishApplying(appliedRows)
-        guard isRenderingActive else {
-            if pendingSnapshotUpdate != nil {
-                pendingSnapshotUpdate = nil
-                needsSnapshotReloadOnNextAppearance = true
+        snapshotCoordinator.state.finishApplying(appliedRows)
+        guard snapshotCoordinator.isRenderingActive else {
+            if snapshotCoordinator.pendingUpdate != nil {
+                snapshotCoordinator.pendingUpdate = nil
+                snapshotCoordinator.markNeedsReloadOnNextAppearance()
             }
             return
         }
@@ -505,8 +531,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func reloadDataFromModel() {
-        guard isRenderingActive else {
-            needsSnapshotReloadOnNextAppearance = true
+        guard snapshotCoordinator.isRenderingActive else {
+            snapshotCoordinator.markNeedsReloadOnNextAppearance()
             return
         }
         let requestIDs = displayRequestIDsFromModel()
@@ -607,11 +633,11 @@ extension NetworkListViewController {
     }
 
     package var hasPendingSnapshotUpdateForTesting: Bool {
-        pendingSnapshotUpdate != nil
+        snapshotCoordinator.pendingUpdate != nil
     }
 
     package func beginSnapshotApplyForTesting(requestIDs: [NetworkRequest.ID]) {
-        snapshotState.beginApplying(
+        snapshotCoordinator.state.beginApplying(
             NetworkListViewController.SnapshotRows(requestIDs: requestIDs)
         )
     }
@@ -638,7 +664,7 @@ extension NetworkListViewController {
     }
 
     private func waitForSnapshotUpdateCompletionForTesting() async {
-        guard snapshotState.isApplying || pendingSnapshotUpdate != nil else {
+        guard snapshotCoordinator.state.isApplying || snapshotCoordinator.pendingUpdate != nil else {
             return
         }
         await withCheckedContinuation { continuation in
@@ -647,7 +673,8 @@ extension NetworkListViewController {
     }
 
     private func resumeSnapshotUpdateCompletionWaitersForTesting() {
-        guard snapshotState.isApplying == false, pendingSnapshotUpdate == nil else {
+        guard snapshotCoordinator.state.isApplying == false,
+              snapshotCoordinator.pendingUpdate == nil else {
             return
         }
         let waiters = snapshotUpdateCompletionWaitersForTesting

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -407,10 +407,6 @@ func networkResponseBodyFetchAppliesResultToCoreRequest() async throws {
 
     #expect(await body.phase == .loaded)
     #expect(await body.textRepresentation == #"{"ok":true}"#)
-    let preparation = try #require(await body.prepareTextRepresentation())
-    await preparation.wait()
-    #expect(await body.textRepresentation?.contains("\n") == true)
-    #expect(await body.textRepresentation?.contains(#""ok""#) == true)
 }
 
 @Test

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -324,6 +324,31 @@ func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
 
 @Test
 @MainActor
+func jsonNumbersWithNonASCIIDigitsStayPlainText() async throws {
+    for text in [
+        #"{"n":-١}"#,
+        #"{"n":1²}"#,
+        #"{"n":1.٢}"#,
+        #"{"n":1e٢}"#,
+    ] {
+        let body = NetworkBody(
+            role: .response,
+            kind: .text,
+            full: text,
+            sourceSyntaxKind: .plainText,
+            phase: .loaded
+        )
+
+        let preparation = try #require(body.prepareTextRepresentation())
+        await preparation.wait()
+
+        #expect(body.textRepresentation == text)
+        #expect(body.textRepresentationSyntaxKind == .plainText)
+    }
+}
+
+@Test
+@MainActor
 func responseBodyFetchFailureIsTerminal() throws {
     let session = NetworkSession()
     let targetID = ProtocolTarget.ID("page")

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -205,13 +205,6 @@ func responseReceivedCreatesFetchableResponseBodyAndAppliesFetchedContent() asyn
     #expect(body.phase == .loaded)
     #expect(body.textRepresentation == #"{"name":"codex","value":42}"#)
     #expect(body.textRepresentationSyntaxKind == .json)
-
-    let preparation = try #require(body.prepareTextRepresentation())
-    await preparation.wait()
-
-    #expect(body.textRepresentation?.contains("\n") == true)
-    #expect(body.textRepresentation?.contains(#""name""#) == true)
-    #expect(body.textRepresentationSyntaxKind == .json)
 }
 
 @Test
@@ -237,7 +230,7 @@ func networkResponseBodyResultDecodesLargePlainAndBase64Payloads() async throws 
 
 @Test
 @MainActor
-func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws {
+func responseBodyTextRefreshesWhenFetchedContentChanges() throws {
     let body = NetworkBody(
         role: .response,
         kind: .text,
@@ -246,11 +239,7 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
         phase: .loaded
     )
 
-    let firstPreparation = try #require(body.prepareTextRepresentation())
-    await firstPreparation.wait()
-
-    #expect(body.textRepresentation?.contains("\n") == true)
-    #expect(body.textRepresentation?.contains(#""first""#) == true)
+    #expect(body.textRepresentation == #"{"first":true}"#)
 
     body.apply(
         NetworkBody.Payload(
@@ -261,18 +250,11 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
 
     #expect(body.textRepresentation == #"{"second":true}"#)
     #expect(body.textRepresentation?.contains(#""first""#) == false)
-
-    let secondPreparation = try #require(body.prepareTextRepresentation())
-    await secondPreparation.wait()
-
-    #expect(body.textRepresentation?.contains("\n") == true)
-    #expect(body.textRepresentation?.contains(#""second""#) == true)
-    #expect(body.textRepresentation?.contains(#""first""#) == false)
 }
 
 @Test
 @MainActor
-func cancelingPreparedResponseBodyTextStopsWorkerAndAllowsReprepare() async throws {
+func largeJSONResponseBodyKeepsCoreTextRaw() {
     let jsonItems = (0..<50_000).map { index in
         #"{"value":\#(index),"enabled":true}"#
     }
@@ -284,25 +266,14 @@ func cancelingPreparedResponseBodyTextStopsWorkerAndAllowsReprepare() async thro
         sourceSyntaxKind: .json,
         phase: .loaded
     )
-    let originalText = body.textRepresentation
 
-    let preparation = try #require(body.prepareTextRepresentation())
-    body.cancelTextRepresentationPreparation()
-    await preparation.wait()
-
-    #expect(body.textRepresentation == originalText)
-
-    let secondPreparation = try #require(body.prepareTextRepresentation())
-    await secondPreparation.wait()
-
-    #expect(body.textRepresentation != originalText)
-    #expect(body.textRepresentation?.contains("\n") == true)
-    #expect(body.textRepresentation?.contains(#""value" : 49999"#) == true)
+    #expect(body.textRepresentation == json)
+    #expect(body.textRepresentationSyntaxKind == .json)
 }
 
 @Test
 @MainActor
-func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
+func invalidJSONLookingPlainTextKeepsPlainTextSyntax() {
     let body = NetworkBody(
         role: .response,
         kind: .text,
@@ -313,18 +284,13 @@ func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
 
     #expect(body.textRepresentation == "[INFO] started")
     #expect(body.textRepresentationSyntaxKind == .plainText)
-
-    if let preparation = body.prepareTextRepresentation() {
-        await preparation.wait()
-    }
-
     #expect(body.textRepresentation == "[INFO] started")
     #expect(body.textRepresentationSyntaxKind == .plainText)
 }
 
 @Test
 @MainActor
-func jsonNumbersWithNonASCIIDigitsStayPlainText() async throws {
+func jsonNumbersWithNonASCIIDigitsStayPlainText() {
     for text in [
         #"{"n":-١}"#,
         #"{"n":1²}"#,
@@ -338,9 +304,6 @@ func jsonNumbersWithNonASCIIDigitsStayPlainText() async throws {
             sourceSyntaxKind: .plainText,
             phase: .loaded
         )
-
-        let preparation = try #require(body.prepareTextRepresentation())
-        await preparation.wait()
 
         #expect(body.textRepresentation == text)
         #expect(body.textRepresentationSyntaxKind == .plainText)

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -272,6 +272,36 @@ func preparedResponseBodyTextInvalidatesWhenFetchedContentChanges() async throws
 
 @Test
 @MainActor
+func cancelingPreparedResponseBodyTextStopsWorkerAndAllowsReprepare() async throws {
+    let jsonItems = (0..<50_000).map { index in
+        #"{"value":\#(index),"enabled":true}"#
+    }
+    let json = "[" + jsonItems.joined(separator: ",") + "]"
+    let body = NetworkBody(
+        role: .response,
+        kind: .text,
+        full: json,
+        sourceSyntaxKind: .json,
+        phase: .loaded
+    )
+    let originalText = body.textRepresentation
+
+    let preparation = try #require(body.prepareTextRepresentation())
+    body.cancelTextRepresentationPreparation()
+    await preparation.wait()
+
+    #expect(body.textRepresentation == originalText)
+
+    let secondPreparation = try #require(body.prepareTextRepresentation())
+    await secondPreparation.wait()
+
+    #expect(body.textRepresentation != originalText)
+    #expect(body.textRepresentation?.contains("\n") == true)
+    #expect(body.textRepresentation?.contains(#""value" : 49999"#) == true)
+}
+
+@Test
+@MainActor
 func invalidJSONLookingPlainTextKeepsPlainTextSyntax() async {
     let body = NetworkBody(
         role: .response,

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -710,6 +710,55 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hiddenSelectionChangeClearsMultiSelectionBeforePendingDOMInvalidationFlush() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let documentID = try #require(session.currentPageRootNode?.id.documentID)
+        let visibleDivID = DOMNode.ID(documentID: documentID, nodeID: .init(7))
+        let inputID = DOMNode.ID(documentID: documentID, nodeID: .init(12))
+
+        view.primaryClickRowForTesting(containing: "<div id=\"start-of-content\"", modifiers: .command)
+        view.primaryClickRowForTesting(containing: "<input disabled>", modifiers: .command)
+        view.primaryClickRowForTesting(containing: "<article", modifiers: .command)
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.map(\.text) == [
+            "      <div id=\"start-of-content\" data-testid=\"cellInnerDiv\"></div>",
+            "      <input disabled>",
+            "      <article>…</article>",
+        ])
+
+        let observedTreeRenderRevisions = await view.documentObservationDeliveryForTesting.values {
+            session.treeRenderInvalidation.revision
+        }
+        let observedSelectionRevisions = await view.selectionObservationDeliveryForTesting.values {
+            session.selectionRevision
+        }
+        defer {
+            observedTreeRenderRevisions.cancel()
+            observedSelectionRevisions.cancel()
+        }
+
+        view.setRenderingActive(false)
+        session.applyAttributeModified(visibleDivID, name: "data-visible", value: "while-hidden")
+        session.selectNode(inputID)
+        let hiddenTreeRevision = session.treeRevision
+        let hiddenSelectionRevision = session.selectionRevision
+        #expect(await observedTreeRenderRevisions.waitUntil { $0 >= hiddenTreeRevision } != nil)
+        #expect(await observedSelectionRevisions.waitUntil { $0 >= hiddenSelectionRevision } != nil)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(!view.renderedTextForTesting.contains("data-visible=\"while-hidden\""))
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.count == 3)
+
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+        view.layoutIfNeeded()
+
+        #expect(view.renderedTextForTesting.contains("data-visible=\"while-hidden\""))
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.isEmpty)
+        #expect(view.selectedRowRectsForTesting().count == 1)
+    }
+
+    @Test
     func selectionRevealWaitsForInFlightRenderedRowsBuild() async throws {
         let session = makeDOMSession(root: selectionRevealRaceDocument())
         let view = await makeTreeView(session: session)

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -348,6 +348,32 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hidingWithQueuedHoverRestorePreservesHighlightRestoreTask() async throws {
+        let session = makeDOMSession()
+        let restoreRecorder = VoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { _, _ in },
+            restoreHighlightAction: {
+                restoreRecorder.record()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.hoverRowForTesting(containing: "<article")
+        view.endHoverForTesting()
+        view.setRenderingActive(false)
+        await restoreRecorder.next()
+
+        #expect(session.selectedNode?.localName == "input")
+        #expect(restoreRecorder.recordCount == 1)
+    }
+
+    @Test
     func hoverHighlightCancelsPendingRestoreHighlight() async throws {
         let session = makeDOMSession()
         let highlightRecorder = NodeActionRecorder()

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -319,6 +319,35 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hidingWithHoveredPageHighlightRestoresHighlightWhileRenderingInactive() async throws {
+        let session = makeDOMSession()
+        let highlightRecorder = NodeActionRecorder()
+        let restoreRecorder = VoidActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { nodeID, owner in
+                highlightRecorder.record(nodeID, owner: owner)
+            },
+            restoreHighlightAction: {
+                restoreRecorder.record()
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+
+        view.hoverRowForTesting(containing: "<article")
+        _ = await highlightRecorder.nextNodeID()
+
+        view.setRenderingActive(false)
+        await restoreRecorder.next()
+
+        #expect(highlightRecorder.recordedOwners == [.transient])
+        #expect(restoreRecorder.recordCount == 1)
+    }
+
+    @Test
     func hoverHighlightCancelsPendingRestoreHighlight() async throws {
         let session = makeDOMSession()
         let highlightRecorder = NodeActionRecorder()

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -374,6 +374,36 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hidingWithQueuedSelectionHighlightRequeuesHighlightOnResume() async throws {
+        let session = makeDOMSession()
+        let highlightRecorder = NodeActionRecorder()
+        let view = DOMTreeTextView(
+            dom: session,
+            highlightNodeAction: { nodeID, owner in
+                highlightRecorder.record(nodeID, owner: owner)
+            }
+        )
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        view.layoutIfNeeded()
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        view.setRenderingActive(false)
+        await Task.yield()
+        await Task.yield()
+
+        #expect(highlightRecorder.recordedNodeIDs.isEmpty)
+
+        view.setRenderingActive(true)
+        let highlightedNodeID = await highlightRecorder.nextNodeID()
+
+        #expect(session.selectedNode?.id == highlightedNodeID)
+        #expect(session.node(for: highlightedNodeID)?.localName == "input")
+        #expect(highlightRecorder.recordedOwners == [.selection])
+    }
+
+    @Test
     func hoverHighlightCancelsPendingRestoreHighlight() async throws {
         let session = makeDOMSession()
         let highlightRecorder = NodeActionRecorder()
@@ -780,6 +810,52 @@ struct DOMTreeTextViewTests {
         view.layoutIfNeeded()
 
         #expect(view.renderedTextForTesting.contains("data-visible=\"while-hidden\""))
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.isEmpty)
+        #expect(view.selectedRowRectsForTesting().count == 1)
+    }
+
+    @Test
+    func hiddenSelectionChangeAwayAndBackStillClearsMultiSelectionOnResume() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let snapshot = session.snapshot()
+        let inputID = try #require(
+            snapshot.nodesByID.first { entry in
+                entry.value.localName == "input"
+            }?.key
+        )
+        let articleID = try #require(
+            snapshot.nodesByID.first { entry in
+                entry.value.localName == "article"
+            }?.key
+        )
+
+        view.primaryClickRowForTesting(containing: "<input disabled>")
+        await Task.yield()
+        view.primaryClickRowForTesting(containing: "<div id=\"start-of-content\"", modifiers: .command)
+        view.primaryClickRowForTesting(containing: "<article", modifiers: .command)
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.count == 3)
+        #expect(session.selectedNode?.id == inputID)
+
+        let observedSelectionRevisions = await view.selectionObservationDeliveryForTesting.values {
+            session.selectionRevision
+        }
+        defer {
+            observedSelectionRevisions.cancel()
+        }
+
+        view.setRenderingActive(false)
+        session.selectNode(articleID)
+        session.selectNode(inputID)
+        let hiddenSelectionRevision = session.selectionRevision
+        #expect(await observedSelectionRevisions.waitUntil { $0 >= hiddenSelectionRevision } != nil)
+
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.count == 3)
+
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+        view.layoutIfNeeded()
+
         #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.isEmpty)
         #expect(view.selectedRowRectsForTesting().count == 1)
     }

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -256,6 +256,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
@@ -279,6 +280,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
@@ -302,6 +304,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
@@ -331,6 +334,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
@@ -364,6 +368,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
@@ -515,6 +520,38 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hiddenVisibleMutationDefersRenderingUntilRenderingResumes() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+        let documentID = try #require(session.currentPageRootNode?.id.documentID)
+        let visibleDivID = DOMNode.ID(documentID: documentID, nodeID: .init(7))
+        let observedTreeRenderRevisions = await view.documentObservationDeliveryForTesting.values {
+            session.treeRenderInvalidation.revision
+        }
+        defer {
+            observedTreeRenderRevisions.cancel()
+        }
+        let baselineText = view.renderedTextForTesting
+        view.resetPerformanceCountersForTesting()
+
+        view.setRenderingActive(false)
+        session.applyAttributeModified(visibleDivID, name: "data-visible", value: "deferred")
+        let hiddenRevision = session.treeRevision
+        #expect(await observedTreeRenderRevisions.waitUntil { $0 >= hiddenRevision } != nil)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(view.buildRenderedRowsCallCountForTesting == 0)
+        #expect(view.renderedTextForTesting == baselineText)
+        #expect(!view.renderedTextForTesting.contains("data-visible=\"deferred\""))
+
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(view.buildRenderedRowsCallCountForTesting == 1)
+        #expect(view.renderedTextForTesting.contains("data-visible=\"deferred\""))
+    }
+
+    @Test
     func inFlightExpansionMutationRebuildsAgainstNewSnapshot() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)
@@ -546,6 +583,31 @@ struct DOMTreeTextViewTests {
     }
 
     @Test
+    func hidingDuringInFlightRenderedRowsBuildCancelsStaleApply() async throws {
+        let session = makeDOMSession()
+        let view = await makeTreeView(session: session)
+
+        view.suspendNextRenderedRowsBuildForTesting()
+        view.toggleRowForTesting(containing: "<article")
+        await view.waitForRenderedRowsBuildSuspensionForTesting()
+
+        view.setRenderingActive(false)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(!view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
+
+        view.resumeRenderedRowsBuildForTesting()
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(!view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
+
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(view.renderedTextForTesting.contains("<span id=\"nested-child\"></span>"))
+    }
+
+    @Test
     func selectionChangeUpdatesDecorationsWithoutRebuildingRenderedRows() async throws {
         let session = makeDOMSession()
         let view = await makeTreeView(session: session)
@@ -564,6 +626,58 @@ struct DOMTreeTextViewTests {
         let didRenderSelection = await selectedRowCounts.waitUntil { $0 == 1 } != nil
         #expect(didRenderSelection)
         #expect(view.buildRenderedRowsCallCountForTesting == 0)
+    }
+
+    @Test
+    func hiddenSelectionChangeDefersRevealUntilRenderingResumes() async throws {
+        let session = makeDOMSession(root: selectionRevealRaceDocument())
+        let view = await makeTreeView(session: session)
+        view.frame = CGRect(x: 0, y: 0, width: 360, height: 96)
+        view.layoutIfNeeded()
+        let initialSnapshot = session.snapshot()
+        let bodyID = try #require(
+            initialSnapshot.nodesByID.first { entry in
+                entry.value.localName == "body"
+            }?.key
+        )
+        let targetID = try #require(
+            initialSnapshot.nodesByID.first { entry in
+                entry.value.attributes.contains { attribute in
+                    attribute.name == "id" && attribute.value == "selected-target"
+                }
+            }?.key
+        )
+        session.applySetChildNodes(
+            parent: bodyID,
+            children: selectionRevealRaceBodyChildren(prefixCount: 80),
+            eventSequence: 10
+        )
+        await view.waitForRenderedRowsForTesting()
+        view.contentOffset = .zero
+        view.clearDrawnSelectedRowRectsForTesting()
+        let observedSelectionRevisions = await view.selectionObservationDeliveryForTesting.values {
+            session.selectionRevision
+        }
+        defer {
+            observedSelectionRevisions.cancel()
+        }
+
+        view.setRenderingActive(false)
+        session.selectNode(targetID)
+        let hiddenSelectionRevision = session.selectionRevision
+        #expect(await observedSelectionRevisions.waitUntil { $0 >= hiddenSelectionRevision } != nil)
+        await view.waitForRenderedRowsForTesting()
+
+        #expect(view.contentOffset.y == 0)
+        #expect(view.drawnSelectedRowRectsForTesting.isEmpty)
+
+        view.setRenderingActive(true)
+        await view.waitForRenderedRowsForTesting()
+        view.layoutIfNeeded()
+
+        let revealState = renderedSelectionRevealState(in: view, containing: "selected-target")
+        #expect(revealState.isSelectedRowRevealed)
+        #expect(view.drawnSelectedRowRectsForTesting.isEmpty == false)
     }
 
     @Test
@@ -746,6 +860,7 @@ struct DOMTreeTextViewTests {
         )
         view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         view.layoutIfNeeded()
+        view.setRenderingActive(true)
         await view.waitForRenderedRowsForTesting()
 
         view.toggleRowForTesting(containing: "<article")
@@ -961,6 +1076,7 @@ private func makeTreeView(session: DOMSession) async -> DOMTreeTextView {
     let view = DOMTreeTextView(dom: session)
     view.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
     view.layoutIfNeeded()
+    view.setRenderingActive(true)
     await view.waitForRenderedRowsForTesting()
     return view
 }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -793,6 +793,62 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func mediaResponsePreviewPausesPlayerButKeepsSurfaceWhenHidden() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://media.example.com/download.php",
+                responseHeaders: ["content-type": "video/mp4"],
+                responseMimeType: "video/mp4"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: "not a real movie",
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        viewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
+
+        let didRenderMediaPreview = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
+        }
+        #expect(didRenderMediaPreview)
+        let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
+        let player = try #require(playerFactory.players.first)
+        #expect(playerFactory.players.count == 1)
+        #expect(player.pauseCallCount == 0)
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+
+        #expect(player.pauseCallCount == 1)
+        #expect(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == temporaryFileURL)
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+        await waitUntilMediaPreviewPrepared(in: viewController)
+
+        #expect(playerFactory.players.count == 1)
+        #expect(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == temporaryFileURL)
+        #expect(player.pauseCallCount == 1)
+    }
+
+    @Test
     func imageResponsePreviewUsesScrollViewAndFitsLargeImage() async throws {
         let imageSize = CGSize(width: 600, height: 1400)
         let network = NetworkSession()
@@ -1842,14 +1898,23 @@ struct NetworkDetailViewControllerTests {
     @MainActor
     private final class MoviePreviewPlayerFactorySpy {
         private(set) var requestedURLs: [URL] = []
+        private(set) var players: [StubMoviePreviewPlayer] = []
 
         func makePlayer(for url: URL) -> AVPlayer {
+            let player = StubMoviePreviewPlayer()
             requestedURLs.append(url)
-            return StubMoviePreviewPlayer()
+            players.append(player)
+            return player
         }
     }
 
-    private final class StubMoviePreviewPlayer: AVPlayer {}
+    private final class StubMoviePreviewPlayer: AVPlayer {
+        private(set) var pauseCallCount = 0
+
+        override func pause() {
+            pauseCallCount += 1
+        }
+    }
 }
 }
 #endif

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -849,6 +849,56 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func mediaResponsePreviewReleasesPlayerAndTemporaryFileWhenSelectionClears() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://media.example.com/download.php",
+                responseHeaders: ["content-type": "video/mp4"],
+                responseMimeType: "video/mp4"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: "not a real movie",
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        viewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
+
+        let didRenderMediaPreview = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
+        }
+        #expect(didRenderMediaPreview)
+        let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        model.selectRequest(nil)
+
+        let didReleaseMediaPreview = await waitUntilRendered(in: viewController) {
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.previewViewForTesting.isHidden
+                && viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == nil
+                && FileManager.default.fileExists(atPath: temporaryFileURL.path) == false
+        }
+        #expect(didReleaseMediaPreview)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+    }
+
+    @Test
     func imageResponsePreviewUsesScrollViewAndFitsLargeImage() async throws {
         let imageSize = CGSize(width: 600, height: 1400)
         let network = NetworkSession()

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -899,6 +899,64 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func hiddenMediaResponsePreviewReleasesPlayerAndTemporaryFileWhenSelectionClearsBeforeReappearing() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://media.example.com/download.php",
+                responseHeaders: ["content-type": "video/mp4"],
+                responseMimeType: "video/mp4"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: "not a real movie",
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        viewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+        await waitUntilMediaPreviewPrepared(in: viewController)
+
+        let didRenderMediaPreview = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
+        }
+        #expect(didRenderMediaPreview)
+        let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        model.selectRequest(nil)
+
+        #expect(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == temporaryFileURL)
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+
+        let didReleaseMediaPreview = await waitUntilRendered(in: viewController) {
+            viewController.contentUnavailableConfiguration != nil
+                && viewController.previewViewForTesting.isHidden
+                && viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == nil
+                && FileManager.default.fileExists(atPath: temporaryFileURL.path) == false
+        }
+        #expect(didReleaseMediaPreview)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+    }
+
+    @Test
     func imageResponsePreviewUsesScrollViewAndFitsLargeImage() async throws {
         let imageSize = CGSize(width: 600, height: 1400)
         let network = NetworkSession()

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -287,38 +287,22 @@ struct NetworkDetailViewControllerTests {
     @Test
     func previewRequestWithoutBodyReplacesPreviousBodyWithUnavailablePlaceholder() async throws {
         let network = NetworkSession()
-        let targetID = ProtocolTarget.ID("page")
-        let bodyKey = network.applyRequestWillBeSent(
-            targetID: targetID,
-            requestID: NetworkRequest.ProtocolID("body"),
-            frameID: DOMFrame.ID("main"),
-            loaderID: "loader",
-            documentURL: "https://example.com",
-            request: NetworkRequest.Payload(
+        let bodyRequest = try #require(
+            applyRequestWithoutResponse(
+                to: network,
+                requestID: "body",
                 url: "https://example.com/form",
-                method: "POST",
-                headers: ["content-type": "application/x-www-form-urlencoded"],
+                requestHeaders: ["content-type": "application/x-www-form-urlencoded"],
                 postData: "name=Jane+Doe"
-            ),
-            resourceType: .xhr,
-            timestamp: 1
+            )
         )
-        let emptyKey = network.applyRequestWillBeSent(
-            targetID: targetID,
-            requestID: NetworkRequest.ProtocolID("empty"),
-            frameID: DOMFrame.ID("main"),
-            loaderID: "loader",
-            documentURL: "https://example.com",
-            request: NetworkRequest.Payload(
-                url: "https://example.com/no-body",
-                method: "GET",
-                headers: [:]
-            ),
-            resourceType: .xhr,
-            timestamp: 2
+        let emptyRequest = try #require(
+            applyRequestWithoutResponse(
+                to: network,
+                requestID: "empty",
+                url: "https://example.com/no-body"
+            )
         )
-        let bodyRequest = try #require(network.request(for: bodyKey))
-        let emptyRequest = try #require(network.request(for: emptyKey))
         let model = NetworkPanelModel(network: network)
         model.selectRequest(bodyRequest)
         let viewController = NetworkDetailViewController(model: model)
@@ -343,6 +327,41 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didReplaceBody)
         #expect(viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains("Jane") == false)
+    }
+
+    @Test
+    func previewRequestWithoutBodyRendersPlaceholderWhenBodySurfaceResumes() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequestWithoutResponse(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/no-body"
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderHeaders = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .headers
+                && viewController.previewViewForTesting.isHidden
+                && viewController.headersTextViewForTesting.renderedTextForTesting.contains("GET /no-body")
+        }
+        #expect(didRenderHeaders)
+
+        viewController.setModeForTesting(.preview)
+
+        let unavailableText = String(localized: "network.body.unavailable", bundle: .module)
+        let didRenderPlaceholder = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .preview
+                && viewController.previewViewForTesting.isHidden == false
+                && viewController.isPreviewRoleControlHiddenForTesting
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == unavailableText
+        }
+        #expect(didRenderPlaceholder)
     }
 
     @Test
@@ -1931,6 +1950,31 @@ struct NetworkDetailViewControllerTests {
                 timestamp: 3
             )
         }
+        return network.request(for: key)
+    }
+
+    private func applyRequestWithoutResponse(
+        to network: NetworkSession,
+        requestID rawRequestID: String,
+        url: String,
+        requestHeaders: [String: String] = [:],
+        postData: String? = nil
+    ) -> NetworkRequest? {
+        let key = network.applyRequestWillBeSent(
+            targetID: ProtocolTarget.ID("page"),
+            requestID: NetworkRequest.ProtocolID(rawRequestID),
+            frameID: DOMFrame.ID("main"),
+            loaderID: "loader",
+            documentURL: "https://example.com",
+            request: NetworkRequest.Payload(
+                url: url,
+                method: postData == nil ? "GET" : "POST",
+                headers: requestHeaders,
+                postData: postData
+            ),
+            resourceType: .xhr,
+            timestamp: 1
+        )
         return network.request(for: key)
     }
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -698,6 +698,45 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func jsonPreviewFormatsCRLFWhitespace() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let bodyText = "{\r\n\"a\":1,\r\n\"b\":[true]\r\n}"
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: bodyText,
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model, initialMode: .preview)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderPrettyBody = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == """
+            {
+              "a" : 1,
+              "b" : [
+                true
+              ]
+            }
+            """
+        }
+
+        #expect(didRenderPrettyBody)
+    }
+
+    @Test
     func hlsResponsePreviewCoordinatorUsesOriginalPlaylistURL() throws {
         let playlistURL = "https://media.example.com/live/master.m3u8"
         let body = NetworkBody(
@@ -2077,6 +2116,57 @@ struct NetworkDetailViewControllerTests {
 
         #expect(listViewController.displayedRequestIDsForTesting.isEmpty)
         #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate + 1)
+    }
+
+    @Test
+    func hiddenListSuspendsBoundCellRenderingUntilAppearingAgain() async throws {
+        let network = NetworkSession()
+        let request = try #require(applyRequest(
+            to: network,
+            requestID: "1",
+            url: "https://media.example.com/clip.mp4",
+            responseHeaders: ["content-type": "video/mp4"],
+            responseMimeType: "video/mp4"
+        ))
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let window = showInWindow(listViewController)
+        defer { window.isHidden = true }
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+        listViewController.collectionViewForTesting.layoutIfNeeded()
+
+        let indexPath = IndexPath(item: 0, section: 0)
+        let cell = try #require(listViewController.networkListCellForTesting(at: indexPath))
+        #expect(cell.fileTypeLabelForTesting == "mp4")
+        #expect(cell.hasActiveRequestObservationForTesting)
+
+        listViewController.beginAppearanceTransition(false, animated: false)
+        listViewController.endAppearanceTransition()
+        #expect(cell.hasActiveRequestObservationForTesting == false)
+
+        network.applyResponseReceived(
+            targetID: ProtocolTarget.ID("page"),
+            requestID: NetworkRequest.ProtocolID("1"),
+            resourceType: .script,
+            response: NetworkRequest.Response.Payload(
+                url: request.request.url,
+                status: 200,
+                statusText: "OK",
+                headers: ["content-type": "text/css"],
+                mimeType: "text/css"
+            ),
+            timestamp: 4
+        )
+        await Task.yield()
+        await Task.yield()
+
+        #expect(cell.fileTypeLabelForTesting == "mp4")
+
+        listViewController.beginAppearanceTransition(true, animated: false)
+        listViewController.endAppearanceTransition()
+
+        #expect(cell.hasActiveRequestObservationForTesting)
+        #expect(cell.fileTypeLabelForTesting == "css")
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1585,6 +1585,70 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func compactContainerBackNavigationReleasesDetailMediaPreviewResources() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://media.example.com/download.php",
+                responseHeaders: ["content-type": "video/mp4"],
+                responseMimeType: "video/mp4"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: "not a real movie",
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = NetworkDetailViewController(model: model)
+        detailViewController.setModeForTesting(.preview)
+        let playerFactory = MoviePreviewPlayerFactorySpy()
+        detailViewController.bodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
+            playerFactory.makePlayer(for:)
+        )
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        let window = showInWindow(navigationController, makeVisible: true)
+        defer { window.isHidden = true }
+
+        model.selectRequest(request)
+        let didPush = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers.last === detailViewController
+        }
+        #expect(didPush)
+        await waitForNavigationTransitionToFinish(in: navigationController)
+        await waitUntilMediaPreviewPrepared(in: detailViewController)
+
+        let didRenderMediaPreview = await waitUntilRendered(in: detailViewController) {
+            detailViewController.bodyViewControllerForTesting.mediaPlayerURLForTesting?.pathExtension == "mp4"
+        }
+        #expect(didRenderMediaPreview)
+        let temporaryFileURL = try #require(detailViewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
+
+        _ = withUIKitAnimationsDisabled {
+            navigationController.popViewController(animated: false)
+        }
+
+        let didReturnToListAndReleasePreview = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers == [listViewController]
+                && model.selectedRequest == nil
+                && detailViewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == nil
+                && FileManager.default.fileExists(atPath: temporaryFileURL.path) == false
+        }
+        #expect(didReturnToListAndReleasePreview)
+        #expect(playerFactory.requestedURLs == [temporaryFileURL])
+    }
+
+    @Test
     func compactContainerPopsDetailWhenSelectedRequestDisappears() async throws {
         let network = NetworkSession()
         let request = try #require(applyRequest(to: network, requestID: "1", url: "https://example.com/app.js"))

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1620,9 +1620,10 @@ struct NetworkDetailViewControllerTests {
         defer { window.isHidden = true }
         viewController.setModeForTesting(.preview)
 
+        let firstBodyID = ObjectIdentifier(firstBody)
         let didStartFirstPreparation = await waitUntilRendered(in: viewController) {
             viewController.currentPreviewRoleForTesting == .response
-                && firstBody.hasActiveTextRepresentationPreparationForTesting
+                && viewController.bodyViewControllerForTesting.activeTextPreviewPreparationBodyIDForTesting == firstBodyID
         }
         #expect(didStartFirstPreparation)
 
@@ -1630,10 +1631,10 @@ struct NetworkDetailViewControllerTests {
 
         let didRenderSecondRequest = await waitUntilRendered(in: viewController) {
             viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""ok""#)
-                && firstBody.hasActiveTextRepresentationPreparationForTesting == false
+                && viewController.bodyViewControllerForTesting.activeTextPreviewPreparationBodyIDForTesting != firstBodyID
         }
         #expect(didRenderSecondRequest)
-        #expect(firstBody.hasActiveTextRepresentationPreparationForTesting == false)
+        #expect(viewController.bodyViewControllerForTesting.activeTextPreviewPreparationBodyIDForTesting != firstBodyID)
     }
 
     @Test
@@ -1719,6 +1720,60 @@ struct NetworkDetailViewControllerTests {
         #expect(didPop)
         await waitForNavigationTransitionToFinish(in: navigationController)
         #expect(detailViewController.previewViewForTesting.isHidden)
+    }
+
+    @Test
+    func compactUserPopDiscardsDetailSurfaceWhenSelectionClearsBeforeTransitionCompletes() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.txt",
+                responseHeaders: ["content-type": "text/plain"],
+                responseMimeType: "text/plain"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(body: "visible detail body", base64Encoded: false)
+        )
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = NetworkDetailViewController(model: model)
+        detailViewController.setModeForTesting(.preview)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        let window = showInWindow(navigationController, makeVisible: true)
+        defer { window.isHidden = true }
+
+        model.selectRequest(request)
+        let didPush = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers.last === detailViewController
+        }
+        #expect(didPush)
+        await waitForNavigationTransitionToFinish(in: navigationController)
+
+        let didRenderDetail = await waitUntilRendered(in: detailViewController) {
+            detailViewController.previewViewForTesting.isHidden == false
+                && detailViewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "visible detail body"
+        }
+        #expect(didRenderDetail)
+
+        _ = navigationController.popViewController(animated: true)
+        if navigationController.transitionCoordinator != nil {
+            model.selectRequest(nil)
+            #expect(detailViewController.previewViewForTesting.isHidden == false)
+            #expect(detailViewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "visible detail body")
+        }
+
+        let didPopAndDiscard = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers == [listViewController]
+                && detailViewController.previewViewForTesting.isHidden
+        }
+        #expect(didPopAndDiscard)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1585,6 +1585,58 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func rebindingPreviewBodyCancelsOutgoingTextPreparation() async throws {
+        let network = NetworkSession()
+        let firstRequest = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/large.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let secondRequest = try #require(
+            applyRequest(
+                to: network,
+                requestID: "2",
+                url: "https://example.com/api/current.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let largeJSON = "[" + (0..<80_000).map { #"{"value":\#($0),"enabled":true}"# }.joined(separator: ",") + "]"
+        firstRequest.applyResponseBody(
+            NetworkBody.Payload(body: largeJSON, base64Encoded: false)
+        )
+        secondRequest.applyResponseBody(
+            NetworkBody.Payload(body: #"{"ok":true}"#, base64Encoded: false)
+        )
+        let firstBody = try #require(firstRequest.responseBody)
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(firstRequest)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+
+        let didStartFirstPreparation = await waitUntilRendered(in: viewController) {
+            viewController.currentPreviewRoleForTesting == .response
+                && firstBody.hasActiveTextRepresentationPreparationForTesting
+        }
+        #expect(didStartFirstPreparation)
+
+        model.selectRequest(secondRequest)
+
+        let didRenderSecondRequest = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""ok""#)
+                && firstBody.hasActiveTextRepresentationPreparationForTesting == false
+        }
+        #expect(didRenderSecondRequest)
+        #expect(firstBody.hasActiveTextRepresentationPreparationForTesting == false)
+    }
+
+    @Test
     func compactContainerPushesAndPopsDetailFromSelection() async throws {
         let network = NetworkSession()
         let request = try #require(applyRequest(to: network, requestID: "1", url: "https://example.com/app.js"))
@@ -1613,6 +1665,60 @@ struct NetworkDetailViewControllerTests {
             navigationController.viewControllers == [listViewController]
         }
         #expect(didPop)
+    }
+
+    @Test
+    func compactProgrammaticPopKeepsDetailSurfaceUntilTransitionCompletes() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.txt",
+                responseHeaders: ["content-type": "text/plain"],
+                responseMimeType: "text/plain"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(body: "visible detail body", base64Encoded: false)
+        )
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = NetworkDetailViewController(model: model)
+        detailViewController.setModeForTesting(.preview)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        let window = showInWindow(navigationController, makeVisible: true)
+        defer { window.isHidden = true }
+
+        model.selectRequest(request)
+        let didPush = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers.last === detailViewController
+        }
+        #expect(didPush)
+        await waitForNavigationTransitionToFinish(in: navigationController)
+
+        let didRenderDetail = await waitUntilRendered(in: detailViewController) {
+            detailViewController.previewViewForTesting.isHidden == false
+                && detailViewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "visible detail body"
+        }
+        #expect(didRenderDetail)
+
+        model.selectRequest(nil)
+        if navigationController.transitionCoordinator != nil {
+            #expect(detailViewController.previewViewForTesting.isHidden == false)
+            #expect(detailViewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "visible detail body")
+        }
+
+        let didPop = await waitUntilNavigationStackSynced(in: navigationController) {
+            navigationController.viewControllers == [listViewController]
+        }
+        #expect(didPop)
+        await waitForNavigationTransitionToFinish(in: navigationController)
+        #expect(detailViewController.previewViewForTesting.isHidden)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -26,8 +26,8 @@ struct NetworkDetailViewControllerTests {
     func listShowsSimpleEmptyStateWithoutRequests() {
         let model = NetworkPanelModel(network: NetworkSession())
         let viewController = NetworkListViewController(model: model)
-
-        viewController.loadViewIfNeeded()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
 
         #expect(viewController.collectionViewForTesting.isHidden)
         #expect(viewController.contentUnavailableConfiguration != nil)
@@ -42,8 +42,8 @@ struct NetworkDetailViewControllerTests {
     func detailShowsEmptyStateWithoutSelection() {
         let model = NetworkPanelModel(network: NetworkSession())
         let viewController = NetworkDetailViewController(model: model)
-
-        viewController.loadViewIfNeeded()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
 
         #expect(viewController.previewViewForTesting.isHidden)
         #expect(viewController.headersTextViewForTesting.isHidden)
@@ -85,6 +85,32 @@ struct NetworkDetailViewControllerTests {
         viewController.loadViewIfNeeded()
 
         #expect(viewController.collectionViewForTesting.backgroundColor == .clear)
+    }
+
+    @Test
+    func listLoadDoesNotEvaluateDisplayRequestsUntilAppearing() async throws {
+        let network = NetworkSession()
+        _ = try #require(applyRequest(
+            to: network,
+            requestID: "1",
+            url: "https://example.com/api/data.json",
+            responseHeaders: ["content-type": "application/json"],
+            responseMimeType: "application/json"
+        ))
+        let model = NetworkPanelModel(network: network)
+        let viewController = NetworkListViewController(model: model)
+
+        viewController.loadViewIfNeeded()
+
+        #expect(viewController.displayRequestIDsEvaluationCountForTesting == 0)
+        #expect(viewController.displayedRequestIDsForTesting.isEmpty)
+
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        await viewController.flushPendingSnapshotUpdateForTesting()
+
+        #expect(viewController.displayedRequestIDsForTesting == model.displayRequestIDs)
+        #expect(viewController.displayRequestIDsEvaluationCountForTesting == 1)
     }
 
     @Test
@@ -452,6 +478,108 @@ struct NetworkDetailViewControllerTests {
             return viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""ok""#)
         }
         #expect(didRenderBody)
+    }
+
+    @Test
+    func hiddenDetailDoesNotFetchResponseBodyUntilAppearingAgain() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        var fetchedIDs: [NetworkRequest.ID] = []
+        let model = NetworkPanelModel(network: network) { id in
+            fetchedIDs.append(id)
+            request.markResponseBodyFetching()
+        }
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.headers)
+
+        let didRenderHeaders = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .headers
+                && viewController.headersTextViewForTesting.renderedTextForTesting.contains("content-type: application/json")
+        }
+        #expect(didRenderHeaders)
+        #expect(fetchedIDs.isEmpty)
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        viewController.setModeForTesting(.preview)
+        await Task.yield()
+        await Task.yield()
+
+        #expect(fetchedIDs.isEmpty)
+        #expect(viewController.headersTextViewForTesting.renderedTextForTesting.contains("content-type: application/json"))
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+
+        let didFetchOnReturn = await waitUntilRendered(in: viewController) {
+            fetchedIDs == [request.id]
+                && viewController.currentModeForTesting == .preview
+                && viewController.currentPreviewRoleForTesting == .response
+        }
+        #expect(didFetchOnReturn)
+    }
+
+    @Test
+    func hiddenDetailKeepsDisplayedBodyAndReconcilesBodyOnReturn() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: #"{"visible":true}"#,
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model, initialMode: .preview)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderVisibleBody = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""visible" : true"#)
+        }
+        #expect(didRenderVisibleBody)
+        let renderedBodyBeforeHide = viewController.bodyViewControllerForTesting.syntaxViewForTesting.text
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: #"{"hidden":true}"#,
+                base64Encoded: false
+            )
+        )
+        await Task.yield()
+        await Task.yield()
+
+        #expect(viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == renderedBodyBeforeHide)
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+
+        let didRenderHiddenBody = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""hidden" : true"#)
+        }
+        #expect(didRenderHiddenBody)
     }
 
     @Test
@@ -983,6 +1111,60 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func hiddenDetailKeepsHeadersAndRebindsSameSelectedRequestOnReturn() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/data.json",
+                responseHeaders: ["x-request": "visible"],
+                responseMimeType: "application/json"
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.headers)
+
+        let didRenderInitialHeaders = await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.renderedTextForTesting.contains("x-request: visible")
+        }
+        #expect(didRenderInitialHeaders)
+        let renderedHeadersBeforeHide = viewController.headersTextViewForTesting.renderedTextForTesting
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        network.applyResponseReceived(
+            targetID: request.id.targetID,
+            requestID: request.id.requestID,
+            resourceType: .script,
+            response: NetworkRequest.Response.Payload(
+                url: "https://example.com/api/data.json",
+                status: 200,
+                statusText: "OK",
+                headers: ["x-request": "hidden-update"],
+                mimeType: "application/json"
+            ),
+            timestamp: 4
+        )
+        await Task.yield()
+        await Task.yield()
+
+        #expect(viewController.headersTextViewForTesting.renderedTextForTesting == renderedHeadersBeforeHide)
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+
+        let didRenderHiddenUpdate = await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.renderedTextForTesting.contains("x-request: hidden-update")
+        }
+        #expect(didRenderHiddenUpdate)
+    }
+
+    @Test
     func requestPreviewRoleDoesNotFetchResponseBodyAfterLoadingFinishes() async throws {
         let network = NetworkSession()
         let request = try #require(
@@ -1309,6 +1491,50 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func hiddenListDefersSnapshotEvaluationUntilAppearingAgain() async throws {
+        let network = NetworkSession()
+        _ = try #require(applyRequest(
+            to: network,
+            requestID: "1",
+            url: "https://media.example.com/clip.mp4",
+            responseHeaders: ["content-type": "video/mp4"],
+            responseMimeType: "video/mp4"
+        ))
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let window = showInWindow(listViewController)
+        defer { window.isHidden = true }
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+        #expect(listViewController.displayedRequestIDsForTesting.count == 1)
+
+        let evaluationCountBeforeHiddenUpdate = listViewController.displayRequestIDsEvaluationCountForTesting
+        let observation = try #require(listViewController.displayRowsObservationDeliveryForTesting)
+        let observedInvalidations = await observation.values {
+            model.displayRowsInvalidationRevision
+        }
+        defer {
+            observedInvalidations.cancel()
+        }
+
+        listViewController.beginAppearanceTransition(false, animated: false)
+        listViewController.endAppearanceTransition()
+        model.setSearchText("does-not-match")
+        let hiddenInvalidationRevision = model.displayRowsInvalidationRevision
+        #expect(await observedInvalidations.waitUntil { $0 == hiddenInvalidationRevision } != nil)
+        await listViewController.flushThrottledDisplayRowsReloadForTesting()
+
+        #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate)
+        #expect(listViewController.displayedRequestIDsForTesting.count == 1)
+
+        listViewController.beginAppearanceTransition(true, animated: false)
+        listViewController.endAppearanceTransition()
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+
+        #expect(listViewController.displayedRequestIDsForTesting.isEmpty)
+        #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate + 1)
+    }
+
+    @Test
     func listControllerDeallocatesWhileDisplayRequestObservationIsActive() async throws {
         let model = NetworkPanelModel(network: NetworkSession())
         let deinitProbe = UITestDeinitProbe()
@@ -1397,7 +1623,7 @@ struct NetworkDetailViewControllerTests {
 
     private func showInWindow(
         _ viewController: UIViewController,
-        makeVisible: Bool = false
+        makeVisible: Bool = true
     ) -> UIWindow {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = viewController

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -663,6 +663,41 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func deeplyNestedJSONPreviewFallsBackToRawText() async throws {
+        let network = NetworkSession()
+        let request = try #require(
+            applyRequest(
+                to: network,
+                requestID: "1",
+                url: "https://example.com/api/deep.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let bodyText = String(repeating: "[", count: 160) + "0" + String(repeating: "]", count: 160)
+        request.applyResponseBody(
+            NetworkBody.Payload(
+                body: bodyText,
+                base64Encoded: false
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(request)
+        let viewController = NetworkDetailViewController(model: model, initialMode: .preview)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderRawBody = await waitUntilRendered(in: viewController) {
+            viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == bodyText
+        }
+        #expect(didRenderRawBody)
+
+        await viewController.bodyViewControllerForTesting.waitUntilTextPreviewPreparationFinishedForTesting()
+
+        #expect(viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == bodyText)
+    }
+
+    @Test
     func hlsResponsePreviewCoordinatorUsesOriginalPlaylistURL() throws {
         let playlistURL = "https://media.example.com/live/master.m3u8"
         let body = NetworkBody(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1535,6 +1535,47 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func hiddenListDefersQueuedSnapshotApplyUntilAppearingAgain() async throws {
+        let network = NetworkSession()
+        let request = try #require(applyRequest(
+            to: network,
+            requestID: "1",
+            url: "https://media.example.com/clip.mp4",
+            responseHeaders: ["content-type": "video/mp4"],
+            responseMimeType: "video/mp4"
+        ))
+        let model = NetworkPanelModel(network: network)
+        let listViewController = NetworkListViewController(model: model)
+        let window = showInWindow(listViewController)
+        defer { window.isHidden = true }
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+        #expect(listViewController.displayedRequestIDsForTesting == [request.id])
+
+        let evaluationCountBeforeHiddenUpdate = listViewController.displayRequestIDsEvaluationCountForTesting
+        listViewController.beginSnapshotApplyForTesting(requestIDs: [request.id])
+        listViewController.queueSnapshotUpdateForTesting(requestIDs: [])
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting)
+
+        listViewController.beginAppearanceTransition(false, animated: false)
+        listViewController.endAppearanceTransition()
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting == false)
+
+        model.setSearchText("does-not-match")
+        listViewController.finishSnapshotApplyForTesting(requestIDs: [request.id])
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+
+        #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate)
+        #expect(listViewController.displayedRequestIDsForTesting == [request.id])
+
+        listViewController.beginAppearanceTransition(true, animated: false)
+        listViewController.endAppearanceTransition()
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+
+        #expect(listViewController.displayedRequestIDsForTesting.isEmpty)
+        #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate + 1)
+    }
+
+    @Test
     func listControllerDeallocatesWhileDisplayRequestObservationIsActive() async throws {
         let model = NetworkPanelModel(network: NetworkSession())
         let deinitProbe = UITestDeinitProbe()

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -285,6 +285,67 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func previewRequestWithoutBodyReplacesPreviousBodyWithUnavailablePlaceholder() async throws {
+        let network = NetworkSession()
+        let targetID = ProtocolTarget.ID("page")
+        let bodyKey = network.applyRequestWillBeSent(
+            targetID: targetID,
+            requestID: NetworkRequest.ProtocolID("body"),
+            frameID: DOMFrame.ID("main"),
+            loaderID: "loader",
+            documentURL: "https://example.com",
+            request: NetworkRequest.Payload(
+                url: "https://example.com/form",
+                method: "POST",
+                headers: ["content-type": "application/x-www-form-urlencoded"],
+                postData: "name=Jane+Doe"
+            ),
+            resourceType: .xhr,
+            timestamp: 1
+        )
+        let emptyKey = network.applyRequestWillBeSent(
+            targetID: targetID,
+            requestID: NetworkRequest.ProtocolID("empty"),
+            frameID: DOMFrame.ID("main"),
+            loaderID: "loader",
+            documentURL: "https://example.com",
+            request: NetworkRequest.Payload(
+                url: "https://example.com/no-body",
+                method: "GET",
+                headers: [:]
+            ),
+            resourceType: .xhr,
+            timestamp: 2
+        )
+        let bodyRequest = try #require(network.request(for: bodyKey))
+        let emptyRequest = try #require(network.request(for: emptyKey))
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(bodyRequest)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+
+        let didRenderBody = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .preview
+                && viewController.currentPreviewRoleForTesting == .request
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe"
+        }
+        #expect(didRenderBody)
+
+        model.selectRequest(emptyRequest)
+
+        let unavailableText = String(localized: "network.body.unavailable", bundle: .module)
+        let didReplaceBody = await waitUntilRendered(in: viewController) {
+            viewController.previewViewForTesting.isHidden == false
+                && viewController.isPreviewRoleControlHiddenForTesting
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == unavailableText
+        }
+        #expect(didReplaceBody)
+        #expect(viewController.bodyViewControllerForTesting.syntaxViewForTesting.text.contains("Jane") == false)
+    }
+
+    @Test
     func detailUpdatesResponseHeadersAfterSelection() async throws {
         let network = NetworkSession()
         let targetID = ProtocolTarget.ID("page")


### PR DESCRIPTION
## Purpose

Suspend expensive WebInspectorUI projection, rendering, and lazy preview preparation while DOM/Network panes are hidden, without stopping Core protocol collection or semantic model updates. Hidden panes keep their already-rendered UI surfaces instead of clearing rows, text, headers, body previews, selection, or scroll state.

## Changes

- Gate DOM tree rendering from `DOMTreeViewController` appearance lifecycle while preserving displayed rows/text/selection and reconciling dirty DOM, selection, and page-highlight intent on resume.
- Keep Network list rendering appearance-scoped: hidden updates mark dirty state only, reappearance reloads once from the current `NetworkPanelModel` snapshot, and already-bound list cells suspend request observation while hidden without clearing their current labels.
- Move Network text preview preparation out of `WebInspectorCore.NetworkBody` and into `WebInspectorUI.NetworkTextPreviewCoordinator`, so Core remains semantic and UI-owned suspend/cancel controls heavy formatting work.
- Parse preview JSON with scalar-level RFC JSON whitespace handling, including CRLF line endings, while keeping cancellation checkpoints in the formatter.
- Replace body-detail patchwork booleans with an explicit `NetworkBodyViewController.Surface` and lifecycle methods that distinguish retain-on-suspend from semantic discard.
- Treat compact navigation detail removal as a stack transition, so request surfaces remain visible during animated/cancelled/non-animated pops and are discarded only after the presentation removal is committed.
- Add regression coverage for hidden DOM mutation/selection/highlight reconciliation, hidden Network list reload deferral, hidden bound-cell suspension, hidden detail fetch/preparation deferral, body preview cancellation/rebind, CRLF JSON formatting, compact pop discard timing, and deep JSON fallback.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/NetworkDetailViewControllerTests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` against pinned `main` base `b44220e25757b8965d8dbde7b3f993bae6ee290f`: clean, no findings
