### PR TITLE
Defer Network filter menu construction

### DIFF
--- a/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUI/Network/List/NetworkListViewController.swift
@@ -71,6 +71,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private var deinitHandlerForTesting: (@MainActor () -> Void)?
     private var snapshotUpdateCompletionWaitersForTesting: [CheckedContinuation<Void, Never>] = []
     private var displayRequestIDsEvaluationCountStorageForTesting = 0
+    private var filterMenuBuildCountStorageForTesting = 0
 #endif
     private lazy var filterHostingMenu = UIHostingMenu(
         rootView: NetworkListFilterMenuView(model: model)
@@ -81,7 +82,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private lazy var filterItem: UIBarButtonItem = {
         let item = UIBarButtonItem(
             image: UIImage(systemName: "line.3.horizontal.decrease"),
-            menu: makeFilterMenu()
+            menu: UIMenu(children: [makeFilterMenuElement()])
         )
         item.accessibilityIdentifier = "WebInspector.Network.FilterButton"
         item.isSelected = model.effectiveResourceFilters.isEmpty == false
@@ -368,8 +369,17 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         renderFilterItem(effectiveResourceFilters: effectiveResourceFilters)
     }
 
+    private func makeFilterMenuElement() -> UIDeferredMenuElement {
+        UIDeferredMenuElement.uncached { [weak self] completion in
+            completion((self?.makeFilterMenu() ?? UIMenu()).children)
+        }
+    }
+
     private func makeFilterMenu() -> UIMenu {
-        (try? filterHostingMenu.menu()) ?? UIMenu()
+#if DEBUG
+        filterMenuBuildCountStorageForTesting += 1
+#endif
+        return (try? filterHostingMenu.menu()) ?? UIMenu()
     }
 
     private func makeOverflowMenuElement() -> UIDeferredMenuElement {
@@ -637,6 +647,10 @@ extension NetworkListViewController {
 
     package var displayRequestIDsEvaluationCountForTesting: Int {
         displayRequestIDsEvaluationCountStorageForTesting
+    }
+
+    package var filterMenuBuildCountForTesting: Int {
+        filterMenuBuildCountStorageForTesting
     }
 
     package var displayedRequestIDsForTesting: [NetworkRequest.ID] {

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -87,6 +87,24 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func listLoadDefersFilterMenuBuildUntilPresentation() throws {
+        let model = NetworkPanelModel(network: NetworkSession())
+        model.setResourceFilter(.media, enabled: true)
+        let viewController = NetworkListViewController(model: model)
+
+        viewController.loadViewIfNeeded()
+
+        let filterItem = viewController.filterItemForTesting
+        #expect(filterItem.accessibilityIdentifier == "WebInspector.Network.FilterButton")
+        #expect(filterItem.isSelected)
+        #expect(viewController.filterMenuBuildCountForTesting == 0)
+        let menu = try #require(filterItem.menu)
+        #expect(menu.children.count == 1)
+        let child = try #require(menu.children.first)
+        #expect(child is UIDeferredMenuElement)
+    }
+
+    @Test
     func listLoadDoesNotEvaluateDisplayRequestsUntilAppearing() async throws {
         let network = NetworkSession()
         _ = try #require(applyRequest(


### PR DESCRIPTION
## Purpose
Reduce Network list setup cost by avoiding eager construction of the SwiftUI-backed filter menu during `viewDidLoad`.

## Changes
- Keep the filter bar button item lightweight at initialization time.
- Resolve the `UIHostingMenu` contents through a `UIDeferredMenuElement` when the menu is presented.
- Preserve filter button selected state and accessibility identifier.
- Add coverage that loading the list does not build the filter menu body eagerly.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -clonedSourcePackagesDirPath /tmp/WebInspectorKitPackageCache -only-testing:WebInspectorUITests` passed, 165 tests.
- `git diff --check` passed.
- Added Network filter menu deferral test passed.