### PR TITLE
Support MachOKit 0.51 fallback flow

### DIFF
--- a/Docs/ArchitectureOverview.md
+++ b/Docs/ArchitectureOverview.md
@@ -49,6 +49,12 @@ flowchart TD
 Responsibilities stay intentionally narrow:
 
 - `WebInspectorNativeBridge`: attach, send raw JSON, receive raw JSON, detach.
+- `WebInspectorNativeSymbols`: resolve private WebKit attach bootstrap
+  addresses. Its MachOKit/dyld shared cache fallback chain is
+  loaded image symbols, loaded dyld shared cache local symbols,
+  file-backed `.symbols` local symbols, and host `FullDyldCache` as the final
+  fallback. It owns redacted fallback diagnostics and does not expose mangled
+  symbol names or framework paths to callers.
 - `WebInspectorTransport`: parse protocol envelopes, unwrap target messages,
   route commands, manage replies, track protocol targets, and preserve
   execution-context owner/source target identity.
@@ -175,5 +181,8 @@ UIKit controllers do not own transport/backend objects directly.
 - Do not keep two long-term UI implementation targets.
 - Do not let UI parse raw protocol messages.
 - Do not let the native bridge understand target routing.
+- Do not move MachOKit or dyld shared cache resolution out of
+  `WebInspectorNativeSymbols`; transport and bridge code should only receive
+  resolved native symbol addresses.
 - Do not store iframe documents as regular DOM children.
 - Do not make redirect hops separate top-level network requests.

--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ceb27894cc5c9181db84611e79857c0a8282131fd151b5f95d220c2b8b33d6e5",
+  "originHash" : "9391e814b6c1a7f376960ff0b88997b14d6699714c576572059caa89c56309eb",
   "pins" : [
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "3f218ab9229b87f76e1985131542b3c9f83327e8",
-        "version" : "0.50.0"
+        "revision" : "62c42ed722166283a9e4b89cd2332710c501d034",
+        "version" : "0.51.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d5b9ed3942c704ade9fa89630b68f66d00f5cf002163dced79fb239fffddc42a",
+  "originHash" : "4ecff7f1295282c9d9208bcdd9ca7c527de3181dd4d2af025e59e5086307de0b",
   "pins" : [
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "3f218ab9229b87f76e1985131542b3c9f83327e8",
-        "version" : "0.50.0"
+        "revision" : "62c42ed722166283a9e4b89cd2332710c501d034",
+        "version" : "0.51.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",
-            exact: "0.50.0"
+            exact: "0.51.0"
         )
     ],
     targets: [

--- a/Sources/WebInspectorNativeSymbols/DEBUG/NativeInspectorAttachSymbolDiagnostics.swift
+++ b/Sources/WebInspectorNativeSymbols/DEBUG/NativeInspectorAttachSymbolDiagnostics.swift
@@ -54,10 +54,13 @@ extension NativeInspectorSymbolResolverCore {
         loadedWebKitImage: MachOImage,
         loadedWebKitText: SegmentCommand64,
         loadedWebKitHeaderAddress: UInt,
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
         loadedWebCoreImage: MachOImage?,
         loadedWebCoreText: SegmentCommand64?,
         loadedWebCoreHeaderAddress: UInt?,
-        imagePathSuffixes: [String]
+        imagePathSuffixes: [String],
+        javaScriptCorePathSuffixes: [String],
+        webCorePathSuffixes: [String]
     ) {
         let missingAttachFunctions = result.missingFunctions.filter {
             $0 == "connectFrontend" || $0 == "disconnectFrontend"
@@ -102,9 +105,12 @@ extension NativeInspectorSymbolResolverCore {
         }
 
         scans.append(contentsOf: unsafe debugSimilarSharedCacheAttachSymbols(
-            loadedWebKitHeaderAddress: loadedWebKitHeaderAddress,
-            loadedWebCoreHeaderAddress: loadedWebCoreHeaderAddress,
-            imagePathSuffixes: imagePathSuffixes
+            loadedWebKitImage: LoadedNativeInspectorImage(headerAddress: loadedWebKitHeaderAddress),
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreHeaderAddress.map { LoadedNativeInspectorImage(headerAddress: $0) },
+            webCorePathSuffixes: webCorePathSuffixes
         ))
 
         let candidates = scans.flatMap(\.candidates)

--- a/Sources/WebInspectorNativeSymbols/DEBUG/NativeInspectorAttachSymbolScanning.swift
+++ b/Sources/WebInspectorNativeSymbols/DEBUG/NativeInspectorAttachSymbolScanning.swift
@@ -76,105 +76,236 @@ extension NativeInspectorSymbolResolverCore {
     }
 
     @unsafe static func debugSimilarSharedCacheAttachSymbols(
-        loadedWebKitHeaderAddress: UInt,
-        loadedWebCoreHeaderAddress: UInt?,
-        imagePathSuffixes: [String]
+        loadedWebKitImage: LoadedNativeInspectorImage,
+        imagePathSuffixes: [String],
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
+        webCorePathSuffixes: [String]
     ) -> [NativeInspectorAttachSymbolScan] {
-        guard let cache = unsafe MachOKitSymbolLookup.currentSharedCache,
-              let slide = cache.slide,
-              slide >= 0,
-              let webKitImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: imagePathSuffixes) }),
-              webKitImage.is64Bit,
-              let webKitText = textSegment(in: webKitImage) else {
-            return []
-        }
-
         var scans = [NativeInspectorAttachSymbolScan]()
-        let unsignedSlide = UInt64(slide)
-        let webKitTextRange = UInt64(loadedWebKitHeaderAddress) ..< UInt64(loadedWebKitHeaderAddress) + UInt64(webKitText.virtualMemorySize)
-        let webKitDylibOffset = UInt64(webKitText.virtualMemoryAddress) - cache.mainCacheHeader.sharedRegionStart
-
-        let webCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: webCoreImagePathSuffixes) })
-        let webCoreText = webCoreImage.flatMap { $0.is64Bit ? textSegment(in: $0) : nil }
-        let webCoreContext: (image: MachOImage, text: SegmentCommand64, textRange: Range<UInt64>, dylibOffset: UInt64)?
-        if let webCoreImage,
-           let webCoreText,
-           let loadedWebCoreHeaderAddress {
-            webCoreContext = (
-                image: webCoreImage,
-                text: webCoreText,
-                textRange: UInt64(loadedWebCoreHeaderAddress) ..< UInt64(loadedWebCoreHeaderAddress) + UInt64(webCoreText.virtualMemorySize),
-                dylibOffset: UInt64(webCoreText.virtualMemoryAddress) - cache.mainCacheHeader.sharedRegionStart
-            )
-        } else {
-            webCoreContext = nil
-        }
-
-        if let localSymbolsInfo = cache.localSymbolsInfo,
-           let symbols64 = localSymbolsInfo.symbols64(in: cache) {
-            let entries = localSymbolsInfo.entries(in: cache)
-            if let entry = entries.first(where: { UInt64($0.dylibOffset) == webKitDylibOffset }) {
-                let symbolRange = entry.nlistStartIndex ..< entry.nlistStartIndex + entry.nlistCount
-                if symbolRange.lowerBound >= 0, symbolRange.upperBound <= symbols64.count {
-                    scans.append(debugSimilarSharedCacheAttachSymbols(
-                        source: "shared-cache",
-                        imageName: "WebKit",
-                        symbols: symbols64,
-                        symbolRange: symbolRange,
-                        textVMAddress: UInt64(webKitText.virtualMemoryAddress),
-                        textRange: webKitTextRange,
-                        slide: unsignedSlide
-                    ))
-                }
-            }
-            if let webCoreContext,
-               let entry = entries.first(where: { UInt64($0.dylibOffset) == webCoreContext.dylibOffset }) {
-                let symbolRange = entry.nlistStartIndex ..< entry.nlistStartIndex + entry.nlistCount
-                if symbolRange.lowerBound >= 0, symbolRange.upperBound <= symbols64.count {
-                    scans.append(debugSimilarSharedCacheAttachSymbols(
-                        source: "shared-cache",
-                        imageName: "WebCore",
-                        symbols: symbols64,
-                        symbolRange: symbolRange,
-                        textVMAddress: UInt64(webCoreContext.text.virtualMemoryAddress),
-                        textRange: webCoreContext.textRange,
-                        slide: unsignedSlide
-                    ))
-                }
-            }
-        }
-
-        if let fileBackedSymbols = try? fileBackedLocalSymbols(
-            mainCacheHeader: cache.mainCacheHeader,
-            dylibOffset: webKitDylibOffset
+        if let context = unsafe loadedSharedCacheContext(
+            loadedImage: loadedWebKitImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes
         ) {
-            scans.append(debugSimilarSharedCacheAttachSymbols(
-                source: "shared-cache-file",
-                imageName: "WebKit",
-                symbols: fileBackedSymbols.symbols,
-                symbolRange: fileBackedSymbols.symbolRange,
-                textVMAddress: UInt64(webKitText.virtualMemoryAddress),
-                textRange: webKitTextRange,
-                slide: unsignedSlide
-            ))
+            appendDebugSharedCacheAttachScans(
+                webKit: context.webKit,
+                webCore: context.webCore,
+                symbols64: context.localSymbols,
+                entries: context.localSymbolEntries,
+                source: "shared-cache",
+                scans: &scans
+            )
+            if let fileBackedContexts = try? fileBackedLocalSymbolContexts(
+                mainCacheHeader: context.cache.mainCacheHeader
+            ) {
+                appendDebugFileBackedSharedCacheAttachScans(
+                    webKit: context.webKit,
+                    webCore: context.webCore,
+                    fileBackedContexts: fileBackedContexts,
+                    source: "shared-cache-file",
+                    scans: &scans
+                )
+            }
         }
-        if let webCoreContext,
-           let fileBackedSymbols = try? fileBackedLocalSymbols(
-                mainCacheHeader: cache.mainCacheHeader,
-                dylibOffset: webCoreContext.dylibOffset
-           ) {
-            scans.append(debugSimilarSharedCacheAttachSymbols(
-                source: "shared-cache-file",
-                imageName: "WebCore",
-                symbols: fileBackedSymbols.symbols,
-                symbolRange: fileBackedSymbols.symbolRange,
-                textVMAddress: UInt64(webCoreContext.text.virtualMemoryAddress),
-                textRange: webCoreContext.textRange,
-                slide: unsignedSlide
-            ))
+
+        if let context = unsafe fullSharedCacheContext(
+            loadedImage: loadedWebKitImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes
+        ) {
+            appendDebugSharedCacheAttachScans(
+                webKit: context.webKit,
+                webCore: context.webCore,
+                symbols64: context.localSymbols,
+                entries: context.localSymbolEntries,
+                source: "full-cache",
+                scans: &scans
+            )
+            if let fileBackedContexts = try? fileBackedLocalSymbolContexts(
+                mainCacheHeader: context.cache.mainCacheHeader
+            ) {
+                appendDebugFileBackedSharedCacheAttachScans(
+                    webKit: context.webKit,
+                    webCore: context.webCore,
+                    fileBackedContexts: fileBackedContexts,
+                    source: "full-cache-file",
+                    scans: &scans
+                )
+            }
         }
 
         return scans
+    }
+
+    static func appendDebugSharedCacheAttachScans(
+        webKit: NativeInspectorSharedCacheImageContext<MachOImage>,
+        webCore: NativeInspectorSharedCacheImageContext<MachOImage>?,
+        symbols64: MachOImage.Symbols64?,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        guard let symbols64 else {
+            return
+        }
+        appendDebugSharedCacheAttachScan(
+            context: webKit,
+            imageName: "WebKit",
+            symbols: symbols64,
+            entries: entries,
+            source: source,
+            scans: &scans
+        )
+        if let webCore {
+            appendDebugSharedCacheAttachScan(
+                context: webCore,
+                imageName: "WebCore",
+                symbols: symbols64,
+                entries: entries,
+                source: source,
+                scans: &scans
+            )
+        }
+    }
+
+    static func appendDebugSharedCacheAttachScans(
+        webKit: NativeInspectorSharedCacheImageContext<MachOFile>,
+        webCore: NativeInspectorSharedCacheImageContext<MachOFile>?,
+        symbols64: MachOFile.Symbols64?,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        guard let symbols64 else {
+            return
+        }
+        appendDebugSharedCacheAttachScan(
+            context: webKit,
+            imageName: "WebKit",
+            symbols: symbols64,
+            entries: entries,
+            source: source,
+            scans: &scans
+        )
+        if let webCore {
+            appendDebugSharedCacheAttachScan(
+                context: webCore,
+                imageName: "WebCore",
+                symbols: symbols64,
+                entries: entries,
+                source: source,
+                scans: &scans
+            )
+        }
+    }
+
+    static func appendDebugSharedCacheAttachScan(
+        context: NativeInspectorSharedCacheImageContext<MachOImage>,
+        imageName: String,
+        symbols: MachOImage.Symbols64,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        guard let symbolRange = localSymbolRange(
+            for: context.dylibOffset,
+            entries: entries,
+            symbolCount: symbols.count
+        ) else {
+            return
+        }
+        scans.append(debugSimilarSharedCacheAttachSymbols(
+            source: source,
+            imageName: imageName,
+            symbols: symbols,
+            symbolRange: symbolRange,
+            textVMAddress: UInt64(context.text.virtualMemoryAddress),
+            textRange: context.textRange,
+            slide: context.slide
+        ))
+    }
+
+    static func appendDebugSharedCacheAttachScan(
+        context: NativeInspectorSharedCacheImageContext<MachOFile>,
+        imageName: String,
+        symbols: MachOFile.Symbols64,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        guard let symbolRange = localSymbolRange(
+            for: context.dylibOffset,
+            entries: entries,
+            symbolCount: symbols.count
+        ) else {
+            return
+        }
+        scans.append(debugSimilarSharedCacheAttachSymbols(
+            source: source,
+            imageName: imageName,
+            symbols: symbols,
+            symbolRange: symbolRange,
+            textVMAddress: UInt64(context.text.virtualMemoryAddress),
+            textRange: context.textRange,
+            slide: context.slide
+        ))
+    }
+
+    static func appendDebugFileBackedSharedCacheAttachScans<Image>(
+        webKit: NativeInspectorSharedCacheImageContext<Image>,
+        webCore: NativeInspectorSharedCacheImageContext<Image>?,
+        fileBackedContexts: [NativeInspectorFileBackedLocalSymbolContext],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        appendDebugFileBackedSharedCacheAttachScan(
+            context: webKit,
+            imageName: "WebKit",
+            fileBackedContexts: fileBackedContexts,
+            source: source,
+            scans: &scans
+        )
+        if let webCore {
+            appendDebugFileBackedSharedCacheAttachScan(
+                context: webCore,
+                imageName: "WebCore",
+                fileBackedContexts: fileBackedContexts,
+                source: source,
+                scans: &scans
+            )
+        }
+    }
+
+    static func appendDebugFileBackedSharedCacheAttachScan<Image>(
+        context: NativeInspectorSharedCacheImageContext<Image>,
+        imageName: String,
+        fileBackedContexts: [NativeInspectorFileBackedLocalSymbolContext],
+        source: String,
+        scans: inout [NativeInspectorAttachSymbolScan]
+    ) {
+        guard let fileBackedSymbols = try? fileBackedLocalSymbols(
+            in: fileBackedContexts,
+            dylibOffset: context.dylibOffset
+        ) else {
+            return
+        }
+        scans.append(debugSimilarSharedCacheAttachSymbols(
+            source: source,
+            imageName: imageName,
+            symbols: fileBackedSymbols.symbols,
+            symbolRange: fileBackedSymbols.symbolRange,
+            textVMAddress: UInt64(context.text.virtualMemoryAddress),
+            textRange: context.textRange,
+            slide: context.slide
+        ))
     }
 
     static func debugSimilarSharedCacheAttachSymbols(

--- a/Sources/WebInspectorNativeSymbols/MachOKitSymbolLookup.swift
+++ b/Sources/WebInspectorNativeSymbols/MachOKitSymbolLookup.swift
@@ -12,6 +12,10 @@ import MachOKit
         DyldCache.host
     }
 
+    static var hostFullSharedCache: FullDyldCache? {
+        FullDyldCache.host
+    }
+
     static var hostSharedCachePath: String? {
         unsafe hostSharedCache?.url.path
     }

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorLoadedImageLookup.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorLoadedImageLookup.swift
@@ -25,6 +25,10 @@ extension NativeInspectorSymbolResolverCore {
         image.segments64.first(where: { $0.segmentName == "__TEXT" })
     }
 
+    static func textSegment(in image: MachOFile) -> SegmentCommand64? {
+        image.segments64.first(where: { $0.segmentName == "__TEXT" })
+    }
+
     static func resolveLoadedImageSymbol(
         named symbolName: String,
         in image: MachOImage,

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheContext.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheContext.swift
@@ -1,0 +1,205 @@
+#if os(iOS) || os(macOS)
+import Foundation
+import MachO
+import MachOKit
+
+struct NativeInspectorSharedCacheImageContext<Image> {
+    let image: Image
+    let text: SegmentCommand64
+    let textRange: Range<UInt64>
+    let dylibOffset: UInt64
+    let slide: UInt64
+}
+
+struct NativeInspectorLoadedSharedCacheContext {
+    let cache: DyldCacheLoaded
+    let webKit: NativeInspectorSharedCacheImageContext<MachOImage>
+    let javaScriptCore: NativeInspectorSharedCacheImageContext<MachOImage>
+    let webCore: NativeInspectorSharedCacheImageContext<MachOImage>?
+    let localSymbols: MachOImage.Symbols64?
+    let localSymbolEntries: [any DyldCacheLocalSymbolsEntryProtocol]
+}
+
+struct NativeInspectorFullSharedCacheContext {
+    let cache: FullDyldCache
+    let webKit: NativeInspectorSharedCacheImageContext<MachOFile>
+    let javaScriptCore: NativeInspectorSharedCacheImageContext<MachOFile>
+    let webCore: NativeInspectorSharedCacheImageContext<MachOFile>?
+    let localSymbols: MachOFile.Symbols64?
+    let localSymbolEntries: [any DyldCacheLocalSymbolsEntryProtocol]
+}
+
+struct NativeInspectorFileBackedLocalSymbolContext {
+    let cache: DyldCache
+    let symbols: MachOFile.Symbols64
+    let entries: [any DyldCacheLocalSymbolsEntryProtocol]
+}
+
+extension NativeInspectorSymbolResolverCore {
+    @unsafe static func loadedSharedCacheContext(
+        loadedImage: LoadedNativeInspectorImage,
+        imagePathSuffixes: [String],
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
+        webCorePathSuffixes: [String]
+    ) -> NativeInspectorLoadedSharedCacheContext? {
+        guard let cache = unsafe MachOKitSymbolLookup.currentSharedCache,
+              let slide = cache.slide,
+              slide >= 0 else {
+            return nil
+        }
+
+        let images = Array(cache.machOImages())
+        guard let webKitImage = images.first(where: { imagePathMatches($0.path, suffixes: imagePathSuffixes) }),
+              let javaScriptCoreImage = images.first(where: { imagePathMatches($0.path, suffixes: javaScriptCorePathSuffixes) }),
+              let webKitContext = sharedCacheImageContext(
+                image: webKitImage,
+                loadedHeaderAddress: loadedImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader,
+                slide: UInt64(slide)
+              ),
+              let javaScriptCoreContext = sharedCacheImageContext(
+                image: javaScriptCoreImage,
+                loadedHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader,
+                slide: UInt64(slide)
+              ) else {
+            return nil
+        }
+
+        let webCoreContext: NativeInspectorSharedCacheImageContext<MachOImage>?
+        if let loadedWebCoreImage,
+           let webCoreImage = images.first(where: { imagePathMatches($0.path, suffixes: webCorePathSuffixes) }) {
+            webCoreContext = sharedCacheImageContext(
+                image: webCoreImage,
+                loadedHeaderAddress: loadedWebCoreImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader,
+                slide: UInt64(slide)
+            )
+        } else {
+            webCoreContext = nil
+        }
+
+        let localSymbolsInfo = cache.localSymbolsInfo
+        return NativeInspectorLoadedSharedCacheContext(
+            cache: cache,
+            webKit: webKitContext,
+            javaScriptCore: javaScriptCoreContext,
+            webCore: webCoreContext,
+            localSymbols: localSymbolsInfo?.symbols64(in: cache),
+            localSymbolEntries: localSymbolsInfo.map { Array($0.entries(in: cache)) } ?? []
+        )
+    }
+
+    @unsafe static func fullSharedCacheContext(
+        loadedImage: LoadedNativeInspectorImage,
+        imagePathSuffixes: [String],
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
+        webCorePathSuffixes: [String]
+    ) -> NativeInspectorFullSharedCacheContext? {
+        guard let cache = unsafe MachOKitSymbolLookup.hostFullSharedCache else {
+            return nil
+        }
+
+        let files = Array(cache.machOFiles())
+        guard let webKitFile = files.first(where: { imagePathMatches($0.imagePath, suffixes: imagePathSuffixes) }),
+              let javaScriptCoreFile = files.first(where: { imagePathMatches($0.imagePath, suffixes: javaScriptCorePathSuffixes) }),
+              let webKitContext = sharedCacheImageContext(
+                image: webKitFile,
+                loadedHeaderAddress: loadedImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader
+              ),
+              let javaScriptCoreContext = sharedCacheImageContext(
+                image: javaScriptCoreFile,
+                loadedHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader
+              ) else {
+            return nil
+        }
+
+        let webCoreContext: NativeInspectorSharedCacheImageContext<MachOFile>?
+        if let loadedWebCoreImage,
+           let webCoreFile = files.first(where: { imagePathMatches($0.imagePath, suffixes: webCorePathSuffixes) }) {
+            webCoreContext = sharedCacheImageContext(
+                image: webCoreFile,
+                loadedHeaderAddress: loadedWebCoreImage.headerAddress,
+                mainCacheHeader: cache.mainCacheHeader
+            )
+        } else {
+            webCoreContext = nil
+        }
+
+        let localSymbolsInfo = cache.localSymbolsInfo
+        return NativeInspectorFullSharedCacheContext(
+            cache: cache,
+            webKit: webKitContext,
+            javaScriptCore: javaScriptCoreContext,
+            webCore: webCoreContext,
+            localSymbols: localSymbolsInfo?.symbols64(in: cache),
+            localSymbolEntries: localSymbolsInfo.map { Array($0.entries(in: cache)) } ?? []
+        )
+    }
+
+    static func sharedCacheImageContext(
+        image: MachOImage,
+        loadedHeaderAddress: UInt,
+        mainCacheHeader: DyldCacheHeader,
+        slide: UInt64
+    ) -> NativeInspectorSharedCacheImageContext<MachOImage>? {
+        guard image.is64Bit,
+              let text = textSegment(in: image) else {
+            return nil
+        }
+        let textStart = UInt64(loadedHeaderAddress)
+        let textRange = textStart ..< textStart + UInt64(text.virtualMemorySize)
+        return NativeInspectorSharedCacheImageContext(
+            image: image,
+            text: text,
+            textRange: textRange,
+            dylibOffset: UInt64(text.virtualMemoryAddress) - mainCacheHeader.sharedRegionStart,
+            slide: slide
+        )
+    }
+
+    static func sharedCacheImageContext(
+        image: MachOFile,
+        loadedHeaderAddress: UInt,
+        mainCacheHeader: DyldCacheHeader
+    ) -> NativeInspectorSharedCacheImageContext<MachOFile>? {
+        guard image.is64Bit,
+              let text = textSegment(in: image) else {
+            return nil
+        }
+        let textStart = UInt64(loadedHeaderAddress)
+        let textRange = textStart ..< textStart + UInt64(text.virtualMemorySize)
+        return NativeInspectorSharedCacheImageContext(
+            image: image,
+            text: text,
+            textRange: textRange,
+            dylibOffset: UInt64(text.virtualMemoryAddress) - mainCacheHeader.sharedRegionStart,
+            slide: textStart - UInt64(text.virtualMemoryAddress)
+        )
+    }
+
+    static func localSymbolRange(
+        for dylibOffset: UInt64,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        symbolCount: Int
+    ) -> Range<Int>? {
+        guard let entry = entries.first(where: { UInt64($0.dylibOffset) == dylibOffset }) else {
+            return nil
+        }
+        let lowerBound = entry.nlistStartIndex
+        let upperBound = lowerBound + entry.nlistCount
+        guard lowerBound >= 0,
+              upperBound >= lowerBound,
+              upperBound <= symbolCount else {
+            return nil
+        }
+        return lowerBound ..< upperBound
+    }
+}
+#endif

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheResolution.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheResolution.swift
@@ -4,298 +4,599 @@ import MachO
 import MachOKit
 
 extension NativeInspectorSymbolResolverCore {
-    static func resolveUsingSharedCache(
+    @unsafe static func resolveUsingSharedCache(
         loadedImage: LoadedNativeInspectorImage,
         imagePathSuffixes: [String],
         loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
         javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
         webCorePathSuffixes: [String] = webCoreImagePathSuffixes,
         loadedImageSymbols: NativeInspectorResolvedSymbolSet,
         symbols: NativeInspectorSymbols
     ) -> NativeInspectorSymbolLookupResult {
-        guard let cache = unsafe MachOKitSymbolLookup.currentSharedCache else {
-            return failure(.sharedCacheUnavailable)
+        let loadedCacheResolution = unsafe resolveUsingLoadedSharedCache(
+            loadedImage: loadedImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes,
+            loadedImageSymbols: loadedImageSymbols,
+            symbols: symbols
+        )
+        if loadedCacheResolution.failureReason == nil {
+            return loadedCacheResolution
         }
 
-        guard let webKitImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: imagePathSuffixes) }) else {
-            return failure(.inspectorImageMissing)
-        }
-        guard let javaScriptCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: javaScriptCorePathSuffixes) }) else {
-            return failure(.supportImageMissing)
-        }
-        let webCoreImage = cache.machOImages().first(where: { imagePathMatches($0.path, suffixes: webCorePathSuffixes) })
-        guard webKitImage.is64Bit, let text = textSegment(in: webKitImage) else {
-            return failure(.inspectorImageMissing)
-        }
-        guard javaScriptCoreImage.is64Bit, let javaScriptCoreText = textSegment(in: javaScriptCoreImage) else {
-            return failure(.supportImageMissing)
-        }
-        let webCoreText = webCoreImage.flatMap { $0.is64Bit ? textSegment(in: $0) : nil }
-        guard let slide = cache.slide, slide >= 0 else {
-            return failure(.sharedCacheUnavailable)
+        #if DEBUG
+        logResolutionAttemptIncomplete(
+            loadedCacheResolution,
+            nextAttempt: "full-cache"
+        )
+        #endif
+
+        let fullCacheResolution = unsafe resolveUsingFullSharedCache(
+            loadedImage: loadedImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes,
+            loadedImageSymbols: loadedImageSymbols,
+            symbols: symbols
+        )
+        return mergedResolution(
+            preferred: loadedCacheResolution,
+            fallback: fullCacheResolution
+        )
+    }
+
+    @unsafe private static func resolveUsingLoadedSharedCache(
+        loadedImage: LoadedNativeInspectorImage,
+        imagePathSuffixes: [String],
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
+        webCorePathSuffixes: [String],
+        loadedImageSymbols: NativeInspectorResolvedSymbolSet,
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorSymbolLookupResult {
+        guard let context = unsafe loadedSharedCacheContext(
+            loadedImage: loadedImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes
+        ) else {
+            return failure(.sharedCacheUnavailable, shouldLog: false)
         }
 
-        let textStart = UInt64(loadedImage.headerAddress)
-        let textRange = textStart ..< textStart + UInt64(text.virtualMemorySize)
-        let dylibOffset = UInt64(text.virtualMemoryAddress) - cache.mainCacheHeader.sharedRegionStart
-        let javaScriptCoreTextStart = UInt64(loadedJavaScriptCoreImage.headerAddress)
-        let javaScriptCoreTextRange = javaScriptCoreTextStart ..< javaScriptCoreTextStart + UInt64(javaScriptCoreText.virtualMemorySize)
-        let javaScriptCoreDylibOffset = UInt64(javaScriptCoreText.virtualMemoryAddress) - cache.mainCacheHeader.sharedRegionStart
         var lastResolvedSymbols: NativeInspectorResolvedSymbolSet?
-
-        if let localSymbolsInfo = cache.localSymbolsInfo {
-            if let entry = localSymbolsInfo.entries(in: cache).first(where: { UInt64($0.dylibOffset) == dylibOffset }),
-               let javaScriptCoreEntry = localSymbolsInfo.entries(in: cache).first(where: { UInt64($0.dylibOffset) == javaScriptCoreDylibOffset }),
-               let symbols64 = localSymbolsInfo.symbols64(in: cache) {
-                let lowerBound = entry.nlistStartIndex
-                let upperBound = lowerBound + entry.nlistCount
-                let javaScriptCoreLowerBound = javaScriptCoreEntry.nlistStartIndex
-                let javaScriptCoreUpperBound = javaScriptCoreLowerBound + javaScriptCoreEntry.nlistCount
-                if lowerBound >= 0,
-                   upperBound >= lowerBound,
-                   upperBound <= symbols64.count,
-                   javaScriptCoreLowerBound >= 0,
-                   javaScriptCoreUpperBound >= javaScriptCoreLowerBound,
-                   javaScriptCoreUpperBound <= symbols64.count {
-                    let resolvedSymbols = NativeInspectorResolvedSymbolSet(
-                        connectFrontend: resolveSharedCacheSymbol(
-                            namedAnyOf: symbols.connectFrontend.decodedCandidates(),
-                            symbols: symbols64,
-                            symbolRange: lowerBound ..< upperBound,
-                            textVMAddress: UInt64(text.virtualMemoryAddress),
-                            textRange: textRange,
-                            slide: UInt64(slide)
-                        ),
-                        disconnectFrontend: resolveSharedCacheSymbol(
-                            namedAnyOf: symbols.disconnectFrontend.decodedCandidates(),
-                            symbols: symbols64,
-                            symbolRange: lowerBound ..< upperBound,
-                            textVMAddress: UInt64(text.virtualMemoryAddress),
-                            textRange: textRange,
-                            slide: UInt64(slide)
-                        ),
-                        stringFromUTF8: resolveSharedCacheSymbol(
-                            namedAnyOf: symbols.stringFromUTF8.decodedCandidates(),
-                            symbols: symbols64,
-                            symbolRange: javaScriptCoreLowerBound ..< javaScriptCoreUpperBound,
-                            textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                            textRange: javaScriptCoreTextRange,
-                            slide: UInt64(slide)
-                        ),
-                        stringImplToNSString: resolveSharedCacheSymbol(
-                            namedAnyOf: symbols.stringImplToNSString.decodedCandidates(),
-                            symbols: symbols64,
-                            symbolRange: javaScriptCoreLowerBound ..< javaScriptCoreUpperBound,
-                            textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                            textRange: javaScriptCoreTextRange,
-                            slide: UInt64(slide)
-                        ),
-                        destroyStringImpl: resolveSharedCacheSymbol(
-                            namedAnyOf: symbols.destroyStringImpl.decodedCandidates(),
-                            symbols: symbols64,
-                            symbolRange: javaScriptCoreLowerBound ..< javaScriptCoreUpperBound,
-                            textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                            textRange: javaScriptCoreTextRange,
-                            slide: UInt64(slide)
-                        ),
-                        backendDispatcherDispatch: preferredResolvedAddress(
-                            resolveSharedCacheSymbol(
-                                namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
-                                symbols: symbols64,
-                                symbolRange: lowerBound ..< upperBound,
-                                textVMAddress: UInt64(text.virtualMemoryAddress),
-                                textRange: textRange,
-                                slide: UInt64(slide)
-                            ),
-                            fallback: resolveSharedCacheSymbol(
-                                namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
-                                symbols: symbols64,
-                                symbolRange: javaScriptCoreLowerBound ..< javaScriptCoreUpperBound,
-                                textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                                textRange: javaScriptCoreTextRange,
-                                slide: UInt64(slide)
-                            )
-                        )
-                    )
-                    let resolvedSymbolsWithFallback = unsafe resolveConnectDisconnectFallbackIfNeeded(
-                        resolvedSymbols,
-                        image: webKitImage,
-                        text: text,
-                        webCoreImage: webCoreImage,
-                        webCoreText: webCoreText,
-                        javaScriptCoreImage: javaScriptCoreImage,
-                        javaScriptCoreText: javaScriptCoreText,
-                        symbols: symbols
-                    )
-                    let usedRuntimeFallback = usesLoadedImageRuntimeFallback(
-                        resolvedSymbols: resolvedSymbolsWithFallback.symbols,
-                        loadedImageSymbols: loadedImageSymbols
-                    )
-                    let resolvedSymbolsWithRuntimeFallback = applyingLoadedImageRuntimeFallback(
-                        to: resolvedSymbolsWithFallback.symbols,
-                        loadedImageSymbols: loadedImageSymbols
-                    )
-                    lastResolvedSymbols = resolvedSymbolsWithRuntimeFallback
-                    if let resolution = successfulResolutionIfComplete(
-                            resolvedSymbolsWithRuntimeFallback,
-                            phase: .sharedCache,
-                            source: sharedCacheSourceDescription(
-                                base: "shared-cache",
-                                usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback,
-                                usedRuntimeFallback: usedRuntimeFallback
-                            ),
-                            webKitHeaderAddress: loadedImage.headerAddress,
-                            javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
-                            usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback
-                        ) {
-                        return resolution
-                    }
-                }
+        if let resolvedSymbols = resolveLocalSymbols(
+            webKit: context.webKit,
+            javaScriptCore: context.javaScriptCore,
+            symbols64: context.localSymbols,
+            entries: context.localSymbolEntries,
+            symbols: symbols
+        ) {
+            let resolution = unsafe finalizedSharedCacheResolution(
+                resolvedSymbols,
+                phase: .sharedCache,
+                sourceBase: "shared-cache",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                loadedImageSymbols: loadedImageSymbols,
+                runtimeWebKit: context.webKit,
+                runtimeJavaScriptCore: context.javaScriptCore,
+                runtimeWebCore: context.webCore,
+                symbols: symbols
+            )
+            lastResolvedSymbols = resolution.resolvedSymbols
+            if let lookupResult = resolution.lookupResult {
+                return lookupResult
             }
         }
 
         do {
-            let fileBackedSymbols = try fileBackedLocalSymbols(
-                mainCacheHeader: cache.mainCacheHeader,
-                dylibOffset: dylibOffset
+            let fileBackedContexts = try fileBackedLocalSymbolContexts(
+                mainCacheHeader: context.cache.mainCacheHeader
             )
-            let javaScriptCoreFileBackedSymbols = try fileBackedLocalSymbols(
-                mainCacheHeader: cache.mainCacheHeader,
-                dylibOffset: javaScriptCoreDylibOffset
-            )
-            let resolvedSymbols = NativeInspectorResolvedSymbolSet(
-                connectFrontend: resolveSharedCacheSymbol(
-                    namedAnyOf: symbols.connectFrontend.decodedCandidates(),
-                    symbols: fileBackedSymbols.symbols,
-                    symbolRange: fileBackedSymbols.symbolRange,
-                    textVMAddress: UInt64(text.virtualMemoryAddress),
-                    textRange: textRange,
-                    slide: UInt64(slide)
-                ),
-                disconnectFrontend: resolveSharedCacheSymbol(
-                    namedAnyOf: symbols.disconnectFrontend.decodedCandidates(),
-                    symbols: fileBackedSymbols.symbols,
-                    symbolRange: fileBackedSymbols.symbolRange,
-                    textVMAddress: UInt64(text.virtualMemoryAddress),
-                    textRange: textRange,
-                    slide: UInt64(slide)
-                ),
-                stringFromUTF8: resolveSharedCacheSymbol(
-                    namedAnyOf: symbols.stringFromUTF8.decodedCandidates(),
-                    symbols: javaScriptCoreFileBackedSymbols.symbols,
-                    symbolRange: javaScriptCoreFileBackedSymbols.symbolRange,
-                    textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                    textRange: javaScriptCoreTextRange,
-                    slide: UInt64(slide)
-                ),
-                stringImplToNSString: resolveSharedCacheSymbol(
-                    namedAnyOf: symbols.stringImplToNSString.decodedCandidates(),
-                    symbols: javaScriptCoreFileBackedSymbols.symbols,
-                    symbolRange: javaScriptCoreFileBackedSymbols.symbolRange,
-                    textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                    textRange: javaScriptCoreTextRange,
-                    slide: UInt64(slide)
-                ),
-                destroyStringImpl: resolveSharedCacheSymbol(
-                    namedAnyOf: symbols.destroyStringImpl.decodedCandidates(),
-                    symbols: javaScriptCoreFileBackedSymbols.symbols,
-                    symbolRange: javaScriptCoreFileBackedSymbols.symbolRange,
-                    textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                    textRange: javaScriptCoreTextRange,
-                    slide: UInt64(slide)
-                ),
-                backendDispatcherDispatch: preferredResolvedAddress(
-                    resolveSharedCacheSymbol(
-                        namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
-                        symbols: fileBackedSymbols.symbols,
-                        symbolRange: fileBackedSymbols.symbolRange,
-                        textVMAddress: UInt64(text.virtualMemoryAddress),
-                        textRange: textRange,
-                        slide: UInt64(slide)
-                    ),
-                    fallback: resolveSharedCacheSymbol(
-                        namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
-                        symbols: javaScriptCoreFileBackedSymbols.symbols,
-                        symbolRange: javaScriptCoreFileBackedSymbols.symbolRange,
-                        textVMAddress: UInt64(javaScriptCoreText.virtualMemoryAddress),
-                        textRange: javaScriptCoreTextRange,
-                        slide: UInt64(slide)
-                    )
-                )
-            )
-            let resolvedSymbolsWithFallback = unsafe resolveConnectDisconnectFallbackIfNeeded(
-                resolvedSymbols,
-                image: webKitImage,
-                text: text,
-                webCoreImage: webCoreImage,
-                webCoreText: webCoreText,
-                javaScriptCoreImage: javaScriptCoreImage,
-                javaScriptCoreText: javaScriptCoreText,
+            if let resolvedSymbols = try resolveFileBackedSymbols(
+                webKit: context.webKit,
+                javaScriptCore: context.javaScriptCore,
+                fileBackedContexts: fileBackedContexts,
                 symbols: symbols
-            )
-            let usedRuntimeFallback = usesLoadedImageRuntimeFallback(
-                resolvedSymbols: resolvedSymbolsWithFallback.symbols,
-                loadedImageSymbols: loadedImageSymbols
-            )
-            let resolvedSymbolsWithRuntimeFallback = applyingLoadedImageRuntimeFallback(
-                to: resolvedSymbolsWithFallback.symbols,
-                loadedImageSymbols: loadedImageSymbols
-            )
-            lastResolvedSymbols = resolvedSymbolsWithRuntimeFallback
-            if let resolution = successfulResolutionIfComplete(
-                    resolvedSymbolsWithRuntimeFallback,
+            ) {
+                let resolution = unsafe finalizedSharedCacheResolution(
+                    resolvedSymbols,
                     phase: .sharedCacheFile,
-                    source: sharedCacheSourceDescription(
-                        base: "shared-cache-file",
-                        usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback,
-                        usedRuntimeFallback: usedRuntimeFallback
-                    ),
-                    webKitHeaderAddress: loadedImage.headerAddress,
-                    javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
-                    usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback
-                ) {
-                return resolution
+                    sourceBase: "shared-cache-file",
+                    loadedImage: loadedImage,
+                    loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                    loadedImageSymbols: loadedImageSymbols,
+                    runtimeWebKit: context.webKit,
+                    runtimeJavaScriptCore: context.javaScriptCore,
+                    runtimeWebCore: context.webCore,
+                    symbols: symbols
+                )
+                lastResolvedSymbols = resolution.resolvedSymbols
+                if let lookupResult = resolution.lookupResult {
+                    return lookupResult
+                }
             }
         } catch let lookupFailure as NativeInspectorSymbolLookupFailure {
-            if let lastResolvedSymbols {
-                return finalizeResolution(
-                    lastResolvedSymbols,
-                    phase: nil,
-                    source: "shared-cache-file",
-                    webKitHeaderAddress: loadedImage.headerAddress,
-                    javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
-                    usedConnectDisconnectFallback: false
-                )
-                    ?? failure(lookupFailure.kind, detail: lookupFailure.detail)
-            }
-            return failure(lookupFailure.kind, detail: lookupFailure.detail)
+            return fallbackResolution(
+                lastResolvedSymbols,
+                phase: .sharedCacheFile,
+                source: "shared-cache-file",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                fallbackFailure: lookupFailure
+            )
         } catch {
-            if let lastResolvedSymbols {
-                return finalizeResolution(
-                    lastResolvedSymbols,
-                    phase: nil,
-                    source: "shared-cache-file",
-                    webKitHeaderAddress: loadedImage.headerAddress,
-                    javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
-                    usedConnectDisconnectFallback: false
+            return fallbackResolution(
+                lastResolvedSymbols,
+                phase: .sharedCacheFile,
+                source: "shared-cache-file",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                fallbackFailure: NativeInspectorSymbolLookupFailure(
+                    kind: .localSymbolsUnavailable,
+                    detail: nil
                 )
-                    ?? failure(.localSymbolsUnavailable)
-            }
-            return failure(.localSymbolsUnavailable)
+            )
         }
 
-        if let lastResolvedSymbols {
-            return finalizeResolution(
+        return fallbackResolution(
+            lastResolvedSymbols,
+            phase: .sharedCache,
+            source: "shared-cache",
+            loadedImage: loadedImage,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            fallbackFailure: NativeInspectorSymbolLookupFailure(
+                kind: .runtimeFunctionSymbolMissing,
+                detail: nil
+            )
+        )
+    }
+
+    @unsafe private static func resolveUsingFullSharedCache(
+        loadedImage: LoadedNativeInspectorImage,
+        imagePathSuffixes: [String],
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        javaScriptCorePathSuffixes: [String],
+        loadedWebCoreImage: LoadedNativeInspectorImage?,
+        webCorePathSuffixes: [String],
+        loadedImageSymbols: NativeInspectorResolvedSymbolSet,
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorSymbolLookupResult {
+        guard let context = unsafe fullSharedCacheContext(
+            loadedImage: loadedImage,
+            imagePathSuffixes: imagePathSuffixes,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
+            webCorePathSuffixes: webCorePathSuffixes
+        ) else {
+            return failure(.sharedCacheUnavailable, shouldLog: false)
+        }
+
+        var lastResolvedSymbols: NativeInspectorResolvedSymbolSet?
+        if let resolvedSymbols = resolveLocalSymbols(
+            webKit: context.webKit,
+            javaScriptCore: context.javaScriptCore,
+            symbols64: context.localSymbols,
+            entries: context.localSymbolEntries,
+            symbols: symbols
+        ) {
+            let resolution = finalizedFileSharedCacheResolution(
+                resolvedSymbols,
+                phase: .fullCache,
+                sourceBase: "full-cache",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                loadedImageSymbols: loadedImageSymbols
+            )
+            lastResolvedSymbols = resolution.resolvedSymbols
+            if let lookupResult = resolution.lookupResult {
+                return lookupResult
+            }
+        }
+
+        do {
+            let fileBackedContexts = try fileBackedLocalSymbolContexts(
+                mainCacheHeader: context.cache.mainCacheHeader
+            )
+            if let resolvedSymbols = try resolveFileBackedSymbols(
+                webKit: context.webKit,
+                javaScriptCore: context.javaScriptCore,
+                fileBackedContexts: fileBackedContexts,
+                symbols: symbols
+            ) {
+                let resolution = finalizedFileSharedCacheResolution(
+                    resolvedSymbols,
+                    phase: .fullCacheFile,
+                    sourceBase: "full-cache-file",
+                    loadedImage: loadedImage,
+                    loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                    loadedImageSymbols: loadedImageSymbols
+                )
+                lastResolvedSymbols = resolution.resolvedSymbols
+                if let lookupResult = resolution.lookupResult {
+                    return lookupResult
+                }
+            }
+        } catch let lookupFailure as NativeInspectorSymbolLookupFailure {
+            return fallbackResolution(
                 lastResolvedSymbols,
-                phase: nil,
-                source: "shared-cache",
+                phase: .fullCacheFile,
+                source: "full-cache-file",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                fallbackFailure: lookupFailure
+            )
+        } catch {
+            return fallbackResolution(
+                lastResolvedSymbols,
+                phase: .fullCacheFile,
+                source: "full-cache-file",
+                loadedImage: loadedImage,
+                loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+                fallbackFailure: NativeInspectorSymbolLookupFailure(
+                    kind: .localSymbolsUnavailable,
+                    detail: nil
+                )
+            )
+        }
+
+        return fallbackResolution(
+            lastResolvedSymbols,
+            phase: .fullCache,
+            source: "full-cache",
+            loadedImage: loadedImage,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
+            fallbackFailure: NativeInspectorSymbolLookupFailure(
+                kind: .runtimeFunctionSymbolMissing,
+                detail: nil
+            )
+        )
+    }
+
+    private static func resolveLocalSymbols(
+        webKit: NativeInspectorSharedCacheImageContext<MachOImage>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<MachOImage>,
+        symbols64: MachOImage.Symbols64?,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorResolvedSymbolSet? {
+        guard let symbols64,
+              let webKitRange = localSymbolRange(for: webKit.dylibOffset, entries: entries, symbolCount: symbols64.count),
+              let javaScriptCoreRange = localSymbolRange(for: javaScriptCore.dylibOffset, entries: entries, symbolCount: symbols64.count) else {
+            return nil
+        }
+        return resolveSymbols(
+            webKit: webKit,
+            javaScriptCore: javaScriptCore,
+            webKitSymbols: symbols64,
+            webKitSymbolRange: webKitRange,
+            javaScriptCoreSymbols: symbols64,
+            javaScriptCoreSymbolRange: javaScriptCoreRange,
+            symbols: symbols
+        )
+    }
+
+    private static func resolveLocalSymbols(
+        webKit: NativeInspectorSharedCacheImageContext<MachOFile>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<MachOFile>,
+        symbols64: MachOFile.Symbols64?,
+        entries: [any DyldCacheLocalSymbolsEntryProtocol],
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorResolvedSymbolSet? {
+        guard let symbols64,
+              let webKitRange = localSymbolRange(for: webKit.dylibOffset, entries: entries, symbolCount: symbols64.count),
+              let javaScriptCoreRange = localSymbolRange(for: javaScriptCore.dylibOffset, entries: entries, symbolCount: symbols64.count) else {
+            return nil
+        }
+        return resolveSymbols(
+            webKit: webKit,
+            javaScriptCore: javaScriptCore,
+            webKitSymbols: symbols64,
+            webKitSymbolRange: webKitRange,
+            javaScriptCoreSymbols: symbols64,
+            javaScriptCoreSymbolRange: javaScriptCoreRange,
+            symbols: symbols
+        )
+    }
+
+    private static func resolveFileBackedSymbols(
+        webKit: NativeInspectorSharedCacheImageContext<MachOImage>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<MachOImage>,
+        fileBackedContexts: [NativeInspectorFileBackedLocalSymbolContext],
+        symbols: NativeInspectorSymbols
+    ) throws -> NativeInspectorResolvedSymbolSet? {
+        let webKitSymbols = try fileBackedLocalSymbols(in: fileBackedContexts, dylibOffset: webKit.dylibOffset)
+        let javaScriptCoreSymbols = try fileBackedLocalSymbols(in: fileBackedContexts, dylibOffset: javaScriptCore.dylibOffset)
+        return resolveSymbols(
+            webKit: webKit,
+            javaScriptCore: javaScriptCore,
+            webKitSymbols: webKitSymbols.symbols,
+            webKitSymbolRange: webKitSymbols.symbolRange,
+            javaScriptCoreSymbols: javaScriptCoreSymbols.symbols,
+            javaScriptCoreSymbolRange: javaScriptCoreSymbols.symbolRange,
+            symbols: symbols
+        )
+    }
+
+    private static func resolveFileBackedSymbols(
+        webKit: NativeInspectorSharedCacheImageContext<MachOFile>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<MachOFile>,
+        fileBackedContexts: [NativeInspectorFileBackedLocalSymbolContext],
+        symbols: NativeInspectorSymbols
+    ) throws -> NativeInspectorResolvedSymbolSet? {
+        let webKitSymbols = try fileBackedLocalSymbols(in: fileBackedContexts, dylibOffset: webKit.dylibOffset)
+        let javaScriptCoreSymbols = try fileBackedLocalSymbols(in: fileBackedContexts, dylibOffset: javaScriptCore.dylibOffset)
+        return resolveSymbols(
+            webKit: webKit,
+            javaScriptCore: javaScriptCore,
+            webKitSymbols: webKitSymbols.symbols,
+            webKitSymbolRange: webKitSymbols.symbolRange,
+            javaScriptCoreSymbols: javaScriptCoreSymbols.symbols,
+            javaScriptCoreSymbolRange: javaScriptCoreSymbols.symbolRange,
+            symbols: symbols
+        )
+    }
+
+    private static func resolveSymbols(
+        webKit: NativeInspectorSharedCacheImageContext<MachOImage>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<MachOImage>,
+        webKitSymbols: MachOImage.Symbols64,
+        webKitSymbolRange: Range<Int>,
+        javaScriptCoreSymbols: MachOImage.Symbols64,
+        javaScriptCoreSymbolRange: Range<Int>,
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorResolvedSymbolSet {
+        NativeInspectorResolvedSymbolSet(
+            connectFrontend: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.connectFrontend.decodedCandidates(),
+                symbols: webKitSymbols,
+                symbolRange: webKitSymbolRange,
+                textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                textRange: webKit.textRange,
+                slide: webKit.slide
+            ),
+            disconnectFrontend: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.disconnectFrontend.decodedCandidates(),
+                symbols: webKitSymbols,
+                symbolRange: webKitSymbolRange,
+                textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                textRange: webKit.textRange,
+                slide: webKit.slide
+            ),
+            stringFromUTF8: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.stringFromUTF8.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            stringImplToNSString: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.stringImplToNSString.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            destroyStringImpl: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.destroyStringImpl.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            backendDispatcherDispatch: preferredResolvedAddress(
+                resolveSharedCacheSymbol(
+                    namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
+                    symbols: webKitSymbols,
+                    symbolRange: webKitSymbolRange,
+                    textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                    textRange: webKit.textRange,
+                    slide: webKit.slide
+                ),
+                fallback: resolveSharedCacheSymbol(
+                    namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
+                    symbols: javaScriptCoreSymbols,
+                    symbolRange: javaScriptCoreSymbolRange,
+                    textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                    textRange: javaScriptCore.textRange,
+                    slide: javaScriptCore.slide
+                )
+            )
+        )
+    }
+
+    private static func resolveSymbols<Image>(
+        webKit: NativeInspectorSharedCacheImageContext<Image>,
+        javaScriptCore: NativeInspectorSharedCacheImageContext<Image>,
+        webKitSymbols: MachOFile.Symbols64,
+        webKitSymbolRange: Range<Int>,
+        javaScriptCoreSymbols: MachOFile.Symbols64,
+        javaScriptCoreSymbolRange: Range<Int>,
+        symbols: NativeInspectorSymbols
+    ) -> NativeInspectorResolvedSymbolSet {
+        NativeInspectorResolvedSymbolSet(
+            connectFrontend: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.connectFrontend.decodedCandidates(),
+                symbols: webKitSymbols,
+                symbolRange: webKitSymbolRange,
+                textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                textRange: webKit.textRange,
+                slide: webKit.slide
+            ),
+            disconnectFrontend: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.disconnectFrontend.decodedCandidates(),
+                symbols: webKitSymbols,
+                symbolRange: webKitSymbolRange,
+                textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                textRange: webKit.textRange,
+                slide: webKit.slide
+            ),
+            stringFromUTF8: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.stringFromUTF8.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            stringImplToNSString: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.stringImplToNSString.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            destroyStringImpl: resolveSharedCacheSymbol(
+                namedAnyOf: symbols.destroyStringImpl.decodedCandidates(),
+                symbols: javaScriptCoreSymbols,
+                symbolRange: javaScriptCoreSymbolRange,
+                textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                textRange: javaScriptCore.textRange,
+                slide: javaScriptCore.slide
+            ),
+            backendDispatcherDispatch: preferredResolvedAddress(
+                resolveSharedCacheSymbol(
+                    namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
+                    symbols: webKitSymbols,
+                    symbolRange: webKitSymbolRange,
+                    textVMAddress: UInt64(webKit.text.virtualMemoryAddress),
+                    textRange: webKit.textRange,
+                    slide: webKit.slide
+                ),
+                fallback: resolveSharedCacheSymbol(
+                    namedAnyOf: symbols.backendDispatcherDispatch.decodedCandidates(),
+                    symbols: javaScriptCoreSymbols,
+                    symbolRange: javaScriptCoreSymbolRange,
+                    textVMAddress: UInt64(javaScriptCore.text.virtualMemoryAddress),
+                    textRange: javaScriptCore.textRange,
+                    slide: javaScriptCore.slide
+                )
+            )
+        )
+    }
+
+    @unsafe private static func finalizedSharedCacheResolution(
+        _ resolvedSymbols: NativeInspectorResolvedSymbolSet,
+        phase: NativeInspectorSymbolResolutionPhase,
+        sourceBase: String,
+        loadedImage: LoadedNativeInspectorImage,
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        loadedImageSymbols: NativeInspectorResolvedSymbolSet,
+        runtimeWebKit: NativeInspectorSharedCacheImageContext<MachOImage>,
+        runtimeJavaScriptCore: NativeInspectorSharedCacheImageContext<MachOImage>,
+        runtimeWebCore: NativeInspectorSharedCacheImageContext<MachOImage>?,
+        symbols: NativeInspectorSymbols
+    ) -> (lookupResult: NativeInspectorSymbolLookupResult?, resolvedSymbols: NativeInspectorResolvedSymbolSet) {
+        let resolvedSymbolsWithFallback = unsafe resolveConnectDisconnectFallbackIfNeeded(
+            resolvedSymbols,
+            image: runtimeWebKit.image,
+            text: runtimeWebKit.text,
+            webCoreImage: runtimeWebCore?.image,
+            webCoreText: runtimeWebCore?.text,
+            javaScriptCoreImage: runtimeJavaScriptCore.image,
+            javaScriptCoreText: runtimeJavaScriptCore.text,
+            symbols: symbols
+        )
+        let usedRuntimeFallback = usesLoadedImageRuntimeFallback(
+            resolvedSymbols: resolvedSymbolsWithFallback.symbols,
+            loadedImageSymbols: loadedImageSymbols
+        )
+        let resolvedSymbolsWithRuntimeFallback = applyingLoadedImageRuntimeFallback(
+            to: resolvedSymbolsWithFallback.symbols,
+            loadedImageSymbols: loadedImageSymbols
+        )
+        let lookupResult = successfulResolutionIfComplete(
+            resolvedSymbolsWithRuntimeFallback,
+            phase: phase,
+            source: sharedCacheSourceDescription(
+                base: sourceBase,
+                usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback,
+                usedRuntimeFallback: usedRuntimeFallback
+            ),
+            webKitHeaderAddress: loadedImage.headerAddress,
+            javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
+            usedConnectDisconnectFallback: resolvedSymbolsWithFallback.usedFallback
+        )
+        return (lookupResult, resolvedSymbolsWithRuntimeFallback)
+    }
+
+    private static func finalizedFileSharedCacheResolution(
+        _ resolvedSymbols: NativeInspectorResolvedSymbolSet,
+        phase: NativeInspectorSymbolResolutionPhase,
+        sourceBase: String,
+        loadedImage: LoadedNativeInspectorImage,
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        loadedImageSymbols: NativeInspectorResolvedSymbolSet
+    ) -> (lookupResult: NativeInspectorSymbolLookupResult?, resolvedSymbols: NativeInspectorResolvedSymbolSet) {
+        let usedRuntimeFallback = usesLoadedImageRuntimeFallback(
+            resolvedSymbols: resolvedSymbols,
+            loadedImageSymbols: loadedImageSymbols
+        )
+        let resolvedSymbolsWithRuntimeFallback = applyingLoadedImageRuntimeFallback(
+            to: resolvedSymbols,
+            loadedImageSymbols: loadedImageSymbols
+        )
+        let lookupResult = successfulResolutionIfComplete(
+            resolvedSymbolsWithRuntimeFallback,
+            phase: phase,
+            source: sharedCacheSourceDescription(
+                base: sourceBase,
+                usedConnectDisconnectFallback: false,
+                usedRuntimeFallback: usedRuntimeFallback
+            ),
+            webKitHeaderAddress: loadedImage.headerAddress,
+            javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
+            usedConnectDisconnectFallback: false
+        )
+        return (lookupResult, resolvedSymbolsWithRuntimeFallback)
+    }
+
+    private static func fallbackResolution(
+        _ resolvedSymbols: NativeInspectorResolvedSymbolSet?,
+        phase: NativeInspectorSymbolResolutionPhase?,
+        source: String,
+        loadedImage: LoadedNativeInspectorImage,
+        loadedJavaScriptCoreImage: LoadedNativeInspectorImage,
+        fallbackFailure: NativeInspectorSymbolLookupFailure
+    ) -> NativeInspectorSymbolLookupResult {
+        if let resolvedSymbols {
+            return finalizeResolution(
+                resolvedSymbols,
+                phase: phase,
+                source: source,
                 webKitHeaderAddress: loadedImage.headerAddress,
                 javaScriptCoreHeaderAddress: loadedJavaScriptCoreImage.headerAddress,
                 usedConnectDisconnectFallback: false
             )
-                ?? failure(.runtimeFunctionSymbolMissing)
+                ?? failure(
+                    fallbackFailure.kind,
+                    detail: fallbackFailure.detail,
+                    phase: phase,
+                    source: source,
+                    shouldLog: false
+                )
         }
-        return failure(.runtimeFunctionSymbolMissing)
+        return failure(
+            fallbackFailure.kind,
+            detail: fallbackFailure.detail,
+            phase: phase,
+            source: source,
+            shouldLog: false
+        )
     }
 }
 #endif

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheSymbolLookup.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSharedCacheSymbolLookup.swift
@@ -55,10 +55,10 @@ extension NativeInspectorSymbolResolverCore {
         }
 
         if activeSharedCachePath.hasSuffix(".symbols") {
-            return URL(fileURLWithPath: activeSharedCachePath)
+            return URL(fileURLWithPath: activeSharedCachePath, isDirectory: false)
         }
 
-        return URL(fileURLWithPath: activeSharedCachePath + ".symbols")
+        return URL(fileURLWithPath: activeSharedCachePath + ".symbols", isDirectory: false)
     }
 
     static func sharedCacheSortKey(for fileName: String) -> Int {
@@ -75,6 +75,15 @@ extension NativeInspectorSymbolResolverCore {
         mainCacheHeader: DyldCacheHeader,
         dylibOffset: UInt64
     ) throws -> MachOKitFileBackedLocalSymbols {
+        try fileBackedLocalSymbols(
+            in: fileBackedLocalSymbolContexts(mainCacheHeader: mainCacheHeader),
+            dylibOffset: dylibOffset
+        )
+    }
+
+    static func fileBackedLocalSymbolContexts(
+        mainCacheHeader: DyldCacheHeader
+    ) throws -> [NativeInspectorFileBackedLocalSymbolContext] {
         let symbolCacheURLs = sharedCacheSymbolFileURLs()
         guard !symbolCacheURLs.isEmpty else {
             throw NativeInspectorSymbolLookupFailure(
@@ -84,6 +93,7 @@ extension NativeInspectorSymbolResolverCore {
         }
 
         var lastFailure: NativeInspectorSymbolLookupFailure?
+        var contexts = [NativeInspectorFileBackedLocalSymbolContext]()
 
         for symbolCacheURL in symbolCacheURLs {
             do {
@@ -98,13 +108,6 @@ extension NativeInspectorSymbolResolverCore {
                     )
                     continue
                 }
-                guard let entry = localSymbolsInfo.entries(in: symbolCache).first(where: { UInt64($0.dylibOffset) == dylibOffset }) else {
-                    lastFailure = NativeInspectorSymbolLookupFailure(
-                        kind: .localSymbolEntryMissing,
-                        detail: nil
-                    )
-                    continue
-                }
                 guard let symbols = localSymbolsInfo.symbols64(in: symbolCache) else {
                     lastFailure = NativeInspectorSymbolLookupFailure(
                         kind: .localSymbolsUnavailable,
@@ -113,9 +116,12 @@ extension NativeInspectorSymbolResolverCore {
                     continue
                 }
 
-                return MachOKitFileBackedLocalSymbols(
-                    symbols: symbols,
-                    symbolRange: entry.nlistRange
+                contexts.append(
+                    NativeInspectorFileBackedLocalSymbolContext(
+                        cache: symbolCache,
+                        symbols: symbols,
+                        entries: Array(localSymbolsInfo.entries(in: symbolCache))
+                    )
                 )
             } catch {
                 lastFailure = NativeInspectorSymbolLookupFailure(
@@ -125,8 +131,37 @@ extension NativeInspectorSymbolResolverCore {
             }
         }
 
+        if !contexts.isEmpty {
+            return contexts
+        }
         throw lastFailure ?? NativeInspectorSymbolLookupFailure(
             kind: .localSymbolsUnavailable,
+            detail: nil
+        )
+    }
+
+    static func fileBackedLocalSymbols(
+        in contexts: [NativeInspectorFileBackedLocalSymbolContext],
+        dylibOffset: UInt64
+    ) throws -> MachOKitFileBackedLocalSymbols {
+        var sawSymbolContext = false
+        for context in contexts {
+            sawSymbolContext = true
+            guard let symbolRange = localSymbolRange(
+                for: dylibOffset,
+                entries: context.entries,
+                symbolCount: context.symbols.count
+            ) else {
+                continue
+            }
+            return MachOKitFileBackedLocalSymbols(
+                symbols: context.symbols,
+                symbolRange: symbolRange
+            )
+        }
+
+        throw NativeInspectorSymbolLookupFailure(
+            kind: sawSymbolContext ? .localSymbolEntryMissing : .localSymbolsUnavailable,
             detail: nil
         )
     }

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolutionFlow.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolResolutionFlow.swift
@@ -85,11 +85,12 @@ extension NativeInspectorSymbolResolverCore {
         )
         #endif
 
-        let sharedCacheResolution = resolveUsingSharedCache(
+        let sharedCacheResolution = unsafe resolveUsingSharedCache(
             loadedImage: loadedImage,
             imagePathSuffixes: imagePathSuffixes,
             loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
             javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            loadedWebCoreImage: loadedWebCoreImage,
             webCorePathSuffixes: webCorePathSuffixes,
             loadedImageSymbols: loadedImageResultsWithFallback.symbols,
             symbols: symbols
@@ -104,10 +105,13 @@ extension NativeInspectorSymbolResolverCore {
             loadedWebKitImage: image,
             loadedWebKitText: text,
             loadedWebKitHeaderAddress: loadedImage.headerAddress,
+            loadedJavaScriptCoreImage: loadedJavaScriptCoreImage,
             loadedWebCoreImage: webCoreImage,
             loadedWebCoreText: webCoreText,
             loadedWebCoreHeaderAddress: loadedWebCoreImage?.headerAddress,
-            imagePathSuffixes: imagePathSuffixes
+            imagePathSuffixes: imagePathSuffixes,
+            javaScriptCorePathSuffixes: javaScriptCorePathSuffixes,
+            webCorePathSuffixes: webCorePathSuffixes
         )
         #endif
         return mergedLookupResult

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolTypes.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorSymbolTypes.swift
@@ -50,6 +50,8 @@ enum NativeInspectorSymbolResolutionPhase {
     case loadedImage
     case sharedCache
     case sharedCacheFile
+    case fullCache
+    case fullCacheFile
 
     var message: String {
         switch self {
@@ -59,6 +61,10 @@ enum NativeInspectorSymbolResolutionPhase {
             return "shared-cache"
         case .sharedCacheFile:
             return "shared-cache-file"
+        case .fullCache:
+            return "full-cache"
+        case .fullCacheFile:
+            return "full-cache-file"
         }
     }
 }

--- a/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
+++ b/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
@@ -103,6 +103,74 @@ struct NativeInspectorSymbolResolverTests {
     }
 
     @Test
+    func sharedCacheSymbolFileURLsDeduplicateActiveSymbolsPath() {
+        let activeSymbolsPath = "/System/Library/dyld/dyld_shared_cache_arm64e.symbols"
+        let paths = NativeInspectorSymbolResolver.sharedCacheSymbolFileURLsForTesting(
+            activeSharedCachePath: activeSymbolsPath
+        ).map(\.standardizedFileURL.path)
+
+        #expect(paths.first == activeSymbolsPath)
+        #expect(paths.filter { $0 == activeSymbolsPath }.count == 1)
+    }
+
+    @Test
+    func sharedCacheSymbolFileURLSortsPreferredArchitecturesFirst() {
+        #expect(NativeInspectorSymbolResolverCore.sharedCacheSortKey(for: "dyld_shared_cache_arm64e.symbols") == 0)
+        #expect(NativeInspectorSymbolResolverCore.sharedCacheSortKey(for: "dyld_shared_cache_arm64.symbols") == 1)
+        #expect(NativeInspectorSymbolResolverCore.sharedCacheSortKey(for: "dyld_shared_cache_x86_64.symbols") == 2)
+    }
+
+    @Test
+    func sharedCacheSourceDescriptionsReportFallbackPartsInOrder() {
+        #expect(
+            NativeInspectorSymbolResolverCore.sharedCacheSourceDescription(
+                base: "full-cache",
+                usedConnectDisconnectFallback: false,
+                usedRuntimeFallback: false
+            ) == "full-cache"
+        )
+        #expect(
+            NativeInspectorSymbolResolverCore.sharedCacheSourceDescription(
+                base: "full-cache-file",
+                usedConnectDisconnectFallback: true,
+                usedRuntimeFallback: true
+            ) == "full-cache-file+text-scan+loaded-image-runtime"
+        )
+    }
+
+    @Test
+    func sharedCacheFallbackMergePrefersLaterSuccessfulFullCacheResult() {
+        let sharedCacheFailure = NativeInspectorSymbolLookupResult(
+            functionAddresses: .zero,
+            failureReason: "local symbol lookup unavailable: phase=shared-cache source=shared-cache",
+            failureKind: .localSymbolsUnavailable,
+            phase: .sharedCache,
+            missingFunctions: [],
+            source: "shared-cache",
+            usedConnectDisconnectFallback: false
+        )
+        let fullCacheSuccess = NativeInspectorSymbolLookupResult(
+            functionAddresses: completeNativeInspectorSymbolAddresses,
+            failureReason: nil,
+            failureKind: nil,
+            phase: .fullCache,
+            missingFunctions: [],
+            source: "full-cache",
+            usedConnectDisconnectFallback: false
+        )
+
+        let merged = NativeInspectorSymbolResolverCore.mergedResolution(
+            preferred: sharedCacheFailure,
+            fallback: fullCacheSuccess
+        )
+
+        #expect(merged.failureReason == nil)
+        #expect(merged.phase == .fullCache)
+        #expect(merged.source == "full-cache")
+        #expect(merged.functionAddresses == completeNativeInspectorSymbolAddresses)
+    }
+
+    @Test
     func imagePathSuffixesMatchExpectedFrameworkLocations() {
         let suffixes = NativeInspectorSymbolResolver.imagePathSuffixesForTesting()
 
@@ -236,7 +304,42 @@ struct NativeInspectorSymbolResolverTests {
         #expect(!diagnostics.contains("definitelyMissingFromUTF8Foo"))
     }
 
+    @Test
+    func fullCacheFallbackDiagnosticsRemainRedacted() {
+        let source = NativeInspectorSymbolResolverCore.sharedCacheSourceDescription(
+            base: "full-cache-file",
+            usedConnectDisconnectFallback: true,
+            usedRuntimeFallback: true
+        )
+        let reason = NativeInspectorSymbolResolverCore.formattedFailureReason(
+            kind: .runtimeFunctionSymbolMissing,
+            detail: nil,
+            phase: .fullCacheFile,
+            source: source,
+            missingFunctions: ["connectFrontend", "stringFromUTF8"],
+            usedConnectDisconnectFallback: true
+        )
+
+        #expect(reason.contains("phase=full-cache-file"))
+        #expect(reason.contains("source=full-cache-file+text-scan+loaded-image-runtime"))
+        #expect(reason.contains("missing=connectFrontend,stringFromUTF8"))
+        #expect(reason.contains("textScanFallback=true"))
+        #expect(!reason.contains("__ZN"))
+        #expect(!reason.contains("_ZN"))
+        #expect(!reason.contains("WTF"))
+        #expect(!reason.contains("/System/"))
+    }
+
 }
+
+private let completeNativeInspectorSymbolAddresses = NativeInspectorSymbolAddresses(
+    connectFrontendAddress: 0x1_0000,
+    disconnectFrontendAddress: 0x1_0100,
+    stringFromUTF8Address: 0x2_0000,
+    stringImplToNSStringAddress: 0x2_0100,
+    destroyStringImplAddress: 0x2_0200,
+    backendDispatcherDispatchAddress: 0x1_0200
+)
 
 private struct NativeSymbolFixture {
     let pathSuffixes: [String]

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fbba817fd7fc5d884ba5861588f664d59b31110db433be93b712f7af8b0ba482",
+  "originHash" : "1d9cdedc1ca81b4f675c92967bf9abb0cb9742628920eb7d48ced48f03c2bb7c",
   "pins" : [
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "3f218ab9229b87f76e1985131542b3c9f83327e8",
-        "version" : "0.50.0"
+        "revision" : "62c42ed722166283a9e4b89cd2332710c501d034",
+        "version" : "0.51.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose

Update MachOKit to 0.51.0 and complete the native symbol fallback work needed for the new dyld cache capabilities without changing the Transport, Bridge, public API, or C ABI surface.

## Changes

- Pins MachOKit to 0.51.0 and updates all three Package.resolved files to 62c42ed722166283a9e4b89cd2332710c501d034.
- Centralizes loaded/shared-cache image and local-symbol context inside WebInspectorNativeSymbols.
- Adds a host FullDyldCache fallback after loaded image, DyldCacheLoaded, and file-backed .symbols attempts.
- Adds distinct full-cache and full-cache-file source diagnostics while preserving redaction of private symbol and framework path details.
- Reuses the shared cache context for DEBUG similar-symbol scanning.
- Covers fallback source formatting, merge precedence, redacted diagnostics, URL de-dupe/sort behavior, and documents the owner boundary.

## Testing

- swift build --target WebInspectorNativeSymbols
- swift test --filter NativeInspectorSymbolResolverTests
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorNativeTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'
- WEBINSPECTORKIT_RUN_NATIVE_RUNTIME_SMOKE=1 xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorNativeTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' succeeded but Xcode did not pass the environment into the simulator test process, so the opt-in smoke tests were skipped.
- xcrun simctl spawn 9882C514-1F08-4957-BB30-96B6793A3B11 launchctl setenv WEBINSPECTORKIT_RUN_NATIVE_RUNTIME_SMOKE 1, then xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorNativeTests -destination 'id=9882C514-1F08-4957-BB30-96B6793A3B11' ran the runtime smoke tests and passed.
- codex-review: finding 0