### PR TITLE
Fix flaky inspector UI tests

### DIFF
--- a/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUI/DOM/Tree/DOMTreeTextView.swift
@@ -1038,6 +1038,11 @@ final class DOMTreeTextView: UIScrollView, UITextInput, UITextInteractionDelegat
     private func select(_ nodeID: DOMNode.ID) {
         multiSelection.notePrimarySelection(nodeID)
         dom.selectNode(nodeID)
+        if isRenderingActive {
+            handleSelectedNodeChange(selectionRevision: dom.selectionRevision)
+        } else {
+            selectionReconciliationState.recordSelectionObservation(revision: dom.selectionRevision)
+        }
         queuePageSelectionHighlight(for: nodeID)
     }
 
@@ -2472,6 +2477,14 @@ extension DOMTreeTextView {
 
     var selectionObservationDeliveryForTesting: PortableObservationTracking.Token {
         selectionObservation!
+    }
+
+    func routeCurrentSelectionInvalidationForTesting() {
+        routeSelectionInvalidation(from: dom, selectionRevision: dom.selectionRevision)
+    }
+
+    func waitForPageHighlightTaskForTesting() async {
+        await pageHighlightTask?.value
     }
 
     var rowCountForTesting: Int {

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -967,10 +967,6 @@ func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() asyn
     }
     let firstMessages = try await waitForCSSRefreshMessages(backend, after: sentCount)
     #expect(await targetMessageMethods(backend).dropFirst(sentCount).contains("CSS.enable") == false)
-    let cssEnableTask = Task {
-        try await waitForTargetMessage(backend, method: "CSS.enable", after: sentCount)
-    }
-    await backend.waitUntilTargetMessageWaiterRegistered(method: "CSS.enable", after: sentCount)
     await receiveTargetErrorReply(
         transport,
         targetID: firstMessages.matched.targetIdentifier,
@@ -978,7 +974,7 @@ func selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt() asyn
         message: "CSS agent is not enabled"
     )
 
-    let cssEnable = try await cssEnableTask.value
+    let cssEnable = try await backend.waitForTargetMessage(method: "CSS.enable", after: sentCount)
     let retrySentCount = await backend.sentTargetMessages().count
     await receiveTargetReply(
         transport,

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -947,7 +947,6 @@ struct DOMContainerTests {
         await dom.waitUntilDocumentRequestsIdle(targetID: documentRequest.targetIdentifier)
 
         #expect(await renderedDocumentState.waitUntilValue(true))
-        await Task.yield()
         await treeTextView.waitForRenderedRowsForTesting()
         #expect(treeTextView.renderedTextForTesting.contains("<html"))
         #expect(await backend.sentTargetMessages().count == 1)

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -312,7 +312,7 @@ struct DOMTreeTextViewTests {
         view.endHoverForTesting()
         view.endHoverForTesting()
         await restoreRecorder.next()
-        await Task.yield()
+        await view.waitForPageHighlightTaskForTesting()
 
         #expect(session.selectedNode?.localName == "input")
         #expect(restoreRecorder.recordCount == 1)
@@ -390,8 +390,7 @@ struct DOMTreeTextViewTests {
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
         view.setRenderingActive(false)
-        await Task.yield()
-        await Task.yield()
+        await view.waitForPageHighlightTaskForTesting()
 
         #expect(highlightRecorder.recordedNodeIDs.isEmpty)
 
@@ -459,8 +458,7 @@ struct DOMTreeTextViewTests {
         view.primaryClickRowForTesting(containing: "<input disabled>")
         view.hoverRowForTesting(containing: "<article")
         view.endHoverForTesting()
-        await Task.yield()
-        await Task.yield()
+        await view.waitForPageHighlightTaskForTesting()
 
         #expect(session.selectedNode?.localName == "input")
         #expect(highlightRecorder.recordedNodeIDs.isEmpty)
@@ -831,11 +829,12 @@ struct DOMTreeTextViewTests {
         )
 
         view.primaryClickRowForTesting(containing: "<input disabled>")
-        await Task.yield()
         view.primaryClickRowForTesting(containing: "<div id=\"start-of-content\"", modifiers: .command)
         view.primaryClickRowForTesting(containing: "<article", modifiers: .command)
         #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.count == 3)
         #expect(session.selectedNode?.id == inputID)
+        view.routeCurrentSelectionInvalidationForTesting()
+        #expect(view.multiSelectedLineSnapshotsInDisplayOrderForTesting.count == 3)
 
         let observedSelectionRevisions = await view.selectionObservationDeliveryForTesting.values {
             session.selectionRevision
@@ -889,7 +888,7 @@ struct DOMTreeTextViewTests {
         await view.waitForRenderedRowsBuildSuspensionForTesting()
 
         session.selectNode(targetID)
-        await Task.yield()
+        view.routeCurrentSelectionInvalidationForTesting()
 
         view.resumeRenderedRowsBuildForTesting()
         await view.waitForRenderedRowsForTesting()
@@ -938,7 +937,7 @@ struct DOMTreeTextViewTests {
         await view.waitForRenderedRowsBuildSuspensionForTesting()
 
         session.selectNode(oldSelectedNodeID)
-        await Task.yield()
+        view.routeCurrentSelectionInvalidationForTesting()
 
         let command = session.beginInspectSelectionRequest(
             targetID: protocolTargetID,
@@ -1214,14 +1213,40 @@ private final class CancellableVoidActionRecorder {
     private(set) var cancellationCount = 0
     private var startContinuation: CheckedContinuation<Void, Never>?
     private var cancellationContinuation: CheckedContinuation<Void, Never>?
+    private var runContinuation: CheckedContinuation<Void, Never>?
+    private var didRecordCancellation = false
 
     func run() async {
         startedCount += 1
         startContinuation?.resume()
         startContinuation = nil
-        while !Task.isCancelled {
-            await Task.yield()
+        if Task.isCancelled {
+            recordCancellation()
+            return
         }
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if didRecordCancellation {
+                    continuation.resume()
+                } else {
+                    runContinuation = continuation
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.recordCancellation()
+            }
+        }
+    }
+
+    private func recordCancellation() {
+        guard !didRecordCancellation else {
+            return
+        }
+        didRecordCancellation = true
+        let continuation = runContinuation
+        runContinuation = nil
+        continuation?.resume()
         cancellationCount += 1
         cancellationContinuation?.resume()
         cancellationContinuation = nil

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1,6 +1,5 @@
 #if canImport(UIKit)
 import AVFoundation
-import Dispatch
 import ObservationBridge
 import Synchronization
 import Testing
@@ -593,8 +592,6 @@ struct NetworkDetailViewControllerTests {
         viewController.beginAppearanceTransition(false, animated: false)
         viewController.endAppearanceTransition()
         viewController.setModeForTesting(.preview)
-        await Task.yield()
-        await Task.yield()
 
         #expect(fetchedIDs.isEmpty)
         #expect(viewController.headersTextViewForTesting.renderedTextForTesting.contains("content-type: application/json"))
@@ -648,8 +645,6 @@ struct NetworkDetailViewControllerTests {
                 base64Encoded: false
             )
         )
-        await Task.yield()
-        await Task.yield()
 
         #expect(viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == renderedBodyBeforeHide)
 
@@ -925,7 +920,6 @@ struct NetworkDetailViewControllerTests {
         #expect(didRenderMediaPreview)
         let temporaryFileURL = try #require(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting)
         let playerIdentity = try #require(viewController.bodyViewControllerForTesting.mediaPlayerIdentityForTesting)
-        let delivery = try #require(viewController.selectedRequestRenderObservationDeliveryForTesting)
         #expect(playerFactory.requestedURLs == [temporaryFileURL])
 
         network.applyDataReceived(
@@ -936,13 +930,10 @@ struct NetworkDetailViewControllerTests {
             timestamp: 4
         )
 
-        let observedValues = await delivery.values {
-            request.encodedDataLength == 64
-                && viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == temporaryFileURL
-                && viewController.bodyViewControllerForTesting.mediaPlayerIdentityForTesting == playerIdentity
-                && FileManager.default.fileExists(atPath: temporaryFileURL.path)
-        }
-        #expect(observedValues.latestValue == true)
+        #expect(request.encodedDataLength == 64)
+        #expect(viewController.bodyViewControllerForTesting.mediaPlayerURLForTesting == temporaryFileURL)
+        #expect(viewController.bodyViewControllerForTesting.mediaPlayerIdentityForTesting == playerIdentity)
+        #expect(FileManager.default.fileExists(atPath: temporaryFileURL.path))
         #expect(playerFactory.requestedURLs == [temporaryFileURL])
     }
 
@@ -1410,7 +1401,6 @@ struct NetworkDetailViewControllerTests {
         let selectedRange = NSRange(location: 2, length: 4)
         viewController.headersTextViewForTesting.selectedRangeForTesting = selectedRange
         let assignmentCount = viewController.headersTextViewForTesting.attributedTextAssignmentCountForTesting
-        let delivery = try #require(viewController.selectedRequestRenderObservationDeliveryForTesting)
 
         network.applyDataReceived(
             targetID: request.id.targetID,
@@ -1420,12 +1410,9 @@ struct NetworkDetailViewControllerTests {
             timestamp: 4
         )
 
-        let observedValues = await delivery.values {
-            request.encodedDataLength == 64
-                && viewController.headersTextViewForTesting.attributedTextAssignmentCountForTesting == assignmentCount
-                && viewController.headersTextViewForTesting.selectedRangeForTesting == selectedRange
-        }
-        #expect(observedValues.latestValue == true)
+        #expect(request.encodedDataLength == 64)
+        #expect(viewController.headersTextViewForTesting.attributedTextAssignmentCountForTesting == assignmentCount)
+        #expect(viewController.headersTextViewForTesting.selectedRangeForTesting == selectedRange)
     }
 
     @Test
@@ -1468,8 +1455,6 @@ struct NetworkDetailViewControllerTests {
             ),
             timestamp: 4
         )
-        await Task.yield()
-        await Task.yield()
 
         #expect(viewController.headersTextViewForTesting.renderedTextForTesting == renderedHeadersBeforeHide)
 
@@ -2157,8 +2142,6 @@ struct NetworkDetailViewControllerTests {
             ),
             timestamp: 4
         )
-        await Task.yield()
-        await Task.yield()
 
         #expect(cell.fileTypeLabelForTesting == "mp4")
 
@@ -2414,50 +2397,6 @@ struct NetworkDetailViewControllerTests {
         return bundle.localizedString(forKey: key, value: nil, table: nil)
     }
 
-    private final class BlockingMediaPreviewClassifier: @unchecked Sendable {
-        private struct State: Sendable {
-            var shouldBlockNextCall = true
-            var isBlocked = false
-        }
-
-        private let state = Mutex(State())
-        private let unblockSemaphore = DispatchSemaphore(value: 0)
-
-        func classify(
-            mimeType: String?,
-            url: String?
-        ) -> NetworkRequest.Display.MediaPreviewClassification {
-            let shouldBlock = state.withLock { state in
-                guard state.shouldBlockNextCall else {
-                    return false
-                }
-                state.shouldBlockNextCall = false
-                return true
-            }
-            if shouldBlock {
-                state.withLock { state in
-                    state.isBlocked = true
-                }
-                unblockSemaphore.wait()
-            }
-            return NetworkRequest.Display.MediaPreviewSupport.classification(mimeType: mimeType, url: url)
-        }
-
-        func waitUntilBlocked() async -> Bool {
-            for _ in 0..<100 {
-                if state.withLock({ $0.isBlocked }) {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return false
-        }
-
-        func unblock() {
-            unblockSemaphore.signal()
-        }
-    }
-
     @MainActor
     private final class MoviePreviewPlayerFactorySpy {
         private(set) var requestedURLs: [URL] = []
@@ -2470,14 +2409,18 @@ struct NetworkDetailViewControllerTests {
             return player
         }
     }
-
-    private final class StubMoviePreviewPlayer: AVPlayer {
-        private(set) var pauseCallCount = 0
-
-        override func pause() {
-            pauseCallCount += 1
-        }
-    }
 }
+}
+
+private final class StubMoviePreviewPlayer: AVPlayer {
+    private let pauseCounter = Mutex(0)
+
+    var pauseCallCount: Int {
+        pauseCounter.withLock { $0 }
+    }
+
+    override func pause() {
+        pauseCounter.withLock { $0 += 1 }
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Reconcile DOM tree primary selection synchronously so delayed observation cannot clear view-local multi-selection.
- Replace test-side Task.yield() waits with deterministic observation/task completion hooks.
- Tighten Network detail tests to assert no-op request update invariants directly and remove unused polling helper state.
- Make the CSS compatibility-enable retry test wait on FakeTransportBackend's stored positive signal instead of a pre-registered timeout task.

## Verification
- xcodebuild test via XcodeBuildMCP, scheme WebInspectorUITests: 164 passed, 0 failed.
- xcodebuild test via XcodeBuildMCP, scheme WebInspectorCoreTests: 295 passed, 0 failed.
- xcodebuild test via XcodeBuildMCP, scheme WebInspectorKitTests: 543 passed, 0 failed, 2 skipped.
- selectedElementStyleRefreshEnablesCSSAgentOnlyAfterBackendRequiresIt repeated 30 times via XcodeBuildMCP: passed.
- rg -n "Task\.yield\(" Tests: no matches.
- git diff --check.
- codex-review against main: no findings.

## Related
- Investigated CI run https://github.com/lynnswap/WebInspectorKit/actions/runs/27822663109/job/82339263501
- Original investigation: https://github.com/lynnswap/WebInspectorKit/actions/runs/27818684088/job/82326199352