### PR TITLE
Update editor dependencies

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ceb27894cc5c9181db84611e79857c0a8282131fd151b5f95d220c2b8b33d6e5",
+  "originHash" : "1948f55ee106c9c4f67872021c80ab8e55eac4b22513a65aae62502bfce8f744",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "4f046ab5862e5d98687b03f9e522e6de48b7efca",
-        "version" : "0.12.0"
+        "revision" : "e78ba90b122fdf86f3cb654b4478f257dfb6e453",
+        "version" : "0.13.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
-        "version" : "0.14.0"
+        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0330638e1efa496cd1e463fe685e44f9c11842411669aea4c17315c7235d1974",
+  "originHash" : "70daad6b0cd9195f1ad27ad59df43d555bd4f6abe1b6810074d621dee33bd334",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "4f046ab5862e5d98687b03f9e522e6de48b7efca",
-        "version" : "0.12.0"
+        "revision" : "e78ba90b122fdf86f3cb654b4478f257dfb6e453",
+        "version" : "0.13.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
-        "version" : "0.14.0"
+        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/lynnswap/ObservationBridge.git",
-            exact: "0.12.0"
+            exact: "0.13.0"
         ),
         .package(
             url: "https://github.com/lynnswap/UIHostingMenu.git",
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.14.0"
+            exact: "0.16.0"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c27cefb259997cd52eb699c233ef5827f7cb9739cd8b709bc407107c14aa336",
+  "originHash" : "d4a057c19039f4886b4b3265e5d34c0969ba229c0709373e4a791d9febeaa978",
   "pins" : [
     {
       "identity" : "machokit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/ObservationBridge.git",
       "state" : {
-        "revision" : "4f046ab5862e5d98687b03f9e522e6de48b7efca",
-        "version" : "0.12.0"
+        "revision" : "e78ba90b122fdf86f3cb654b4478f257dfb6e453",
+        "version" : "0.13.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "5006ef42823848523d0e897567eace5db6ea6fd3",
-        "version" : "0.14.0"
+        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
+        "version" : "0.16.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Update the editor-related package dependencies to the latest requested releases.

## Changes
- Bump `ObservationBridge` from `0.12.0` to `0.13.0`.
- Bump `SyntaxEditorUI` from `0.14.0` to `0.16.0`.
- Refresh SwiftPM resolved pins for the root package, `WebInspectorKit.xcworkspace`, and `Monocly.xcodeproj`.

## Testing
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `xcodebuild -resolvePackageDependencies -project Monocly/Monocly.xcodeproj -scheme Monocly`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild build -project Monocly/Monocly.xcodeproj -scheme Monocly -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `git diff --check`
- Codex review: clean, no findings