### PR TITLE
Fix deterministic inspector teardown cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,53 @@ jobs:
           puts "Resolved Xcode: #{selected}"
           RUBY
 
+      - name: Check Swift tools compatibility
+        run: |
+          ruby <<'RUBY'
+          required = File.read("Package.swift")[/swift-tools-version:\s*(\d+(?:\.\d+)*)/, 1]
+          abort("Package.swift does not declare swift-tools-version") unless required
+
+          output = `swift package --version 2>&1`
+          abort(output) unless $?.success?
+
+          installed = output[/Swift Package Manager - Swift\s+(\d+(?:\.\d+)*)/, 1]
+          abort("Unable to parse SwiftPM version from: #{output}") unless installed
+
+          def version_components(version)
+            version.split(".").map(&:to_i)
+          end
+
+          def version_lt?(lhs, rhs)
+            lhs_components = version_components(lhs)
+            rhs_components = version_components(rhs)
+            length = [lhs_components.length, rhs_components.length].max
+            lhs_components.fill(0, lhs_components.length...length)
+            rhs_components.fill(0, rhs_components.length...length)
+            (lhs_components <=> rhs_components) == -1
+          end
+
+          unsupported = version_lt?(installed, required)
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "SKIP_IOS_TESTS=#{unsupported}"
+          end
+
+          if unsupported
+            puts output
+            puts "::warning::Skipping #{ENV.fetch("TEST_SCHEME")} because SwiftPM #{installed} cannot resolve swift-tools-version #{required}."
+          else
+            puts "SwiftPM #{installed} satisfies swift-tools-version #{required}."
+          end
+          RUBY
+
       - name: Resolve iOS simulator destination
         run: |
           ruby <<'RUBY'
           require "json"
+
+          if ENV["SKIP_IOS_TESTS"] == "true"
+            puts "Skipping simulator resolution: Swift tools version is unsupported."
+            exit 0
+          end
 
           ios_major = ENV.fetch("IOS_MAJOR")
           xcode_major = ENV.fetch("XCODE_MAJOR")
@@ -150,6 +193,11 @@ jobs:
       - name: Run iOS tests
         run: |
           set -o pipefail
+
+          if [ "${SKIP_IOS_TESTS:-false}" = "true" ]; then
+            echo "Skipping ${TEST_SCHEME}: selected Xcode cannot resolve this Swift tools version."
+            exit 0
+          fi
 
           xcodebuild test \
             -workspace WebInspectorKit.xcworkspace \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,14 @@ jobs:
             xcode_major: '26'
             ios_major: '26'
             test_scheme: WebInspectorKitTests
+            simulator_device: iPhone 17 Pro
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}
       TEST_SCHEME: ${{ matrix.test_scheme }}
+      SIMULATOR_DEVICE: ${{ matrix.simulator_device }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -79,12 +81,35 @@ jobs:
           puts "Resolved Xcode: #{selected}"
           RUBY
 
-      - name: Resolve latest iOS simulator
+      - name: Resolve iOS simulator destination
         run: |
           ruby <<'RUBY'
           require "json"
 
           ios_major = ENV.fetch("IOS_MAJOR")
+          xcode_major = ENV.fetch("XCODE_MAJOR")
+          simulator_device = ENV.fetch("SIMULATOR_DEVICE", "")
+
+          def write_destination(destination:, version:)
+            File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+              env.puts "DESTINATION=#{destination}"
+              env.puts "RESOLVED_IOS_VERSION=#{version}"
+            end
+          end
+
+          if ios_major == xcode_major && !simulator_device.empty?
+            sdk_version = `xcodebuild -version -sdk iphonesimulator SDKVersion`.strip
+            abort("Unable to resolve iPhoneSimulator SDK version") unless $?.success? && !sdk_version.empty?
+            abort("Resolved iPhoneSimulator SDK #{sdk_version}, expected iOS #{ios_major}.x") unless sdk_version.split(".").first == ios_major
+
+            write_destination(
+              destination: "platform=iOS Simulator,name=#{simulator_device},OS=#{sdk_version}",
+              version: sdk_version
+            )
+            puts "Resolved simulator destination from iOS SDK: #{simulator_device} iOS #{sdk_version}"
+            exit 0
+          end
+
           devices = JSON.parse(`xcrun simctl list devices available --json`).fetch("devices")
           matches = []
 
@@ -110,10 +135,7 @@ jobs:
           end
 
           _, version, device_name, udid = matches.max_by { |components, _, _, _| components }
-          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
-            env.puts "DESTINATION=platform=iOS Simulator,id=#{udid}"
-            env.puts "RESOLVED_IOS_VERSION=#{version}"
-          end
+          write_destination(destination: "platform=iOS Simulator,id=#{udid}", version: version)
           puts "Resolved simulator: #{device_name} iOS #{version} (#{udid})"
           RUBY
 
@@ -125,36 +147,9 @@ jobs:
           echo "Resolved iOS: ${RESOLVED_IOS_VERSION}"
           echo "Test scheme: ${TEST_SCHEME}"
 
-      - name: Check SwiftPM tools compatibility
-        run: |
-          set +e
-          swift package resolve > /tmp/swift-package-resolve.log 2>&1
-          resolve_status=$?
-          set -e
-
-          if [ "${resolve_status}" -eq 0 ]; then
-            echo "SKIP_IOS_TESTS=false" >> "${GITHUB_ENV}"
-            exit 0
-          fi
-
-          if grep -E "using Swift tools version|installed version" /tmp/swift-package-resolve.log >/dev/null; then
-            cat /tmp/swift-package-resolve.log
-            echo "::warning::Skipping ${TEST_SCHEME} because the selected Xcode cannot resolve this Swift tools version."
-            echo "SKIP_IOS_TESTS=true" >> "${GITHUB_ENV}"
-            exit 0
-          fi
-
-          cat /tmp/swift-package-resolve.log
-          exit "${resolve_status}"
-
       - name: Run iOS tests
         run: |
           set -o pipefail
-
-          if [ "${SKIP_IOS_TESTS:-false}" = "true" ]; then
-            echo "Skipping ${TEST_SCHEME}: selected Xcode cannot resolve this Swift tools version."
-            exit 0
-          fi
 
           xcodebuild test \
             -workspace WebInspectorKit.xcworkspace \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             ios_major: '26'
             test_scheme: WebInspectorKitTests
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
             ios_major: '26'
             test_scheme: WebInspectorKitTests
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}
@@ -162,6 +163,9 @@ jobs:
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
             -maximum-concurrent-test-simulator-destinations 1 \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 30 \
+            -maximum-test-execution-time-allowance 60 \
             -showBuildTimingSummary \
             -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
             | tee "${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"

--- a/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionControllers.swift
@@ -719,7 +719,6 @@ final class DOMSessionDocumentRequestHandle {
 
     func cancel() {
         task?.cancel()
-        task = nil
     }
 
     #if DEBUG

--- a/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
+++ b/Sources/WebInspectorCore/DOM/DOMSessionProtocolOperations.swift
@@ -74,7 +74,15 @@ extension DOMSession {
         let pickerSession = elementPicker.currentSession
         let pickerTargetID = pickerSession?.targetID
         let inspectModeTargetID = isSelectingElement ? pickerTargetID ?? currentPageTargetID : nil
-        let highlightHides = backendInteractionRetirementHighlightHides(preferredTargetID: pickerTargetID)
+        let fallbackHighlightTargetID: ProtocolTarget.ID? = if pickerSession != nil || highlightController.hasPossibleVisibleHighlight {
+            currentPageTargetID
+        } else {
+            nil
+        }
+        let highlightHides = backendInteractionRetirementHighlightHides(
+            preferredTargetID: pickerTargetID,
+            fallbackTargetID: fallbackHighlightTargetID
+        )
         let requiresActiveConnection = scope == .presentationEnd
         if let inspectModeTargetID,
            targetSupportsTeardownBackendInteraction(inspectModeTargetID),
@@ -263,7 +271,8 @@ extension DOMSession {
     }
 
     private func backendInteractionRetirementHighlightHides(
-        preferredTargetID: ProtocolTarget.ID?
+        preferredTargetID: ProtocolTarget.ID?,
+        fallbackTargetID: ProtocolTarget.ID?
     ) -> [DOMSessionHighlightController.PossibleVisibleHighlight] {
         var highlights: [DOMSessionHighlightController.PossibleVisibleHighlight] = []
         func append(_ targetID: ProtocolTarget.ID?) {
@@ -283,7 +292,7 @@ extension DOMSession {
         ) {
             append(highlight.targetID)
         }
-        append(currentPageTargetID)
+        append(fallbackTargetID)
         return highlights
     }
 
@@ -1311,6 +1320,7 @@ extension DOMSession {
                 return
             }
             defer {
+                handle.task = nil
                 documentRequests.finish(handle)
             }
             do {
@@ -1353,6 +1363,11 @@ extension DOMSession {
         invalidateDocument(targetID: targetID)
         if targetKind == .frame {
             startDocumentRequest(targetID: targetID, force: true, reason: "frameDocumentUpdated")
+            return
+        }
+
+        if activeRequest != nil {
+            startDocumentRequest(targetID: targetID, force: true, reason: "documentUpdated")
             return
         }
 

--- a/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
+++ b/Tests/WebInspectorCoreTests/InspectorSessionTests.swift
@@ -687,6 +687,7 @@ func selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh() as
     session.attachment.dom.setSelectedNodeStyleHydrationActive(false)
     #expect(session.attachment.dom.elementStyles.selectedPhase == .needsRefresh)
     await session.attachment.dom.waitUntilSelectedStyleRefreshIdle()
+    #expect(await pendingTargetReplyKeys(transport).isEmpty)
 
     let secondSentCount = await backend.sentTargetMessages().count
     session.attachment.dom.setSelectedNodeStyleHydrationActive(true)
@@ -6650,9 +6651,11 @@ func detachCancelsPumpsAndClearsModelState() async throws {
     let session = await InspectorSession(configuration: .test)
     try await connect(session, transport: transport, backend: backend)
 
+    let sentCountBeforeDetach = await backend.sentTargetMessages().count
     await session.detach()
 
     #expect(await backend.isDetached())
+    #expect(await backend.sentTargetMessages().count == sentCountBeforeDetach)
     #expect(await session.hasActiveConnection == false)
     #expect(await session.attachment.dom.snapshot().currentPageTargetID == nil)
     #expect(await session.attachment.network.snapshot().orderedRequestIDs.isEmpty)
@@ -7772,7 +7775,7 @@ private struct CSSRefreshMessages: Sendable {
 private func waitForCSSRefreshMessages(
     _ backend: FakeTransportBackend,
     after count: Int,
-    protocolNodeID: DOMNode.ProtocolID? = nil
+    protocolNodeID: WebInspectorCore.DOMNode.ProtocolID? = nil
 ) async throws -> CSSRefreshMessages {
     try await withThrowingTaskGroup(of: CSSRefreshMessages.self) { group in
         defer {
@@ -7801,7 +7804,7 @@ private func waitForCSSRefreshMessages(
 private func waitForCSSRefreshMessageBatch(
     _ backend: FakeTransportBackend,
     after count: Int,
-    protocolNodeID: DOMNode.ProtocolID?
+    protocolNodeID: WebInspectorCore.DOMNode.ProtocolID?
 ) async throws -> CSSRefreshMessages {
     var observedTargetMessageCount = 0
     while true {
@@ -7826,7 +7829,7 @@ private func waitForCSSRefreshMessageBatch(
 
 private func cssRefreshMessages(
     in messages: [SentTargetMessage],
-    protocolNodeID: DOMNode.ProtocolID?
+    protocolNodeID: WebInspectorCore.DOMNode.ProtocolID?
 ) throws -> CSSRefreshMessages? {
     guard let matched = try cssRefreshMessage(
         in: messages,
@@ -7850,7 +7853,7 @@ private func cssRefreshMessages(
 private func cssRefreshMessage(
     in messages: [SentTargetMessage],
     method: String,
-    protocolNodeID: DOMNode.ProtocolID?
+    protocolNodeID: WebInspectorCore.DOMNode.ProtocolID?
 ) throws -> SentTargetMessage? {
     try messages.first { message in
         guard try messageMethod(message.message) == method else {

--- a/Tests/WebInspectorTransportTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorTransportTests/TransportSessionTests.swift
@@ -290,6 +290,37 @@ func cancellationFailsPendingReplyImmediately() async throws {
 }
 
 @Test
+func targetCommandCancellationFailsPendingReplyWithoutTimeout() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: nil)
+    await session.receiveRootMessage(#"{"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"page-main","type":"page","frameId":"main-frame","isProvisional":false}}}"#)
+
+    let sendTask = Task {
+        try await session.send(
+            ProtocolCommand(domain: .css, method: "CSS.getMatchedStylesForNode", routing: .target(.init("page-main")))
+        )
+    }
+    let sent = try await waitForTargetMessage(backend)
+    let innerID = try messageID(sent.message)
+    #expect(await session.snapshot().pendingTargetReplyKeys == [
+        TransportSession.ReplyKey(targetID: .init("page-main"), commandID: innerID),
+    ])
+
+    sendTask.cancel()
+
+    do {
+        _ = try await waitForBackendValue(timeout: testWaitTimeout) {
+            try await sendTask.value
+        }
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+    } catch {
+        Issue.record("Expected CancellationError, got \(error)")
+    }
+    #expect(await session.snapshot().pendingTargetReplyKeys.isEmpty)
+}
+
+@Test
 func fakeBackendTargetMessageWaiterUsesAfterAndOrdinal() async throws {
     let backend = FakeTransportBackend()
 


### PR DESCRIPTION
## Purpose
Fix CI hangs caused by inspector teardown and cancellation paths that could wait on backend replies that never arrive, while keeping timeouts as a guard instead of the success path. Also reduce CI pre-test overhead and keep the iOS 18 native lane skipped until the hosted runner has a SwiftPM version that can resolve this package.

## Changes
- Avoid sending plain DOM detach highlight cleanup when there is no active picker or possible visible highlight.
- Keep DOM document request handles observable until the cancelled task finishes, and force a fresh page `DOM.getDocument` when `DOM.documentUpdated` arrives during an in-flight page request.
- Add regression coverage for target command cancellation with `responseTimeout: nil` and CSS refresh cancellation cleanup.
- Add GitHub Actions test execution timeout guards and a 10 minute job timeout.
- Replace the slow SwiftPM resolve preflight with a lightweight Swift tools compatibility check that skips unsupported jobs.
- Resolve the iOS 26 simulator destination from the selected iPhoneSimulator SDK instead of listing all simulator devices.

## Testing
- `swift test --filter targetCommandCancellationFailsPendingReplyWithoutTimeout`
- `swift test --filter 'detachCancelsPumpsAndClearsModelState|documentUpdatedAllowsNewDocumentRequestWhilePreviousRequestIsPending|selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh'`
- `swift test --filter 'targetDestroyedRemovesExecutionContextsOwnedByRuntimeAgentTarget|nestedFrameProjectionWaitsForParentFrameDocumentBeforeOwnerMatching|networkResponseBodyFetchErrorDoesNotRetry|selectedElementStyleHydrationCancellationResetsLoadingForFutureRefresh|consoleEnableTargetNotFoundDoesNotMarkCommandUnsupported|subframeCommitDoesNotRetargetPageRuntimeOrConsoleState|frameDocumentRequestDoesNotBlockPageDOMEvents'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -test-timeouts-enabled YES -default-test-execution-time-allowance 30 -maximum-test-execution-time-allowance 60`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:WebInspectorTransportTests/TransportSessionTests/targetCommandCancellationFailsPendingReplyWithoutTimeout -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -test-timeouts-enabled YES -default-test-execution-time-allowance 30 -maximum-test-execution-time-allowance 60`
- Swift tools compatibility script check with SwiftPM 6.2.4 against `swift-tools-version: 6.3`
- `git diff --check`
- Codex review against base `main`: no findings