### PR TITLE
Fix unused CSS variable reveal focus crash

### DIFF
--- a/Sources/WebInspectorUI/DOM/Element/DOMElementStyleHiddenVariablesCollectionCell.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementStyleHiddenVariablesCollectionCell.swift
@@ -49,6 +49,8 @@ package final class DOMElementStyleHiddenVariablesCollectionCell: UICollectionVi
     }
 
     @objc private func revealButtonPressed() {
+        // The reveal diff removes this pressed cell; disable first so UIKit does not keep it focusable.
+        revealButton.isEnabled = false
         onReveal?()
     }
 
@@ -67,6 +69,10 @@ package final class DOMElementStyleHiddenVariablesCollectionCell: UICollectionVi
 
 #if DEBUG
 extension DOMElementStyleHiddenVariablesCollectionCell {
+    package var isRevealButtonEnabledForTesting: Bool {
+        revealButton.isEnabled
+    }
+
     package func tapRevealForTesting() {
         revealButtonPressed()
     }

--- a/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUI/DOM/Element/DOMElementViewController.swift
@@ -19,6 +19,7 @@ package final class DOMElementViewController: UICollectionViewController {
 
     package var disablesSnapshotAnimationsForTesting = false
     package private(set) var lastSnapshotApplyModeForTesting: DOMElementStyleSnapshotCoordinator.ApplyMode = .none
+    package private(set) var styleSnapshotApplyModesForTesting: [DOMElementStyleSnapshotCoordinator.ApplyMode] = []
     package private(set) var styleSnapshotApplyCountForTesting = 0
     private var styleRenderGeneration = 0
     private var nextStyleRenderWaiterID: UInt64 = 0
@@ -242,7 +243,9 @@ package final class DOMElementViewController: UICollectionViewController {
                 return
             }
 #if DEBUG
-            lastSnapshotApplyModeForTesting = .diff(animated: animated)
+            let applyMode = DOMElementStyleSnapshotCoordinator.ApplyMode.diff(animated: animated)
+            lastSnapshotApplyModeForTesting = applyMode
+            styleSnapshotApplyModesForTesting.append(applyMode)
             let shouldAnimateSnapshot = animated && !disablesSnapshotAnimationsForTesting
             styleSnapshotApplyCountForTesting += 1
 #else
@@ -262,7 +265,9 @@ package final class DOMElementViewController: UICollectionViewController {
                 return
             }
 #if DEBUG
-            lastSnapshotApplyModeForTesting = .reloadData
+            let applyMode = DOMElementStyleSnapshotCoordinator.ApplyMode.reloadData
+            lastSnapshotApplyModeForTesting = applyMode
+            styleSnapshotApplyModesForTesting.append(applyMode)
             styleSnapshotApplyCountForTesting += 1
 #endif
             dataSource.applySnapshotUsingReloadData(snapshot) { [weak self] in

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -543,8 +543,11 @@ struct DOMContainerTests {
         #expect(collapsedDeclarations.contains("--palette-primary: #111;"))
         #expect(collapsedDeclarations.contains("--unused-a: red;") == false)
         #expect(collapsedDeclarations.contains("--unused-b: blue;") == false)
+        #expect(revealCell.isRevealButtonEnabledForTesting)
 
+        let applyModesBeforeReveal = viewController.styleSnapshotApplyModesForTesting
         revealCell.tapRevealForTesting()
+        #expect(revealCell.isRevealButtonEnabledForTesting == false)
 
         let didRevealUnusedVariables = await waitUntilRendered(in: viewController) {
             let declarations = stylePropertyViews(in: viewController).map(\.declarationTextForTesting)
@@ -555,7 +558,10 @@ struct DOMContainerTests {
         }
 
         #expect(didRevealUnusedVariables)
-        #expect(viewController.lastSnapshotApplyModeForTesting == .diff(animated: true))
+        let revealApplyModes = Array(
+            viewController.styleSnapshotApplyModesForTesting.dropFirst(applyModesBeforeReveal.count)
+        )
+        #expect(revealApplyModes == [.diff(animated: true)])
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Fix an intermittent UIKit focus crash when revealing unused CSS variables in the DOM Element styles list, while preserving the animated reveal behavior and ensuring the reveal button row disappears after activation.

## Changes
- Disable the reveal button immediately before applying the animated diff that removes its cell, preventing UIKit from keeping the pressed control as a focusable item during removal.
- Keep the reveal flow as a single animated diff so newly visible unused CSS variable rows still animate in and the placeholder button row is removed.
- Add DEBUG snapshot apply mode history and extend the DOM container test to verify the reveal uses one animated diff, disables the pressed button, reveals the unused variables, and removes the placeholder cell.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` clean after follow-up review