### PR TITLE
Resolve CSS source ranges without fallback scans

### DIFF
--- a/Sources/WebInspectorCore/CSS/CSSStyleTextRewriter.swift
+++ b/Sources/WebInspectorCore/CSS/CSSStyleTextRewriter.swift
@@ -14,19 +14,23 @@ extension CSSStyle {
         init(style: CSSStyle.Payload) {
             self.init(
                 properties: style.cssProperties.map(RewriteProperty.init),
-                cssText: style.cssText
+                cssText: style.cssText,
+                styleRange: style.range
             )
         }
 
         init(style: CSSStyle) {
             self.init(
                 properties: style.cssProperties.map(RewriteProperty.init),
-                cssText: style.cssText
+                cssText: style.cssText,
+                styleRange: style.range
             )
         }
 
-        private init(properties: [RewriteProperty], cssText: String?) {
-            self.styleTextIndex = cssText.flatMap(StyleTextIndex.init(cssText:))
+        private init(properties: [RewriteProperty], cssText: String?, styleRange: CSSStyle.SourceRange?) {
+            self.styleTextIndex = cssText.flatMap {
+                StyleTextIndex(cssText: $0, styleRange: styleRange, properties: properties)
+            }
             self.properties = properties
             self.previousPropertyTextOccurrences = Self.previousPropertyTextOccurrences(for: properties)
             self.canSerializeStyleText = properties.allSatisfy(\.canSerializeStyleText)
@@ -139,16 +143,32 @@ extension CSSStyle {
     }
 
     private struct StyleTextIndex {
+        private enum SourceRangeResolutionMode {
+            case localFirst
+            case stylesheetRelativeFirst
+        }
+
         private let nsText: NSString
         private let lineStartOffsets: [Int]
+        private let styleRange: CSSStyle.SourceRange?
+        private let sourceRangeResolutionMode: SourceRangeResolutionMode
         private var declarationRangesByText: [String: [NSRange]] = [:]
 
-        init?(cssText: String) {
+        init?(cssText: String, styleRange: CSSStyle.SourceRange?, properties: [RewriteProperty]) {
             guard !cssText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 return nil
             }
-            self.nsText = cssText as NSString
-            self.lineStartOffsets = CSSStyle.TextRewriter.lineStartUTF16Offsets(in: cssText)
+            let nsText = cssText as NSString
+            let lineStartOffsets = CSSStyle.TextRewriter.lineStartUTF16Offsets(in: cssText)
+            self.nsText = nsText
+            self.lineStartOffsets = lineStartOffsets
+            self.styleRange = styleRange
+            self.sourceRangeResolutionMode = Self.sourceRangeResolutionMode(
+                properties: properties,
+                styleRange: styleRange,
+                nsText: nsText,
+                lineStartOffsets: lineStartOffsets
+            )
         }
 
         mutating func authoredDeclarationRange(
@@ -156,10 +176,27 @@ extension CSSStyle {
             sourceRange: CSSStyle.SourceRange?,
             previousOccurrence: Int
         ) -> NSRange? {
-            if let range = sourceRange.flatMap(nsRange(sourceRange:)),
-               NSMaxRange(range) <= nsText.length,
-               nsText.substring(with: range).trimmingCharacters(in: .whitespacesAndNewlines) == propertyText {
-                return range
+            if let sourceRange {
+                let relativeSourceRange = styleRelativeSourceRange(sourceRange)
+                switch sourceRangeResolutionMode {
+                case .localFirst:
+                    if let range = authoredDeclarationRange(for: propertyText, sourceRange: sourceRange) {
+                        return range
+                    }
+                    if let relativeSourceRange,
+                       let range = authoredDeclarationRange(for: propertyText, sourceRange: relativeSourceRange) {
+                        return range
+                    }
+                case .stylesheetRelativeFirst:
+                    if let relativeSourceRange,
+                       let range = authoredDeclarationRange(for: propertyText, sourceRange: relativeSourceRange) {
+                        return range
+                    }
+                    if relativeSourceRange == nil,
+                       let range = authoredDeclarationRange(for: propertyText, sourceRange: sourceRange) {
+                        return range
+                    }
+                }
             }
 
             let ranges = declarationRanges(for: propertyText)
@@ -176,7 +213,48 @@ extension CSSStyle {
             nsText.replacingCharacters(in: range, with: replacementText)
         }
 
+        private func authoredDeclarationRange(
+            for propertyText: String,
+            sourceRange: CSSStyle.SourceRange
+        ) -> NSRange? {
+            Self.authoredDeclarationRange(
+                for: propertyText,
+                sourceRange: sourceRange,
+                nsText: nsText,
+                lineStartOffsets: lineStartOffsets
+            )
+        }
+
+        private static func authoredDeclarationRange(
+            for propertyText: String,
+            sourceRange: CSSStyle.SourceRange,
+            nsText: NSString,
+            lineStartOffsets: [Int]
+        ) -> NSRange? {
+            guard let range = nsRange(
+                sourceRange: sourceRange,
+                lineStartOffsets: lineStartOffsets,
+                textLength: nsText.length
+            ),
+                  nsText.substring(with: range).trimmingCharacters(in: .whitespacesAndNewlines) == propertyText else {
+                return nil
+            }
+            return range
+        }
+
         private func nsRange(sourceRange: CSSStyle.SourceRange) -> NSRange? {
+            Self.nsRange(
+                sourceRange: sourceRange,
+                lineStartOffsets: lineStartOffsets,
+                textLength: nsText.length
+            )
+        }
+
+        private static func nsRange(
+            sourceRange: CSSStyle.SourceRange,
+            lineStartOffsets: [Int],
+            textLength: Int
+        ) -> NSRange? {
             guard sourceRange.startLine >= 0,
                   sourceRange.endLine >= sourceRange.startLine,
                   sourceRange.startColumn >= 0,
@@ -191,10 +269,117 @@ extension CSSStyle {
             let startOffset = lineStartOffsets[sourceRange.startLine] + sourceRange.startColumn
             let endOffset = lineStartOffsets[sourceRange.endLine] + sourceRange.endColumn
             guard endOffset >= startOffset,
-                  endOffset <= nsText.length else {
+                  endOffset <= textLength else {
                 return nil
             }
             return NSRange(location: startOffset, length: endOffset - startOffset)
+        }
+
+        private func styleRelativeSourceRange(_ sourceRange: CSSStyle.SourceRange) -> CSSStyle.SourceRange? {
+            guard let styleRange else {
+                return nil
+            }
+            return Self.styleRelativeSourceRange(sourceRange, styleRange: styleRange)
+        }
+
+        private static func styleRelativeSourceRange(
+            _ sourceRange: CSSStyle.SourceRange,
+            styleRange: CSSStyle.SourceRange
+        ) -> CSSStyle.SourceRange? {
+            guard
+                  styleRange.startLine >= 0,
+                  styleRange.endLine >= styleRange.startLine,
+                  styleRange.startColumn >= 0,
+                  styleRange.endColumn >= 0,
+                  sourceRange.startLine >= 0,
+                  sourceRange.endLine >= sourceRange.startLine,
+                  sourceRange.startColumn >= 0,
+                  sourceRange.endColumn >= 0,
+                  isStylesheetSourceRange(sourceRange, containedIn: styleRange) else {
+                return nil
+            }
+
+            let startLine = sourceRange.startLine - styleRange.startLine
+            let endLine = sourceRange.endLine - styleRange.startLine
+            var startColumn = sourceRange.startColumn
+            var endColumn = sourceRange.endColumn
+            if startLine == 0 {
+                startColumn -= styleRange.startColumn
+            }
+            if endLine == 0 {
+                endColumn -= styleRange.startColumn
+            }
+
+            guard startLine >= 0,
+                  endLine >= startLine,
+                  startColumn >= 0,
+                  endColumn >= 0 else {
+                return nil
+            }
+
+            return CSSStyle.SourceRange(
+                startLine: startLine,
+                startColumn: startColumn,
+                endLine: endLine,
+                endColumn: endColumn
+            )
+        }
+
+        private static func isStylesheetSourceRange(
+            _ sourceRange: CSSStyle.SourceRange,
+            containedIn styleRange: CSSStyle.SourceRange
+        ) -> Bool {
+            let startsAfterStyleStart = sourceRange.startLine > styleRange.startLine
+                || (sourceRange.startLine == styleRange.startLine
+                    && sourceRange.startColumn >= styleRange.startColumn)
+            let endsBeforeStyleEnd = sourceRange.endLine < styleRange.endLine
+                || (sourceRange.endLine == styleRange.endLine
+                    && sourceRange.endColumn <= styleRange.endColumn)
+            return startsAfterStyleStart && endsBeforeStyleEnd
+        }
+
+        private static func sourceRangeResolutionMode(
+            properties: [RewriteProperty],
+            styleRange: CSSStyle.SourceRange?,
+            nsText: NSString,
+            lineStartOffsets: [Int]
+        ) -> SourceRangeResolutionMode {
+            guard let styleRange else {
+                return .localFirst
+            }
+
+            var localMatches = 0
+            var stylesheetRelativeMatches = 0
+            for property in properties {
+                guard let propertyText = property.trimmedText,
+                      !propertyText.isEmpty,
+                      let sourceRange = property.sourceRange else {
+                    continue
+                }
+
+                if authoredDeclarationRange(
+                    for: propertyText,
+                    sourceRange: sourceRange,
+                    nsText: nsText,
+                    lineStartOffsets: lineStartOffsets
+                ) != nil {
+                    localMatches += 1
+                }
+
+                guard let relativeRange = styleRelativeSourceRange(sourceRange, styleRange: styleRange) else {
+                    continue
+                }
+                if authoredDeclarationRange(
+                    for: propertyText,
+                    sourceRange: relativeRange,
+                    nsText: nsText,
+                    lineStartOffsets: lineStartOffsets
+                ) != nil {
+                    stylesheetRelativeMatches += 1
+                }
+            }
+
+            return stylesheetRelativeMatches > localMatches ? .stylesheetRelativeFirst : .localFirst
         }
 
         private mutating func declarationRanges(for propertyText: String) -> [NSRange] {

--- a/Tests/WebInspectorCoreTests/CSSModelTests.swift
+++ b/Tests/WebInspectorCoreTests/CSSModelTests.swift
@@ -791,8 +791,250 @@ func cssStyleRewriteContextReusesStyleTextScansDuringNormalization() throws {
     #expect(rangedSnapshot.lineStartUTF16OffsetScans == 1)
     #expect(rangedSnapshot.declarationRangeScans == 0)
 
-    let duplicateStyle = CSSStyle.Payload(
+    let localRangeWithStyleRangeStyle = CSSStyle.Payload(
         id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 1),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 0, startColumn: 0, endLine: 0, endColumn: 11)
+            ),
+        ],
+        cssText: "color: red;",
+        range: CSSStyle.SourceRange(startLine: 5, startColumn: 6, endLine: 5, endColumn: 17)
+    )
+
+    let (localRangeWithStyleRangeNormalizedStyle, localRangeWithStyleRangeSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            localRangeWithStyleRangeStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(localRangeWithStyleRangeNormalizedStyle.cssProperties.map(\.isEditable) == [true])
+    #expect(localRangeWithStyleRangeSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(localRangeWithStyleRangeSnapshot.declarationRangeScans == 0)
+
+    let localDuplicateRangeWithStyleRangeStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 2),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 0, startColumn: 0, endLine: 0, endColumn: 11)
+            ),
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 1, startColumn: 0, endLine: 1, endColumn: 11)
+            ),
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 2, startColumn: 0, endLine: 2, endColumn: 11)
+            ),
+        ],
+        cssText: """
+        color: red;
+        color: red;
+        color: red;
+        """,
+        range: CSSStyle.SourceRange(startLine: 1, startColumn: 0, endLine: 4, endColumn: 0)
+    )
+
+    let (localDuplicateRangeWithStyleRangeNormalizedStyle, localDuplicateRangeWithStyleRangeSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            localDuplicateRangeWithStyleRangeStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(localDuplicateRangeWithStyleRangeNormalizedStyle.cssProperties.map(\.isEditable) == [true, true, true])
+    #expect(localDuplicateRangeWithStyleRangeSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(localDuplicateRangeWithStyleRangeSnapshot.declarationRangeScans == 0)
+
+    let (localDuplicateRangeWithStyleRangeRewrittenText, localDuplicateRangeWithStyleRangeRewriteSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.TextRewriter.rewrittenStyleText(
+            style: localDuplicateRangeWithStyleRangeNormalizedStyle,
+            propertyIndex: 2,
+            enabled: false
+        )
+    }
+    #expect(localDuplicateRangeWithStyleRangeRewrittenText == """
+    color: red;
+    color: red;
+    /* color: red; */
+    """)
+    #expect(localDuplicateRangeWithStyleRangeRewriteSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(localDuplicateRangeWithStyleRangeRewriteSnapshot.declarationRangeScans == 0)
+
+    let stylesheetRelativeStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 3),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "margin",
+                value: "0",
+                text: "margin: 0;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 6, startColumn: 2, endLine: 6, endColumn: 12)
+            ),
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 7, startColumn: 2, endLine: 7, endColumn: 13)
+            ),
+        ],
+        cssText: """
+
+          margin: 0;
+          color: red;
+        """,
+        range: CSSStyle.SourceRange(startLine: 5, startColumn: 6, endLine: 8, endColumn: 0)
+    )
+
+    let (stylesheetRelativeNormalizedStyle, stylesheetRelativeSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            stylesheetRelativeStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(stylesheetRelativeNormalizedStyle.cssProperties.map(\.isEditable) == [true, true])
+    #expect(stylesheetRelativeSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(stylesheetRelativeSnapshot.declarationRangeScans == 0)
+
+    let sameLineStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 4),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 20, startColumn: 7, endLine: 20, endColumn: 18)
+            ),
+            CSSProperty.Payload(
+                name: "background",
+                value: "blue",
+                text: "background: blue;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 20, startColumn: 19, endLine: 20, endColumn: 36)
+            ),
+        ],
+        cssText: "color: red; background: blue;",
+        range: CSSStyle.SourceRange(startLine: 20, startColumn: 7, endLine: 20, endColumn: 36)
+    )
+
+    let (sameLineNormalizedStyle, sameLineSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            sameLineStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(sameLineNormalizedStyle.cssProperties.map(\.isEditable) == [true, true])
+    #expect(sameLineSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(sameLineSnapshot.declarationRangeScans == 0)
+
+    let (sameLineRewrittenText, sameLineRewriteSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.TextRewriter.rewrittenStyleText(
+            style: sameLineNormalizedStyle,
+            propertyIndex: 1,
+            enabled: false
+        )
+    }
+    #expect(sameLineRewrittenText == "color: red; /* background: blue; */")
+    #expect(sameLineRewriteSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(sameLineRewriteSnapshot.declarationRangeScans == 0)
+
+    let duplicateStylesheetRelativeStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 5),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 1, startColumn: 0, endLine: 1, endColumn: 11)
+            ),
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 2, startColumn: 0, endLine: 2, endColumn: 11)
+            ),
+        ],
+        cssText: """
+        color: red;
+        color: red;
+        """,
+        range: CSSStyle.SourceRange(startLine: 1, startColumn: 0, endLine: 3, endColumn: 0)
+    )
+
+    let (duplicateStylesheetRelativeNormalizedStyle, duplicateStylesheetRelativeSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            duplicateStylesheetRelativeStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(duplicateStylesheetRelativeNormalizedStyle.cssProperties.map(\.isEditable) == [true, true])
+    #expect(duplicateStylesheetRelativeSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(duplicateStylesheetRelativeSnapshot.declarationRangeScans == 0)
+
+    let (duplicateStylesheetRelativeRewrittenText, duplicateStylesheetRelativeRewriteSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.TextRewriter.rewrittenStyleText(
+            style: duplicateStylesheetRelativeNormalizedStyle,
+            propertyIndex: 0,
+            enabled: false
+        )
+    }
+    #expect(duplicateStylesheetRelativeRewrittenText == """
+    /* color: red; */
+    color: red;
+    """)
+    #expect(duplicateStylesheetRelativeRewriteSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(duplicateStylesheetRelativeRewriteSnapshot.declarationRangeScans == 0)
+
+    let mismatchedRangeStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 6),
+        cssProperties: [
+            CSSProperty.Payload(
+                name: "color",
+                value: "red",
+                text: "color: red;",
+                status: .active,
+                range: CSSStyle.SourceRange(startLine: 20, startColumn: 7, endLine: 20, endColumn: 18)
+            ),
+        ],
+        cssText: "background: blue; color: red;",
+        range: CSSStyle.SourceRange(startLine: 20, startColumn: 7, endLine: 20, endColumn: 36)
+    )
+
+    let (mismatchedRangeNormalizedStyle, mismatchedRangeSnapshot) = CSSStyle.TextRewriter.withInstrumentationCounters {
+        CSSStyle.SectionBuilder.normalizedStyle(
+            mismatchedRangeStyle,
+            isEditable: true,
+            ruleOrigin: .author
+        )
+    }
+    #expect(mismatchedRangeNormalizedStyle.cssProperties.map(\.isEditable) == [true])
+    #expect(mismatchedRangeSnapshot.lineStartUTF16OffsetScans == 1)
+    #expect(mismatchedRangeSnapshot.declarationRangeScans == 1)
+
+    let duplicateStyle = CSSStyle.Payload(
+        id: CSSStyle.ID(styleSheetID: .init("sheet"), ordinal: 7),
         cssProperties: [
             CSSProperty.Payload(
                 name: "color",


### PR DESCRIPTION
## Purpose
Avoid expensive CSS declaration fallback scans when WebKit reports property ranges relative to the stylesheet instead of the style text.

## Changes
- Pass `CSSStyle.range` into the style text rewriter index.
- Validate both local and stylesheet-relative source ranges by comparing the referenced substring to the authored declaration text.
- Prefer the coordinate interpretation that matches more declarations, preserving correct behavior for duplicate declarations.
- Keep the existing fallback scan for invalid or mismatched ranges.
- Add coverage for local ranges, stylesheet-relative ranges, same-line ranges, duplicate declarations, and mismatch fallback.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -clonedSourcePackagesDirPath /tmp/WebInspectorKitPackageCache -only-testing:WebInspectorCoreTests` passed, 295 tests.
- `git diff --check` passed.
- `codex-review` reported no actionable findings.