### PR TITLE
Reconfigure only dirty DOM style rows

### DIFF
--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
@@ -21,6 +21,15 @@ package struct DOMElementStylePresentationSection {
 }
 
 @MainActor
+package struct DOMElementStylePresentationRender {
+    package var snapshot: NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    >
+    package var reconfiguredItemIdentifiers: [DOMElementStylePresentationItemIdentifier]
+}
+
+@MainActor
 package enum DOMElementStyleDiffableSnapshotBuilder {
     package static func visibleSections(
         sections: [CSSStyle.Section],
@@ -92,19 +101,39 @@ package enum DOMElementStyleDiffableSnapshotBuilder {
 @Observable
 package final class DOMElementStylePresentationState {
     package enum RenderResult {
-        case loaded(
-            NSDiffableDataSourceSnapshot<
-                CSSStyle.Section.ID,
-                DOMElementStylePresentationItemIdentifier
-            >
-        )
+        case loaded(DOMElementStylePresentationRender)
         case pending
         case unavailable
+    }
+
+    private struct ItemFingerprint: Equatable {
+        var propertyObjectID: ObjectIdentifier
+        var propertyID: CSSProperty.ID?
+        var name: String
+        var value: String
+        var priority: String
+        var text: String?
+        var status: CSSProperty.Status
+        var isEditable: Bool
+        var isModifiedByInspector: Bool
+
+        init(property: CSSProperty) {
+            propertyObjectID = ObjectIdentifier(property)
+            propertyID = property.id
+            name = property.name
+            value = property.value
+            priority = property.priority
+            text = property.text
+            status = property.status
+            isEditable = property.isEditable
+            isModifiedByInspector = property.isModifiedByInspector
+        }
     }
 
     @ObservationIgnored private var expandedUnusedVariableSectionIDs = Set<CSSStyle.Section.ID>()
     @ObservationIgnored private var displayedNodeStyles: CSSNodeStyles?
     @ObservationIgnored private var visibleSections: [DOMElementStylePresentationSection] = []
+    @ObservationIgnored private var displayedItemFingerprints: [DOMElementStylePresentationItemIdentifier: ItemFingerprint] = [:]
 
     package init() {}
 
@@ -117,7 +146,7 @@ package final class DOMElementStylePresentationState {
         case .loaded:
             displayedNodeStyles = nodeStyles
             rebuildVisibleSections()
-            return .loaded(diffableSnapshot())
+            return .loaded(renderSnapshot())
         case .loading, .needsRefresh:
             return renderPending()
         case .unavailable, .failed:
@@ -130,7 +159,7 @@ package final class DOMElementStylePresentationState {
         case .loaded:
             if displayedNodeStyles != nil {
                 rebuildVisibleSections()
-                return .loaded(diffableSnapshot())
+                return .loaded(renderSnapshot())
             }
             return renderUnavailable()
         case .loading, .needsRefresh:
@@ -142,10 +171,7 @@ package final class DOMElementStylePresentationState {
 
     package func showHiddenUnusedVariables(
         in sectionID: CSSStyle.Section.ID
-    ) -> NSDiffableDataSourceSnapshot<
-        CSSStyle.Section.ID,
-        DOMElementStylePresentationItemIdentifier
-    >? {
+    ) -> DOMElementStylePresentationRender? {
         guard let displayedNodeStyles else {
             return nil
         }
@@ -156,7 +182,7 @@ package final class DOMElementStylePresentationState {
         }
         expandedUnusedVariableSectionIDs.insert(sectionID)
         rebuildVisibleSections()
-        return diffableSnapshot()
+        return renderSnapshot()
     }
 
     package func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
@@ -190,6 +216,7 @@ package final class DOMElementStylePresentationState {
         expandedUnusedVariableSectionIDs.removeAll()
         displayedNodeStyles = nil
         visibleSections = []
+        displayedItemFingerprints.removeAll()
         return .unavailable
     }
 
@@ -213,6 +240,42 @@ package final class DOMElementStylePresentationState {
         DOMElementStyleDiffableSnapshotBuilder.makeSnapshot(
             visibleSections: visibleSections
         )
+    }
+
+    private func renderSnapshot() -> DOMElementStylePresentationRender {
+        let snapshot = diffableSnapshot()
+        let fingerprints = visibleItemFingerprints()
+        let reconfiguredItemIdentifiers = snapshot.itemIdentifiers.filter { item in
+            guard let fingerprint = fingerprints[item] else {
+                return false
+            }
+            return displayedItemFingerprints[item] != fingerprint
+        }
+        displayedItemFingerprints = fingerprints
+        return DOMElementStylePresentationRender(
+            snapshot: snapshot,
+            reconfiguredItemIdentifiers: reconfiguredItemIdentifiers
+        )
+    }
+
+    private func visibleItemFingerprints() -> [DOMElementStylePresentationItemIdentifier: ItemFingerprint] {
+        guard let displayedNodeStyles else {
+            return [:]
+        }
+        let sectionsByID = Dictionary(uniqueKeysWithValues: displayedNodeStyles.sections.map { ($0.id, $0) })
+        var fingerprints: [DOMElementStylePresentationItemIdentifier: ItemFingerprint] = [:]
+        for visibleSection in visibleSections {
+            guard let section = sectionsByID[visibleSection.id] else {
+                continue
+            }
+            for item in visibleSection.items {
+                guard let property = property(for: item, in: section) else {
+                    continue
+                }
+                fingerprints[item] = ItemFingerprint(property: property)
+            }
+        }
+        return fingerprints
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -19,6 +19,7 @@ package final class DOMElementViewController: UICollectionViewController {
 
     package var disablesSnapshotAnimationsForTesting = false
     package private(set) var lastSnapshotAnimatedForTesting = false
+    package private(set) var styleSnapshotApplyCountForTesting = 0
     private var styleRenderGeneration = 0
     private var nextStyleRenderWaiterID: UInt64 = 0
     private var styleRenderWaiters: [UInt64: StyleRenderWaiter] = [:]
@@ -227,8 +228,8 @@ package final class DOMElementViewController: UICollectionViewController {
 
     private func render(_ result: DOMElementStylePresentationState.RenderResult) {
         switch result {
-        case let .loaded(snapshot):
-            renderStyles(snapshot)
+        case let .loaded(render):
+            renderStyles(render)
         case .pending:
             renderPendingStyles()
         case .unavailable:
@@ -259,15 +260,15 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func renderStyles(
-        _ snapshot: NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >
+        _ render: DOMElementStylePresentationRender
     ) {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
-        applySnapshot(snapshot)
+        applySnapshot(
+            render.snapshot,
+            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers
+        )
     }
 
     private func applyEmptySnapshot() {
@@ -275,6 +276,9 @@ package final class DOMElementViewController: UICollectionViewController {
             CSSStyle.Section.ID,
             DOMElementStylePresentationItemIdentifier
         >()
+#if DEBUG
+        styleSnapshotApplyCountForTesting += 1
+#endif
         dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
 #if DEBUG
             self?.finishStyleRenderForTesting()
@@ -287,6 +291,7 @@ package final class DOMElementViewController: UICollectionViewController {
             CSSStyle.Section.ID,
             DOMElementStylePresentationItemIdentifier
         >,
+        reconfiguredItemIdentifiers: [DOMElementStylePresentationItemIdentifier] = [],
         animatingDifferences: Bool = false
     ) {
         let currentSnapshot = dataSource.snapshot()
@@ -295,8 +300,20 @@ package final class DOMElementViewController: UICollectionViewController {
 #endif
         guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
             || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
+            let reconfiguredItemIdentifiers = reconfiguredItemIdentifiers.filter { item in
+                snapshot.indexOfItem(item) != nil
+            }
+            guard !reconfiguredItemIdentifiers.isEmpty else {
+#if DEBUG
+                finishStyleRenderForTesting()
+#endif
+                return
+            }
             var reconfiguredSnapshot = snapshot
-            reconfiguredSnapshot.reconfigureItems(snapshot.itemIdentifiers)
+            reconfiguredSnapshot.reconfigureItems(reconfiguredItemIdentifiers)
+#if DEBUG
+            styleSnapshotApplyCountForTesting += 1
+#endif
             dataSource.apply(reconfiguredSnapshot, animatingDifferences: false) { [weak self] in
 #if DEBUG
                 self?.finishStyleRenderForTesting()
@@ -308,6 +325,9 @@ package final class DOMElementViewController: UICollectionViewController {
         let shouldAnimateSnapshot = animatingDifferences && !disablesSnapshotAnimationsForTesting
 #else
         let shouldAnimateSnapshot = animatingDifferences
+#endif
+#if DEBUG
+        styleSnapshotApplyCountForTesting += 1
 #endif
         dataSource.apply(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
 #if DEBUG
@@ -328,10 +348,14 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func showHiddenUnusedVariables(in sectionID: CSSStyle.Section.ID) {
-        guard let snapshot = stylePresentationState.showHiddenUnusedVariables(in: sectionID) else {
+        guard let render = stylePresentationState.showHiddenUnusedVariables(in: sectionID) else {
             return
         }
-        applySnapshot(snapshot, animatingDifferences: true)
+        applySnapshot(
+            render.snapshot,
+            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers,
+            animatingDifferences: true
+        )
     }
 
     private func toggleAction() -> DOMElementStylePropertyView.ToggleAction? {
@@ -372,6 +396,15 @@ package final class DOMElementViewController: UICollectionViewController {
             if styleRenderGeneration > generation {
                 resolveStyleRenderWaiterForTesting(id: waiterID, result: true)
             }
+        }
+    }
+
+    package func renderCurrentStylesForTesting() {
+        let elementStyles = inspection.dom.elementStyles
+        if let selectedNodeStyles = elementStyles.selectedNodeStyles {
+            render(selectedNodeStyles)
+        } else {
+            render(elementStyles.selectedPhase)
         }
     }
 

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -179,6 +179,34 @@ struct DOMContainerTests {
     }
 
     @Test
+    func elementViewControllerCompletesCleanStyleRenderWithoutApplyingSnapshot() async throws {
+        let dom = makeDOMSession(capabilities: .pageDefault)
+        let body = try #require(firstElement(named: "body", in: dom))
+        dom.selectNode(body.id)
+
+        let css = dom.elementStyles
+        try applyBodyStyles(to: css, in: dom)
+
+        let viewController = makeElementViewController(dom: dom)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderRows = await waitUntilRendered(in: viewController) {
+            viewController.collectionView.numberOfSections == 1
+                && viewController.collectionView.numberOfItems(inSection: 0) == 3
+        }
+        #expect(didRenderRows)
+
+        let applyCount = viewController.styleSnapshotApplyCountForTesting
+        let generation = viewController.styleRenderGenerationForTesting
+
+        viewController.renderCurrentStylesForTesting()
+
+        #expect(await viewController.waitForStyleRenderForTesting(after: generation))
+        #expect(viewController.styleSnapshotApplyCountForTesting == applyCount)
+    }
+
+    @Test
     func elementViewControllerUpdatesVisibleSectionHeaderDuringSameNodeStyleRefresh() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let body = try #require(firstElement(named: "body", in: dom))

--- a/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
+++ b/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
@@ -10,6 +10,66 @@ extension WebInspectorUIRenderingTests {
 @Suite
 struct DOMElementStylePresentationStateTests {
     @Test
+    func presentationStateReturnsNoDirtyItemsWhenNodeStylesDoNotChange() throws {
+        let state = DOMElementStylePresentationState()
+        let nodeStyles = makeNodeStyles(sections: makeFlatStyleSections())
+        _ = try loadedRender(from: state.render(nodeStyles))
+
+        let cleanRender = try loadedRender(from: state.render(nodeStyles))
+
+        #expect(cleanRender.reconfiguredItemIdentifiers.isEmpty)
+    }
+
+    @Test
+    func presentationStateMarksOnlyChangedPropertyItemDirty() throws {
+        let state = DOMElementStylePresentationState()
+        let sections = makeFlatStyleSections()
+        let nodeStyles = makeNodeStyles(sections: sections)
+        let initialRender = try loadedRender(from: state.render(nodeStyles))
+        let marginItem = try itemIdentifier(named: "margin", in: initialRender.snapshot, state: state)
+        let paddingItem = try itemIdentifier(named: "padding", in: initialRender.snapshot, state: state)
+
+        let margin = try #require(sections.first?.style.cssProperties.first)
+        margin.value = "4px"
+        margin.text = "margin: 4px;"
+
+        let marginRender = try loadedRender(from: state.render(nodeStyles))
+        #expect(marginRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
+        #expect(marginRender.reconfiguredItemIdentifiers == [marginItem])
+
+        let padding = try #require(sections.first?.style.cssProperties.dropFirst().first)
+        padding.name = "padding-inline"
+        padding.text = "/* padding-inline: 8px; */"
+        padding.status = .disabled
+
+        let paddingRender = try loadedRender(from: state.render(nodeStyles))
+        #expect(paddingRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
+        #expect(paddingRender.reconfiguredItemIdentifiers == [paddingItem])
+    }
+
+    @Test
+    func presentationStateMarksPropertyDirtyWhenObjectChangesWithoutIdentifierChange() throws {
+        let state = DOMElementStylePresentationState()
+        let sections = makeFlatStyleSections()
+        let nodeStyles = makeNodeStyles(sections: sections)
+        let initialRender = try loadedRender(from: state.render(nodeStyles))
+        let marginItem = try itemIdentifier(named: "margin", in: initialRender.snapshot, state: state)
+
+        let marginID = try #require(sections.first?.style.cssProperties.first?.id)
+        let section = try #require(sections.first)
+        section.style.cssProperties[0] = property(
+            id: marginID,
+            name: "margin",
+            value: "0",
+            text: "margin: 0;"
+        )
+
+        let refreshedRender = try loadedRender(from: state.render(nodeStyles))
+        #expect(refreshedRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
+        #expect(refreshedRender.reconfiguredItemIdentifiers == [marginItem])
+    }
+
+    @Test
     func presentationStateRevealsHiddenUnusedVariablesWithTransientSnapshot() throws {
         let state = DOMElementStylePresentationState()
         let sections = makeStyleSections(inheritedOrdinal: 0)
@@ -20,7 +80,8 @@ struct DOMElementStylePresentationStateTests {
         #expect(containsVisibleProperty(named: "--unused-a", in: initialSnapshot, state: state) == false)
 
         let inheritedSection = try #require(sections.first { $0.kind == .inheritedRule(ancestorIndex: 0) })
-        let revealedSnapshot = try #require(state.showHiddenUnusedVariables(in: inheritedSection.id))
+        let revealedRender = try #require(state.showHiddenUnusedVariables(in: inheritedSection.id))
+        let revealedSnapshot = revealedRender.snapshot
         #expect(revealedSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1) == false)
         #expect(containsVisibleProperty(named: "--unused-a", in: revealedSnapshot, state: state))
     }
@@ -46,17 +107,23 @@ struct DOMElementStylePresentationStateTests {
         #expect(state.showHiddenUnusedVariables(in: oldInheritedSection.id) == nil)
     }
 
+    private func loadedRender(
+        from result: DOMElementStylePresentationState.RenderResult
+    ) throws -> DOMElementStylePresentationRender {
+        guard case let .loaded(render) = result else {
+            Issue.record("Expected loaded style presentation state")
+            throw TestFailure()
+        }
+        return render
+    }
+
     private func loadedSnapshot(
         from result: DOMElementStylePresentationState.RenderResult
     ) throws -> NSDiffableDataSourceSnapshot<
         CSSStyle.Section.ID,
         DOMElementStylePresentationItemIdentifier
     > {
-        guard case let .loaded(snapshot) = result else {
-            Issue.record("Expected loaded style presentation state")
-            throw TestFailure()
-        }
-        return snapshot
+        try loadedRender(from: result).snapshot
     }
 
     private func containsVisibleProperty(
@@ -76,6 +143,24 @@ struct DOMElementStylePresentationStateTests {
         }
     }
 
+    private func itemIdentifier(
+        named name: String,
+        in snapshot: NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >,
+        state: DOMElementStylePresentationState
+    ) throws -> DOMElementStylePresentationItemIdentifier {
+        let item = snapshot.itemIdentifiers.first { item in
+            guard let section = state.section(for: item.sectionID),
+                  let property = state.property(for: item, in: section) else {
+                return false
+            }
+            return property.name == name
+        }
+        return try #require(item)
+    }
+
     private func makeNodeStyles(sections: [CSSStyle.Section]) -> CSSNodeStyles {
         let targetID = ProtocolTarget.ID("page-main")
         let documentID = DOMDocument.ID(
@@ -93,6 +178,43 @@ struct DOMElementStylePresentationStateTests {
             phase: .loaded,
             sections: sections
         )
+    }
+
+    private func makeFlatStyleSections() -> [CSSStyle.Section] {
+        let targetID = ProtocolTarget.ID("page-main")
+        let documentID = DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: .init(1)
+        )
+        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+        let styleSheetID = CSSStyleSheet.ID("flat-styles")
+        let styleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
+
+        return [
+            CSSStyle.Section(
+                id: CSSStyle.Section.ID(nodeID: nodeID, kind: .rule, ordinal: 0),
+                kind: .rule,
+                title: "body",
+                style: CSSStyle(
+                    id: styleID,
+                    cssProperties: [
+                        property(
+                            id: CSSProperty.ID(styleID: styleID, propertyIndex: 0),
+                            name: "margin",
+                            value: "0",
+                            text: "margin: 0;"
+                        ),
+                        property(
+                            id: CSSProperty.ID(styleID: styleID, propertyIndex: 1),
+                            name: "padding",
+                            value: "8px",
+                            text: "padding: 8px;"
+                        ),
+                    ]
+                ),
+                isEditable: true
+            ),
+        ]
     }
 
     private func makeStyleSections(


### PR DESCRIPTION
## Purpose
Reduce DOM element style refresh work by avoiding full-row reconfiguration when the visible style snapshot has not structurally changed.

## Changes
- Return a style render object that carries the diffable snapshot plus dirty item identifiers.
- Track fingerprints for visible CSS property rows, including object identity and displayed property fields.
- Reconfigure only dirty rows when section and item identifiers are unchanged.
- Skip diffable data source apply entirely when no visible row changed, while still completing render waiters in debug tests.
- Add coverage for clean renders, changed property rows, object replacement with the same identifier, and clean view-controller renders.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -clonedSourcePackagesDirPath /tmp/WebInspectorKitPackageCache -only-testing:WebInspectorUITests` passed, 168 tests.
- `git diff --check` passed.
- `codex-review` reported no actionable findings.