### PR TITLE
Coordinate inspector teardown lifecycle

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserInspectorWindowHostingController+UIKit.swift
@@ -51,6 +51,7 @@ final class BrowserInspectorWindowHostingController: UIViewController {
 
         placeholderLabel.removeFromSuperview()
         let container = WebInspectorViewController(session: inspectorContext.inspectorSession)
+        container.automaticallyDetachesOnDismiss = false
         addChild(container)
         container.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(container.view)

--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -726,6 +726,18 @@ extension BrowserPageViewController {
     var inspectorButtonItemForTesting: UIBarButtonItem {
         inspectorButtonItem
     }
+
+    var inspectorPresentationObservationIsActiveForTesting: Bool {
+        inspectorPresentationObservation != nil
+    }
+
+    var presentedInspectorSheetForTesting: WebInspectorViewController? {
+        inspectorCoordinator.presentedSheetControllerForTesting as? WebInspectorViewController
+    }
+
+    func openInspectorAsSheetForTesting() -> Bool {
+        openInspectorAsSheet()
+    }
 }
 #endif
 #endif

--- a/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
+++ b/Monocly/Monocly/Presentation/BrowserInspectorCoordinator.swift
@@ -81,6 +81,7 @@ final class BrowserInspectorCoordinator {
 
         let anchor = resolvePresentationAnchor(from: presenter)
         let sheetController = WebInspectorViewController(session: inspectorSession)
+        sheetController.automaticallyDetachesOnDismiss = false
         if #available(iOS 26.0, *) {
             sheetController.drawsBackground = false
         }

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -752,6 +752,53 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func inspectorSheetDismissReenablesExistingToolbarButtonWithoutTraitRefresh() async throws {
+        let initialURL = try #require(URL(string: "about:blank"))
+        let store = BrowserWindowStore(
+            url: initialURL,
+            automaticallyLoadsInitialRequest: false,
+            sessionStore: nil
+        )
+        let pageViewController = BrowserPageViewController(
+            store: store,
+            inspectorSession: WebInspectorSession(),
+            launchConfiguration: BrowserLaunchConfiguration(initialURL: initialURL),
+            progressHideScheduler: ManualDelayScheduler()
+        )
+        let navigationController = UINavigationController(rootViewController: pageViewController)
+        let window = UIWindow(windowScene: try makeWindowScene())
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        defer {
+            navigationController.dismiss(animated: false)
+            window.isHidden = true
+        }
+        pageViewController.loadViewIfNeeded()
+        window.layoutIfNeeded()
+        #expect(await waitUntil {
+            pageViewController.inspectorPresentationObservationIsActiveForTesting
+        })
+        let inspectorButtonItem = pageViewController.inspectorButtonItemForTesting
+        #expect(inspectorButtonItem.isEnabled)
+
+        #expect(pageViewController.openInspectorAsSheetForTesting())
+        let sheetController = try #require(pageViewController.presentedInspectorSheetForTesting)
+        #expect(sheetController.automaticallyDetachesOnDismiss == false)
+        #expect(await waitUntil {
+            inspectorButtonItem.isEnabled == false
+        })
+
+        let presentationController = try #require(sheetController.presentationController)
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+
+        #expect(await waitUntil {
+            pageViewController.presentedInspectorSheetForTesting == nil
+                && inspectorButtonItem.isEnabled
+        })
+        #expect(pageViewController.inspectorButtonItemForTesting === inspectorButtonItem)
+    }
+
+    @Test
     func tabSwitchInstallsSelectedWebViewOnceAndPreservesTabIdentity() async throws {
         let fixture = try makeAttachmentLifecycleFixture()
         let pageViewController = BrowserPageViewController(

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -215,6 +215,7 @@ struct MonoclyLifecycleTests {
                 coordinator.presentedSheetControllerForTesting as? WebInspectorViewController
             )
             #expect(didPresent)
+            #expect(sheetController.automaticallyDetachesOnDismiss == false)
             if #available(iOS 26.0, *) {
                 #expect(sheetController.drawsBackground == false)
             }

--- a/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
+++ b/Monocly/MonoclyTests/MonoclyLifecycleTests.swift
@@ -436,8 +436,10 @@ struct MonoclyLifecycleTests {
             let inspectorWindow = try #require(sceneDelegate.window)
             context.retain(inspectorWindow)
             #expect(inspectorWindow.rootViewController === sceneDelegate.inspectorViewController)
+            let inspectorContainer = try #require(sceneDelegate.inspectorViewController?.inspectorContainerForTesting)
+            #expect(inspectorContainer.automaticallyDetachesOnDismiss == false)
             if #available(iOS 26.0, *) {
-                #expect(sceneDelegate.inspectorViewController?.inspectorContainerForTesting?.drawsBackground == true)
+                #expect(inspectorContainer.drawsBackground == true)
             }
             #expect(coordinator.hasInspectorWindowForTesting)
 

--- a/Sources/WebInspectorCore/DOM/DOMModel.swift
+++ b/Sources/WebInspectorCore/DOM/DOMModel.swift
@@ -162,6 +162,14 @@ package final class DOMSession {
     }
 
     package func reset() {
+        documentRequests.cancelAll()
+        if let cancelledToken = styleHydration.cancelRefresh() {
+            elementStyles.cancelRefresh(cancelledToken)
+        }
+        styleHydration.cancelPropertyUpdates()
+        highlightController.clearAll()
+        elementPicker.clear()
+        deleteUndoController.clear(undoTarget: self)
         currentPage.clear()
         targetGraph.reset()
         documentStore.reset()

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -87,6 +87,15 @@ final class DOMSessionHighlightController {
             .first
     }
 
+    func possibleVisibleHighlight(targetID: ProtocolTarget.ID) -> PossibleVisibleHighlight {
+        PossibleVisibleHighlight(
+            targetID: targetID,
+            generation: possibleVisibleGeneration(targetID: targetID),
+            nodeID: possibleVisibleNodeID(targetID: targetID),
+            owner: possibleVisibleOwner(targetID: targetID)
+        )
+    }
+
     func isPossibleVisibleHighlight(
         targetID: ProtocolTarget.ID,
         generation: UInt64,
@@ -174,6 +183,10 @@ final class DOMSessionElementPickerController {
         phase.session?.targetID
     }
 
+    var currentSession: Session? {
+        phase.session
+    }
+
     var isSelecting: Bool {
         phase.session != nil
     }
@@ -235,6 +248,15 @@ final class DOMSessionElementPickerController {
         phase = .idle
         resumeIdleWaitersIfNeeded()
         return targetID
+    }
+
+    @discardableResult
+    func clear(ifCurrent session: Session) -> Bool {
+        guard phase.session === session else {
+            return false
+        }
+        clear()
+        return true
     }
 
     func waitUntilIdle() async {

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -49,6 +49,30 @@ extension DOMSession {
         cancelCSSActionRequests()
     }
 
+    package func retireBackendInteractionForTeardown() async {
+        cancelDocumentRequests()
+        cancelCSSActionRequests()
+
+        let pickerTargetID = elementPicker.targetID
+        let inspectModeTargetID = isSelectingElement ? pickerTargetID ?? currentPageTargetID : nil
+        if let inspectModeTargetID,
+           targetSupportsTeardownBackendInteraction(inspectModeTargetID),
+           let intent = setInspectModeEnabledIntent(targetID: inspectModeTargetID, enabled: false) {
+            await performTeardownCommand(intent)
+        }
+
+        for targetID in teardownHighlightHideTargetIDs(preferredTargetID: pickerTargetID) {
+            guard let intent = hideHighlightIntent(targetID: targetID) else {
+                continue
+            }
+            await performTeardownCommand(intent)
+        }
+
+        highlightController.clearAll()
+        clearElementPickerState(invalidatePendingSelection: true)
+        clearDeleteUndoHistory()
+    }
+
     package func waitUntilDocumentRequestsIdle(targetID: ProtocolTarget.ID? = nil) async {
         await documentRequests.waitUntilIdle(targetID: targetID)
     }
@@ -106,6 +130,8 @@ extension DOMSession {
         requiresActiveConnection: Bool,
         highlightOwner: DOMPageHighlightOwner? = nil
     ) async throws -> ProtocolCommand.Result {
+        let commandChannel = try requireCommandChannel(requiresActiveConnection: requiresActiveConnection)
+        let command = try protocolCommands.command(for: intent)
         if case let .highlightNode(target) = intent {
             highlightController.markHighlightMayBeVisible(
                 targetID: target.commandTargetID,
@@ -120,7 +146,7 @@ extension DOMSession {
         }
         let result: ProtocolCommand.Result
         do {
-            result = try await send(intent, requiresActiveConnection: requiresActiveConnection)
+            result = try await send(command, using: commandChannel)
         } catch {
             if let missingTargetID = missingTargetID(from: error) {
                 clearHighlightOwnershipIfMissingTarget(missingTargetID, for: intent)
@@ -182,6 +208,90 @@ extension DOMSession {
         }
     }
 
+    private func targetSupportsTeardownBackendInteraction(_ targetID: ProtocolTarget.ID) -> Bool {
+        guard containsTarget(targetID),
+              targetKind(for: targetID) != .frame else {
+            return false
+        }
+        return true
+    }
+
+    private func teardownHighlightHideTargetIDs(preferredTargetID: ProtocolTarget.ID?) -> [ProtocolTarget.ID] {
+        var targetIDs: [ProtocolTarget.ID] = []
+        func append(_ targetID: ProtocolTarget.ID?) {
+            guard let targetID,
+                  targetSupportsTeardownBackendInteraction(targetID),
+                  !targetIDs.contains(targetID) else {
+                return
+            }
+            targetIDs.append(targetID)
+        }
+
+        append(preferredTargetID)
+        for highlight in highlightController.possibleVisibleHighlights(
+            preferredFirst: preferredTargetID,
+            fallbackTargetID: nil,
+            preserving: nil
+        ) {
+            append(highlight.targetID)
+        }
+        append(currentPageTargetID)
+        return targetIDs
+    }
+
+    private func performTeardownCommand(_ intent: DOMCommand.Intent) async {
+        do {
+            try await perform(intent, requiresActiveConnection: false)
+        } catch {
+            InspectorRuntimeLog.warning(
+                "dom.teardownCleanup.failed method=\(teardownCommandMethodName(for: intent)) target=\(teardownCommandTargetDescription(for: intent)) error=\(error)"
+            )
+        }
+    }
+
+    private func teardownCommandMethodName(for intent: DOMCommand.Intent) -> String {
+        switch intent {
+        case .getDocument:
+            "DOM.getDocument"
+        case .requestChildNodes:
+            "DOM.requestChildNodes"
+        case .requestNode:
+            "DOM.requestNode"
+        case .highlightNode:
+            "DOM.highlightNode"
+        case .hideHighlight:
+            "DOM.hideHighlight"
+        case .setInspectModeEnabled:
+            "DOM.setInspectModeEnabled"
+        case .getOuterHTML:
+            "DOM.getOuterHTML"
+        case .removeNode:
+            "DOM.removeNode"
+        case .undo:
+            "DOM.undo"
+        case .redo:
+            "DOM.redo"
+        }
+    }
+
+    private func teardownCommandTargetDescription(for intent: DOMCommand.Intent) -> String {
+        let targetID: ProtocolTarget.ID? = switch intent {
+        case let .getDocument(targetID),
+             let .requestChildNodes(targetID, _, _),
+             let .requestNode(_, targetID, _),
+             let .hideHighlight(targetID),
+             let .setInspectModeEnabled(targetID, _),
+             let .undo(targetID),
+             let .redo(targetID):
+            targetID
+        case let .highlightNode(target),
+             let .getOuterHTML(target),
+             let .removeNode(target):
+            target.commandTargetID
+        }
+        return targetID?.rawValue ?? "nil"
+    }
+
     @discardableResult
     private func send(
         _ intent: DOMCommand.Intent,
@@ -189,7 +299,15 @@ extension DOMSession {
     ) async throws -> ProtocolCommand.Result {
         let commandChannel = try requireCommandChannel(requiresActiveConnection: requiresActiveConnection)
         let command = try protocolCommands.command(for: intent)
-        return try await commandChannel.send(command)
+        return try await send(command, using: commandChannel)
+    }
+
+    @discardableResult
+    private func send(
+        _ command: ProtocolCommand,
+        using commandChannel: ProtocolCommandChannel
+    ) async throws -> ProtocolCommand.Result {
+        try await commandChannel.send(command)
     }
 
     @discardableResult

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -6,6 +6,11 @@ private enum DOMBackendInteractionRetirementScope {
     case attachmentTeardown
 }
 
+private enum DOMHideHighlightGenerationPolicy {
+    case current
+    case captured(UInt64?)
+}
+
 private enum DOMInspectRoute {
     case remoteObject(targetID: ProtocolTarget.ID, objectID: String)
     case protocolNode(targetID: ProtocolTarget.ID, nodeID: DOMNode.ProtocolID)
@@ -66,8 +71,10 @@ extension DOMSession {
     }
 
     private func retireBackendInteraction(scope: DOMBackendInteractionRetirementScope) async {
-        let pickerTargetID = elementPicker.targetID
+        let pickerSession = elementPicker.currentSession
+        let pickerTargetID = pickerSession?.targetID
         let inspectModeTargetID = isSelectingElement ? pickerTargetID ?? currentPageTargetID : nil
+        let highlightHides = backendInteractionRetirementHighlightHides(preferredTargetID: pickerTargetID)
         let requiresActiveConnection = scope == .presentationEnd
         if let inspectModeTargetID,
            targetSupportsTeardownBackendInteraction(inspectModeTargetID),
@@ -79,19 +86,27 @@ extension DOMSession {
             )
         }
 
-        for targetID in backendInteractionRetirementHighlightHideTargetIDs(preferredTargetID: pickerTargetID) {
-            guard let intent = hideHighlightIntent(targetID: targetID) else {
+        for highlight in highlightHides {
+            guard shouldSendBackendInteractionRetirementHide(
+                highlight,
+                capturedPickerSession: pickerSession
+            ),
+                let intent = hideHighlightIntent(targetID: highlight.targetID) else {
                 continue
             }
             await performBackendInteractionRetirementCommand(
                 intent,
                 requiresActiveConnection: requiresActiveConnection,
-                scope: scope
+                scope: scope,
+                hideGenerationPolicy: .captured(highlight.generation)
             )
         }
 
-        highlightController.clearAll()
-        clearElementPickerState(invalidatePendingSelection: true)
+        clearRetiredBackendInteractionState(
+            scope: scope,
+            pickerSession: pickerSession,
+            highlights: highlightHides
+        )
     }
 
     package func waitUntilDocumentRequestsIdle(targetID: ProtocolTarget.ID? = nil) async {
@@ -149,7 +164,8 @@ extension DOMSession {
     private func perform(
         _ intent: DOMCommand.Intent,
         requiresActiveConnection: Bool,
-        highlightOwner: DOMPageHighlightOwner? = nil
+        highlightOwner: DOMPageHighlightOwner? = nil,
+        hideGenerationPolicy: DOMHideHighlightGenerationPolicy = .current
     ) async throws -> ProtocolCommand.Result {
         let commandChannel = try requireCommandChannel(requiresActiveConnection: requiresActiveConnection)
         let command = try protocolCommands.command(for: intent)
@@ -161,7 +177,12 @@ extension DOMSession {
             )
         }
         let hideGeneration: UInt64? = if case let .hideHighlight(targetID) = intent {
-            highlightController.possibleVisibleGeneration(targetID: targetID)
+            switch hideGenerationPolicy {
+            case .current:
+                highlightController.possibleVisibleGeneration(targetID: targetID)
+            case let .captured(generation):
+                generation
+            }
         } else {
             nil
         }
@@ -241,15 +262,17 @@ extension DOMSession {
         containsTarget(targetID)
     }
 
-    private func backendInteractionRetirementHighlightHideTargetIDs(preferredTargetID: ProtocolTarget.ID?) -> [ProtocolTarget.ID] {
-        var targetIDs: [ProtocolTarget.ID] = []
+    private func backendInteractionRetirementHighlightHides(
+        preferredTargetID: ProtocolTarget.ID?
+    ) -> [DOMSessionHighlightController.PossibleVisibleHighlight] {
+        var highlights: [DOMSessionHighlightController.PossibleVisibleHighlight] = []
         func append(_ targetID: ProtocolTarget.ID?) {
             guard let targetID,
                   targetSupportsBackendInteractionHighlightHide(targetID),
-                  !targetIDs.contains(targetID) else {
+                  !highlights.contains(where: { $0.targetID == targetID }) else {
                 return
             }
-            targetIDs.append(targetID)
+            highlights.append(highlightController.possibleVisibleHighlight(targetID: targetID))
         }
 
         append(preferredTargetID)
@@ -261,16 +284,63 @@ extension DOMSession {
             append(highlight.targetID)
         }
         append(currentPageTargetID)
-        return targetIDs
+        return highlights
+    }
+
+    private func shouldSendBackendInteractionRetirementHide(
+        _ highlight: DOMSessionHighlightController.PossibleVisibleHighlight,
+        capturedPickerSession: DOMSessionElementPickerController.Session?
+    ) -> Bool {
+        if let generation = highlight.generation {
+            return highlightController.isPossibleVisibleHighlight(
+                targetID: highlight.targetID,
+                generation: generation,
+                nodeID: highlight.nodeID,
+                owner: highlight.owner
+            )
+        }
+
+        if let currentPickerSession = elementPicker.currentSession {
+            return capturedPickerSession === currentPickerSession
+        }
+
+        return highlightController.possibleVisibleGeneration(targetID: highlight.targetID) == nil
+    }
+
+    private func clearRetiredBackendInteractionState(
+        scope: DOMBackendInteractionRetirementScope,
+        pickerSession: DOMSessionElementPickerController.Session?,
+        highlights: [DOMSessionHighlightController.PossibleVisibleHighlight]
+    ) {
+        switch scope {
+        case .attachmentTeardown:
+            highlightController.clearAll()
+            clearElementPickerState(invalidatePendingSelection: true)
+        case .presentationEnd:
+            for highlight in highlights {
+                highlightController.clearHighlight(
+                    targetID: highlight.targetID,
+                    matchingGeneration: highlight.generation
+                )
+            }
+            if let pickerSession {
+                clearElementPickerState(ifCurrent: pickerSession, invalidatePendingSelection: true)
+            }
+        }
     }
 
     private func performBackendInteractionRetirementCommand(
         _ intent: DOMCommand.Intent,
         requiresActiveConnection: Bool,
-        scope: DOMBackendInteractionRetirementScope
+        scope: DOMBackendInteractionRetirementScope,
+        hideGenerationPolicy: DOMHideHighlightGenerationPolicy = .current
     ) async {
         do {
-            try await perform(intent, requiresActiveConnection: requiresActiveConnection)
+            try await perform(
+                intent,
+                requiresActiveConnection: requiresActiveConnection,
+                hideGenerationPolicy: hideGenerationPolicy
+            )
         } catch {
             InspectorRuntimeLog.warning(
                 "dom.backendInteractionRetirement.failed scope=\(scopeLogName(scope)) method=\(teardownCommandMethodName(for: intent)) target=\(teardownCommandTargetDescription(for: intent)) error=\(error)"
@@ -1428,6 +1498,19 @@ extension DOMSession {
 
     private func clearElementPickerState(invalidatePendingSelection: Bool = false) {
         elementPicker.clear()
+        syncElementPickerSelectionState()
+        if invalidatePendingSelection {
+            selectNode(selectedNodeID)
+        }
+    }
+
+    private func clearElementPickerState(
+        ifCurrent session: DOMSessionElementPickerController.Session,
+        invalidatePendingSelection: Bool = false
+    ) {
+        guard elementPicker.clear(ifCurrent: session) else {
+            return
+        }
         syncElementPickerSelectionState()
         if invalidatePendingSelection {
             selectNode(selectedNodeID)

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -79,7 +79,7 @@ extension DOMSession {
             )
         }
 
-        for targetID in teardownHighlightHideTargetIDs(preferredTargetID: pickerTargetID) {
+        for targetID in backendInteractionRetirementHighlightHideTargetIDs(preferredTargetID: pickerTargetID) {
             guard let intent = hideHighlightIntent(targetID: targetID) else {
                 continue
             }
@@ -237,11 +237,15 @@ extension DOMSession {
         return true
     }
 
-    private func teardownHighlightHideTargetIDs(preferredTargetID: ProtocolTarget.ID?) -> [ProtocolTarget.ID] {
+    private func targetSupportsBackendInteractionHighlightHide(_ targetID: ProtocolTarget.ID) -> Bool {
+        containsTarget(targetID)
+    }
+
+    private func backendInteractionRetirementHighlightHideTargetIDs(preferredTargetID: ProtocolTarget.ID?) -> [ProtocolTarget.ID] {
         var targetIDs: [ProtocolTarget.ID] = []
         func append(_ targetID: ProtocolTarget.ID?) {
             guard let targetID,
-                  targetSupportsTeardownBackendInteraction(targetID),
+                  targetSupportsBackendInteractionHighlightHide(targetID),
                   !targetIDs.contains(targetID) else {
                 return
             }

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -1,6 +1,11 @@
 import Foundation
 import WebInspectorTransport
 
+private enum DOMBackendInteractionRetirementScope {
+    case presentationEnd
+    case attachmentTeardown
+}
+
 private enum DOMInspectRoute {
     case remoteObject(targetID: ProtocolTarget.ID, objectID: String)
     case protocolNode(targetID: ProtocolTarget.ID, nodeID: DOMNode.ProtocolID)
@@ -49,28 +54,44 @@ extension DOMSession {
         cancelCSSActionRequests()
     }
 
+    package func retireBackendInteractionForPresentationEnd() async {
+        await retireBackendInteraction(scope: .presentationEnd)
+    }
+
     package func retireBackendInteractionForTeardown() async {
         cancelDocumentRequests()
         cancelCSSActionRequests()
+        await retireBackendInteraction(scope: .attachmentTeardown)
+        clearDeleteUndoHistory()
+    }
 
+    private func retireBackendInteraction(scope: DOMBackendInteractionRetirementScope) async {
         let pickerTargetID = elementPicker.targetID
         let inspectModeTargetID = isSelectingElement ? pickerTargetID ?? currentPageTargetID : nil
+        let requiresActiveConnection = scope == .presentationEnd
         if let inspectModeTargetID,
            targetSupportsTeardownBackendInteraction(inspectModeTargetID),
            let intent = setInspectModeEnabledIntent(targetID: inspectModeTargetID, enabled: false) {
-            await performTeardownCommand(intent)
+            await performBackendInteractionRetirementCommand(
+                intent,
+                requiresActiveConnection: requiresActiveConnection,
+                scope: scope
+            )
         }
 
         for targetID in teardownHighlightHideTargetIDs(preferredTargetID: pickerTargetID) {
             guard let intent = hideHighlightIntent(targetID: targetID) else {
                 continue
             }
-            await performTeardownCommand(intent)
+            await performBackendInteractionRetirementCommand(
+                intent,
+                requiresActiveConnection: requiresActiveConnection,
+                scope: scope
+            )
         }
 
         highlightController.clearAll()
         clearElementPickerState(invalidatePendingSelection: true)
-        clearDeleteUndoHistory()
     }
 
     package func waitUntilDocumentRequestsIdle(targetID: ProtocolTarget.ID? = nil) async {
@@ -239,13 +260,26 @@ extension DOMSession {
         return targetIDs
     }
 
-    private func performTeardownCommand(_ intent: DOMCommand.Intent) async {
+    private func performBackendInteractionRetirementCommand(
+        _ intent: DOMCommand.Intent,
+        requiresActiveConnection: Bool,
+        scope: DOMBackendInteractionRetirementScope
+    ) async {
         do {
-            try await perform(intent, requiresActiveConnection: false)
+            try await perform(intent, requiresActiveConnection: requiresActiveConnection)
         } catch {
             InspectorRuntimeLog.warning(
-                "dom.teardownCleanup.failed method=\(teardownCommandMethodName(for: intent)) target=\(teardownCommandTargetDescription(for: intent)) error=\(error)"
+                "dom.backendInteractionRetirement.failed scope=\(scopeLogName(scope)) method=\(teardownCommandMethodName(for: intent)) target=\(teardownCommandTargetDescription(for: intent)) error=\(error)"
             )
+        }
+    }
+
+    private func scopeLogName(_ scope: DOMBackendInteractionRetirementScope) -> String {
+        switch scope {
+        case .presentationEnd:
+            "presentationEnd"
+        case .attachmentTeardown:
+            "attachmentTeardown"
         }
     }
 

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -275,6 +275,7 @@ private enum InspectorConnectionPhase {
     case idle
     case pending(InspectorConnection)
     case active(InspectorConnection)
+    case retiring(InspectorConnection)
 
     var activeConnection: InspectorConnection? {
         guard case let .active(connection) = self else {
@@ -290,22 +291,27 @@ private enum InspectorConnectionPhase {
         return connection
     }
 
-    var connectionsForDetach: [InspectorConnection] {
+    var connectionForDetachStart: InspectorConnection? {
         switch self {
-        case .idle:
-            []
+        case .idle, .retiring:
+            nil
         case let .pending(connection), let .active(connection):
-            [connection]
+            connection
         }
-    }
-
-    var hasAnyConnection: Bool {
-        connectionsForDetach.isEmpty == false
     }
 
     func isCurrent(_ candidate: InspectorConnection) -> Bool {
         switch self {
         case .idle:
+            false
+        case let .pending(connection), let .active(connection), let .retiring(connection):
+            connection === candidate
+        }
+    }
+
+    func isConnectLifecycleCurrent(_ candidate: InspectorConnection) -> Bool {
+        switch self {
+        case .idle, .retiring:
             false
         case let .pending(connection), let .active(connection):
             connection === candidate
@@ -377,6 +383,8 @@ package final class InspectorSession {
     @ObservationIgnored private let configuration: InspectorSession.Configuration
     @ObservationIgnored private var connectionPhase: InspectorConnectionPhase
     @ObservationIgnored private var protocolEventDispatchers: ProtocolDomainEventDispatcherRegistry
+    @ObservationIgnored private var isDetaching: Bool
+    @ObservationIgnored private var detachWaiters: [CheckedContinuation<Void, Never>]
 
     private var connection: InspectorConnection? {
         connectionPhase.activeConnection
@@ -416,6 +424,8 @@ package final class InspectorSession {
         protocolEventDispatchers = ProtocolDomainEventDispatcherRegistry()
         lastError = nil
         connectionPhase = .idle
+        isDetaching = false
+        detachWaiters = []
         configureProtocolEventDispatchers()
     }
 
@@ -439,6 +449,8 @@ package final class InspectorSession {
         protocolEventDispatchers = ProtocolDomainEventDispatcherRegistry()
         lastError = nil
         connectionPhase = .idle
+        isDetaching = false
+        detachWaiters = []
         configureProtocolEventDispatchers()
     }
 
@@ -462,6 +474,8 @@ package final class InspectorSession {
         protocolEventDispatchers = ProtocolDomainEventDispatcherRegistry()
         lastError = nil
         connectionPhase = .idle
+        isDetaching = false
+        detachWaiters = []
         configureProtocolEventDispatchers()
     }
 
@@ -560,7 +574,7 @@ package final class InspectorSession {
             startRuntimeConsoleEnableForAttachedTargets()
             lastError = nil
         } catch {
-            guard connectionPhase.isCurrent(nextConnection) else {
+            guard connectionPhase.isConnectLifecycleCurrent(nextConnection) else {
                 throw error
             }
             nextConnection.receiver?.close()
@@ -581,27 +595,78 @@ package final class InspectorSession {
     }
 
     package func detach() async {
-        guard connectionPhase.hasAnyConnection else {
+        if isDetaching {
+            await waitUntilDetachCompletes()
+            return
+        }
+        guard let previousConnection = connectionPhase.connectionForDetachStart else {
             return
         }
 
-        let previousConnections = connectionPhase.connectionsForDetach
-        connectionPhase = .idle
-        dom.recordCommandAvailabilityMutation()
-        unbindProtocolChannel()
-
-        for previousConnection in previousConnections {
-            cancelRuntimeConsoleEnableTasks(previousConnection)
-            previousConnection.receiver?.close()
-            stopPumps(previousConnection)
-            await previousConnection.transport.detach()
-            restoreInspectabilityIfNeeded(for: previousConnection)
+        isDetaching = true
+        defer {
+            isDetaching = false
+            resumeDetachWaiters()
         }
+
+        await AttachmentTeardownCoordinator(connection: previousConnection).detach(session: self)
+    }
+
+    private struct AttachmentTeardownCoordinator {
+        var connection: InspectorConnection
+
+        func detach(session: InspectorSession) async {
+            await session.performAttachmentTeardown(connection: connection)
+        }
+    }
+
+    private func performAttachmentTeardown(connection previousConnection: InspectorConnection) async {
+        connectionPhase = .retiring(previousConnection)
+        dom.recordCommandAvailabilityMutation()
+
+        cancelRuntimeConsoleEnableTasks(previousConnection)
+        await dom.retireBackendInteractionForTeardown()
+
+        unbindProtocolChannel()
+        previousConnection.receiver?.close()
+        stopPumps(previousConnection)
+        await previousConnection.transport.detach()
+        restoreInspectabilityIfNeeded(for: previousConnection)
+
+        if connectionPhase.isCurrent(previousConnection) {
+            connectionPhase = .idle
+            dom.recordCommandAvailabilityMutation()
+        }
+        resetAttachmentModels()
+        lastError = nil
+    }
+
+    private func waitUntilDetachCompletes() async {
+        guard isDetaching else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if isDetaching {
+                detachWaiters.append(continuation)
+            } else {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func resumeDetachWaiters() {
+        let waiters = detachWaiters
+        detachWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func resetAttachmentModels() {
         dom.reset()
         network.reset()
         runtime.reset()
         console.reset()
-        lastError = nil
     }
 
     package var hasInspectablePageWebView: Bool {
@@ -957,7 +1022,7 @@ package final class InspectorSession {
     }
 
     private func ensureCurrentConnection(_ candidate: InspectorConnection) throws {
-        guard isCurrentConnection(candidate) else {
+        guard connectionPhase.isConnectLifecycleCurrent(candidate) else {
             throw TransportSession.Error.transportClosed
         }
     }

--- a/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
+++ b/Sources/WebInspectorCore/Inspector/AttachedInspection.swift
@@ -612,6 +612,13 @@ package final class InspectorSession {
         await AttachmentTeardownCoordinator(connection: previousConnection).detach(session: self)
     }
 
+    package func retireBackendInteractionForPresentationEnd() async {
+        guard hasActiveConnection else {
+            return
+        }
+        await dom.retireBackendInteractionForPresentationEnd()
+    }
+
     private struct AttachmentTeardownCoordinator {
         var connection: InspectorConnection
 

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -62,6 +62,15 @@ public final class WebInspectorSession {
         await detachAction(inspector)
     }
 
+    package func retireRootPresentation(detach: Bool) async {
+        interface.removeContentCache()
+        guard detach else {
+            await inspector.retireBackendInteractionForPresentationEnd()
+            return
+        }
+        await self.detach()
+    }
+
     private func startPageUserInterfaceStyleObservation(for webView: WKWebView) {
         let observer = WebInspectorPageUserInterfaceStyleObserver(webView: webView) { [weak self] style in
             self?.setPageUserInterfaceStyle(style)

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -189,6 +189,12 @@ package final class InterfaceModel {
         contentCache.removeAll()
     }
 
+    #if DEBUG
+    package var contentCacheCountForTesting: Int {
+        contentCache.countForTesting
+    }
+    #endif
+
     package var selectedTab: WebInspectorTab? {
         guard let selectedItemID else {
             return nil

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -3,14 +3,39 @@ import UIKit
 import WebKit
 
 @MainActor
-public final class WebInspectorViewController: UIViewController {
+private final class WebInspectorRootPresentationLifecycleCoordinator {
+    private var didFinishCurrentPresentation = false
+
+    func beginPresentation() {
+        didFinishCurrentPresentation = false
+    }
+
+    func finishIfNeeded(_ finish: () -> Void) {
+        guard didFinishCurrentPresentation == false else {
+            return
+        }
+        didFinishCurrentPresentation = true
+        finish()
+    }
+
+    #if DEBUG
+    var hasFinishedCurrentPresentationForTesting: Bool {
+        didFinishCurrentPresentation
+    }
+    #endif
+}
+
+@MainActor
+public final class WebInspectorViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
     private enum HostKind {
         case compact
         case regular
     }
 
     public let session: WebInspectorSession
+    public var automaticallyDetachesOnDismiss = true
     private var drawsBackgroundStorage = true
+    private let presentationLifecycleCoordinator = WebInspectorRootPresentationLifecycleCoordinator()
 
     @available(iOS 26.0, *)
     public var drawsBackground: Bool {
@@ -43,6 +68,7 @@ public final class WebInspectorViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        installPresentationLifecycleDelegateIfAvailable()
         applyBackgroundFromTraits()
         rebuildLayout(forceHostReplacement: true)
         registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
@@ -55,6 +81,54 @@ public final class WebInspectorViewController: UIViewController {
         }
     }
 
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        presentationLifecycleCoordinator.beginPresentation()
+        installPresentationLifecycleDelegateIfAvailable()
+    }
+
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        guard isTerminalRootDisappearance,
+              transitionCoordinator?.isCancelled != true else {
+            return
+        }
+        finishRootPresentationLifecycle()
+    }
+
+    public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        let wasPresentedAsRoot = isRootPresentationActive
+        super.dismiss(animated: flag) { [weak self] in
+            guard let self else {
+                completion?()
+                return
+            }
+            if wasPresentedAsRoot,
+               self.viewIfLoaded?.window == nil {
+                self.finishRootPresentationLifecycle()
+            }
+            completion?()
+        }
+        if wasPresentedAsRoot,
+           flag == false {
+            finishRootPresentationLifecycle()
+        }
+    }
+
+    public override func didMove(toParent parent: UIViewController?) {
+        super.didMove(toParent: parent)
+        guard parent == nil,
+              isViewLoaded,
+              view.window == nil else {
+            return
+        }
+        finishRootPresentationLifecycle()
+    }
+
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        finishRootPresentationLifecycle()
+    }
+
     public func attach(to webView: WKWebView) async throws {
         try await session.attach(to: webView)
     }
@@ -65,6 +139,38 @@ public final class WebInspectorViewController: UIViewController {
 
     private var effectiveHostKind: HostKind {
         (horizontalSizeClassOverrideForTesting ?? traitCollection.horizontalSizeClass) == .compact ? .compact : .regular
+    }
+
+    private var isTerminalRootDisappearance: Bool {
+        isBeingDismissed
+            || isMovingFromParent
+            || navigationController?.isBeingDismissed == true
+            || navigationController?.isMovingFromParent == true
+            || parent?.isBeingDismissed == true
+            || parent?.isMovingFromParent == true
+    }
+
+    private var isRootPresentationActive: Bool {
+        presentingViewController != nil
+            || presentationController?.presentedViewController === self
+            || navigationController?.presentingViewController != nil
+            || navigationController?.presentationController?.presentedViewController === navigationController
+    }
+
+    private func installPresentationLifecycleDelegateIfAvailable() {
+        presentationController?.delegate = self
+    }
+
+    private func finishRootPresentationLifecycle() {
+        presentationLifecycleCoordinator.finishIfNeeded { [session, automaticallyDetachesOnDismiss] in
+            session.interface.removeContentCache()
+            guard automaticallyDetachesOnDismiss else {
+                return
+            }
+            Task { @MainActor [session] in
+                await session.detach()
+            }
+        }
     }
 
     private func handleHorizontalSizeClassChange() {
@@ -131,6 +237,19 @@ public final class WebInspectorViewController: UIViewController {
     package var activeHostViewControllerForTesting: UIViewController? {
         activeHost
     }
+
+    #if DEBUG
+    package func finishRootPresentationLifecycleForTesting(cancelled: Bool = false) {
+        guard cancelled == false else {
+            return
+        }
+        finishRootPresentationLifecycle()
+    }
+
+    package var hasFinishedRootPresentationLifecycleForTesting: Bool {
+        presentationLifecycleCoordinator.hasFinishedCurrentPresentationForTesting
+    }
+    #endif
 }
 
 #endif

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -109,6 +109,11 @@ public final class WebInspectorViewController: UIViewController {
         installPresentationHostWindowObserverIfNeeded()
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        installPresentationHostWindowObserverIfNeeded()
+    }
+
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         guard isTerminalRootDisappearance,
@@ -184,7 +189,8 @@ public final class WebInspectorViewController: UIViewController {
     }
 
     private func installPresentationHostWindowObserverIfNeeded() {
-        guard let hostView = navigationController?.view,
+        guard let hostView = navigationController?.view ?? viewIfLoaded,
+              hostView.window != nil,
               observedPresentationHostView !== hostView else {
             return
         }

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -25,6 +25,18 @@ private final class WebInspectorRootPresentationLifecycleCoordinator {
     #endif
 }
 
+private final class WebInspectorPresentationHostWindowObserverView: UIView {
+    var onDetachedFromWindow: (() -> Void)?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window == nil else {
+            return
+        }
+        onDetachedFromWindow?()
+    }
+}
+
 @MainActor
 public final class WebInspectorViewController: UIViewController {
     private enum HostKind {
@@ -36,6 +48,17 @@ public final class WebInspectorViewController: UIViewController {
     public var automaticallyDetachesOnDismiss = true
     private var drawsBackgroundStorage = true
     private let presentationLifecycleCoordinator = WebInspectorRootPresentationLifecycleCoordinator()
+    private lazy var presentationHostWindowObserver: WebInspectorPresentationHostWindowObserverView = {
+        let view = WebInspectorPresentationHostWindowObserverView(frame: .zero)
+        view.isHidden = true
+        view.isUserInteractionEnabled = false
+        view.onDetachedFromWindow = { [weak self] in
+            self?.presentationHostWindowDidDetach()
+        }
+        return view
+    }()
+    private weak var observedPresentationHostView: UIView?
+    private var suppressPresentationHostWindowObserver = false
 
     @available(iOS 26.0, *)
     public var drawsBackground: Bool {
@@ -83,6 +106,7 @@ public final class WebInspectorViewController: UIViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         presentationLifecycleCoordinator.beginPresentation()
+        installPresentationHostWindowObserverIfNeeded()
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -157,6 +181,27 @@ public final class WebInspectorViewController: UIViewController {
                 await session.retireRootPresentation(detach: automaticallyDetachesOnDismiss)
             }
         }
+    }
+
+    private func installPresentationHostWindowObserverIfNeeded() {
+        guard let hostView = navigationController?.view,
+              observedPresentationHostView !== hostView else {
+            return
+        }
+
+        suppressPresentationHostWindowObserver = true
+        presentationHostWindowObserver.removeFromSuperview()
+        suppressPresentationHostWindowObserver = false
+
+        observedPresentationHostView = hostView
+        hostView.addSubview(presentationHostWindowObserver)
+    }
+
+    private func presentationHostWindowDidDetach() {
+        guard suppressPresentationHostWindowObserver == false else {
+            return
+        }
+        finishRootPresentationLifecycle()
     }
 
     private func handleHorizontalSizeClassChange() {

--- a/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorViewController.swift
@@ -26,7 +26,7 @@ private final class WebInspectorRootPresentationLifecycleCoordinator {
 }
 
 @MainActor
-public final class WebInspectorViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
+public final class WebInspectorViewController: UIViewController {
     private enum HostKind {
         case compact
         case regular
@@ -68,7 +68,6 @@ public final class WebInspectorViewController: UIViewController, UIAdaptivePrese
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        installPresentationLifecycleDelegateIfAvailable()
         applyBackgroundFromTraits()
         rebuildLayout(forceHostReplacement: true)
         registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
@@ -84,7 +83,6 @@ public final class WebInspectorViewController: UIViewController, UIAdaptivePrese
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         presentationLifecycleCoordinator.beginPresentation()
-        installPresentationLifecycleDelegateIfAvailable()
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -125,10 +123,6 @@ public final class WebInspectorViewController: UIViewController, UIAdaptivePrese
         finishRootPresentationLifecycle()
     }
 
-    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        finishRootPresentationLifecycle()
-    }
-
     public func attach(to webView: WKWebView) async throws {
         try await session.attach(to: webView)
     }
@@ -157,18 +151,10 @@ public final class WebInspectorViewController: UIViewController, UIAdaptivePrese
             || navigationController?.presentationController?.presentedViewController === navigationController
     }
 
-    private func installPresentationLifecycleDelegateIfAvailable() {
-        presentationController?.delegate = self
-    }
-
     private func finishRootPresentationLifecycle() {
         presentationLifecycleCoordinator.finishIfNeeded { [session, automaticallyDetachesOnDismiss] in
-            session.interface.removeContentCache()
-            guard automaticallyDetachesOnDismiss else {
-                return
-            }
             Task { @MainActor [session] in
-                await session.detach()
+                await session.retireRootPresentation(detach: automaticallyDetachesOnDismiss)
             }
         }
     }

--- a/Sources/WebInspectorUI/Tabs/TabModels.swift
+++ b/Sources/WebInspectorUI/Tabs/TabModels.swift
@@ -93,6 +93,12 @@ extension WebInspectorTab {
             }
             viewControllerByKey.removeAll()
         }
+
+        #if DEBUG
+        package var countForTesting: Int {
+            viewControllerByKey.count
+        }
+        #endif
     }
 }
 

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -6748,6 +6748,81 @@ func presentationEndCleanupHidesVisibleDOMHighlightWithoutDetachingTransport() a
 }
 
 @Test
+func presentationEndCleanupDoesNotClearNewHighlightStartedDuringCleanup() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeInitialHighlight = await backend.sentTargetMessages().count
+    let initialHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let initialHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeInitialHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: initialHighlight.targetIdentifier,
+        messageID: try messageID(initialHighlight.message),
+        result: "{}"
+    )
+    await initialHighlightTask.value
+
+    let initialGeneration = try #require(
+        await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain)
+    )
+    let countBeforeCleanup = await backend.sentTargetMessages().count
+    let cleanupTask = Task {
+        await session.retireBackendInteractionForPresentationEnd()
+    }
+    let cleanupHide = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeCleanup
+    )
+    #expect(cleanupHide.targetIdentifier == ProtocolTarget.ID.pageMain)
+
+    let countBeforeNewHighlight = await backend.sentTargetMessages().count
+    let newHighlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let newHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.highlightNode",
+        after: countBeforeNewHighlight
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: newHighlight.targetIdentifier,
+        messageID: try messageID(newHighlight.message),
+        result: "{}"
+    )
+    await newHighlightTask.value
+
+    let newGeneration = try #require(
+        await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain)
+    )
+    #expect(newGeneration != initialGeneration)
+
+    await receiveTargetReply(
+        transport,
+        targetID: cleanupHide.targetIdentifier,
+        messageID: try messageID(cleanupHide.message),
+        result: "{}"
+    )
+    await cleanupTask.value
+
+    #expect(await session.attachment.dom.highlightController.possibleVisibleGeneration(targetID: .pageMain) == newGeneration)
+    #expect(await backend.isDetached() == false)
+    #expect(await session.hasActiveConnection)
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func presentationEndCleanupHidesVisibleFrameDOMHighlightWithoutDetachingTransport() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -6659,6 +6659,190 @@ func detachCancelsPumpsAndClearsModelState() async throws {
 }
 
 @Test
+func detachHidesVisibleDOMHighlightBeforeTransportDetach() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(backend, method: "DOM.highlightNode", after: countBeforeHighlight)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeDetach = await backend.sentTargetMessages().count
+    let detachTask = Task {
+        await session.detach()
+    }
+    let hideHighlight = try await waitForTargetMessage(backend, method: "DOM.hideHighlight", after: countBeforeDetach)
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(await backend.isDetached() == false)
+
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await detachTask.value
+
+    let methodsAfterDetachStart = await backend.sentTargetMessages().dropFirst(countBeforeDetach).compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterDetachStart == ["DOM.hideHighlight"])
+    #expect(await backend.isDetached())
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)
+    #expect(await session.lastError == nil)
+}
+
+@Test
+func detachDisablesActiveElementPickerAndHidesHighlightBeforeTransportDetach() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+
+    let countBeforeDetach = await backend.sentTargetMessages().count
+    let detachTask = Task {
+        await session.detach()
+    }
+    let disableInspectMode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeDetach
+    )
+    #expect(disableInspectMode.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try boolParameter("enabled", in: disableInspectMode.message) == false)
+    #expect(await backend.isDetached() == false)
+
+    let countBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disableInspectMode.targetIdentifier,
+        messageID: try messageID(disableInspectMode.message),
+        result: "{}"
+    )
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeDisableReply
+    )
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(await backend.isDetached() == false)
+
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await detachTask.value
+
+    let methodsAfterDetachStart = await backend.sentTargetMessages().dropFirst(countBeforeDetach).compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterDetachStart == ["DOM.setInspectModeEnabled", "DOM.hideHighlight"])
+    #expect(await backend.isDetached())
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)
+    #expect(await session.lastError == nil)
+}
+
+@Test
+func detachDoesNotRestoreSelectedHighlightAfterRetiringElementPicker() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+    await session.attachment.dom.selectNode(htmlID)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+
+    let countBeforeDetach = await backend.sentTargetMessages().count
+    let detachTask = Task {
+        await session.detach()
+    }
+    let disableInspectMode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeDetach
+    )
+    let countBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disableInspectMode.targetIdentifier,
+        messageID: try messageID(disableInspectMode.message),
+        result: "{}"
+    )
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeDisableReply
+    )
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await detachTask.value
+
+    let methodsAfterDetachStart = await backend.sentTargetMessages().dropFirst(countBeforeDetach).compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterDetachStart == ["DOM.setInspectModeEnabled", "DOM.hideHighlight"])
+    #expect(methodsAfterDetachStart.contains("DOM.highlightNode") == false)
+    #expect(await session.attachment.dom.snapshot().selection.selectedNodeID == nil)
+}
+
+@Test
+func detachCompletesAndResetsModelsWhenTeardownCleanupTimesOut() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(
+        backend: backend,
+        responseTimeout: .milliseconds(20)
+    )
+    let session = await InspectorSession(
+        configuration: .init(
+            responseTimeout: .milliseconds(20),
+            bootstrapTimeout: testBootstrapTimeout
+        )
+    )
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(backend, method: "DOM.highlightNode", after: countBeforeHighlight)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeDetach = await backend.sentTargetMessages().count
+    let detachTask = Task {
+        await session.detach()
+    }
+    let hideHighlight = try await waitForTargetMessage(backend, method: "DOM.hideHighlight", after: countBeforeDetach)
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await detachTask.value
+
+    #expect(await backend.isDetached())
+    #expect(await session.hasActiveConnection == false)
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)
+    #expect(await session.attachment.network.snapshot().orderedRequestIDs.isEmpty)
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func detachDuringConnectKeepsSessionDetached() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -6748,6 +6748,83 @@ func presentationEndCleanupHidesVisibleDOMHighlightWithoutDetachingTransport() a
 }
 
 @Test
+func presentationEndCleanupHidesVisibleFrameDOMHighlightWithoutDetachingTransport() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    await receiveAndApplyRootMessage(
+        transport,
+        message: #"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"frame-ad","type":"frame","frameId":"ad-frame","parentFrameId":"main-frame","isProvisional":false}}}"#,
+        in: session
+    )
+    _ = await session.attachment.dom.replaceDocumentRoot(
+        WebInspectorCore.DOMNode.Payload(
+            nodeID: .init(101),
+            nodeType: .document,
+            nodeName: "#document",
+            regularChildren: .loaded([
+                WebInspectorCore.DOMNode.Payload(nodeID: .init(102), nodeType: .element, nodeName: "HTML", localName: "html"),
+            ])
+        ),
+        targetID: .frameAd
+    )
+    let frameHTMLID = try #require(await session.attachment.dom.snapshot().currentNodeIDByKey[.init(targetID: .frameAd, nodeID: .init(102))])
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: frameHTMLID)
+    }
+    let highlight = try await waitForTargetMessage(backend, method: "DOM.highlightNode", after: countBeforeHighlight)
+    #expect(highlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeCleanup = await backend.sentTargetMessages().count
+    let cleanupTask = Task {
+        await session.retireBackendInteractionForPresentationEnd()
+    }
+    let hideHighlight = try await waitForTargetMessage(backend, method: "DOM.hideHighlight", after: countBeforeCleanup)
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.frameAd)
+    #expect(await backend.isDetached() == false)
+
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    let fallbackHideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        ordinal: 1,
+        after: countBeforeCleanup
+    )
+    #expect(fallbackHideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    await receiveTargetReply(
+        transport,
+        targetID: fallbackHideHighlight.targetIdentifier,
+        messageID: try messageID(fallbackHideHighlight.message),
+        result: "{}"
+    )
+    await cleanupTask.value
+
+    let cleanupMessages = await backend.sentTargetMessages().dropFirst(countBeforeCleanup)
+    let methodsAfterCleanupStart = cleanupMessages.compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterCleanupStart == ["DOM.hideHighlight", "DOM.hideHighlight"])
+    #expect(cleanupMessages.map(\.targetIdentifier) == [ProtocolTarget.ID.frameAd, ProtocolTarget.ID.pageMain])
+    #expect(await backend.isDetached() == false)
+    #expect(await session.hasActiveConnection)
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == ProtocolTarget.ID.pageMain)
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func detachDisablesActiveElementPickerAndHidesHighlightBeforeTransportDetach() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -6703,6 +6703,51 @@ func detachHidesVisibleDOMHighlightBeforeTransportDetach() async throws {
 }
 
 @Test
+func presentationEndCleanupHidesVisibleDOMHighlightWithoutDetachingTransport() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    let htmlID = try await waitForCurrentNode(in: session, targetID: .pageMain, protocolNodeID: .init(2))
+
+    let countBeforeHighlight = await backend.sentTargetMessages().count
+    let highlightTask = Task {
+        await session.attachment.dom.highlightNode(for: htmlID)
+    }
+    let highlight = try await waitForTargetMessage(backend, method: "DOM.highlightNode", after: countBeforeHighlight)
+    await receiveTargetReply(
+        transport,
+        targetID: highlight.targetIdentifier,
+        messageID: try messageID(highlight.message),
+        result: "{}"
+    )
+    await highlightTask.value
+
+    let countBeforeCleanup = await backend.sentTargetMessages().count
+    let cleanupTask = Task {
+        await session.retireBackendInteractionForPresentationEnd()
+    }
+    let hideHighlight = try await waitForTargetMessage(backend, method: "DOM.hideHighlight", after: countBeforeCleanup)
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(await backend.isDetached() == false)
+
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await cleanupTask.value
+
+    let methodsAfterCleanupStart = await backend.sentTargetMessages().dropFirst(countBeforeCleanup).compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterCleanupStart == ["DOM.hideHighlight"])
+    #expect(await backend.isDetached() == false)
+    #expect(await session.hasActiveConnection)
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == ProtocolTarget.ID.pageMain)
+    #expect(await session.lastError == nil)
+}
+
+@Test
 func detachDisablesActiveElementPickerAndHidesHighlightBeforeTransportDetach() async throws {
     let backend = FakeTransportBackend()
     let transport = testTransport(backend)
@@ -6750,6 +6795,58 @@ func detachDisablesActiveElementPickerAndHidesHighlightBeforeTransportDetach() a
     #expect(methodsAfterDetachStart == ["DOM.setInspectModeEnabled", "DOM.hideHighlight"])
     #expect(await backend.isDetached())
     #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)
+    #expect(await session.lastError == nil)
+}
+
+@Test
+func presentationEndCleanupDisablesActiveElementPickerAndHidesHighlightWithoutDetachingTransport() async throws {
+    let backend = FakeTransportBackend()
+    let transport = testTransport(backend)
+    let session = await InspectorSession(configuration: .test)
+    try await connect(session, transport: transport, backend: backend)
+    try await beginPicker(session: session, transport: transport, backend: backend)
+
+    let countBeforeCleanup = await backend.sentTargetMessages().count
+    let cleanupTask = Task {
+        await session.retireBackendInteractionForPresentationEnd()
+    }
+    let disableInspectMode = try await waitForTargetMessage(
+        backend,
+        method: "DOM.setInspectModeEnabled",
+        after: countBeforeCleanup
+    )
+    #expect(disableInspectMode.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(try boolParameter("enabled", in: disableInspectMode.message) == false)
+    #expect(await backend.isDetached() == false)
+
+    let countBeforeDisableReply = await backend.sentTargetMessages().count
+    await receiveTargetReply(
+        transport,
+        targetID: disableInspectMode.targetIdentifier,
+        messageID: try messageID(disableInspectMode.message),
+        result: "{}"
+    )
+    let hideHighlight = try await waitForTargetMessage(
+        backend,
+        method: "DOM.hideHighlight",
+        after: countBeforeDisableReply
+    )
+    #expect(hideHighlight.targetIdentifier == ProtocolTarget.ID.pageMain)
+    #expect(await backend.isDetached() == false)
+
+    await receiveTargetReply(
+        transport,
+        targetID: hideHighlight.targetIdentifier,
+        messageID: try messageID(hideHighlight.message),
+        result: "{}"
+    )
+    await cleanupTask.value
+
+    let methodsAfterCleanupStart = await backend.sentTargetMessages().dropFirst(countBeforeCleanup).compactMap { try? messageMethod($0.message) }
+    #expect(methodsAfterCleanupStart == ["DOM.setInspectModeEnabled", "DOM.hideHighlight"])
+    #expect(await backend.isDetached() == false)
+    #expect(await session.hasActiveConnection)
+    #expect(await session.attachment.dom.snapshot().currentPageTargetID == ProtocolTarget.ID.pageMain)
     #expect(await session.lastError == nil)
 }
 

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -263,6 +263,38 @@ struct ParentContainerTests {
     }
 
     @Test
+    func hiddenNavigationControllerRemovalFinishesRootPresentationLifecycle() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .dom,
+            session: session,
+            hostLayout: .compact
+        )
+        let viewController = WebInspectorViewController(session: session)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        let window = showInWindow(navigationController)
+        defer { window.isHidden = true }
+
+        #expect(navigationController.view.window === window)
+        #expect(session.interface.contentCacheCountForTesting > 0)
+
+        let coveringViewController = UIViewController()
+        navigationController.pushViewController(coveringViewController, animated: false)
+        #expect(await waitUntil { navigationController.topViewController === coveringViewController })
+        #expect(detachRecorder.count == 0)
+        #expect(session.interface.contentCacheCountForTesting > 0)
+
+        window.rootViewController = UIViewController()
+        window.layoutIfNeeded()
+        #expect(navigationController.view.window == nil)
+        #expect(await waitUntil { detachRecorder.count == 1 })
+        #expect(session.interface.contentCacheCountForTesting == 0)
+    }
+
+    @Test
     func viewControllerDoesNotReplaceExternalPresentationControllerDelegate() async throws {
         let presenter = UIViewController()
         let viewController = WebInspectorViewController(session: makeSessionWithNoOpAttachment())

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -239,7 +239,7 @@ struct ParentContainerTests {
     }
 
     @Test
-    func rootPresentationDelegateAndDisappearFallbackDetachOnlyOnce() async throws {
+    func rootPresentationFallbacksDetachOnlyOnce() async throws {
         let detachRecorder = DetachRecorder()
         let session = makeSessionWithNoOpAttachment(detachAction: { _ in
             detachRecorder.record()
@@ -260,6 +260,25 @@ struct ParentContainerTests {
 
         #expect(detachRecorder.count == 1)
         #expect(session.interface.contentCacheCountForTesting == 0)
+    }
+
+    @Test
+    func viewControllerDoesNotReplaceExternalPresentationControllerDelegate() async throws {
+        let presenter = UIViewController()
+        let viewController = WebInspectorViewController(session: makeSessionWithNoOpAttachment())
+        let window = showInWindow(presenter)
+        defer { window.isHidden = true }
+
+        presenter.present(viewController, animated: false)
+        #expect(await waitUntil { presenter.presentedViewController === viewController })
+        let presentationController = try #require(viewController.presentationController)
+        let externalDelegate = PresentationDelegateRecorder()
+        presentationController.delegate = externalDelegate
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+
+        #expect(presentationController.delegate === externalDelegate)
     }
 
     @Test
@@ -600,6 +619,8 @@ struct ParentContainerTests {
             count += 1
         }
     }
+
+    private final class PresentationDelegateRecorder: NSObject, UIAdaptivePresentationControllerDelegate {}
 
     private func waitUntil(
         timeoutAttempts: Int = 50,

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -295,6 +295,32 @@ struct ParentContainerTests {
     }
 
     @Test
+    func directWindowRootRemovalFinishesRootPresentationLifecycle() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .dom,
+            session: session,
+            hostLayout: .compact
+        )
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(viewController.view.window === window)
+        #expect(session.interface.contentCacheCountForTesting > 0)
+
+        window.rootViewController = UIViewController()
+        window.layoutIfNeeded()
+
+        #expect(viewController.view.window == nil)
+        #expect(await waitUntil { detachRecorder.count == 1 })
+        #expect(session.interface.contentCacheCountForTesting == 0)
+    }
+
+    @Test
     func viewControllerDoesNotReplaceExternalPresentationControllerDelegate() async throws {
         let presenter = UIViewController()
         let viewController = WebInspectorViewController(session: makeSessionWithNoOpAttachment())

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -217,6 +217,125 @@ struct ParentContainerTests {
     }
 
     @Test
+    func programmaticDismissAutomaticallyDetachesOnce() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        let presenter = UIViewController()
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(presenter)
+        defer { window.isHidden = true }
+
+        presenter.present(viewController, animated: false)
+        #expect(await waitUntil { presenter.presentedViewController === viewController })
+
+        viewController.dismiss(animated: false)
+        #expect(await waitUntil { detachRecorder.count == 1 })
+
+        viewController.finishRootPresentationLifecycleForTesting()
+        _ = await waitUntil { detachRecorder.count == 1 }
+        #expect(detachRecorder.count == 1)
+    }
+
+    @Test
+    func rootPresentationDelegateAndDisappearFallbackDetachOnlyOnce() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .dom,
+            session: session,
+            hostLayout: .compact
+        )
+        let viewController = WebInspectorViewController(session: session)
+        viewController.loadViewIfNeeded()
+        #expect(session.interface.contentCacheCountForTesting > 0)
+
+        viewController.finishRootPresentationLifecycleForTesting()
+        #expect(await waitUntil { detachRecorder.count == 1 })
+        viewController.finishRootPresentationLifecycleForTesting()
+        _ = await waitUntil { detachRecorder.count == 1 }
+
+        #expect(detachRecorder.count == 1)
+        #expect(session.interface.contentCacheCountForTesting == 0)
+    }
+
+    @Test
+    func interactiveDismissCancelDoesNotDetachOrDropContentCache() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .network,
+            session: session,
+            hostLayout: .compact
+        )
+        let viewController = WebInspectorViewController(session: session)
+        viewController.loadViewIfNeeded()
+        let cacheCountBeforeCancel = session.interface.contentCacheCountForTesting
+
+        viewController.finishRootPresentationLifecycleForTesting(cancelled: true)
+        await Task.yield()
+
+        #expect(detachRecorder.count == 0)
+        #expect(viewController.hasFinishedRootPresentationLifecycleForTesting == false)
+        #expect(session.interface.contentCacheCountForTesting == cacheCountBeforeCancel)
+    }
+
+    @Test
+    func hostReplacementAndCompactTabSwitchDoNotDetachRootSession() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        let viewController = WebInspectorViewController(session: session)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.horizontalSizeClassOverrideForTesting = .compact
+        let compactHost = try #require(viewController.activeHostViewControllerForTesting as? CompactTabBarController)
+        compactHost.loadViewIfNeeded()
+        session.interface.selectItem(withID: WebInspectorTab.DisplayItem.domElementID)
+        await Task.yield()
+        viewController.horizontalSizeClassOverrideForTesting = .regular
+        await Task.yield()
+
+        #expect(detachRecorder.count == 0)
+        #expect(viewController.hasFinishedRootPresentationLifecycleForTesting == false)
+    }
+
+    @Test
+    func rootDismissDropsContentCacheWithoutAutomaticDetach() async throws {
+        let detachRecorder = DetachRecorder()
+        let session = makeSessionWithNoOpAttachment(detachAction: { _ in
+            detachRecorder.record()
+        })
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .dom,
+            session: session,
+            hostLayout: .compact
+        )
+        _ = WebInspectorTab.ContentFactory.makeViewController(
+            for: .network,
+            session: session,
+            hostLayout: .regular
+        )
+        let viewController = WebInspectorViewController(session: session)
+        viewController.automaticallyDetachesOnDismiss = false
+        viewController.loadViewIfNeeded()
+        #expect(session.interface.contentCacheCountForTesting > 0)
+
+        viewController.finishRootPresentationLifecycleForTesting()
+        await Task.yield()
+
+        #expect(detachRecorder.count == 0)
+        #expect(session.interface.contentCacheCountForTesting == 0)
+    }
+
+    @Test
     func topLevelContainerPropagatesBackgroundDrawingTraitToHosts() throws {
         guard #available(iOS 26.0, *) else {
             return
@@ -472,6 +591,27 @@ struct ParentContainerTests {
             attachAction: attachAction,
             detachAction: detachAction
         )
+    }
+
+    private final class DetachRecorder {
+        private(set) var count = 0
+
+        func record() {
+            count += 1
+        }
+    }
+
+    private func waitUntil(
+        timeoutAttempts: Int = 50,
+        predicate: @MainActor () -> Bool
+    ) async -> Bool {
+        for _ in 0..<timeoutAttempts {
+            if predicate() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return predicate()
     }
 
     private struct PageUserInterfaceStyleObservation {


### PR DESCRIPTION
Purpose
- Coordinate inspector attachment teardown so backend DOM highlight and picker state are retired before transport detach.

Changes
- Add a retiring connection phase and attachment teardown coordinator for ordered detach.
- Add DOM teardown cleanup for inspect mode and visible highlights without surfacing cleanup failures as session errors.
- Add root presentation lifecycle handling for dismiss, parent removal, navigation pop, cache cleanup, and optional automatic detach.
- Add regression coverage for DOM teardown ordering and root UI lifecycle paths.

Testing
- git diff --check
- xcodebuild build-for-testing -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- xcodebuild test-without-building -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/ParentContainerTests
- Attempted xcodebuild test-without-building -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorCoreTests; the added teardown tests passed in the log before xcodebuild stalled in XCTestWaiter and was interrupted.