### PR TITLE
Prevent network preview role switch animation

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailSegmentedControlControllers.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailSegmentedControlControllers.swift
@@ -67,21 +67,28 @@ final class NetworkPreviewRoleControlController {
     ) -> Bool {
         self.selectedRole = selectedRole
         self.isVisible = isVisible
-        if self.roles != roles {
-            self.roles = roles
-            segmentedControl.removeAllSegments()
-            for (index, role) in roles.enumerated() {
-                segmentedControl.insertSegment(
-                    withTitle: Self.title(for: role),
-                    at: index,
-                    animated: false
-                )
-            }
-        }
-        containerView.isHidden = isVisible == false
-        segmentedControl.selectedSegmentIndex = selectedRole.flatMap(roles.firstIndex(of:))
+        let selectedSegmentIndex = selectedRole.flatMap(roles.firstIndex(of:))
             ?? UISegmentedControl.noSegment
-        segmentedControl.accessibilityLabel = selectedRole.map(Self.title(for:))
+
+        UIView.performWithoutAnimation {
+            if self.roles != roles {
+                self.roles = roles
+                segmentedControl.selectedSegmentIndex = UISegmentedControl.noSegment
+                segmentedControl.removeAllSegments()
+                for (index, role) in roles.enumerated() {
+                    segmentedControl.insertSegment(
+                        withTitle: Self.title(for: role),
+                        at: index,
+                        animated: false
+                    )
+                }
+            }
+            containerView.isHidden = isVisible == false
+            segmentedControl.selectedSegmentIndex = selectedSegmentIndex
+            segmentedControl.accessibilityLabel = selectedRole.map(Self.title(for:))
+            segmentedControl.layoutIfNeeded()
+            containerView.layoutIfNeeded()
+        }
         return isVisible
     }
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -352,6 +352,52 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func responseOnlyPreviewRoleExpandsToBothWithoutChangingLogicalSelection() async throws {
+        let network = NetworkSession()
+        let responseOnlyRequest = try #require(
+            applyRequest(
+                to: network,
+                requestID: "response-only",
+                url: "https://example.com/response.json",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let requestAndResponse = try #require(
+            applyRequest(
+                to: network,
+                requestID: "both",
+                url: "https://example.com/both.json",
+                requestHeaders: ["content-type": "application/x-www-form-urlencoded"],
+                postData: "name=Jane+Doe",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json"
+            )
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(responseOnlyRequest)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+
+        let didRenderResponseOnly = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .preview
+                && viewController.currentPreviewRoleForTesting == .response
+                && viewController.isPreviewRoleControlHiddenForTesting
+        }
+        #expect(didRenderResponseOnly)
+
+        model.selectRequest(requestAndResponse)
+
+        let didRenderBoth = await waitUntilRendered(in: viewController) {
+            viewController.currentPreviewRoleForTesting == .response
+                && viewController.isPreviewRoleControlHiddenForTesting == false
+        }
+        #expect(didRenderBoth)
+    }
+
+    @Test
     func previewRequestWithoutBodyRendersPlaceholderWhenBodySurfaceResumes() async throws {
         let network = NetworkSession()
         let request = try #require(


### PR DESCRIPTION
## Purpose

Prevent the Network detail preview role segmented control from animating from Request to Response when switching from a response-only entry to an entry that has both request and response bodies.

## Changes

- Rebuild and update the preview role segmented control without animation.
- Clear the stale selected segment before changing the segment set, then apply the final logical selection.
- Add UI coverage for expanding from a response-only preview role set to both request and response while keeping Response selected.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` reported no findings.