### PR TITLE
Suppress DOM element style animations on selection changes

### DIFF
--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
@@ -141,6 +141,10 @@ package final class DOMElementStylePresentationState {
         visibleSections.map(\.id)
     }
 
+    package var displayedNodeStylesID: CSSNodeStyles.ID? {
+        displayedNodeStyles?.id
+    }
+
     package func render(_ nodeStyles: CSSNodeStyles) -> RenderResult {
         switch nodeStyles.phase {
         case .loaded:

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePresentationModel.swift
@@ -1,6 +1,5 @@
 #if canImport(UIKit)
 import WebInspectorCore
-import Observation
 import UIKit
 
 @MainActor
@@ -18,15 +17,6 @@ package struct DOMElementStylePresentationItemIdentifier: Hashable {
 package struct DOMElementStylePresentationSection {
     package var id: CSSStyle.Section.ID
     package var items: [DOMElementStylePresentationItemIdentifier]
-}
-
-@MainActor
-package struct DOMElementStylePresentationRender {
-    package var snapshot: NSDiffableDataSourceSnapshot<
-        CSSStyle.Section.ID,
-        DOMElementStylePresentationItemIdentifier
-    >
-    package var reconfiguredItemIdentifiers: [DOMElementStylePresentationItemIdentifier]
 }
 
 @MainActor
@@ -98,42 +88,49 @@ package enum DOMElementStyleDiffableSnapshotBuilder {
 }
 
 @MainActor
-@Observable
-package final class DOMElementStylePresentationState {
-    package enum RenderResult {
-        case loaded(DOMElementStylePresentationRender)
-        case pending
+package final class DOMElementStyleSnapshotCoordinator {
+    package typealias Snapshot = NSDiffableDataSourceSnapshot<
+        CSSStyle.Section.ID,
+        DOMElementStylePresentationItemIdentifier
+    >
+
+    package enum ApplyMode: Equatable {
+        case none
+        case diff(animated: Bool)
+        case reloadData
+    }
+
+    package enum PlaceholderMode: Equatable {
+        case none
         case unavailable
     }
 
-    private struct ItemFingerprint: Equatable {
-        var propertyObjectID: ObjectIdentifier
-        var propertyID: CSSProperty.ID?
-        var name: String
-        var value: String
-        var priority: String
-        var text: String?
-        var status: CSSProperty.Status
-        var isEditable: Bool
-        var isModifiedByInspector: Bool
-
-        init(property: CSSProperty) {
-            propertyObjectID = ObjectIdentifier(property)
-            propertyID = property.id
-            name = property.name
-            value = property.value
-            priority = property.priority
-            text = property.text
-            status = property.status
-            isEditable = property.isEditable
-            isModifiedByInspector = property.isModifiedByInspector
-        }
+    package struct SnapshotUpdate {
+        package var snapshot: Snapshot?
+        package var applyMode: ApplyMode
+        package var placeholderMode: PlaceholderMode
     }
 
-    @ObservationIgnored private var expandedUnusedVariableSectionIDs = Set<CSSStyle.Section.ID>()
-    @ObservationIgnored private var displayedNodeStyles: CSSNodeStyles?
-    @ObservationIgnored private var visibleSections: [DOMElementStylePresentationSection] = []
-    @ObservationIgnored private var displayedItemFingerprints: [DOMElementStylePresentationItemIdentifier: ItemFingerprint] = [:]
+    private struct SelectionEpoch {
+        var objectID: ObjectIdentifier
+        var hasRenderedLoadedSnapshot = false
+    }
+
+    private struct VisibleBindingTopology: Equatable {
+        var sectionObjectIDs: [CSSStyle.Section.ID: ObjectIdentifier]
+        var propertyObjectIDs: [DOMElementStylePresentationItemIdentifier: ObjectIdentifier]
+
+        static let empty = VisibleBindingTopology(
+            sectionObjectIDs: [:],
+            propertyObjectIDs: [:]
+        )
+    }
+
+    private var expandedUnusedVariableSectionIDs = Set<CSSStyle.Section.ID>()
+    private var displayedNodeStyles: CSSNodeStyles?
+    private var visibleSections: [DOMElementStylePresentationSection] = []
+    private var visibleBindingTopology = VisibleBindingTopology.empty
+    private var selectionEpoch: SelectionEpoch?
 
     package init() {}
 
@@ -141,44 +138,46 @@ package final class DOMElementStylePresentationState {
         visibleSections.map(\.id)
     }
 
-    package var displayedNodeStylesID: CSSNodeStyles.ID? {
-        displayedNodeStyles?.id
+    package func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles) {
+        let objectID = ObjectIdentifier(nodeStyles)
+        guard selectionEpoch?.objectID != objectID else {
+            return
+        }
+        selectionEpoch = SelectionEpoch(objectID: objectID)
     }
 
-    package func render(_ nodeStyles: CSSNodeStyles) -> RenderResult {
+    package func updateSelectedNodeStyles(_ nodeStyles: CSSNodeStyles) -> SnapshotUpdate {
+        bindSelectedNodeStyles(nodeStyles)
         switch nodeStyles.phase {
         case .loaded:
-            displayedNodeStyles = nodeStyles
-            rebuildVisibleSections()
-            return .loaded(renderSnapshot())
+            return updateLoadedSnapshot(nodeStyles)
         case .loading, .needsRefresh:
-            return renderPending()
+            return updatePendingSnapshot()
         case .unavailable, .failed:
-            return renderUnavailable()
+            return updateUnavailableSnapshot()
         }
     }
 
-    package func render(_ phase: CSSNodeStyles.Phase) -> RenderResult {
+    package func updateUnavailablePhase(_ phase: CSSNodeStyles.Phase) -> SnapshotUpdate {
+        selectionEpoch = nil
         switch phase {
         case .loaded:
-            if displayedNodeStyles != nil {
-                rebuildVisibleSections()
-                return .loaded(renderSnapshot())
-            }
-            return renderUnavailable()
+            return updateUnavailableSnapshot()
         case .loading, .needsRefresh:
-            return renderPending()
+            return updatePendingSnapshot()
         case .unavailable, .failed:
-            return renderUnavailable()
+            return updateUnavailableSnapshot()
         }
     }
 
-    package func showHiddenUnusedVariables(
+    package func revealHiddenUnusedVariables(
         in sectionID: CSSStyle.Section.ID
-    ) -> DOMElementStylePresentationRender? {
+    ) -> SnapshotUpdate? {
         guard let displayedNodeStyles else {
             return nil
         }
+        let oldSectionIDs = visibleSectionIDs
+        let oldItemIDs = visibleItemIDs
         let currentSectionIDs = Set(displayedNodeStyles.sections.map(\.id))
         expandedUnusedVariableSectionIDs.formIntersection(currentSectionIDs)
         guard currentSectionIDs.contains(sectionID) else {
@@ -186,7 +185,16 @@ package final class DOMElementStylePresentationState {
         }
         expandedUnusedVariableSectionIDs.insert(sectionID)
         rebuildVisibleSections()
-        return renderSnapshot()
+        let snapshot = diffableSnapshot()
+        visibleBindingTopology = makeVisibleBindingTopology()
+        guard Self.hasStructuralChanges(
+            oldSectionIDs: oldSectionIDs,
+            oldItemIDs: oldItemIDs,
+            snapshot: snapshot
+        ) else {
+            return SnapshotUpdate(snapshot: nil, applyMode: .none, placeholderMode: .none)
+        }
+        return SnapshotUpdate(snapshot: snapshot, applyMode: .diff(animated: true), placeholderMode: .none)
     }
 
     package func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
@@ -209,19 +217,67 @@ package final class DOMElementStylePresentationState {
         return section.style.cssProperties[propertyIndex]
     }
 
-    private func renderPending() -> RenderResult {
-        guard displayedNodeStyles != nil else {
-            return renderUnavailable()
-        }
-        return .pending
+    private var visibleItemIDs: [DOMElementStylePresentationItemIdentifier] {
+        visibleSections.flatMap(\.items)
     }
 
-    private func renderUnavailable() -> RenderResult {
+    private func updateLoadedSnapshot(_ nodeStyles: CSSNodeStyles) -> SnapshotUpdate {
+        let oldSectionIDs = visibleSectionIDs
+        let oldItemIDs = visibleItemIDs
+        let oldBindingTopology = visibleBindingTopology
+        let replacesSelection = selectionEpoch?.hasRenderedLoadedSnapshot == false
+        let hadVisibleSnapshot = visibleSections.isEmpty == false
+
+        displayedNodeStyles = nodeStyles
+        rebuildVisibleSections()
+
+        let snapshot = diffableSnapshot()
+        let newBindingTopology = makeVisibleBindingTopology()
+        let hasStructuralChanges = Self.hasStructuralChanges(
+            oldSectionIDs: oldSectionIDs,
+            oldItemIDs: oldItemIDs,
+            snapshot: snapshot
+        )
+        let hasBindingChanges = oldBindingTopology != newBindingTopology
+
+        let applyMode: ApplyMode
+        if replacesSelection {
+            applyMode = hadVisibleSnapshot ? .reloadData : .diff(animated: false)
+        } else if hasStructuralChanges {
+            applyMode = .diff(animated: true)
+        } else if hasBindingChanges {
+            applyMode = .reloadData
+        } else {
+            selectionEpoch?.hasRenderedLoadedSnapshot = true
+            visibleBindingTopology = newBindingTopology
+            return SnapshotUpdate(snapshot: nil, applyMode: .none, placeholderMode: .none)
+        }
+        selectionEpoch?.hasRenderedLoadedSnapshot = true
+        visibleBindingTopology = newBindingTopology
+        return SnapshotUpdate(snapshot: snapshot, applyMode: applyMode, placeholderMode: .none)
+    }
+
+    private func updatePendingSnapshot() -> SnapshotUpdate {
+        guard displayedNodeStyles != nil else {
+            return updateUnavailableSnapshot()
+        }
+        return SnapshotUpdate(snapshot: nil, applyMode: .none, placeholderMode: .none)
+    }
+
+    private func updateUnavailableSnapshot() -> SnapshotUpdate {
+        let oldSectionIDs = visibleSectionIDs
+        let oldItemIDs = visibleItemIDs
         expandedUnusedVariableSectionIDs.removeAll()
         displayedNodeStyles = nil
         visibleSections = []
-        displayedItemFingerprints.removeAll()
-        return .unavailable
+        visibleBindingTopology = .empty
+        let snapshot = diffableSnapshot()
+        let applyMode: ApplyMode = Self.hasStructuralChanges(
+            oldSectionIDs: oldSectionIDs,
+            oldItemIDs: oldItemIDs,
+            snapshot: snapshot
+        ) ? .diff(animated: false) : .none
+        return SnapshotUpdate(snapshot: snapshot, applyMode: applyMode, placeholderMode: .unavailable)
     }
 
     private func rebuildVisibleSections() {
@@ -246,40 +302,41 @@ package final class DOMElementStylePresentationState {
         )
     }
 
-    private func renderSnapshot() -> DOMElementStylePresentationRender {
-        let snapshot = diffableSnapshot()
-        let fingerprints = visibleItemFingerprints()
-        let reconfiguredItemIdentifiers = snapshot.itemIdentifiers.filter { item in
-            guard let fingerprint = fingerprints[item] else {
-                return false
-            }
-            return displayedItemFingerprints[item] != fingerprint
-        }
-        displayedItemFingerprints = fingerprints
-        return DOMElementStylePresentationRender(
-            snapshot: snapshot,
-            reconfiguredItemIdentifiers: reconfiguredItemIdentifiers
-        )
-    }
-
-    private func visibleItemFingerprints() -> [DOMElementStylePresentationItemIdentifier: ItemFingerprint] {
+    private func makeVisibleBindingTopology() -> VisibleBindingTopology {
         guard let displayedNodeStyles else {
-            return [:]
+            return .empty
         }
+
         let sectionsByID = Dictionary(uniqueKeysWithValues: displayedNodeStyles.sections.map { ($0.id, $0) })
-        var fingerprints: [DOMElementStylePresentationItemIdentifier: ItemFingerprint] = [:]
+        var sectionObjectIDs: [CSSStyle.Section.ID: ObjectIdentifier] = [:]
+        var propertyObjectIDs: [DOMElementStylePresentationItemIdentifier: ObjectIdentifier] = [:]
+
         for visibleSection in visibleSections {
             guard let section = sectionsByID[visibleSection.id] else {
                 continue
             }
+            sectionObjectIDs[visibleSection.id] = ObjectIdentifier(section)
             for item in visibleSection.items {
                 guard let property = property(for: item, in: section) else {
                     continue
                 }
-                fingerprints[item] = ItemFingerprint(property: property)
+                propertyObjectIDs[item] = ObjectIdentifier(property)
             }
         }
-        return fingerprints
+
+        return VisibleBindingTopology(
+            sectionObjectIDs: sectionObjectIDs,
+            propertyObjectIDs: propertyObjectIDs
+        )
+    }
+
+    private static func hasStructuralChanges(
+        oldSectionIDs: [CSSStyle.Section.ID],
+        oldItemIDs: [DOMElementStylePresentationItemIdentifier],
+        snapshot: Snapshot
+    ) -> Bool {
+        oldSectionIDs != snapshot.sectionIdentifiers
+            || oldItemIDs != snapshot.itemIdentifiers
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyCollectionCell.swift
@@ -10,6 +10,7 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
     private var propertyObservation: PortableObservationTracking.Token?
     private let propertyView = DOMElementStylePropertyView()
     private weak var property: CSSProperty?
+    private var toggleAction: DOMElementStylePropertyView.ToggleAction?
 
     override package init(frame: CGRect) {
         super.init(frame: frame)
@@ -43,10 +44,7 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
         onToggle: DOMElementStylePropertyView.ToggleAction?
     ) {
         self.property = property
-        propertyView.bind(
-            property: property,
-            onToggle: onToggle
-        )
+        toggleAction = onToggle
 
         propertyObservation?.cancel()
         propertyObservation = withPortableContinuousObservation { [weak self, weak property] _ in
@@ -54,16 +52,10 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
                 return
             }
             guard let property else {
-                renderBackground(
-                    isModifiedByInspector: false,
-                    state: configurationState
-                )
+                self.clear()
                 return
             }
-            self.renderBackground(
-                isModifiedByInspector: property.isModifiedByInspector,
-                state: self.configurationState
-            )
+            self.render(property)
         }
     }
 
@@ -71,6 +63,7 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
         propertyObservation?.cancel()
         propertyObservation = nil
         property = nil
+        toggleAction = nil
         propertyView.clear()
         renderBackground(
             isModifiedByInspector: false,
@@ -82,6 +75,8 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
         propertyObservation?.cancel()
         propertyObservation = nil
         property = nil
+        toggleAction = nil
+        propertyView.clear()
         renderBackground(
             isModifiedByInspector: false,
             state: configurationState
@@ -100,6 +95,14 @@ package final class DOMElementStylePropertyCollectionCell: UICollectionViewListC
             propertyView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             propertyView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
+    }
+
+    private func render(_ property: CSSProperty) {
+        propertyView.render(property: property, onToggle: toggleAction)
+        renderBackground(
+            isModifiedByInspector: property.isModifiedByInspector,
+            state: configurationState
+        )
     }
 
     private func renderBackground(

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStylePropertyView.swift
@@ -1,13 +1,11 @@
 #if canImport(UIKit)
 import WebInspectorCore
-import ObservationBridge
 import UIKit
 
 @MainActor
 package final class DOMElementStylePropertyView: UIView {
     package typealias ToggleAction = @MainActor (CSSProperty.ID, Bool) -> Bool
 
-    private var propertyObservation: PortableObservationTracking.Token?
     private let declarationTextView = UITextView()
     private let toggleSwitch = UISwitch()
     private var property: CSSProperty?
@@ -23,27 +21,23 @@ package final class DOMElementStylePropertyView: UIView {
         nil
     }
 
-    isolated deinit {
-        propertyObservation?.cancel()
+    package func bind(
+        property: CSSProperty,
+        onToggle: ToggleAction? = nil
+    ) {
+        render(property: property, onToggle: onToggle)
     }
 
-    package func bind(
+    package func render(
         property: CSSProperty,
         onToggle: ToggleAction? = nil
     ) {
         self.property = property
         toggleAction = onToggle
-
-        propertyObservation?.cancel()
-        propertyObservation = withPortableContinuousObservation { [weak self, weak property] _ in
-            guard let property else { return }
-            self?.renderAll(from: property)
-        }
+        renderAll(from: property)
     }
 
     package func clear() {
-        propertyObservation?.cancel()
-        propertyObservation = nil
         property = nil
         toggleAction = nil
         declarationTextView.attributedText = nil

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleSectionHeaderView.swift
@@ -1,7 +1,6 @@
 #if canImport(UIKit)
 import WebInspectorCore
-import Observation
-import SwiftUI
+import ObservationBridge
 import UIKit
 
 package enum DOMElementStyleSectionHeaderText {
@@ -79,14 +78,14 @@ package enum DOMElementStyleSectionHeaderText {
 
 @MainActor
 final class DOMElementStyleSectionHeaderView: UICollectionViewListCell {
-    private let model = DOMElementStyleSectionHeaderModel()
+    private var sectionObservation: PortableObservationTracking.Token?
+    private weak var section: CSSStyle.Section?
+    private var renderedTitle = ""
+    private var renderedOriginText: String?
+    private var renderedAccessibilityOriginText: String?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        let model = model
-        contentConfiguration = UIHostingConfiguration {
-            DOMElementStyleSectionHeaderContent(model: model)
-        }
     }
 
     @available(*, unavailable)
@@ -99,34 +98,44 @@ final class DOMElementStyleSectionHeaderView: UICollectionViewListCell {
         bind(nil)
     }
 
+    isolated deinit {
+        sectionObservation?.cancel()
+    }
+
     func bind(_ section: CSSStyle.Section?) {
-        model.section = section
-    }
-}
+        guard let section else {
+            sectionObservation?.cancel()
+            sectionObservation = nil
+            self.section = nil
+            render(nil)
+            return
+        }
 
-@MainActor
-@Observable
-private final class DOMElementStyleSectionHeaderModel {
-    var section: CSSStyle.Section?
-}
-
-private struct DOMElementStyleSectionHeaderContent: View {
-    var model: DOMElementStyleSectionHeaderModel
-
-    private var title: String {
-        model.section?.title ?? ""
-    }
-
-    private var originText: String? {
-        model.section?.rule.flatMap(DOMElementStyleSectionHeaderText.displayOriginText(for:))
-    }
-
-    private var accessibilityOriginText: String? {
-        model.section?.rule.flatMap(DOMElementStyleSectionHeaderText.accessibilityOriginText(for:))
+        if self.section === section {
+            return
+        }
+        self.section = section
+        sectionObservation?.cancel()
+        sectionObservation = withPortableContinuousObservation { [weak self, weak section] _ in
+            guard let self else {
+                return
+            }
+            self.render(section)
+        }
     }
 
-    private var accessibilityLabel: String {
-        [title, accessibilityOriginText]
+    private func render(_ section: CSSStyle.Section?) {
+        renderedTitle = section?.title ?? ""
+        renderedOriginText = section?.rule.flatMap(DOMElementStyleSectionHeaderText.displayOriginText(for:))
+        renderedAccessibilityOriginText = section?.rule.flatMap(DOMElementStyleSectionHeaderText.accessibilityOriginText(for:))
+
+        var content = defaultContentConfiguration()
+        content.text = renderedTitle
+        content.secondaryText = renderedOriginText
+        content.secondaryTextProperties.color = .secondaryLabel
+        contentConfiguration = content
+
+        let accessibilityLabel = [renderedTitle, renderedAccessibilityOriginText]
             .compactMap { text in
                 guard let text, !text.isEmpty else {
                     return nil
@@ -134,43 +143,19 @@ private struct DOMElementStyleSectionHeaderContent: View {
                 return text
             }
             .joined(separator: ", ")
-    }
-
-    var body: some View {
-        LabeledContent {
-            if let originText {
-                Text(originText)
-                    .truncationMode(.tail)
-                    .multilineTextAlignment(.trailing)
-            }
-        } label: {
-            Text(title)
-        }
-        .textScale(.secondary)
-        .lineLimit(1)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
+        isAccessibilityElement = accessibilityLabel.isEmpty == false
+        self.accessibilityLabel = accessibilityLabel.isEmpty ? nil : accessibilityLabel
     }
 }
 
 #if DEBUG
 extension DOMElementStyleSectionHeaderView {
     package var titleTextForTesting: String {
-        model.titleTextForTesting
+        renderedTitle
     }
 
     package var originTextForTesting: String? {
-        model.originTextForTesting
-    }
-}
-
-private extension DOMElementStyleSectionHeaderModel {
-    var titleTextForTesting: String {
-        section?.title ?? ""
-    }
-
-    var originTextForTesting: String? {
-        section?.rule.flatMap(DOMElementStyleSectionHeaderText.displayOriginText(for:))
+        renderedOriginText
     }
 }
 #endif

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -219,17 +219,24 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func render(_ nodeStyles: CSSNodeStyles) {
-        render(stylePresentationState.render(nodeStyles))
+        let animatesDifferences = stylePresentationState.displayedNodeStylesID == nodeStyles.id
+        render(
+            stylePresentationState.render(nodeStyles),
+            animatingDifferences: animatesDifferences
+        )
     }
 
     private func render(_ state: CSSNodeStyles.Phase) {
         render(stylePresentationState.render(state))
     }
 
-    private func render(_ result: DOMElementStylePresentationState.RenderResult) {
+    private func render(
+        _ result: DOMElementStylePresentationState.RenderResult,
+        animatingDifferences: Bool = false
+    ) {
         switch result {
         case let .loaded(render):
-            renderStyles(render)
+            renderStyles(render, animatingDifferences: animatingDifferences)
         case .pending:
             renderPendingStyles()
         case .unavailable:
@@ -260,14 +267,16 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func renderStyles(
-        _ render: DOMElementStylePresentationRender
+        _ render: DOMElementStylePresentationRender,
+        animatingDifferences: Bool = false
     ) {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
         applySnapshot(
             render.snapshot,
-            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers
+            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers,
+            animatingDifferences: animatingDifferences
         )
     }
 
@@ -278,8 +287,9 @@ package final class DOMElementViewController: UICollectionViewController {
         >()
 #if DEBUG
         styleSnapshotApplyCountForTesting += 1
+        lastSnapshotAnimatedForTesting = false
 #endif
-        dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+        applySnapshotToDataSource(snapshot, animatingDifferences: false) { [weak self] in
 #if DEBUG
             self?.finishStyleRenderForTesting()
 #endif
@@ -295,11 +305,12 @@ package final class DOMElementViewController: UICollectionViewController {
         animatingDifferences: Bool = false
     ) {
         let currentSnapshot = dataSource.snapshot()
+        let hasStructuralChanges = currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
+            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers
 #if DEBUG
-        lastSnapshotAnimatedForTesting = animatingDifferences
+        lastSnapshotAnimatedForTesting = animatingDifferences && hasStructuralChanges
 #endif
-        guard currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
-            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers else {
+        guard hasStructuralChanges else {
             let reconfiguredItemIdentifiers = reconfiguredItemIdentifiers.filter { item in
                 snapshot.indexOfItem(item) != nil
             }
@@ -314,7 +325,7 @@ package final class DOMElementViewController: UICollectionViewController {
 #if DEBUG
             styleSnapshotApplyCountForTesting += 1
 #endif
-            dataSource.apply(reconfiguredSnapshot, animatingDifferences: false) { [weak self] in
+            applySnapshotToDataSource(reconfiguredSnapshot, animatingDifferences: false) { [weak self] in
 #if DEBUG
                 self?.finishStyleRenderForTesting()
 #endif
@@ -329,10 +340,29 @@ package final class DOMElementViewController: UICollectionViewController {
 #if DEBUG
         styleSnapshotApplyCountForTesting += 1
 #endif
-        dataSource.apply(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
+        applySnapshotToDataSource(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
 #if DEBUG
             self?.finishStyleRenderForTesting()
 #endif
+        }
+    }
+
+    private func applySnapshotToDataSource(
+        _ snapshot: NSDiffableDataSourceSnapshot<
+            CSSStyle.Section.ID,
+            DOMElementStylePresentationItemIdentifier
+        >,
+        animatingDifferences: Bool,
+        completion: @escaping () -> Void
+    ) {
+        guard !animatingDifferences else {
+            dataSource.apply(snapshot, animatingDifferences: true, completion: completion)
+            return
+        }
+
+        UIView.performWithoutAnimation {
+            dataSource.apply(snapshot, animatingDifferences: false, completion: completion)
+            collectionView.layoutIfNeeded()
         }
     }
 

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -8,8 +8,8 @@ package final class DOMElementViewController: UICollectionViewController {
     private let inspection: AttachedInspection
     private var elementStylesObservation: PortableObservationTracking.Token?
     private var selectedNodeStyleObservation: PortableObservationTracking.Token?
-    private var observedNodeStylesID: ObjectIdentifier?
-    private let stylePresentationState = DOMElementStylePresentationState()
+    private var selectedNodeStylesObjectID: ObjectIdentifier?
+    private let styleSnapshotCoordinator = DOMElementStyleSnapshotCoordinator()
 
 #if DEBUG
     private struct StyleRenderWaiter {
@@ -18,7 +18,7 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     package var disablesSnapshotAnimationsForTesting = false
-    package private(set) var lastSnapshotAnimatedForTesting = false
+    package private(set) var lastSnapshotApplyModeForTesting: DOMElementStyleSnapshotCoordinator.ApplyMode = .none
     package private(set) var styleSnapshotApplyCountForTesting = 0
     private var styleRenderGeneration = 0
     private var nextStyleRenderWaiterID: UInt64 = 0
@@ -48,6 +48,7 @@ package final class DOMElementViewController: UICollectionViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
+        _ = dataSource
         applyBackgroundFromTraits()
         collectionView.alwaysBounceVertical = true
         collectionView.keyboardDismissMode = .onDrag
@@ -194,198 +195,119 @@ package final class DOMElementViewController: UICollectionViewController {
 
     private func bindSelectedNodeStyles(_ nodeStyles: CSSNodeStyles?, unavailableState: CSSNodeStyles.Phase) {
         guard let nodeStyles else {
-            observedNodeStylesID = nil
-            selectedNodeStyleObservation?.cancel()
-            selectedNodeStyleObservation = nil
-            render(unavailableState)
+            unbindSelectedNodeStyles()
+            applySnapshotUpdate(styleSnapshotCoordinator.updateUnavailablePhase(unavailableState))
             return
         }
 
-        let nodeStylesID = ObjectIdentifier(nodeStyles)
-        guard observedNodeStylesID != nodeStylesID else {
+        let nodeStylesObjectID = ObjectIdentifier(nodeStyles)
+        guard selectedNodeStylesObjectID != nodeStylesObjectID else {
             return
         }
-        observedNodeStylesID = nodeStylesID
         selectedNodeStyleObservation?.cancel()
-        let token = withPortableContinuousObservation { [weak self, weak nodeStyles, nodeStylesID] _ in
+        selectedNodeStylesObjectID = nodeStylesObjectID
+        styleSnapshotCoordinator.bindSelectedNodeStyles(nodeStyles)
+        let token = withPortableContinuousObservation { [weak self, weak nodeStyles, nodeStylesObjectID] _ in
             guard let self,
                   let nodeStyles,
-                  self.observedNodeStylesID == nodeStylesID else {
+                  self.selectedNodeStylesObjectID == nodeStylesObjectID else {
                 return
             }
-            self.render(nodeStyles)
+            self.applySnapshotUpdate(
+                self.styleSnapshotCoordinator.updateSelectedNodeStyles(nodeStyles)
+            )
         }
         selectedNodeStyleObservation = token
     }
 
-    private func render(_ nodeStyles: CSSNodeStyles) {
-        let animatesDifferences = stylePresentationState.displayedNodeStylesID == nodeStyles.id
-        render(
-            stylePresentationState.render(nodeStyles),
-            animatingDifferences: animatesDifferences
-        )
+    private func unbindSelectedNodeStyles() {
+        selectedNodeStylesObjectID = nil
+        selectedNodeStyleObservation?.cancel()
+        selectedNodeStyleObservation = nil
     }
 
-    private func render(_ state: CSSNodeStyles.Phase) {
-        render(stylePresentationState.render(state))
-    }
-
-    private func render(
-        _ result: DOMElementStylePresentationState.RenderResult,
-        animatingDifferences: Bool = false
-    ) {
-        switch result {
-        case let .loaded(render):
-            renderStyles(render, animatingDifferences: animatingDifferences)
-        case .pending:
-            renderPendingStyles()
-        case .unavailable:
-            renderUnavailableStyles()
-        }
-    }
-
-    private func renderUnavailableStyles() {
-        if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
-           configuration.text == String(localized: "dom.element.styles.empty.title", bundle: .module) {
-            applyEmptySnapshot()
-            return
-        }
-        var configuration = UIContentUnavailableConfiguration.empty()
-        configuration.text = String(localized: "dom.element.styles.empty.title", bundle: .module)
-        configuration.textProperties.color = .secondaryLabel
-        contentUnavailableConfiguration = configuration
-        applyEmptySnapshot()
-    }
-
-    private func renderPendingStyles() {
-        if contentUnavailableConfiguration != nil {
-            contentUnavailableConfiguration = nil
-        }
+    private func applySnapshotUpdate(_ update: DOMElementStyleSnapshotCoordinator.SnapshotUpdate) {
+        applyPlaceholder(update.placeholderMode)
+        switch update.applyMode {
+        case .none:
 #if DEBUG
-        finishStyleRenderForTesting()
+            finishStyleRenderForTesting()
 #endif
-    }
-
-    private func renderStyles(
-        _ render: DOMElementStylePresentationRender,
-        animatingDifferences: Bool = false
-    ) {
-        if contentUnavailableConfiguration != nil {
-            contentUnavailableConfiguration = nil
-        }
-        applySnapshot(
-            render.snapshot,
-            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers,
-            animatingDifferences: animatingDifferences
-        )
-    }
-
-    private func applyEmptySnapshot() {
-        let snapshot = NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >()
+        case let .diff(animated):
+            guard let snapshot = update.snapshot else {
 #if DEBUG
-        styleSnapshotApplyCountForTesting += 1
-        lastSnapshotAnimatedForTesting = false
-#endif
-        applySnapshotToDataSource(snapshot, animatingDifferences: false) { [weak self] in
-#if DEBUG
-            self?.finishStyleRenderForTesting()
-#endif
-        }
-    }
-
-    private func applySnapshot(
-        _ snapshot: NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >,
-        reconfiguredItemIdentifiers: [DOMElementStylePresentationItemIdentifier] = [],
-        animatingDifferences: Bool = false
-    ) {
-        let currentSnapshot = dataSource.snapshot()
-        let hasStructuralChanges = currentSnapshot.sectionIdentifiers != snapshot.sectionIdentifiers
-            || currentSnapshot.itemIdentifiers != snapshot.itemIdentifiers
-#if DEBUG
-        lastSnapshotAnimatedForTesting = animatingDifferences && hasStructuralChanges
-#endif
-        guard hasStructuralChanges else {
-            let reconfiguredItemIdentifiers = reconfiguredItemIdentifiers.filter { item in
-                snapshot.indexOfItem(item) != nil
-            }
-            guard !reconfiguredItemIdentifiers.isEmpty else {
-#if DEBUG
+                lastSnapshotApplyModeForTesting = .none
                 finishStyleRenderForTesting()
 #endif
                 return
             }
-            var reconfiguredSnapshot = snapshot
-            reconfiguredSnapshot.reconfigureItems(reconfiguredItemIdentifiers)
 #if DEBUG
+            lastSnapshotApplyModeForTesting = .diff(animated: animated)
+            let shouldAnimateSnapshot = animated && !disablesSnapshotAnimationsForTesting
             styleSnapshotApplyCountForTesting += 1
+#else
+            let shouldAnimateSnapshot = animated
 #endif
-            applySnapshotToDataSource(reconfiguredSnapshot, animatingDifferences: false) { [weak self] in
+            dataSource.apply(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
 #if DEBUG
                 self?.finishStyleRenderForTesting()
 #endif
             }
-            return
-        }
+        case .reloadData:
+            guard let snapshot = update.snapshot else {
 #if DEBUG
-        let shouldAnimateSnapshot = animatingDifferences && !disablesSnapshotAnimationsForTesting
-#else
-        let shouldAnimateSnapshot = animatingDifferences
+                lastSnapshotApplyModeForTesting = .none
+                finishStyleRenderForTesting()
 #endif
+                return
+            }
 #if DEBUG
-        styleSnapshotApplyCountForTesting += 1
+            lastSnapshotApplyModeForTesting = .reloadData
+            styleSnapshotApplyCountForTesting += 1
 #endif
-        applySnapshotToDataSource(snapshot, animatingDifferences: shouldAnimateSnapshot) { [weak self] in
+            dataSource.applySnapshotUsingReloadData(snapshot) { [weak self] in
 #if DEBUG
-            self?.finishStyleRenderForTesting()
+                self?.finishStyleRenderForTesting()
 #endif
+            }
         }
     }
 
-    private func applySnapshotToDataSource(
-        _ snapshot: NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >,
-        animatingDifferences: Bool,
-        completion: @escaping () -> Void
-    ) {
-        guard !animatingDifferences else {
-            dataSource.apply(snapshot, animatingDifferences: true, completion: completion)
-            return
-        }
-
-        UIView.performWithoutAnimation {
-            dataSource.apply(snapshot, animatingDifferences: false, completion: completion)
-            collectionView.layoutIfNeeded()
+    private func applyPlaceholder(_ placeholderMode: DOMElementStyleSnapshotCoordinator.PlaceholderMode) {
+        switch placeholderMode {
+        case .none:
+            if contentUnavailableConfiguration != nil {
+                contentUnavailableConfiguration = nil
+            }
+        case .unavailable:
+            let title = String(localized: "dom.element.styles.empty.title", bundle: .module)
+            if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
+               configuration.text == title {
+                return
+            }
+            var configuration = UIContentUnavailableConfiguration.empty()
+            configuration.text = title
+            configuration.textProperties.color = .secondaryLabel
+            contentUnavailableConfiguration = configuration
         }
     }
 
     private func section(for sectionID: CSSStyle.Section.ID) -> CSSStyle.Section? {
-        stylePresentationState.section(for: sectionID)
+        styleSnapshotCoordinator.section(for: sectionID)
     }
 
     private func property(
         for item: DOMElementStylePresentationItemIdentifier,
         in section: CSSStyle.Section
     ) -> CSSProperty? {
-        stylePresentationState.property(for: item, in: section)
+        styleSnapshotCoordinator.property(for: item, in: section)
     }
 
     private func showHiddenUnusedVariables(in sectionID: CSSStyle.Section.ID) {
-        guard let render = stylePresentationState.showHiddenUnusedVariables(in: sectionID) else {
+        guard let update = styleSnapshotCoordinator.revealHiddenUnusedVariables(in: sectionID) else {
             return
         }
-        applySnapshot(
-            render.snapshot,
-            reconfiguredItemIdentifiers: render.reconfiguredItemIdentifiers,
-            animatingDifferences: true
-        )
+        applySnapshotUpdate(update)
     }
 
     private func toggleAction() -> DOMElementStylePropertyView.ToggleAction? {
@@ -432,9 +354,9 @@ package final class DOMElementViewController: UICollectionViewController {
     package func renderCurrentStylesForTesting() {
         let elementStyles = inspection.dom.elementStyles
         if let selectedNodeStyles = elementStyles.selectedNodeStyles {
-            render(selectedNodeStyles)
+            applySnapshotUpdate(styleSnapshotCoordinator.updateSelectedNodeStyles(selectedNodeStyles))
         } else {
-            render(elementStyles.selectedPhase)
+            applySnapshotUpdate(styleSnapshotCoordinator.updateUnavailablePhase(elementStyles.selectedPhase))
         }
     }
 

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -152,6 +152,7 @@ struct DOMContainerTests {
 
         #expect(didRenderRows)
         let cellIDsBeforeUpdate = visibleCellIDs(in: viewController)
+        let applyCountBeforeUpdate = viewController.styleSnapshotApplyCountForTesting
 
         let identity = try dom.selectedCSSNodeStylesID().get()
         let refreshToken = css.beginRefresh(id: identity)
@@ -176,6 +177,7 @@ struct DOMContainerTests {
         #expect(didUpdateVisibleRow)
         #expect(viewController.collectionView.isHidden == false)
         #expect(visibleCellIDs(in: viewController) == cellIDsBeforeUpdate)
+        #expect(viewController.styleSnapshotApplyCountForTesting == applyCountBeforeUpdate)
     }
 
     @Test
@@ -253,7 +255,7 @@ struct DOMContainerTests {
     }
 
     @Test
-    func elementViewControllerAnimatesStructuralStyleChangesForSameSelectedNode() async throws {
+    func elementViewControllerRequestsAnimatedDifferencesForSameSelectionStructuralStyleChange() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let body = try #require(firstElement(named: "body", in: dom))
         dom.selectNode(body.id)
@@ -283,7 +285,49 @@ struct DOMContainerTests {
         }
 
         #expect(didRenderUpdatedSections)
-        #expect(viewController.lastSnapshotAnimatedForTesting)
+        #expect(viewController.lastSnapshotApplyModeForTesting == .diff(animated: true))
+    }
+
+    @Test
+    func elementViewControllerDoesNotRequestAnimatedDifferencesWhenSwitchingToCachedSelectionStyles() async throws {
+        let dom = makeDOMSession(capabilities: .pageDefault)
+        let input = try #require(firstElement(named: "input", in: dom))
+        dom.selectNode(input.id)
+
+        let css = dom.elementStyles
+        try applyBodyStyles(
+            to: css,
+            in: dom,
+            selector: "input",
+            marginValue: "8px",
+            marginText: "margin: 8px;"
+        )
+
+        let body = try #require(firstElement(named: "body", in: dom))
+        dom.selectNode(body.id)
+        try applyBodyStyles(to: css, in: dom)
+
+        let viewController = makeElementViewController(dom: dom)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
+            stylePropertyViews(in: viewController)
+                .map(\.declarationTextForTesting)
+                .contains("margin: 0;")
+        }
+        #expect(didRenderBodyRows)
+
+        dom.selectNode(input.id)
+
+        let didRenderInputRows = await waitUntilRendered(in: viewController) {
+            stylePropertyViews(in: viewController)
+                .map(\.declarationTextForTesting)
+                .contains("margin: 8px;")
+        }
+
+        #expect(didRenderInputRows)
+        #expect(viewController.lastSnapshotApplyModeForTesting == .reloadData)
     }
 
     @Test
@@ -345,7 +389,7 @@ struct DOMContainerTests {
 
         #expect(didRenderInputRows)
         #expect(viewController.collectionView.isHidden == false)
-        #expect(!viewController.lastSnapshotAnimatedForTesting)
+        #expect(viewController.lastSnapshotApplyModeForTesting == .reloadData)
     }
 
     @Test
@@ -511,7 +555,7 @@ struct DOMContainerTests {
         }
 
         #expect(didRevealUnusedVariables)
-        #expect(viewController.lastSnapshotAnimatedForTesting)
+        #expect(viewController.lastSnapshotApplyModeForTesting == .diff(animated: true))
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -253,6 +253,40 @@ struct DOMContainerTests {
     }
 
     @Test
+    func elementViewControllerAnimatesStructuralStyleChangesForSameSelectedNode() async throws {
+        let dom = makeDOMSession(capabilities: .pageDefault)
+        let body = try #require(firstElement(named: "body", in: dom))
+        dom.selectNode(body.id)
+
+        let css = dom.elementStyles
+        try applyBodyStyles(to: css, in: dom)
+
+        let viewController = makeElementViewController(dom: dom)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let didRenderBodyRows = await waitUntilRendered(in: viewController) {
+            viewController.collectionView.numberOfSections == 1
+                && stylePropertyViews(in: viewController)
+                    .map(\.declarationTextForTesting)
+                    .contains("margin: 0;")
+        }
+        #expect(didRenderBodyRows)
+
+        try applyInheritedVariableStyles(to: css, in: dom)
+
+        let didRenderUpdatedSections = await waitUntilRendered(in: viewController) {
+            viewController.collectionView.numberOfSections == 2
+                && stylePropertyViews(in: viewController)
+                    .map(\.declarationTextForTesting)
+                    .contains("color: var(--foreground);")
+        }
+
+        #expect(didRenderUpdatedSections)
+        #expect(viewController.lastSnapshotAnimatedForTesting)
+    }
+
+    @Test
     func elementViewControllerKeepsCurrentRowsWhileNewSelectionStylesAreHydrating() async throws {
         let dom = makeDOMSession(capabilities: .pageDefault)
         let body = try #require(firstElement(named: "body", in: dom))
@@ -311,6 +345,7 @@ struct DOMContainerTests {
 
         #expect(didRenderInputRows)
         #expect(viewController.collectionView.isHidden == false)
+        #expect(!viewController.lastSnapshotAnimatedForTesting)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
+++ b/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
@@ -8,122 +8,203 @@ import UIKit
 extension WebInspectorUIRenderingTests {
 @MainActor
 @Suite
-struct DOMElementStylePresentationStateTests {
+struct DOMElementStyleSnapshotCoordinatorTests {
     @Test
-    func presentationStateReturnsNoDirtyItemsWhenNodeStylesDoNotChange() throws {
-        let state = DOMElementStylePresentationState()
+    func coordinatorRequestsNonAnimatedDiffForInitialLoadedSelection() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
         let nodeStyles = makeNodeStyles(sections: makeFlatStyleSections())
-        _ = try loadedRender(from: state.render(nodeStyles))
+        coordinator.bindSelectedNodeStyles(nodeStyles)
 
-        let cleanRender = try loadedRender(from: state.render(nodeStyles))
+        let update = coordinator.updateSelectedNodeStyles(nodeStyles)
 
-        #expect(cleanRender.reconfiguredItemIdentifiers.isEmpty)
+        #expect(update.applyMode == .diff(animated: false))
+        #expect(update.placeholderMode == .none)
+        let snapshot = try loadedSnapshot(from: update)
+        #expect(snapshot.sectionIdentifiers == coordinator.visibleSectionIDs)
+        #expect(containsVisibleProperty(named: "margin", in: snapshot, coordinator: coordinator))
     }
 
     @Test
-    func presentationStateMarksOnlyChangedPropertyItemDirty() throws {
-        let state = DOMElementStylePresentationState()
+    func coordinatorReloadsWhenSwitchingToCachedSelectionStyles() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
+        let bodyStyles = makeNodeStyles(sections: makeFlatStyleSections())
+        coordinator.bindSelectedNodeStyles(bodyStyles)
+        _ = coordinator.updateSelectedNodeStyles(bodyStyles)
+
+        let inputStyles = makeNodeStyles(
+            nodeLocalID: 2,
+            sections: makeFlatStyleSections(
+                nodeLocalID: 2,
+                selector: "input",
+                marginValue: "8px",
+                marginText: "margin: 8px;"
+            )
+        )
+        coordinator.bindSelectedNodeStyles(inputStyles)
+
+        let update = coordinator.updateSelectedNodeStyles(inputStyles)
+
+        #expect(update.applyMode == .reloadData)
+        #expect(update.placeholderMode == .none)
+        #expect(try loadedSnapshot(from: update).sectionIdentifiers == coordinator.visibleSectionIDs)
+    }
+
+    @Test
+    func coordinatorReloadsSelectionReplacementWithMatchingDiffableIdentifiers() {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
+        let oldStyles = makeNodeStyles(sections: makeFlatStyleSections())
+        coordinator.bindSelectedNodeStyles(oldStyles)
+        _ = coordinator.updateSelectedNodeStyles(oldStyles)
+
+        let replacementStyles = makeNodeStyles(
+            sections: makeFlatStyleSections(
+                marginValue: "4px",
+                marginText: "margin: 4px;"
+            )
+        )
+        coordinator.bindSelectedNodeStyles(replacementStyles)
+
+        let update = coordinator.updateSelectedNodeStyles(replacementStyles)
+
+        #expect(update.applyMode == .reloadData)
+        #expect(update.placeholderMode == .none)
+    }
+
+    @Test
+    func coordinatorKeepsDisplayedRowsWhileSelectionHydratesThenReloadsLoadedReplacement() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
+        let bodyStyles = makeNodeStyles(sections: makeFlatStyleSections())
+        coordinator.bindSelectedNodeStyles(bodyStyles)
+        _ = coordinator.updateSelectedNodeStyles(bodyStyles)
+
+        let inputStyles = makeNodeStyles(nodeLocalID: 2, sections: [], phase: .loading)
+        coordinator.bindSelectedNodeStyles(inputStyles)
+        let loadingUpdate = coordinator.updateSelectedNodeStyles(inputStyles)
+
+        #expect(loadingUpdate.applyMode == .none)
+        #expect(loadingUpdate.snapshot == nil)
+        #expect(loadingUpdate.placeholderMode == .none)
+        #expect(coordinator.visibleSectionIDs.isEmpty == false)
+
+        inputStyles.sections = makeFlatStyleSections(
+            nodeLocalID: 2,
+            selector: "input",
+            marginValue: "8px",
+            marginText: "margin: 8px;"
+        )
+        inputStyles.phase = .loaded
+        let loadedUpdate = coordinator.updateSelectedNodeStyles(inputStyles)
+
+        #expect(loadedUpdate.applyMode == .reloadData)
+        #expect(loadedUpdate.placeholderMode == .none)
+    }
+
+    @Test
+    func coordinatorAnimatesSameSelectionStructuralStyleChange() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
+        let nodeStyles = makeNodeStyles(sections: makeFlatStyleSections())
+        coordinator.bindSelectedNodeStyles(nodeStyles)
+        _ = coordinator.updateSelectedNodeStyles(nodeStyles)
+
+        nodeStyles.sections = makeStyleSections(inheritedOrdinal: 0)
+        let update = coordinator.updateSelectedNodeStyles(nodeStyles)
+
+        #expect(update.applyMode == .diff(animated: true))
+        let snapshot = try loadedSnapshot(from: update)
+        #expect(snapshot.sectionIdentifiers.count == 2)
+        #expect(containsVisibleProperty(named: "color", in: snapshot, coordinator: coordinator))
+    }
+
+    @Test
+    func coordinatorDoesNotApplySnapshotForPropertyMutationWithoutTopologyChange() {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
         let sections = makeFlatStyleSections()
         let nodeStyles = makeNodeStyles(sections: sections)
-        let initialRender = try loadedRender(from: state.render(nodeStyles))
-        let marginItem = try itemIdentifier(named: "margin", in: initialRender.snapshot, state: state)
-        let paddingItem = try itemIdentifier(named: "padding", in: initialRender.snapshot, state: state)
+        coordinator.bindSelectedNodeStyles(nodeStyles)
+        _ = coordinator.updateSelectedNodeStyles(nodeStyles)
 
-        let margin = try #require(sections.first?.style.cssProperties.first)
+        let margin = sections[0].style.cssProperties[0]
         margin.value = "4px"
         margin.text = "margin: 4px;"
 
-        let marginRender = try loadedRender(from: state.render(nodeStyles))
-        #expect(marginRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
-        #expect(marginRender.reconfiguredItemIdentifiers == [marginItem])
+        let update = coordinator.updateSelectedNodeStyles(nodeStyles)
 
-        let padding = try #require(sections.first?.style.cssProperties.dropFirst().first)
-        padding.name = "padding-inline"
-        padding.text = "/* padding-inline: 8px; */"
-        padding.status = .disabled
-
-        let paddingRender = try loadedRender(from: state.render(nodeStyles))
-        #expect(paddingRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
-        #expect(paddingRender.reconfiguredItemIdentifiers == [paddingItem])
+        #expect(update.applyMode == .none)
+        #expect(update.snapshot == nil)
+        #expect(update.placeholderMode == .none)
     }
 
     @Test
-    func presentationStateMarksPropertyDirtyWhenObjectChangesWithoutIdentifierChange() throws {
-        let state = DOMElementStylePresentationState()
+    func coordinatorReloadsWhenBackingPropertyObjectChangesWithoutStructuralIdentifiers() {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
         let sections = makeFlatStyleSections()
         let nodeStyles = makeNodeStyles(sections: sections)
-        let initialRender = try loadedRender(from: state.render(nodeStyles))
-        let marginItem = try itemIdentifier(named: "margin", in: initialRender.snapshot, state: state)
+        coordinator.bindSelectedNodeStyles(nodeStyles)
+        _ = coordinator.updateSelectedNodeStyles(nodeStyles)
 
-        let marginID = try #require(sections.first?.style.cssProperties.first?.id)
-        let section = try #require(sections.first)
-        section.style.cssProperties[0] = property(
-            id: marginID,
-            name: "margin",
-            value: "0",
-            text: "margin: 0;"
-        )
+        let replacementProperties = makeFlatStyleSections(
+            marginValue: "4px",
+            marginText: "margin: 4px;"
+        )[0].style.cssProperties
+        sections[0].style.cssProperties = replacementProperties
 
-        let refreshedRender = try loadedRender(from: state.render(nodeStyles))
-        #expect(refreshedRender.snapshot.itemIdentifiers == initialRender.snapshot.itemIdentifiers)
-        #expect(refreshedRender.reconfiguredItemIdentifiers == [marginItem])
+        let update = coordinator.updateSelectedNodeStyles(nodeStyles)
+
+        #expect(update.applyMode == .reloadData)
+        #expect(update.placeholderMode == .none)
     }
 
     @Test
-    func presentationStateRevealsHiddenUnusedVariablesWithTransientSnapshot() throws {
-        let state = DOMElementStylePresentationState()
+    func coordinatorRevealsHiddenUnusedVariablesWithAnimatedSnapshot() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
         let sections = makeStyleSections(inheritedOrdinal: 0)
         let nodeStyles = makeNodeStyles(sections: sections)
+        coordinator.bindSelectedNodeStyles(nodeStyles)
 
-        let initialSnapshot = try loadedSnapshot(from: state.render(nodeStyles))
+        let initialSnapshot = try loadedSnapshot(from: coordinator.updateSelectedNodeStyles(nodeStyles))
         #expect(initialSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1))
-        #expect(containsVisibleProperty(named: "--unused-a", in: initialSnapshot, state: state) == false)
+        #expect(containsVisibleProperty(named: "--unused-a", in: initialSnapshot, coordinator: coordinator) == false)
 
         let inheritedSection = try #require(sections.first { $0.kind == .inheritedRule(ancestorIndex: 0) })
-        let revealedRender = try #require(state.showHiddenUnusedVariables(in: inheritedSection.id))
-        let revealedSnapshot = revealedRender.snapshot
+        let revealedUpdate = try #require(coordinator.revealHiddenUnusedVariables(in: inheritedSection.id))
+
+        #expect(revealedUpdate.applyMode == .diff(animated: true))
+        let revealedSnapshot = try loadedSnapshot(from: revealedUpdate)
         #expect(revealedSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1) == false)
-        #expect(containsVisibleProperty(named: "--unused-a", in: revealedSnapshot, state: state))
+        #expect(containsVisibleProperty(named: "--unused-a", in: revealedSnapshot, coordinator: coordinator))
     }
 
     @Test
-    func presentationStatePrunesExpandedUnusedVariableSectionsAfterSectionRefresh() throws {
-        let state = DOMElementStylePresentationState()
+    func coordinatorPrunesExpandedUnusedVariableSectionsAfterSectionRefresh() throws {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
         let oldSections = makeStyleSections(inheritedOrdinal: 0, unusedVariableName: "--unused-a")
         let nodeStyles = makeNodeStyles(sections: oldSections)
-        _ = try loadedSnapshot(from: state.render(nodeStyles))
+        coordinator.bindSelectedNodeStyles(nodeStyles)
+        _ = coordinator.updateSelectedNodeStyles(nodeStyles)
 
         let oldInheritedSection = try #require(oldSections.first { $0.kind == .inheritedRule(ancestorIndex: 0) })
-        _ = try #require(state.showHiddenUnusedVariables(in: oldInheritedSection.id))
+        _ = try #require(coordinator.revealHiddenUnusedVariables(in: oldInheritedSection.id))
 
         let newSections = makeStyleSections(inheritedOrdinal: 1, unusedVariableName: "--unused-b")
         nodeStyles.sections = newSections
-        let refreshedSnapshot = try loadedSnapshot(from: state.render(nodeStyles))
+        let refreshedUpdate = coordinator.updateSelectedNodeStyles(nodeStyles)
+        let refreshedSnapshot = try loadedSnapshot(from: refreshedUpdate)
 
-        #expect(state.section(for: oldInheritedSection.id) == nil)
-        #expect(refreshedSnapshot.sectionIdentifiers == state.visibleSectionIDs)
+        #expect(refreshedUpdate.applyMode == .diff(animated: true))
+        #expect(coordinator.section(for: oldInheritedSection.id) == nil)
+        #expect(refreshedSnapshot.sectionIdentifiers == coordinator.visibleSectionIDs)
         #expect(refreshedSnapshot.itemIdentifiers.containsHiddenUnusedVariables(count: 1))
-        #expect(containsVisibleProperty(named: "--unused-b", in: refreshedSnapshot, state: state) == false)
-        #expect(state.showHiddenUnusedVariables(in: oldInheritedSection.id) == nil)
-    }
-
-    private func loadedRender(
-        from result: DOMElementStylePresentationState.RenderResult
-    ) throws -> DOMElementStylePresentationRender {
-        guard case let .loaded(render) = result else {
-            Issue.record("Expected loaded style presentation state")
-            throw TestFailure()
-        }
-        return render
+        #expect(containsVisibleProperty(named: "--unused-b", in: refreshedSnapshot, coordinator: coordinator) == false)
+        #expect(coordinator.revealHiddenUnusedVariables(in: oldInheritedSection.id) == nil)
     }
 
     private func loadedSnapshot(
-        from result: DOMElementStylePresentationState.RenderResult
+        from update: DOMElementStyleSnapshotCoordinator.SnapshotUpdate
     ) throws -> NSDiffableDataSourceSnapshot<
         CSSStyle.Section.ID,
         DOMElementStylePresentationItemIdentifier
     > {
-        try loadedRender(from: result).snapshot
+        try #require(update.snapshot)
     }
 
     private func containsVisibleProperty(
@@ -132,61 +213,42 @@ struct DOMElementStylePresentationStateTests {
             CSSStyle.Section.ID,
             DOMElementStylePresentationItemIdentifier
         >,
-        state: DOMElementStylePresentationState
+        coordinator: DOMElementStyleSnapshotCoordinator
     ) -> Bool {
         snapshot.itemIdentifiers.contains { item in
-            guard let section = state.section(for: item.sectionID),
-                  let property = state.property(for: item, in: section) else {
+            guard let section = coordinator.section(for: item.sectionID),
+                  let property = coordinator.property(for: item, in: section) else {
                 return false
             }
             return property.name == name
         }
     }
 
-    private func itemIdentifier(
-        named name: String,
-        in snapshot: NSDiffableDataSourceSnapshot<
-            CSSStyle.Section.ID,
-            DOMElementStylePresentationItemIdentifier
-        >,
-        state: DOMElementStylePresentationState
-    ) throws -> DOMElementStylePresentationItemIdentifier {
-        let item = snapshot.itemIdentifiers.first { item in
-            guard let section = state.section(for: item.sectionID),
-                  let property = state.property(for: item, in: section) else {
-                return false
-            }
-            return property.name == name
-        }
-        return try #require(item)
-    }
-
-    private func makeNodeStyles(sections: [CSSStyle.Section]) -> CSSNodeStyles {
-        let targetID = ProtocolTarget.ID("page-main")
-        let documentID = DOMDocument.ID(
-            targetID: targetID,
-            localDocumentLifetimeID: .init(1)
-        )
-        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+    private func makeNodeStyles(
+        nodeLocalID: Int = 1,
+        sections: [CSSStyle.Section],
+        phase: CSSNodeStyles.Phase = .loaded
+    ) -> CSSNodeStyles {
+        let identity = makeIdentity(nodeLocalID: nodeLocalID)
         return CSSNodeStyles(
             id: CSSNodeStyles.ID(
-                nodeID: nodeID,
-                targetID: targetID,
-                documentID: documentID,
-                protocolNodeID: .init(1)
+                nodeID: identity.nodeID,
+                targetID: identity.targetID,
+                documentID: identity.documentID,
+                protocolNodeID: .init(nodeLocalID)
             ),
-            phase: .loaded,
+            phase: phase,
             sections: sections
         )
     }
 
-    private func makeFlatStyleSections() -> [CSSStyle.Section] {
-        let targetID = ProtocolTarget.ID("page-main")
-        let documentID = DOMDocument.ID(
-            targetID: targetID,
-            localDocumentLifetimeID: .init(1)
-        )
-        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+    private func makeFlatStyleSections(
+        nodeLocalID: Int = 1,
+        selector: String = "body",
+        marginValue: String = "0",
+        marginText: String = "margin: 0;"
+    ) -> [CSSStyle.Section] {
+        let nodeID = makeIdentity(nodeLocalID: nodeLocalID).nodeID
         let styleSheetID = CSSStyleSheet.ID("flat-styles")
         let styleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
 
@@ -194,15 +256,15 @@ struct DOMElementStylePresentationStateTests {
             CSSStyle.Section(
                 id: CSSStyle.Section.ID(nodeID: nodeID, kind: .rule, ordinal: 0),
                 kind: .rule,
-                title: "body",
+                title: selector,
                 style: CSSStyle(
                     id: styleID,
                     cssProperties: [
                         property(
                             id: CSSProperty.ID(styleID: styleID, propertyIndex: 0),
                             name: "margin",
-                            value: "0",
-                            text: "margin: 0;"
+                            value: marginValue,
+                            text: marginText
                         ),
                         property(
                             id: CSSProperty.ID(styleID: styleID, propertyIndex: 1),
@@ -218,15 +280,11 @@ struct DOMElementStylePresentationStateTests {
     }
 
     private func makeStyleSections(
+        nodeLocalID: Int = 1,
         inheritedOrdinal: Int,
         unusedVariableName: String = "--unused-a"
     ) -> [CSSStyle.Section] {
-        let targetID = ProtocolTarget.ID("page-main")
-        let documentID = DOMDocument.ID(
-            targetID: targetID,
-            localDocumentLifetimeID: .init(1)
-        )
-        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(1))
+        let nodeID = makeIdentity(nodeLocalID: nodeLocalID).nodeID
         let styleSheetID = CSSStyleSheet.ID("styles")
 
         let ruleStyleID = CSSStyle.ID(styleSheetID: styleSheetID, ordinal: 0)
@@ -280,6 +338,22 @@ struct DOMElementStylePresentationStateTests {
         ]
     }
 
+    private func makeIdentity(
+        nodeLocalID: Int
+    ) -> (
+        targetID: ProtocolTarget.ID,
+        documentID: DOMDocument.ID,
+        nodeID: DOMNode.ID
+    ) {
+        let targetID = ProtocolTarget.ID("page-main")
+        let documentID = DOMDocument.ID(
+            targetID: targetID,
+            localDocumentLifetimeID: .init(1)
+        )
+        let nodeID = DOMNode.ID(documentID: documentID, nodeID: .init(nodeLocalID))
+        return (targetID, documentID, nodeID)
+    }
+
     private func property(
         id: CSSProperty.ID,
         name: String,
@@ -297,8 +371,6 @@ struct DOMElementStylePresentationStateTests {
     }
 }
 }
-
-private struct TestFailure: Error {}
 
 @MainActor
 private extension [DOMElementStylePresentationItemIdentifier] {


### PR DESCRIPTION
## Purpose

Prevent the DOM Element styles list from animating when the selected DOM node changes, while preserving animation for structural style changes on the same selected `CSSNodeStyles` object.

## Changes

- Replace the previous presentation-state compensation path with `DOMElementStyleSnapshotCoordinator`.
- Centralize snapshot apply policy as `.none`, `.diff(animated:)`, or `.reloadData`.
- Treat selection replacement, cached selection switch, and hydrating replacement as non-animated/reload paths.
- Keep same-selection structural changes and hidden-variable reveal animated.
- Remove item fingerprint/reconfigure compensation; property and header content updates now render through native UIKit views observing their bound Core objects.
- Add focused tests for requested apply mode and reusable view identity/render behavior without testing actual animation timing.

## Testing

- `git diff --check`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' -only-testing:WebInspectorUITests`
- `xcodebuild test -quiet -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` was attempted; it hit the existing `DOMTreeTextViewTests.documentResetClearsLocalExpansionStateEvenWhenNodeIDsRepeat` issue, which is intentionally deferred to a later phase.
- Codex review against `main`: no findings.