### PR TITLE
Preserve network preview role preference

### DIFF
--- a/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUI/Network/Detail/NetworkDetailViewController.swift
@@ -454,9 +454,6 @@ package final class NetworkDetailViewController: UIViewController {
     private func renderPreview(selectedRequest request: NetworkRequest) {
         let roles = availablePreviewRoles(in: request)
         let selectedRole = selectedPreviewRole(from: roles)
-        if let selectedRole, selectedRole != previewRole {
-            previewRole = selectedRole
-        }
         renderPreviewRoleControl(roles: roles, selectedRole: selectedRole)
 
         guard let role = selectedRole else {
@@ -620,6 +617,10 @@ extension NetworkDetailViewController {
     }
 
     var currentPreviewRoleForTesting: NetworkBody.Role {
+        selectedPreviewRole(from: previewRoles) ?? previewRole
+    }
+
+    var logicalPreviewRoleForTesting: NetworkBody.Role {
         previewRole
     }
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -398,6 +398,74 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func requestPreviewRoleSurvivesResponseOnlySelection() async throws {
+        let network = NetworkSession()
+        let requestAndResponse = try #require(
+            applyRequest(
+                to: network,
+                requestID: "both",
+                url: "https://example.com/both.json",
+                requestHeaders: ["content-type": "application/x-www-form-urlencoded"],
+                postData: "name=Jane+Doe",
+                responseHeaders: ["content-type": "text/plain"],
+                responseMimeType: "text/plain"
+            )
+        )
+        let responseOnlyRequest = try #require(
+            applyRequest(
+                to: network,
+                requestID: "response-only",
+                url: "https://example.com/response.txt",
+                responseHeaders: ["content-type": "text/plain"],
+                responseMimeType: "text/plain"
+            )
+        )
+        responseOnlyRequest.applyResponseBody(
+            NetworkBody.Payload(body: "response only body", base64Encoded: false)
+        )
+        let model = NetworkPanelModel(network: network)
+        model.selectRequest(requestAndResponse)
+        let viewController = NetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        viewController.setModeForTesting(.preview)
+
+        let didRenderBoth = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .preview
+                && viewController.isPreviewRoleControlHiddenForTesting == false
+        }
+        #expect(didRenderBoth)
+
+        viewController.selectPreviewRoleForTesting(.request)
+
+        let didRenderRequestPreview = await waitUntilRendered(in: viewController) {
+            viewController.currentPreviewRoleForTesting == .request
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe"
+        }
+        #expect(didRenderRequestPreview)
+
+        model.selectRequest(responseOnlyRequest)
+
+        let didRenderResponseOnly = await waitUntilRendered(in: viewController) {
+            viewController.currentPreviewRoleForTesting == .response
+                && viewController.logicalPreviewRoleForTesting == .request
+                && viewController.isPreviewRoleControlHiddenForTesting
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "response only body"
+        }
+        #expect(didRenderResponseOnly)
+
+        model.selectRequest(requestAndResponse)
+
+        let didRestoreRequestPreview = await waitUntilRendered(in: viewController) {
+            viewController.currentPreviewRoleForTesting == .request
+                && viewController.logicalPreviewRoleForTesting == .request
+                && viewController.isPreviewRoleControlHiddenForTesting == false
+                && viewController.bodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe"
+        }
+        #expect(didRestoreRequestPreview)
+    }
+
+    @Test
     func previewRequestWithoutBodyRendersPlaceholderWhenBodySurfaceResumes() async throws {
         let network = NetworkSession()
         let request = try #require(


### PR DESCRIPTION
## Purpose

Keep the Network detail preview request/response choice stable across selection changes, even when the newly selected request only has one preview role available.

## Changes

- Stop mutating the stored preview role when the current request requires an effective fallback role.
- Keep testing helpers clear about logical preference versus the currently effective rendered role.
- Add coverage for selecting Request, visiting a response-only entry, then returning to an entry with both Request and Response bodies.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` against `main`: no findings
