### PR TITLE
Add custom inspector tab API

### DIFF
--- a/Docs/MIGRATION.md
+++ b/Docs/MIGRATION.md
@@ -67,7 +67,7 @@ Snapshot depth, subtree depth, and DOM auto-update debounce are no longer public
 configuration. Remove app-side tuning for those values; the native DOM runtime
 owns those policies.
 
-## 4. Remove custom tab builders
+## 4. Replace custom tab builders
 
 The `v0.1.5` SwiftUI tab builder API was removed.
 
@@ -76,7 +76,7 @@ The `v0.1.5` SwiftUI tab builder API was removed.
 | `WITab.dom()` | `.dom` |
 | `WITab.element()` | included inside the DOM UI |
 | `WITab.network()` | `.network` |
-| custom `WITab(...)` content | no current app-facing replacement |
+| custom `WITab(...)` content | `WebInspectorTab(id:title:image:makeViewController:)` or `WebInspectorTab(id:title:systemImage:makeViewController:)` |
 
 Use the built-in tabs exposed by `WebInspectorViewController`:
 
@@ -86,7 +86,21 @@ let controller = WebInspectorViewController(
 )
 ```
 
-Custom tabs are not part of the current public surface.
+Custom tabs now use UIKit view controllers:
+
+```swift
+let consoleTab = WebInspectorTab(
+    id: "app_console",
+    title: "Console",
+    systemImage: "terminal"
+) { session in
+    ConsoleViewController(inspectorSession: session)
+}
+
+let controller = WebInspectorViewController(
+    tabs: [.dom, .network, consoleTab]
+)
+```
 
 ## 5. Remove old DOM and Network model usage
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,22 @@ let inspector = WebInspectorViewController(
 )
 ```
 
-The current public tab surface exposes the built-in DOM and Network tabs.
+The built-in tab surface exposes DOM and Network tabs. Apps can also add UIKit
+tabs with a `UIViewController` factory:
+
+```swift
+let consoleTab = WebInspectorTab(
+    id: "app_console",
+    title: "Console",
+    systemImage: "terminal"
+) { session in
+    ConsoleViewController(inspectorSession: session)
+}
+
+let inspector = WebInspectorViewController(
+    tabs: [.dom, .network, consoleTab]
+)
+```
 
 ## Documentation
 

--- a/Sources/WebInspectorUI/Containers/WebInspectorPageUserInterfaceStyleObserver.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorPageUserInterfaceStyleObserver.swift
@@ -35,6 +35,12 @@ package enum WebInspectorPageUserInterfaceStyle {
 }
 
 @MainActor
+package protocol WebInspectorPageUserInterfaceStyleObserving: AnyObject {
+    func start()
+    func invalidate()
+}
+
+@MainActor
 package final class WebInspectorPageUserInterfaceStyleObserver {
     private weak var webView: WKWebView?
     private let apply: @MainActor (UIUserInterfaceStyle) -> Void
@@ -119,6 +125,8 @@ package final class WebInspectorPageUserInterfaceStyleObserver {
         )
     }
 }
+
+extension WebInspectorPageUserInterfaceStyleObserver: WebInspectorPageUserInterfaceStyleObserving {}
 
 private final class WebInspectorPageUserInterfaceStyleObserverGeneration: Sendable {
     private let storage = Mutex<UInt64>(0)

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -15,7 +15,11 @@ public final class WebInspectorSession {
     public private(set) var pageUserInterfaceStyle: UIUserInterfaceStyle = .unspecified
     @ObservationIgnored private let attachAction: @MainActor (InspectorSession, WKWebView) async throws -> Void
     @ObservationIgnored private let detachAction: @MainActor (InspectorSession) async -> Void
-    @ObservationIgnored private var pageUserInterfaceStyleObserver: WebInspectorPageUserInterfaceStyleObserver?
+    @ObservationIgnored private let makePageUserInterfaceStyleObserver: @MainActor (
+        WKWebView,
+        @escaping @MainActor (UIUserInterfaceStyle) -> Void
+    ) -> any WebInspectorPageUserInterfaceStyleObserving
+    @ObservationIgnored private var pageUserInterfaceStyleObserver: (any WebInspectorPageUserInterfaceStyleObserving)?
 
     public convenience init(tabs: [WebInspectorTab] = [.dom, .network]) {
         self.init(inspector: InspectorSession(), tabs: tabs)
@@ -29,12 +33,19 @@ public final class WebInspectorSession {
         },
         detachAction: @escaping @MainActor (InspectorSession) async -> Void = { inspector in
             await inspector.detach()
+        },
+        makePageUserInterfaceStyleObserver: @escaping @MainActor (
+            WKWebView,
+            @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> any WebInspectorPageUserInterfaceStyleObserving = { webView, apply in
+            WebInspectorPageUserInterfaceStyleObserver(webView: webView, apply: apply)
         }
     ) {
         self.inspector = inspector
         self.interface = InterfaceModel(tabs: tabs)
         self.attachAction = attachAction
         self.detachAction = detachAction
+        self.makePageUserInterfaceStyleObserver = makePageUserInterfaceStyleObserver
     }
 
     isolated deinit {
@@ -72,7 +83,7 @@ public final class WebInspectorSession {
     }
 
     private func startPageUserInterfaceStyleObservation(for webView: WKWebView) {
-        let observer = WebInspectorPageUserInterfaceStyleObserver(webView: webView) { [weak self] style in
+        let observer = makePageUserInterfaceStyleObserver(webView) { [weak self] style in
             self?.setPageUserInterfaceStyle(style)
         }
         pageUserInterfaceStyleObserver = observer

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -136,11 +136,14 @@ package final class InterfaceModel {
         guard tabs.contains(tab) else {
             return
         }
-        selectItem(.tab(tab.id))
+        selectItem(displayItem(for: tab))
     }
 
     package func selectTab(withID tabID: WebInspectorTab.ID) {
-        selectItem(.tab(tabID))
+        guard let tab = tabs.first(where: { $0.id == tabID }) else {
+            return
+        }
+        selectTab(tab)
     }
 
     package func selectItem(_ displayItem: WebInspectorTab.DisplayItem) {
@@ -165,7 +168,7 @@ package final class InterfaceModel {
         pruneContentCache(retaining: reachableContentKeys(for: uniqueTabs))
         guard let selectedItemID,
               isValidItemID(selectedItemID) else {
-            self.selectedItemID = uniqueTabs.first?.id
+            self.selectedItemID = uniqueTabs.first.map { displayItem(for: $0).id }
             return
         }
     }
@@ -211,15 +214,35 @@ package final class InterfaceModel {
         let selectedSourceTabID = selectedItemID == WebInspectorTab.DisplayItem.domElementID
             ? WebInspectorTab.dom.id
             : selectedItemID
+        if let customTab = tabs.first(where: { tab in
+            tab.builtIn == nil
+                && WebInspectorTab.DisplayItem.customTabID(tab.id) == selectedItemID
+        }) {
+            return customTab
+        }
         return tabs.first { $0.id == selectedSourceTabID }
     }
 
     private func isValidItemID(_ displayItemID: WebInspectorTab.DisplayItem.ID) -> Bool {
-        if tabs.contains(where: { $0.id == displayItemID }) {
+        if tabs.contains(where: { tab in
+            tab.builtIn != nil && tab.id == displayItemID
+        }) {
+            return true
+        }
+        if tabs.contains(where: { tab in
+            tab.builtIn == nil && WebInspectorTab.DisplayItem.customTabID(tab.id) == displayItemID
+        }) {
             return true
         }
         return displayItemID == WebInspectorTab.DisplayItem.domElementID
             && tabs.contains(where: { $0.builtIn == .dom })
+    }
+
+    private func displayItem(for tab: WebInspectorTab) -> WebInspectorTab.DisplayItem {
+        if tab.builtIn != nil {
+            return .tab(tab.id)
+        }
+        return .customTab(tab.id)
     }
 
     private func reachableContentKeys(for tabs: [WebInspectorTab]) -> Set<WebInspectorTab.ContentKey> {

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -113,7 +113,7 @@ package final class InterfaceModel {
     package init(tabs: [WebInspectorTab] = [.dom, .network]) {
         let uniqueTabs = Self.uniqueTabs(tabs)
         self.tabs = uniqueTabs
-        selectedItemID = uniqueTabs.first?.id
+        selectedItemID = uniqueTabs.first.map { Self.displayItem(for: $0).id }
     }
 
     package func displayItems(for hostLayout: WebInspectorTab.HostLayout) -> [WebInspectorTab.DisplayItem] {
@@ -136,7 +136,7 @@ package final class InterfaceModel {
         guard tabs.contains(tab) else {
             return
         }
-        selectItem(displayItem(for: tab))
+        selectItem(Self.displayItem(for: tab))
     }
 
     package func selectTab(withID tabID: WebInspectorTab.ID) {
@@ -168,7 +168,7 @@ package final class InterfaceModel {
         pruneContentCache(retaining: reachableContentKeys(for: uniqueTabs))
         guard let selectedItemID,
               isValidItemID(selectedItemID) else {
-            self.selectedItemID = uniqueTabs.first.map { displayItem(for: $0).id }
+            self.selectedItemID = uniqueTabs.first.map { Self.displayItem(for: $0).id }
             return
         }
     }
@@ -238,7 +238,7 @@ package final class InterfaceModel {
             && tabs.contains(where: { $0.builtIn == .dom })
     }
 
-    private func displayItem(for tab: WebInspectorTab) -> WebInspectorTab.DisplayItem {
+    private static func displayItem(for tab: WebInspectorTab) -> WebInspectorTab.DisplayItem {
         if tab.builtIn != nil {
             return .tab(tab.id)
         }

--- a/Sources/WebInspectorUI/DOM/DOMTabController.swift
+++ b/Sources/WebInspectorUI/DOM/DOMTabController.swift
@@ -32,6 +32,8 @@ package struct DOMTabController: WebInspectorTab.BuiltInController {
         switch displayItem {
         case let .tab(tabID):
             tabID == self.tabID ? descriptor : nil
+        case .customTab:
+            nil
         case let .domElement(parent):
             parent == tabID ? elementDescriptor : nil
         }
@@ -46,6 +48,8 @@ package struct DOMTabController: WebInspectorTab.BuiltInController {
             [contentKey(ContentID.tree)]
         case (.compact, .domElement):
             [contentKey(ContentID.element)]
+        case (_, .customTab):
+            []
         case (.regular, _):
             [
                 contentKey(ContentID.tree),
@@ -70,6 +74,8 @@ package struct DOMTabController: WebInspectorTab.BuiltInController {
                 rootViewController: cachedElementViewController(session: session),
                 inspector: session.inspector
             )
+        case (_, .customTab):
+            UIViewController()
         case (.regular, _):
             RegularSplitRootViewController(
                 contentViewController: DOMSplitViewController(

--- a/Sources/WebInspectorUI/Tabs/BuiltInTabControllers.swift
+++ b/Sources/WebInspectorUI/Tabs/BuiltInTabControllers.swift
@@ -49,8 +49,11 @@ extension WebInspectorTab {
 
         package init() {}
 
-        package func controller(for tab: WebInspectorTab) -> any WebInspectorTab.BuiltInController {
-            controller(for: tab.builtIn)
+        package func controller(for tab: WebInspectorTab) -> (any WebInspectorTab.BuiltInController)? {
+            guard let builtIn = tab.builtIn else {
+                return nil
+            }
+            return controller(for: builtIn)
         }
 
         package func controller(for builtIn: WebInspectorTab.BuiltIn) -> any WebInspectorTab.BuiltInController {
@@ -114,7 +117,24 @@ extension WebInspectorTab {
                 return UIViewController()
             }
 
-            return catalog.controller(for: tab).makeViewController(
+            if case let .custom(content) = tab.content {
+                let viewController = session.interface.viewController(for: customContentKey(for: tab)) {
+                    content.makeViewController(session)
+                }
+                switch hostLayout {
+                case .compact:
+                    viewController.webInspectorDetachFromContainerForReuse()
+                    return viewController
+                case .regular:
+                    return RegularSplitRootViewController(contentViewController: viewController)
+                }
+            }
+
+            guard let controller = catalog.controller(for: tab) else {
+                return UIViewController()
+            }
+
+            return controller.makeViewController(
                 for: displayItem,
                 session: session,
                 layout: hostLayout
@@ -138,10 +158,18 @@ extension WebInspectorTab {
                 return []
             }
 
-            return catalog.controller(for: tab).contentKeys(
+            guard let controller = catalog.controller(for: tab) else {
+                return [customContentKey(for: tab)]
+            }
+
+            return controller.contentKeys(
                 for: hostLayout,
                 displayItem: displayItem
             )
+        }
+
+        private static func customContentKey(for tab: WebInspectorTab) -> WebInspectorTab.ContentKey {
+            WebInspectorTab.ContentKey(tabID: tab.id, contentID: "root")
         }
     }
 }

--- a/Sources/WebInspectorUI/Tabs/BuiltInTabControllers.swift
+++ b/Sources/WebInspectorUI/Tabs/BuiltInTabControllers.swift
@@ -112,8 +112,15 @@ extension WebInspectorTab {
                 )
             }
 
-            guard case let .tab(tabID) = displayItem,
-                  let tab = tabs.first(where: { $0.id == tabID }) else {
+            let tabID: WebInspectorTab.ID
+            switch displayItem {
+            case let .tab(id), let .customTab(id):
+                tabID = id
+            case .domElement:
+                return UIViewController()
+            }
+
+            guard let tab = tabs.first(where: { $0.id == tabID }) else {
                 return UIViewController()
             }
 
@@ -153,8 +160,15 @@ extension WebInspectorTab {
                 )
             }
 
-            guard case let .tab(tabID) = displayItem,
-                  let tab = tabs.first(where: { $0.id == tabID }) else {
+            let tabID: WebInspectorTab.ID
+            switch displayItem {
+            case let .tab(id), let .customTab(id):
+                tabID = id
+            case .domElement:
+                return []
+            }
+
+            guard let tab = tabs.first(where: { $0.id == tabID }) else {
                 return []
             }
 

--- a/Sources/WebInspectorUI/Tabs/TabModels.swift
+++ b/Sources/WebInspectorUI/Tabs/TabModels.swift
@@ -13,9 +13,14 @@ extension WebInspectorTab {
         package typealias ID = String
 
         case tab(WebInspectorTab.ID)
+        case customTab(WebInspectorTab.ID)
         case domElement(parent: WebInspectorTab.ID)
 
         package static let domElementID: ID = domElementID(parent: "webinspector_dom")
+
+        package static func customTabID(_ tabID: WebInspectorTab.ID) -> ID {
+            "webinspector_custom.\(tabID)"
+        }
 
         package static func domElementID(parent: WebInspectorTab.ID) -> ID {
             "\(parent).element"
@@ -25,6 +30,8 @@ extension WebInspectorTab {
             switch self {
             case let .tab(tabID):
                 tabID
+            case let .customTab(tabID):
+                Self.customTabID(tabID)
             case let .domElement(parent):
                 Self.domElementID(parent: parent)
             }
@@ -32,7 +39,7 @@ extension WebInspectorTab {
 
         package var sourceTabID: WebInspectorTab.ID {
             switch self {
-            case let .tab(tabID), let .domElement(parent: tabID):
+            case let .tab(tabID), let .customTab(tabID), let .domElement(parent: tabID):
                 tabID
             }
         }
@@ -115,7 +122,7 @@ extension WebInspectorTab {
         ) -> [WebInspectorTab.DisplayItem] {
             tabs.flatMap { tab -> [WebInspectorTab.DisplayItem] in
                 guard let controller = catalog.controller(for: tab) else {
-                    return [.tab(tab.id)]
+                    return [.customTab(tab.id)]
                 }
                 return controller.displayItems(for: hostLayout)
             }
@@ -157,6 +164,15 @@ extension WebInspectorTab {
                     )
                 }
                 return controller.descriptor(for: displayItem)
+            case let .customTab(tabID):
+                guard let tab = tabs.first(where: { $0.id == tabID }),
+                      tab.builtIn == nil else {
+                    return nil
+                }
+                return WebInspectorTab.DisplayDescriptor(
+                    title: tab.title,
+                    image: tab.image
+                )
             case .domElement:
                 return catalog.controller(for: WebInspectorTab.BuiltIn.dom).descriptor(for: displayItem)
             }

--- a/Sources/WebInspectorUI/Tabs/TabModels.swift
+++ b/Sources/WebInspectorUI/Tabs/TabModels.swift
@@ -113,8 +113,11 @@ extension WebInspectorTab {
             for hostLayout: WebInspectorTab.HostLayout,
             tabs: [WebInspectorTab]
         ) -> [WebInspectorTab.DisplayItem] {
-            tabs.flatMap { tab in
-                catalog.controller(for: tab).displayItems(for: hostLayout)
+            tabs.flatMap { tab -> [WebInspectorTab.DisplayItem] in
+                guard let controller = catalog.controller(for: tab) else {
+                    return [.tab(tab.id)]
+                }
+                return controller.displayItems(for: hostLayout)
             }
         }
 
@@ -147,7 +150,13 @@ extension WebInspectorTab {
                 guard let tab = tabs.first(where: { $0.id == tabID }) else {
                     return nil
                 }
-                return catalog.controller(for: tab).descriptor(for: displayItem)
+                guard let controller = catalog.controller(for: tab) else {
+                    return WebInspectorTab.DisplayDescriptor(
+                        title: tab.title,
+                        image: tab.image
+                    )
+                }
+                return controller.descriptor(for: displayItem)
             case .domElement:
                 return catalog.controller(for: WebInspectorTab.BuiltIn.dom).descriptor(for: displayItem)
             }

--- a/Sources/WebInspectorUI/Tabs/WebInspectorTab.swift
+++ b/Sources/WebInspectorUI/Tabs/WebInspectorTab.swift
@@ -8,11 +8,28 @@ public struct WebInspectorTab: Equatable, Hashable, Identifiable {
     public let id: ID
     public let title: String
     public let image: UIImage?
-    package let builtIn: BuiltIn
+    package let content: Content
 
     package enum BuiltIn: Hashable {
         case dom
         case network
+    }
+
+    @MainActor
+    package struct CustomContent {
+        package let makeViewController: @MainActor (WebInspectorSession) -> UIViewController
+    }
+
+    package enum Content {
+        case builtIn(BuiltIn)
+        case custom(CustomContent)
+    }
+
+    package var builtIn: BuiltIn? {
+        guard case let .builtIn(builtIn) = content else {
+            return nil
+        }
+        return builtIn
     }
 
     public static nonisolated func == (lhs: WebInspectorTab, rhs: WebInspectorTab) -> Bool {
@@ -32,7 +49,39 @@ public struct WebInspectorTab: Equatable, Hashable, Identifiable {
         self.id = id
         self.title = title
         self.image = image
-        self.builtIn = builtIn
+        self.content = .builtIn(builtIn)
+    }
+
+    /// Creates an app-provided inspector tab backed by a UIKit view controller.
+    ///
+    /// The factory is called the first time the tab content is needed for a
+    /// session. WebInspectorKit caches the returned controller for the tab ID
+    /// and reuses it across compact and regular presentations.
+    public init(
+        id: ID,
+        title: String,
+        image: UIImage? = nil,
+        makeViewController: @escaping @MainActor (_ session: WebInspectorSession) -> UIViewController
+    ) {
+        self.id = id
+        self.title = title
+        self.image = image
+        self.content = .custom(CustomContent(makeViewController: makeViewController))
+    }
+
+    /// Creates an app-provided inspector tab using an SF Symbols image name.
+    public init(
+        id: ID,
+        title: String,
+        systemImage: String,
+        makeViewController: @escaping @MainActor (_ session: WebInspectorSession) -> UIViewController
+    ) {
+        self.init(
+            id: id,
+            title: title,
+            image: UIImage(systemName: systemImage),
+            makeViewController: makeViewController
+        )
     }
 
     public static let dom = WebInspectorTab(

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -226,7 +226,7 @@ struct ParentContainerTests {
                 == [
                     WebInspectorTab.dom.id,
                     WebInspectorTab.DisplayItem.domElementID,
-                    customTab.id,
+                    WebInspectorTab.DisplayItem.customTabID(customTab.id),
                     WebInspectorTab.network.id,
                 ]
         )
@@ -234,25 +234,25 @@ struct ParentContainerTests {
             projection.displayItems(for: .regular, tabs: session.interface.tabs).map(\.id)
                 == [
                     WebInspectorTab.dom.id,
-                    customTab.id,
+                    WebInspectorTab.DisplayItem.customTabID(customTab.id),
                     WebInspectorTab.network.id,
                 ]
         )
         #expect(
             projection.descriptor(
-                for: .tab(customTab.id),
+                for: .customTab(customTab.id),
                 tabs: session.interface.tabs
             )?.title == "Console"
         )
 
         let compactContent = WebInspectorTab.ContentFactory.makeViewController(
-            for: .tab(customTab.id),
+            for: .customTab(customTab.id),
             session: session,
             hostLayout: .compact,
             tabs: session.interface.tabs
         )
         let regularContent = WebInspectorTab.ContentFactory.makeViewController(
-            for: .tab(customTab.id),
+            for: .customTab(customTab.id),
             session: session,
             hostLayout: .regular,
             tabs: session.interface.tabs
@@ -262,7 +262,7 @@ struct ParentContainerTests {
         #expect(customViewController.parent === regularContent)
 
         let reparentedContent = WebInspectorTab.ContentFactory.makeViewController(
-            for: .tab(customTab.id),
+            for: .customTab(customTab.id),
             session: session,
             hostLayout: .compact,
             tabs: session.interface.tabs
@@ -273,6 +273,45 @@ struct ParentContainerTests {
         #expect(reparentedContent.parent == nil)
         #expect(factorySession === session)
         #expect(factoryCallCount == 1)
+    }
+
+    @Test
+    func customTabDisplayItemDoesNotCollideWithInternalDOMElementIdentifier() throws {
+        let customViewController = UIViewController()
+        let customTab = WebInspectorTab(
+            id: WebInspectorTab.DisplayItem.domElementID,
+            title: "Custom Element",
+            image: nil
+        ) { _ in
+            customViewController
+        }
+        let session = WebInspectorSession(tabs: [.dom, customTab])
+        let projection = WebInspectorTab.DisplayProjection()
+        let compactDisplayItems = projection.displayItems(for: .compact, tabs: session.interface.tabs)
+        let displayItemIDs = compactDisplayItems.map(\.id)
+        let customDisplayID = WebInspectorTab.DisplayItem.customTabID(customTab.id)
+
+        #expect(
+            displayItemIDs == [
+                WebInspectorTab.dom.id,
+                WebInspectorTab.DisplayItem.domElementID,
+                customDisplayID,
+            ]
+        )
+        #expect(Set(displayItemIDs).count == displayItemIDs.count)
+
+        session.interface.selectItem(withID: customDisplayID)
+
+        #expect(session.interface.resolvedSelection(for: .compact) == .customTab(customTab.id))
+        #expect(session.interface.selectedTab == customTab)
+
+        let customContent = WebInspectorTab.ContentFactory.makeViewController(
+            for: .customTab(customTab.id),
+            session: session,
+            hostLayout: .compact,
+            tabs: session.interface.tabs
+        )
+        #expect(customContent === customViewController)
     }
 
     @Test
@@ -315,7 +354,7 @@ struct ParentContainerTests {
                 == [
                     WebInspectorTab.dom.id,
                     WebInspectorTab.DisplayItem.domElementID,
-                    customTab.id,
+                    WebInspectorTab.DisplayItem.customTabID(customTab.id),
                 ]
         )
 

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -75,21 +75,23 @@ struct ParentContainerTests {
 
     @Test
     func sessionClearsPageUserInterfaceStyleAndStopsObservingOnDetach() async throws {
-        let session = makeSessionWithNoOpAttachment()
+        let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
+        let session = makeSessionWithNoOpAttachment(
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
         let webView = WKWebView(frame: .zero)
 
         try await session.attach(to: webView)
-        let styleObservation = await observePageUserInterfaceStyle(in: session)
-        defer { styleObservation.cancel() }
-
-        webView.underPageBackgroundColor = .black
-        #expect(await styleObservation.values.waitUntilValue(UIUserInterfaceStyle.dark.rawValue))
+        let observer = try #require(observerRecorder.observers.first)
+        #expect(observer.isStarted)
+        #expect(session.pageUserInterfaceStyle == .dark)
 
         await session.detach()
 
+        #expect(observer.isInvalidated)
         #expect(session.hasPageUserInterfaceStyleObserverForTesting == false)
         #expect(session.pageUserInterfaceStyle == .unspecified)
-        webView.underPageBackgroundColor = .white
+        observer.publish(.light)
         #expect(session.pageUserInterfaceStyle == .unspecified)
     }
 
@@ -97,18 +99,20 @@ struct ParentContainerTests {
     func sessionClearsPageUserInterfaceStyleAndStopsObservingWhenAttachFails() async throws {
         let observedWebView = WKWebView(frame: .zero)
         let observedWebViewID = ObjectIdentifier(observedWebView)
-        let session = makeSessionWithNoOpAttachment { _, webView in
-            if ObjectIdentifier(webView) != observedWebViewID {
-                throw AttachmentFailure()
-            }
-        }
+        let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
+        let session = makeSessionWithNoOpAttachment(
+            attachAction: { _, webView in
+                if ObjectIdentifier(webView) != observedWebViewID {
+                    throw AttachmentFailure()
+                }
+            },
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
 
         try await session.attach(to: observedWebView)
-        let styleObservation = await observePageUserInterfaceStyle(in: session)
-        defer { styleObservation.cancel() }
-
-        observedWebView.underPageBackgroundColor = .black
-        #expect(await styleObservation.values.waitUntilValue(UIUserInterfaceStyle.dark.rawValue))
+        let observer = try #require(observerRecorder.observers.first)
+        #expect(observer.isStarted)
+        #expect(session.pageUserInterfaceStyle == .dark)
 
         do {
             try await session.attach(to: WKWebView(frame: .zero))
@@ -117,27 +121,28 @@ struct ParentContainerTests {
             #expect(error is AttachmentFailure)
         }
 
+        #expect(observerRecorder.observers.count == 1)
+        #expect(observer.isInvalidated)
         #expect(session.hasPageUserInterfaceStyleObserverForTesting == false)
         #expect(session.pageUserInterfaceStyle == .unspecified)
-        observedWebView.underPageBackgroundColor = .white
+        observer.publish(.light)
         #expect(session.pageUserInterfaceStyle == .unspecified)
     }
 
     @Test
     func viewControllerDoesNotApplyPageUserInterfaceStyle() async throws {
-        let session = makeSessionWithNoOpAttachment()
+        let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
+        let session = makeSessionWithNoOpAttachment(
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
         let viewController = WebInspectorViewController(session: session)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         let webView = WKWebView(frame: .zero)
 
         try await session.attach(to: webView)
-        let styleObservation = await observePageUserInterfaceStyle(in: session)
-        defer { styleObservation.cancel() }
 
-        webView.underPageBackgroundColor = .black
-
-        #expect(await styleObservation.values.waitUntilValue(UIUserInterfaceStyle.dark.rawValue))
+        #expect(session.pageUserInterfaceStyle == .dark)
         #expect(viewController.overrideUserInterfaceStyle == .unspecified)
     }
 
@@ -829,13 +834,77 @@ struct ParentContainerTests {
 
     private func makeSessionWithNoOpAttachment(
         attachAction: @escaping @MainActor (InspectorSession, WKWebView) async throws -> Void = { _, _ in },
-        detachAction: @escaping @MainActor (InspectorSession) async -> Void = { _ in }
+        detachAction: @escaping @MainActor (InspectorSession) async -> Void = { _ in },
+        makePageUserInterfaceStyleObserver: @escaping @MainActor (
+            WKWebView,
+            @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> any WebInspectorPageUserInterfaceStyleObserving = { webView, apply in
+            WebInspectorPageUserInterfaceStyleObserver(webView: webView, apply: apply)
+        }
     ) -> WebInspectorSession {
         WebInspectorSession(
             inspector: InspectorSession(),
             attachAction: attachAction,
-            detachAction: detachAction
+            detachAction: detachAction,
+            makePageUserInterfaceStyleObserver: makePageUserInterfaceStyleObserver
         )
+    }
+
+    @MainActor
+    private final class PageUserInterfaceStyleObserverRecorder {
+        private let styleOnStart: UIUserInterfaceStyle
+        private(set) var observers: [PageUserInterfaceStyleObserverDouble] = []
+
+        init(styleOnStart: UIUserInterfaceStyle) {
+            self.styleOnStart = styleOnStart
+        }
+
+        func makeObserver(
+            webView: WKWebView,
+            apply: @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> any WebInspectorPageUserInterfaceStyleObserving {
+            let observer = PageUserInterfaceStyleObserverDouble(
+                styleOnStart: styleOnStart,
+                apply: apply
+            )
+            observers.append(observer)
+            return observer
+        }
+    }
+
+    @MainActor
+    private final class PageUserInterfaceStyleObserverDouble: WebInspectorPageUserInterfaceStyleObserving {
+        private let styleOnStart: UIUserInterfaceStyle
+        private let apply: @MainActor (UIUserInterfaceStyle) -> Void
+        private(set) var isStarted = false
+        private(set) var isInvalidated = false
+
+        init(
+            styleOnStart: UIUserInterfaceStyle,
+            apply: @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) {
+            self.styleOnStart = styleOnStart
+            self.apply = apply
+        }
+
+        func start() {
+            guard isInvalidated == false else {
+                return
+            }
+            isStarted = true
+            publish(styleOnStart)
+        }
+
+        func invalidate() {
+            isInvalidated = true
+        }
+
+        func publish(_ style: UIUserInterfaceStyle) {
+            guard isInvalidated == false else {
+                return
+            }
+            apply(style)
+        }
     }
 
     private final class DetachRecorder {

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -205,6 +205,130 @@ struct ParentContainerTests {
     }
 
     @Test
+    func customTabUsesPublicDescriptorAndCachedViewControllerFactory() throws {
+        let customViewController = UIViewController()
+        var factoryCallCount = 0
+        var factorySession: WebInspectorSession?
+        let customTab = WebInspectorTab(
+            id: "webinspector_custom_console",
+            title: "Console",
+            systemImage: "terminal"
+        ) { session in
+            factoryCallCount += 1
+            factorySession = session
+            return customViewController
+        }
+        let session = WebInspectorSession(tabs: [.dom, customTab, .network])
+        let projection = WebInspectorTab.DisplayProjection()
+
+        #expect(
+            projection.displayItems(for: .compact, tabs: session.interface.tabs).map(\.id)
+                == [
+                    WebInspectorTab.dom.id,
+                    WebInspectorTab.DisplayItem.domElementID,
+                    customTab.id,
+                    WebInspectorTab.network.id,
+                ]
+        )
+        #expect(
+            projection.displayItems(for: .regular, tabs: session.interface.tabs).map(\.id)
+                == [
+                    WebInspectorTab.dom.id,
+                    customTab.id,
+                    WebInspectorTab.network.id,
+                ]
+        )
+        #expect(
+            projection.descriptor(
+                for: .tab(customTab.id),
+                tabs: session.interface.tabs
+            )?.title == "Console"
+        )
+
+        let compactContent = WebInspectorTab.ContentFactory.makeViewController(
+            for: .tab(customTab.id),
+            session: session,
+            hostLayout: .compact,
+            tabs: session.interface.tabs
+        )
+        let regularContent = WebInspectorTab.ContentFactory.makeViewController(
+            for: .tab(customTab.id),
+            session: session,
+            hostLayout: .regular,
+            tabs: session.interface.tabs
+        )
+        regularContent.loadViewIfNeeded()
+        #expect(regularContent !== customViewController)
+        #expect(customViewController.parent === regularContent)
+
+        let reparentedContent = WebInspectorTab.ContentFactory.makeViewController(
+            for: .tab(customTab.id),
+            session: session,
+            hostLayout: .compact,
+            tabs: session.interface.tabs
+        )
+
+        #expect(compactContent === customViewController)
+        #expect(reparentedContent === customViewController)
+        #expect(reparentedContent.parent == nil)
+        #expect(factorySession === session)
+        #expect(factoryCallCount == 1)
+    }
+
+    @Test
+    func regularCustomTabWrapsNavigationControllerContent() throws {
+        let customRootViewController = UIViewController()
+        let customNavigationController = UINavigationController(rootViewController: customRootViewController)
+        let customTab = WebInspectorTab(
+            id: "webinspector_custom_navigation",
+            title: "Custom",
+            image: nil
+        ) { _ in
+            customNavigationController
+        }
+        let session = WebInspectorSession(tabs: [customTab])
+        let host = RegularTabContentViewController(session: session)
+
+        host.loadViewIfNeeded()
+
+        let installedRoot = try #require(host.viewControllers.first)
+        installedRoot.loadViewIfNeeded()
+        #expect(installedRoot !== customNavigationController)
+        #expect(installedRoot is UINavigationController == false)
+        #expect(customNavigationController.parent === installedRoot)
+    }
+
+    @Test
+    func compactAndRegularHostsDisplayCustomTabs() throws {
+        let customTab = WebInspectorTab(
+            id: "webinspector_custom_console",
+            title: "Console",
+            systemImage: "terminal"
+        ) { _ in
+            UIViewController()
+        }
+        let session = WebInspectorSession(tabs: [.dom, customTab])
+
+        let compactHost = CompactTabBarController(session: session)
+        #expect(
+            compactHost.displayedTabIdentifiersForTesting
+                == [
+                    WebInspectorTab.dom.id,
+                    WebInspectorTab.DisplayItem.domElementID,
+                    customTab.id,
+                ]
+        )
+
+        let regularHost = RegularTabContentViewController(session: session)
+        regularHost.loadViewIfNeeded()
+        let segmentedControl = regularHost.segmentedControlForTesting
+
+        #expect(segmentedControl.numberOfSegments == 2)
+        #expect(segmentedControl.titleForSegment(at: 0) == "DOM")
+        #expect(segmentedControl.titleForSegment(at: 1) == "Console")
+    }
+
+    @Test
     func topLevelContainerSwitchesBetweenCompactAndRegularHosts() throws {
         let viewController = WebInspectorViewController()
         viewController.loadViewIfNeeded()

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -300,6 +300,11 @@ struct ParentContainerTests {
         )
         #expect(Set(displayItemIDs).count == displayItemIDs.count)
 
+        let initiallySelectedCustomSession = WebInspectorSession(tabs: [customTab, .dom])
+        #expect(initiallySelectedCustomSession.interface.selectedItemID == customDisplayID)
+        #expect(initiallySelectedCustomSession.interface.resolvedSelection(for: .compact) == .customTab(customTab.id))
+        #expect(initiallySelectedCustomSession.interface.selectedTab == customTab)
+
         session.interface.selectItem(withID: customDisplayID)
 
         #expect(session.interface.resolvedSelection(for: .compact) == .customTab(customTab.id))


### PR DESCRIPTION
## Purpose
Add a supported custom tab path for v0.2.0 so apps can keep app-specific inspector panels while migrating from the old SwiftUI `WITab` builder.

## Changes
- Add public `WebInspectorTab` initializers for UIKit `UIViewController` factories, including an SF Symbols convenience initializer.
- Route custom tabs through the existing display projection and content cache so compact and regular hosts can render them consistently.
- Namespace custom tab display item identifiers so app-provided tab IDs cannot collide with internal display items such as the DOM Element item.
- Wrap custom tab content in regular layout to support controllers such as `UINavigationController` without pushing them into the outer navigation stack.
- Update README and migration docs with the new custom tab API.
- Add UI container coverage for custom tab projection, descriptor lookup, caching, reparenting, regular layout wrapping, and internal ID collision handling.

## Testing
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -test-timeouts-enabled YES -default-test-execution-time-allowance 30 -maximum-test-execution-time-allowance 60`
- `git diff --check`
- Codex review: clean
