### PR TITLE
Update SyntaxEditorUI to 0.16.2

### DIFF
--- a/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monocly/Monocly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9391e814b6c1a7f376960ff0b88997b14d6699714c576572059caa89c56309eb",
+  "originHash" : "495e8085de23ed61fab3ee6127df6f3919c2c39ee8b99e39e4e0d6bf9f9a5349",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
-        "version" : "0.16.1"
+        "revision" : "973eb113bb652e39444808baca24240ae5d1f230",
+        "version" : "0.16.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4ecff7f1295282c9d9208bcdd9ca7c527de3181dd4d2af025e59e5086307de0b",
+  "originHash" : "debd21fc8a2f7dde4ef5a47a73e4586bc3312e14cccf60f2d00a12c76ea1fd73",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
-        "version" : "0.16.1"
+        "revision" : "973eb113bb652e39444808baca24240ae5d1f230",
+        "version" : "0.16.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/SyntaxEditorUI.git",
-            exact: "0.16.1"
+            exact: "0.16.2"
         ),
         .package(
             url: "https://github.com/p-x9/MachOKit.git",

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d9cdedc1ca81b4f675c92967bf9abb0cb9742628920eb7d48ced48f03c2bb7c",
+  "originHash" : "4395c753bb7ee1e6a0a159d4c914f13e4c93b96f263ca54ecb88ba1814706795",
   "pins" : [
     {
       "identity" : "machokit",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxEditorUI.git",
       "state" : {
-        "revision" : "1429341f756fc2d7ce59e5b5a61d6adc5f291f12",
-        "version" : "0.16.1"
+        "revision" : "973eb113bb652e39444808baca24240ae5d1f230",
+        "version" : "0.16.2"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Update SyntaxEditorUI to v0.16.2 to pick up the upstream stale syntax highlight rendering fix after repeated paste operations.

## Changes
- Bumped the SyntaxEditorUI exact dependency from 0.16.1 to 0.16.2.
- Refreshed SwiftPM resolved pins for the package, workspace, and Monocly project workspace.

## Testing
- `swift package resolve`
- `xcodebuild -resolvePackageDependencies -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit`
- `xcodebuild -list -project Monocly/Monocly.xcodeproj`
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- Codex review against `main`: no findings
