### PR TITLE
fix(network): align detail preview insets

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1948f55ee106c9c4f67872021c80ab8e55eac4b22513a65aae62502bfce8f744",
+  "originHash" : "ceb27894cc5c9181db84611e79857c0a8282131fd151b5f95d220c2b8b33d6e5",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
-        "version" : "0.16.0"
+        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
+        "version" : "0.16.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "70daad6b0cd9195f1ad27ad59df43d555bd4f6abe1b6810074d621dee33bd334",
+  "originHash" : "d5b9ed3942c704ade9fa89630b68f66d00f5cf002163dced79fb239fffddc42a",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
-        "version" : "0.16.0"
+        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
+        "version" : "0.16.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.16.0"
+            exact: "0.16.1"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
+++ b/Sources/WebInspectorUI/Network/Containers/NetworkContainerSupport.swift
@@ -102,24 +102,6 @@ func webInspectorConfigureScrollEdgeObservedScrollView(
     if scrollView.backgroundColor != resolvedBackgroundColor {
         scrollView.backgroundColor = resolvedBackgroundColor
     }
-
-    if #available(iOS 26.0, *) {
-        // WebInspector paints these scroll view backgrounds directly; automatic
-        // edge capture can otherwise form UIKit observation/layout feedback loops.
-        let hardStyle = UIScrollEdgeEffect.Style.hard
-        if scrollView.topEdgeEffect.style !== hardStyle {
-            scrollView.topEdgeEffect.style = hardStyle
-        }
-        if scrollView.bottomEdgeEffect.style !== hardStyle {
-            scrollView.bottomEdgeEffect.style = hardStyle
-        }
-        if scrollView.topEdgeEffect.isHidden == false {
-            scrollView.topEdgeEffect.isHidden = true
-        }
-        if scrollView.bottomEdgeEffect.isHidden == false {
-            scrollView.bottomEdgeEffect.isHidden = true
-        }
-    }
 }
 
 @MainActor

--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -80,13 +80,6 @@ package final class NetworkDetailViewController: UIViewController {
     private var modelObservationDelivery: PortableObservationTracking.Token?
     private var selectedRequestRenderObservationDelivery: PortableObservationTracking.Token?
 #endif
-    private lazy var previewContainerView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.isHidden = true
-        view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
-        return view
-    }()
     private lazy var headersTextView: NetworkHeadersTextView = {
         let view = NetworkHeadersTextView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -210,7 +203,7 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func updateBodyRenderingActiveForCurrentSurface() {
-        setBodyRenderingActive(isRenderingActive && previewContainerView.isHidden == false)
+        setBodyRenderingActive(isRenderingActive && bodyViewController.view.isHidden == false)
     }
 
     private func applyBackgroundFromTraits() {
@@ -222,16 +215,17 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func installContentViews() {
         addChild(bodyViewController)
-        view.addSubview(previewContainerView)
+        view.addSubview(bodyViewController.view)
+        view.addSubview(previewRoleControlController.containerView)
         view.addSubview(headersTextView)
         bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        bodyViewController.view.isHidden = true
+        bodyViewController.view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
         previewRoleControlController.containerView.translatesAutoresizingMaskIntoConstraints = false
-        previewContainerView.addSubview(bodyViewController.view)
-        previewContainerView.addSubview(previewRoleControlController.containerView)
         bodyViewController.didMove(toParent: self)
 
         let bodyTopToPreviewContainerConstraint = bodyViewController.view.topAnchor.constraint(
-            equalTo: previewContainerView.topAnchor
+            equalTo: view.topAnchor
         )
         let bodyTopToPreviewRoleControlConstraint = bodyViewController.view.topAnchor.constraint(
             equalTo: previewRoleControlController.containerView.bottomAnchor
@@ -241,16 +235,18 @@ package final class NetworkDetailViewController: UIViewController {
         bodyTopToPreviewContainerConstraint.isActive = true
 
         NSLayoutConstraint.activate([
-            previewContainerView.topAnchor.constraint(equalTo: view.topAnchor),
-            previewContainerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            previewContainerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            previewContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            bodyViewController.view.leadingAnchor.constraint(equalTo: previewContainerView.leadingAnchor),
-            bodyViewController.view.trailingAnchor.constraint(equalTo: previewContainerView.trailingAnchor),
-            bodyViewController.view.bottomAnchor.constraint(equalTo: previewContainerView.bottomAnchor),
-            previewRoleControlController.containerView.topAnchor.constraint(equalTo: previewContainerView.safeAreaLayoutGuide.topAnchor),
-            previewRoleControlController.containerView.leadingAnchor.constraint(equalTo: previewContainerView.leadingAnchor),
-            previewRoleControlController.containerView.trailingAnchor.constraint(equalTo: previewContainerView.trailingAnchor),
+            bodyViewController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            bodyViewController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            bodyViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            previewRoleControlController.containerView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor
+            ),
+            previewRoleControlController.containerView.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor
+            ),
+            previewRoleControlController.containerView.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor
+            ),
             headersTextView.topAnchor.constraint(equalTo: view.topAnchor),
             headersTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             headersTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
@@ -262,7 +258,18 @@ package final class NetworkDetailViewController: UIViewController {
         if #available(iOS 26.0, *) {
             bodyTopToPreviewRoleControlConstraint?.isActive = false
             bodyTopToPreviewContainerConstraint?.isActive = true
+            let topInset = isVisible
+                ? previewRoleControlController.containerView.systemLayoutSizeFitting(
+                    UIView.layoutFittingCompressedSize
+                ).height
+                : 0
+            if bodyViewController.additionalSafeAreaInsets.top != topInset {
+                bodyViewController.additionalSafeAreaInsets.top = topInset
+            }
         } else {
+            if bodyViewController.additionalSafeAreaInsets.top != 0 {
+                bodyViewController.additionalSafeAreaInsets.top = 0
+            }
             bodyTopToPreviewContainerConstraint?.isActive = isVisible == false
             bodyTopToPreviewRoleControlConstraint?.isActive = isVisible
         }
@@ -411,7 +418,8 @@ package final class NetworkDetailViewController: UIViewController {
     private func showEmptySelection(bodySurface: NetworkBodyViewController.Surface) {
         bodyViewController.setSurface(bodySurface)
         setBodyRenderingActive(false)
-        previewContainerView.isHidden = true
+        bodyViewController.view.isHidden = true
+        previewRoleControlController.containerView.isHidden = true
         headersTextView.isHidden = true
         headersTextView.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
@@ -429,12 +437,14 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func showPreview() {
         headersTextView.isHidden = true
-        previewContainerView.isHidden = false
+        bodyViewController.view.isHidden = false
     }
 
     private func showHeaders() {
         setBodyRenderingActive(false)
-        previewContainerView.isHidden = true
+        bodyViewController.view.isHidden = true
+        previewRoleControlController.containerView.isHidden = true
+        updatePreviewRoleControlLayout(isVisible: false)
         scrollEdgeController.isPreviewRoleControlVisible = false
         bodyViewController.setSurface(.none)
         headersTextView.isHidden = false
@@ -483,7 +493,7 @@ package final class NetworkDetailViewController: UIViewController {
     ) {
         previewRoles = roles
         let isControlVisible = roles.count >= 2
-        let isVisibleInPreview = isControlVisible && previewContainerView.isHidden == false
+        let isVisibleInPreview = isControlVisible && bodyViewController.view.isHidden == false
         previewRoleControlController.render(
             roles: roles,
             selectedRole: selectedRole,
@@ -590,7 +600,7 @@ package final class NetworkDetailViewController: UIViewController {
 #if DEBUG
 extension NetworkDetailViewController {
     var previewViewForTesting: UIView {
-        previewContainerView
+        bodyViewController.view
     }
 
     var previewRoleControlContainerViewForTesting: UIView {
@@ -660,6 +670,42 @@ extension NetworkDetailViewController {
     UINavigationController(
         rootViewController: NetworkDetailViewController(
             model: NetworkPreviewFixtures.makePanelModel(mode: .detail)
+        )
+    )
+}
+
+#Preview("Network Detail Preview Response Only Short") {
+    UINavigationController(
+        rootViewController: NetworkDetailViewController(
+            model: NetworkPreviewFixtures.makePanelModel(mode: .detailResponseOnlyShort),
+            initialMode: .preview
+        )
+    )
+}
+
+#Preview("Network Detail Preview Request and Response Short") {
+    UINavigationController(
+        rootViewController: NetworkDetailViewController(
+            model: NetworkPreviewFixtures.makePanelModel(mode: .detailRequestAndResponseShort),
+            initialMode: .preview
+        )
+    )
+}
+
+#Preview("Network Detail Preview Response Only Long") {
+    UINavigationController(
+        rootViewController: NetworkDetailViewController(
+            model: NetworkPreviewFixtures.makePanelModel(mode: .detailResponseOnlyLong),
+            initialMode: .preview
+        )
+    )
+}
+
+#Preview("Network Detail Preview Request and Response Long") {
+    UINavigationController(
+        rootViewController: NetworkDetailViewController(
+            model: NetworkPreviewFixtures.makePanelModel(mode: .detailRequestAndResponseLong),
+            initialMode: .preview
         )
     )
 }

--- a/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
+++ b/Sources/WebInspectorUI/Preview/NetworkPreviewFixtures.swift
@@ -7,13 +7,24 @@ enum NetworkPreviewFixtures {
         case root
         case rootLongTitle
         case detail
+        case detailResponseOnlyShort
+        case detailRequestAndResponseShort
+        case detailResponseOnlyLong
+        case detailRequestAndResponseLong
     }
 
     static func makePanelModel(mode: Mode) -> NetworkPanelModel {
         let network = makeNetworkSession(mode: mode)
         let model = NetworkPanelModel(network: network)
-        if mode == .detail {
+        switch mode {
+        case .detail,
+             .detailResponseOnlyShort,
+             .detailRequestAndResponseShort,
+             .detailResponseOnlyLong,
+             .detailRequestAndResponseLong:
             model.selectRequest(model.displayRequests.first)
+        case .root, .rootLongTitle:
+            break
         }
         return model
     }
@@ -25,6 +36,75 @@ enum NetworkPreviewFixtures {
     }
 
     static func applySampleData(to network: NetworkSession, mode: Mode) {
+        switch mode {
+        case .detailResponseOnlyShort:
+            applyRequest(
+                to: network,
+                requestID: "1001",
+                url: "https://api.example.com/v1/status.json",
+                method: "GET",
+                resourceType: .xhr,
+                responseMimeType: "application/json",
+                status: 200,
+                statusText: "OK",
+                timestamp: 1.0,
+                encodedBodyLength: 64,
+                responseBody: shortPreviewJSONBody(kind: "response-only")
+            )
+            return
+        case .detailRequestAndResponseShort:
+            applyRequest(
+                to: network,
+                requestID: "1001",
+                url: "https://telemetry.example/log.json",
+                method: "POST",
+                resourceType: .xhr,
+                responseMimeType: "application/json",
+                status: 200,
+                statusText: "OK",
+                timestamp: 1.0,
+                encodedBodyLength: 64,
+                requestHeaders: ["content-type": "application/json"],
+                postData: shortPreviewJSONBody(kind: "request"),
+                responseBody: shortPreviewJSONBody(kind: "response")
+            )
+            return
+        case .detailResponseOnlyLong:
+            applyRequest(
+                to: network,
+                requestID: "1001",
+                url: "https://api.example.com/v1/status.json",
+                method: "GET",
+                resourceType: .xhr,
+                responseMimeType: "application/json",
+                status: 200,
+                statusText: "OK",
+                timestamp: 1.0,
+                encodedBodyLength: 1_024,
+                responseBody: longPreviewJSONBody(kind: "response-only")
+            )
+            return
+        case .detailRequestAndResponseLong:
+            applyRequest(
+                to: network,
+                requestID: "1001",
+                url: "https://telemetry.example/log.json",
+                method: "POST",
+                resourceType: .xhr,
+                responseMimeType: "application/json",
+                status: 200,
+                statusText: "OK",
+                timestamp: 1.0,
+                encodedBodyLength: 1_024,
+                requestHeaders: ["content-type": "application/json"],
+                postData: longPreviewJSONBody(kind: "request"),
+                responseBody: longPreviewJSONBody(kind: "response")
+            )
+            return
+        case .root, .rootLongTitle, .detail:
+            break
+        }
+
         applyRequest(
             to: network,
             requestID: "1001",
@@ -75,10 +155,16 @@ enum NetworkPreviewFixtures {
         status: Int,
         statusText: String,
         timestamp: Double,
-        encodedBodyLength: Int
+        encodedBodyLength: Int,
+        requestHeaders: [String: String]? = nil,
+        postData: String? = nil,
+        responseBody: String? = nil
     ) -> NetworkRequest.ID {
         let targetID = ProtocolTarget.ID("preview-page")
         let requestID = NetworkRequest.ProtocolID(requestID)
+        let resolvedPostData = postData ?? (method == "POST" ? "sample=true&source=wi-preview" : nil)
+        let resolvedRequestHeaders = requestHeaders
+            ?? (resolvedPostData == nil ? [:] : ["content-type": "application/x-www-form-urlencoded"])
         let key = network.applyRequestWillBeSent(
             targetID: targetID,
             requestID: requestID,
@@ -88,8 +174,8 @@ enum NetworkPreviewFixtures {
             request: NetworkRequest.Payload(
                 url: url,
                 method: method,
-                headers: method == "POST" ? ["content-type": "application/x-www-form-urlencoded"] : [:],
-                postData: method == "POST" ? "sample=true&source=wi-preview" : nil
+                headers: resolvedRequestHeaders,
+                postData: resolvedPostData
             ),
             resourceType: resourceType,
             timestamp: timestamp,
@@ -126,11 +212,23 @@ enum NetworkPreviewFixtures {
         if responseMimeType == "application/json" {
             network.request(for: key)?.applyResponseBody(
                 NetworkBody.Payload(
-                    body: #"{"result":"ok","items":[1,2,3],"source":"preview"}"#,
+                    body: responseBody ?? #"{"result":"ok","items":[1,2,3],"source":"preview"}"#,
                     base64Encoded: false
                 )
             )
         }
         return key
+    }
+
+    private static func shortPreviewJSONBody(kind: String) -> String {
+        #"{"kind":"\#(kind)","result":"ok","source":"preview"}"#
+    }
+
+    private static func longPreviewJSONBody(kind: String) -> String {
+        let items = (1...24).map { index in
+            let enabled = index.isMultiple(of: 2) ? "true" : "false"
+            return #"{"id":\#(index),"name":"\#(kind)-item-\#(index)","enabled":\#(enabled)}"#
+        }.joined(separator: ",")
+        return #"{"kind":"\#(kind)","result":"ok","items":[\#(items)],"metadata":{"source":"preview","count":24}}"#
     }
 }

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d4a057c19039f4886b4b3265e5d34c0969ba229c0709373e4a791d9febeaa978",
+  "originHash" : "fbba817fd7fc5d884ba5861588f664d59b31110db433be93b712f7af8b0ba482",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "a1d9165499617e1a1decbf3568569cc185ed5866",
-        "version" : "0.16.0"
+        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
+        "version" : "0.16.1"
       }
     },
     {


### PR DESCRIPTION
Purpose

Fix Network Detail preview inset handling so text and media previews rely on the system scroll-edge inset behavior, and update the SyntaxEditorUI dependency to the released v0.16.1 fix.

Changes

- Pin SyntaxEditorUI to v0.16.1.
- Align Network Detail preview layout with the headers surface so the preview body fills the detail view while the role control remains at the top safe area.
- Register the currently visible preview scroll view with the scroll-edge interaction for text and image previews.
- Add preview fixtures for short request/response coverage.

Testing

- git diff --check
- Reviewed related NetworkDetailViewControllerTests coverage; no additional WebInspectorKit tests were needed because SyntaxEditorUI owns the internal content-size and adjusted-inset behavior.