### PR TITLE
Clean up cancelled transport command replies

### DIFF
--- a/Sources/WebInspectorTransport/TransportSession.swift
+++ b/Sources/WebInspectorTransport/TransportSession.swift
@@ -66,6 +66,7 @@ package actor TransportSession {
     }
 
     package func send(_ command: ProtocolCommand) async throws -> ProtocolCommand.Result {
+        try Task.checkCancellation()
         guard !closed else {
             throw TransportSession.Error.transportClosed
         }
@@ -192,15 +193,16 @@ package actor TransportSession {
             hasBufferedProvisionalResponse: false
         ), commandID: commandID)
         do {
+            try Task.checkCancellation()
             let message = try TransportMessageParser.makeCommandString(
                 id: commandID,
                 method: command.method,
                 parametersData: command.parametersData
             )
             try await backend.sendJSONString(message)
+            try Task.checkCancellation()
         } catch {
-            _ = replyStore.removeRootReply(commandID: commandID)
-            await promise.fulfill(.failure(error))
+            await failPendingReply(.root(commandID), error: error)
             throw error
         }
         return try await awaitReply(
@@ -227,6 +229,7 @@ package actor TransportSession {
             hasBufferedProvisionalResponse: false
         ), key: key, rootWrapperID: outerCommandID)
         do {
+            try Task.checkCancellation()
             let message = try TransportMessageParser.makeCommandString(
                 id: innerCommandID,
                 method: command.method,
@@ -238,9 +241,9 @@ package actor TransportSession {
                 message: message
             )
             try await backend.sendJSONString(wrapperMessage)
+            try Task.checkCancellation()
         } catch {
-            _ = replyStore.removeTargetReply(for: key)
-            await promise.fulfill(.failure(error))
+            await failPendingReply(.target(key), error: error)
             throw error
         }
         return try await awaitReply(
@@ -292,6 +295,9 @@ package actor TransportSession {
         method: String,
         targetID: ProtocolTarget.ID?
     ) async throws -> ProtocolCommand.Result {
+        if Task.isCancelled {
+            await failPendingReply(key, error: CancellationError())
+        }
         let timeoutTask: Task<Void, Never>? = responseTimeout.map { responseTimeout in
             let timeoutSleep = self.timeoutSleep
             let responseTimeoutDidFire = self.responseTimeoutDidFire

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -732,6 +732,21 @@ func selectedElementStyleHydrationSelectionChangeStartsReplacementRefresh() asyn
         after: secondSentCount,
         protocolNodeID: .init(2)
     )
+    let secondReplyKeys = [
+        TransportSession.ReplyKey(
+            targetID: secondMessages.matched.targetIdentifier,
+            commandID: try messageID(secondMessages.matched.message)
+        ),
+        TransportSession.ReplyKey(
+            targetID: secondMessages.inline.targetIdentifier,
+            commandID: try messageID(secondMessages.inline.message)
+        ),
+        TransportSession.ReplyKey(
+            targetID: secondMessages.computed.targetIdentifier,
+            commandID: try messageID(secondMessages.computed.message)
+        ),
+    ].sorted()
+    #expect(await transport.snapshot().pendingTargetReplyKeys == secondReplyKeys)
     #expect(try messageParameters(secondMessages.matched.message)["nodeId"] as? Int == 2)
     #expect(session.attachment.dom.elementStyles.selectedNodeStyles?.id.nodeID == htmlID)
     #expect(session.attachment.dom.elementStyles.selectedPhase == .loading)


### PR DESCRIPTION
## Purpose
Fix a race where cancelled transport commands could leave pending replies around the CSS style hydration replacement path.

## Changes
- Check task cancellation before and after sending root and target protocol commands.
- Route cancellation cleanup through the existing pending-reply failure path so retargeted target replies are removed consistently.
- Assert the style hydration replacement test leaves only the new selected node's CSS refresh replies pending.

## Testing
- WebInspectorKitTests scheme on iOS 26.5 simulator: 515 passed, 0 failed, 2 skipped
- WebInspectorKit scheme on iPhone 17 latest OS: 515 passed, 0 failed, 2 skipped
- git diff --check
- codex-review: no findings
