### PR TITLE
Cache network display filtering

### DIFF
--- a/Sources/WebInspectorCoreConsoleNetwork/Network/NetworkModel.swift
+++ b/Sources/WebInspectorCoreConsoleNetwork/Network/NetworkModel.swift
@@ -322,6 +322,22 @@ extension NetworkSession {
         package var orderedRequestIDs: [NetworkRequest.ID]
         package var requestsByID: [NetworkRequest.ID: NetworkRequest.Snapshot]
     }
+
+    package struct DisplayChanges: Equatable, Sendable {
+        package var revision: Int
+        package var changedRequestIDs: Set<NetworkRequest.ID>
+        package var requiresFullReconcile: Bool
+
+        package init(
+            revision: Int,
+            changedRequestIDs: Set<NetworkRequest.ID>,
+            requiresFullReconcile: Bool
+        ) {
+            self.revision = revision
+            self.changedRequestIDs = changedRequestIDs
+            self.requiresFullReconcile = requiresFullReconcile
+        }
+    }
 }
 
 @MainActor
@@ -452,13 +468,22 @@ private struct NetworkRequestStore {
     }
 }
 
+private struct NetworkRequestDisplayChange {
+    var revision: Int
+    var requestID: NetworkRequest.ID?
+    var requiresFullReconcile: Bool
+}
+
 @MainActor
 @Observable
 package final class NetworkSession {
+    private static let requestDisplayChangeHistoryLimit = 2_048
+
     private var requestStore: NetworkRequestStore
     package private(set) var requestTopologyRevision: Int
     package private(set) var requestContentRevision: Int
     package private(set) var requestDisplayRevision: Int
+    @ObservationIgnored private var requestDisplayChangeHistory: [NetworkRequestDisplayChange]
     @ObservationIgnored private var commandChannel: ProtocolCommandChannel?
     @ObservationIgnored private let protocolCommands: NetworkProtocolCommands
     @ObservationIgnored private var recordError: ((InspectorError?) -> Void)?
@@ -468,6 +493,7 @@ package final class NetworkSession {
         requestTopologyRevision = 0
         requestContentRevision = 0
         requestDisplayRevision = 0
+        requestDisplayChangeHistory = []
         commandChannel = nil
         protocolCommands = NetworkProtocolCommands()
         recordError = nil
@@ -487,7 +513,49 @@ package final class NetworkSession {
 
     package func reset() {
         requestStore.removeAll()
-        recordRequestTopologyChange()
+        recordRequestTopologyChange(requiresDisplayFullReconcile: true)
+    }
+
+    package func requestDisplayChanges(after revision: Int) -> NetworkSession.DisplayChanges {
+        let currentRevision = requestDisplayRevision
+        guard revision < currentRevision else {
+            return NetworkSession.DisplayChanges(
+                revision: currentRevision,
+                changedRequestIDs: [],
+                requiresFullReconcile: false
+            )
+        }
+        guard revision >= 0 else {
+            return NetworkSession.DisplayChanges(
+                revision: currentRevision,
+                changedRequestIDs: [],
+                requiresFullReconcile: true
+            )
+        }
+
+        let pendingChanges = requestDisplayChangeHistory.filter { $0.revision > revision }
+        guard let firstPendingChange = pendingChanges.first,
+              firstPendingChange.revision == revision &+ 1 else {
+            return NetworkSession.DisplayChanges(
+                revision: currentRevision,
+                changedRequestIDs: [],
+                requiresFullReconcile: true
+            )
+        }
+
+        var changedRequestIDs: Set<NetworkRequest.ID> = []
+        var requiresFullReconcile = false
+        for change in pendingChanges {
+            if let requestID = change.requestID {
+                changedRequestIDs.insert(requestID)
+            }
+            requiresFullReconcile = requiresFullReconcile || change.requiresFullReconcile
+        }
+        return NetworkSession.DisplayChanges(
+            revision: currentRevision,
+            changedRequestIDs: changedRequestIDs,
+            requiresFullReconcile: requiresFullReconcile
+        )
     }
 
     package func bindProtocolChannel(
@@ -591,7 +659,7 @@ package final class NetworkSession {
                 existing.backendResourceIdentifier = backendResourceIdentifier ?? existing.backendResourceIdentifier
             }
             requestStore.markActive(key)
-            recordRequestDisplayChange()
+            recordRequestDisplayChange(requestID: key)
             return key
         }
 
@@ -611,7 +679,7 @@ package final class NetworkSession {
             )
         )
         requestStore.markActive(key)
-        recordRequestTopologyChange()
+        recordRequestTopologyChange(displayRequestID: key)
         return key
     }
 
@@ -624,7 +692,8 @@ package final class NetworkSession {
         response: NetworkRequest.Response.Payload,
         timestamp: Double
     ) {
-        guard let request = requestStore.request(for: .init(targetID: targetID, requestID: requestID)) else {
+        let key = NetworkRequest.ID(targetID: targetID, requestID: requestID)
+        guard let request = requestStore.request(for: key) else {
             return
         }
         request.frameID = frameID ?? request.frameID
@@ -638,7 +707,7 @@ package final class NetworkSession {
         request.ensureResponseBody()
         request.responseReceivedTimestamp = timestamp
         request.state = .responded
-        recordRequestDisplayChange()
+        recordRequestDisplayChange(requestID: key)
     }
 
     package func applyDataReceived(
@@ -743,9 +812,9 @@ package final class NetworkSession {
         networkRequest.finishedOrFailedTimestamp = timestamp
         networkRequest.state = .finished
         if didExist {
-            recordRequestDisplayChange()
+            recordRequestDisplayChange(requestID: key)
         } else {
-            recordRequestTopologyChange()
+            recordRequestTopologyChange(displayRequestID: key)
         }
         return key
     }
@@ -761,7 +830,7 @@ package final class NetworkSession {
             existing.request.url = url
             existing.resourceType = .webSocket
             existing.webSocketReadyState = .connecting
-            recordRequestDisplayChange()
+            recordRequestDisplayChange(requestID: key)
             return key
         }
 
@@ -781,7 +850,7 @@ package final class NetworkSession {
         networkRequest.webSocketReadyState = .connecting
         requestStore.insert(networkRequest)
         requestStore.markActive(key)
-        recordRequestTopologyChange()
+        recordRequestTopologyChange(displayRequestID: key)
         return key
     }
 
@@ -826,7 +895,7 @@ package final class NetworkSession {
         networkRequest.responseReceivedTimestamp = timestamp
         networkRequest.webSocketReadyState = .open
         networkRequest.state = .responded
-        recordRequestDisplayChange()
+        recordRequestDisplayChange(requestID: key)
     }
 
     package func applyWebSocketFrameReceived(
@@ -929,13 +998,29 @@ package final class NetworkSession {
         return commandChannel
     }
 
-    private func recordRequestTopologyChange() {
+    private func recordRequestTopologyChange(
+        displayRequestID: NetworkRequest.ID? = nil,
+        requiresDisplayFullReconcile: Bool = false
+    ) {
         requestTopologyRevision &+= 1
-        recordRequestDisplayChange()
+        recordRequestDisplayChange(requestID: displayRequestID, requiresFullReconcile: requiresDisplayFullReconcile)
     }
 
-    private func recordRequestDisplayChange() {
+    private func recordRequestDisplayChange(
+        requestID: NetworkRequest.ID? = nil,
+        requiresFullReconcile: Bool = false
+    ) {
         requestDisplayRevision &+= 1
+        requestDisplayChangeHistory.append(
+            NetworkRequestDisplayChange(
+                revision: requestDisplayRevision,
+                requestID: requestID,
+                requiresFullReconcile: requiresFullReconcile
+            )
+        )
+        if requestDisplayChangeHistory.count > Self.requestDisplayChangeHistoryLimit {
+            requestDisplayChangeHistory.removeFirst(requestDisplayChangeHistory.count - Self.requestDisplayChangeHistoryLimit)
+        }
         recordRequestContentChange()
     }
 

--- a/Sources/WebInspectorUINetwork/NetworkPanelDisplayIndex.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelDisplayIndex.swift
@@ -1,0 +1,393 @@
+import WebInspectorCore
+
+@MainActor
+struct NetworkPanelDisplayCriteria: Equatable {
+    var searchText: String
+    var resourceFilters: Set<NetworkRequest.Display.ResourceFilter>
+
+    var requiresEntries: Bool {
+        searchText.isEmpty == false || resourceFilters.isEmpty == false
+    }
+
+    var requiresResourceFilter: Bool {
+        resourceFilters.isEmpty == false
+    }
+}
+
+@MainActor
+private struct NetworkPanelDisplayEntry {
+    var requestID: NetworkRequest.ID
+    var requestURLSummary: NetworkRequest.Display.URLSummary
+    var responseURLSummary: NetworkRequest.Display.URLSummary?
+    var fileTypeLabel: String
+    var searchTokens: [String]
+    var resourceFilter: NetworkRequest.Display.ResourceFilter?
+
+    init(request: NetworkRequest) {
+        let projection = request.displayProjection()
+        requestID = request.id
+        requestURLSummary = projection.requestURLSummary
+        responseURLSummary = projection.responseURLSummary
+        fileTypeLabel = projection.fileTypeLabel
+        searchTokens = projection.searchTokens
+        resourceFilter = nil
+    }
+
+    mutating func ensureResourceFilter(
+        for request: NetworkRequest,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) -> NetworkRequest.Display.ResourceFilter {
+        if let resourceFilter {
+            return resourceFilter
+        }
+        let resourceFilter = NetworkRequest.Display.resourceFilter(
+            resourceType: request.resourceType,
+            response: request.response,
+            requestURLSummary: requestURLSummary,
+            responseURLSummary: responseURLSummary,
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
+        self.resourceFilter = resourceFilter
+        return resourceFilter
+    }
+
+    mutating func matches(
+        criteria: NetworkPanelDisplayCriteria,
+        request: NetworkRequest,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) -> Bool {
+        if criteria.requiresResourceFilter {
+            let resourceFilter = ensureResourceFilter(
+                for: request,
+                mediaPreviewClassifier: mediaPreviewClassifier
+            )
+            guard criteria.resourceFilters.contains(resourceFilter) else {
+                return false
+            }
+        }
+
+        if criteria.searchText.isEmpty == false {
+            guard searchTokens.contains(where: { $0.localizedStandardContains(criteria.searchText) }) else {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+@MainActor
+struct NetworkPanelDisplayIndex {
+    private enum TopologyChange: Equatable {
+        case none
+        case appended([NetworkRequest.ID])
+        case rebuilt
+
+        var isChanged: Bool {
+            switch self {
+            case .none:
+                false
+            case .appended, .rebuilt:
+                true
+            }
+        }
+    }
+
+    private var orderedRequestIDs: [NetworkRequest.ID] = []
+    private var orderRanksByID: [NetworkRequest.ID: Int] = [:]
+    private var entriesByID: [NetworkRequest.ID: NetworkPanelDisplayEntry] = [:]
+    private var matchingRequestIDs: Set<NetworkRequest.ID> = []
+    private var criteria: NetworkPanelDisplayCriteria?
+    private var topologyRevision: Int?
+    private var displayRevision: Int = 0
+
+    private(set) var filteredRequestIDs: [NetworkRequest.ID] = []
+
+#if DEBUG
+    private(set) var displayEntryBuildCount: Int = 0
+    private(set) var rebuiltDisplayRequestIDs: [NetworkRequest.ID] = []
+    private(set) var fullMembershipEvaluationCount: Int = 0
+
+    mutating func resetTestingCounters() {
+        displayEntryBuildCount = 0
+        rebuiltDisplayRequestIDs = []
+        fullMembershipEvaluationCount = 0
+    }
+
+    var displayEntryCacheCount: Int {
+        entriesByID.count
+    }
+#endif
+
+    mutating func reconcile(
+        network: NetworkSession,
+        orderedRequestIDs currentOrderedRequestIDs: [NetworkRequest.ID],
+        criteria currentCriteria: NetworkPanelDisplayCriteria,
+        topologyRevision currentTopologyRevision: Int,
+        displayRevision currentDisplayRevision: Int?,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) -> [NetworkRequest.ID] {
+        let previousCriteria = criteria
+        let criteriaChanged = previousCriteria != currentCriteria
+        criteria = currentCriteria
+
+        let topologyChange = reconcileTopology(
+            orderedRequestIDs: currentOrderedRequestIDs,
+            topologyRevision: currentTopologyRevision
+        )
+
+        guard currentCriteria.requiresEntries else {
+            if criteriaChanged || topologyChange.isChanged {
+                matchingRequestIDs.removeAll(keepingCapacity: true)
+                filteredRequestIDs = Array(orderedRequestIDs.reversed())
+            }
+            return filteredRequestIDs
+        }
+
+        guard let currentDisplayRevision else {
+            return filteredRequestIDs
+        }
+
+        var dirtyRequestIDs: Set<NetworkRequest.ID> = []
+        var requiresFullEntryRebuild = false
+        if displayRevision < currentDisplayRevision {
+            let displayChanges = network.requestDisplayChanges(after: displayRevision)
+            dirtyRequestIDs = displayChanges.changedRequestIDs
+            requiresFullEntryRebuild = displayChanges.requiresFullReconcile
+            displayRevision = displayChanges.revision
+        }
+        if case let .appended(appendedRequestIDs) = topologyChange {
+            dirtyRequestIDs.formUnion(appendedRequestIDs)
+        }
+
+        if requiresFullEntryRebuild {
+            rebuildAllEntriesAndMembership(
+                network: network,
+                criteria: currentCriteria,
+                mediaPreviewClassifier: mediaPreviewClassifier
+            )
+            return filteredRequestIDs
+        }
+
+        if criteriaChanged || topologyChange == .rebuilt {
+            rebuildDirtyEntries(dirtyRequestIDs, network: network)
+            rebuildMembership(
+                network: network,
+                criteria: currentCriteria,
+                mediaPreviewClassifier: mediaPreviewClassifier
+            )
+            return filteredRequestIDs
+        }
+
+        for requestID in dirtyRequestIDs {
+            rebuildEntryAndUpdateMembership(
+                requestID,
+                network: network,
+                criteria: currentCriteria,
+                mediaPreviewClassifier: mediaPreviewClassifier
+            )
+        }
+
+        return filteredRequestIDs
+    }
+
+    private mutating func reconcileTopology(
+        orderedRequestIDs currentOrderedRequestIDs: [NetworkRequest.ID],
+        topologyRevision currentTopologyRevision: Int
+    ) -> TopologyChange {
+        guard topologyRevision != currentTopologyRevision || orderedRequestIDs != currentOrderedRequestIDs else {
+            return .none
+        }
+
+        let appendedRequestIDs = appendedRequestIDs(from: orderedRequestIDs, to: currentOrderedRequestIDs)
+        orderedRequestIDs = currentOrderedRequestIDs
+        topologyRevision = currentTopologyRevision
+        rebuildOrderRanks()
+        pruneEntriesToCurrentRequests()
+
+        if let appendedRequestIDs {
+            if appendedRequestIDs.isEmpty {
+                return .none
+            }
+            return .appended(Array(appendedRequestIDs))
+        }
+        return .rebuilt
+    }
+
+    private func appendedRequestIDs(
+        from previousRequestIDs: [NetworkRequest.ID],
+        to currentRequestIDs: [NetworkRequest.ID]
+    ) -> ArraySlice<NetworkRequest.ID>? {
+        guard currentRequestIDs.count >= previousRequestIDs.count else {
+            return nil
+        }
+        for index in previousRequestIDs.indices where previousRequestIDs[index] != currentRequestIDs[index] {
+            return nil
+        }
+        return currentRequestIDs.dropFirst(previousRequestIDs.count)
+    }
+
+    private mutating func rebuildOrderRanks() {
+        orderRanksByID.removeAll(keepingCapacity: true)
+        orderRanksByID.reserveCapacity(orderedRequestIDs.count)
+        for (rank, requestID) in orderedRequestIDs.enumerated() {
+            orderRanksByID[requestID] = rank
+        }
+    }
+
+    private mutating func pruneEntriesToCurrentRequests() {
+        let currentRequestIDs = Set(orderedRequestIDs)
+        entriesByID = entriesByID.filter { currentRequestIDs.contains($0.key) }
+        matchingRequestIDs.formIntersection(currentRequestIDs)
+        filteredRequestIDs.removeAll { currentRequestIDs.contains($0) == false }
+    }
+
+    private mutating func rebuildDirtyEntries(
+        _ requestIDs: Set<NetworkRequest.ID>,
+        network: NetworkSession
+    ) {
+        for requestID in requestIDs {
+            if network.request(for: requestID) == nil {
+                removeRequestFromIndex(requestID)
+            } else {
+                entriesByID[requestID] = makeEntry(for: requestID, network: network)
+            }
+        }
+    }
+
+    private mutating func rebuildAllEntriesAndMembership(
+        network: NetworkSession,
+        criteria: NetworkPanelDisplayCriteria,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) {
+        entriesByID.removeAll(keepingCapacity: true)
+        rebuildMembership(
+            network: network,
+            criteria: criteria,
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
+    }
+
+    private mutating func rebuildMembership(
+        network: NetworkSession,
+        criteria: NetworkPanelDisplayCriteria,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) {
+#if DEBUG
+        fullMembershipEvaluationCount += 1
+#endif
+        matchingRequestIDs.removeAll(keepingCapacity: true)
+        filteredRequestIDs.removeAll(keepingCapacity: true)
+        filteredRequestIDs.reserveCapacity(orderedRequestIDs.count)
+
+        for requestID in orderedRequestIDs.reversed() {
+            guard matchesRequest(
+                requestID,
+                network: network,
+                criteria: criteria,
+                mediaPreviewClassifier: mediaPreviewClassifier
+            ) else {
+                continue
+            }
+            matchingRequestIDs.insert(requestID)
+            filteredRequestIDs.append(requestID)
+        }
+    }
+
+    private mutating func rebuildEntryAndUpdateMembership(
+        _ requestID: NetworkRequest.ID,
+        network: NetworkSession,
+        criteria: NetworkPanelDisplayCriteria,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) {
+        let wasMatching = matchingRequestIDs.contains(requestID)
+        guard network.request(for: requestID) != nil else {
+            removeRequestFromIndex(requestID)
+            return
+        }
+
+        entriesByID[requestID] = makeEntry(for: requestID, network: network)
+        let isMatching = matchesRequest(
+            requestID,
+            network: network,
+            criteria: criteria,
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
+
+        switch (wasMatching, isMatching) {
+        case (false, false):
+            break
+        case (false, true):
+            matchingRequestIDs.insert(requestID)
+            insertFilteredRequestIDInDisplayOrder(requestID)
+        case (true, false):
+            matchingRequestIDs.remove(requestID)
+            filteredRequestIDs.removeAll { $0 == requestID }
+        case (true, true):
+            break
+        }
+    }
+
+    private mutating func matchesRequest(
+        _ requestID: NetworkRequest.ID,
+        network: NetworkSession,
+        criteria: NetworkPanelDisplayCriteria,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) -> Bool {
+        guard let request = network.request(for: requestID) else {
+            removeRequestFromIndex(requestID)
+            return false
+        }
+        if entriesByID[requestID] == nil {
+            entriesByID[requestID] = makeEntry(for: requestID, network: network)
+        }
+        guard var entry = entriesByID[requestID] else {
+            return false
+        }
+        let matches = entry.matches(
+            criteria: criteria,
+            request: request,
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
+        entriesByID[requestID] = entry
+        return matches
+    }
+
+    private mutating func makeEntry(
+        for requestID: NetworkRequest.ID,
+        network: NetworkSession
+    ) -> NetworkPanelDisplayEntry? {
+        guard let request = network.request(for: requestID) else {
+            return nil
+        }
+#if DEBUG
+        displayEntryBuildCount += 1
+        rebuiltDisplayRequestIDs.append(requestID)
+#endif
+        return NetworkPanelDisplayEntry(request: request)
+    }
+
+    private mutating func removeRequestFromIndex(_ requestID: NetworkRequest.ID) {
+        entriesByID.removeValue(forKey: requestID)
+        matchingRequestIDs.remove(requestID)
+        filteredRequestIDs.removeAll { $0 == requestID }
+    }
+
+    private mutating func insertFilteredRequestIDInDisplayOrder(_ requestID: NetworkRequest.ID) {
+        guard filteredRequestIDs.contains(requestID) == false else {
+            return
+        }
+        let requestRank = orderRanksByID[requestID] ?? Int.min
+        var lowerBound = 0
+        var upperBound = filteredRequestIDs.count
+        while lowerBound < upperBound {
+            let midpoint = (lowerBound + upperBound) / 2
+            let midpointRank = orderRanksByID[filteredRequestIDs[midpoint]] ?? Int.min
+            if midpointRank > requestRank {
+                lowerBound = midpoint + 1
+            } else {
+                upperBound = midpoint
+            }
+        }
+        filteredRequestIDs.insert(requestID, at: lowerBound)
+    }
+}

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -47,6 +47,7 @@ package final class NetworkPanelModel {
     package private(set) var effectiveResourceFilters: Set<NetworkRequest.Display.ResourceFilter> = []
     @ObservationIgnored private let responseBodyFetchCoordinator: NetworkResponseBodyFetchCoordinator
     @ObservationIgnored private let mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    @ObservationIgnored private var displayIndex: NetworkPanelDisplayIndex
 
     package init(
         network: NetworkSession,
@@ -58,32 +59,23 @@ package final class NetworkPanelModel {
         self.network = network
         self.responseBodyFetchCoordinator = NetworkResponseBodyFetchCoordinator(action: responseBodyFetchAction)
         self.mediaPreviewClassifier = mediaPreviewClassifier
+        self.displayIndex = NetworkPanelDisplayIndex()
     }
 
     package var displayRequestIDs: [NetworkRequest.ID] {
         let requestIDs = network.orderedRequestIDs
-        let query = normalizedSearchText
-        let resourceFilters = effectiveResourceFilters
-        guard query.isEmpty == false || resourceFilters.isEmpty == false else {
-            return Array(requestIDs.reversed())
-        }
-
-        var filteredIDs: [NetworkRequest.ID] = []
-        filteredIDs.reserveCapacity(requestIDs.count)
-        for requestID in requestIDs {
-            guard let request = network.request(for: requestID) else {
-                continue
-            }
-            if resourceFilters.isEmpty == false,
-               resourceFilters.contains(request.displayResourceFilter(mediaPreviewClassifier: mediaPreviewClassifier)) == false {
-                continue
-            }
-            guard request.matchesDisplaySearchText(query) else {
-                continue
-            }
-            filteredIDs.append(requestID)
-        }
-        return Array(filteredIDs.reversed())
+        let criteria = NetworkPanelDisplayCriteria(
+            searchText: normalizedSearchText,
+            resourceFilters: effectiveResourceFilters
+        )
+        return displayIndex.reconcile(
+            network: network,
+            orderedRequestIDs: requestIDs,
+            criteria: criteria,
+            topologyRevision: network.requestTopologyRevision,
+            displayRevision: criteria.requiresEntries ? network.requestDisplayRevision : nil,
+            mediaPreviewClassifier: mediaPreviewClassifier
+        )
     }
 
     package var displayRequests: [NetworkRequest] {
@@ -161,6 +153,30 @@ package final class NetworkPanelModel {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+
+#if DEBUG
+extension NetworkPanelModel {
+    package var displayEntryBuildCountForTesting: Int {
+        displayIndex.displayEntryBuildCount
+    }
+
+    package var rebuiltDisplayRequestIDsForTesting: [NetworkRequest.ID] {
+        displayIndex.rebuiltDisplayRequestIDs
+    }
+
+    package var displayEntryCacheCountForTesting: Int {
+        displayIndex.displayEntryCacheCount
+    }
+
+    package var fullMembershipEvaluationCountForTesting: Int {
+        displayIndex.fullMembershipEvaluationCount
+    }
+
+    package func resetDisplayIndexTestingCounters() {
+        displayIndex.resetTestingCounters()
+    }
+}
+#endif
 
 extension NetworkPanelModel {
     package struct DisplayRowsInvalidationRevision: Equatable {

--- a/Sources/WebInspectorUINetwork/NetworkRequest+Display.swift
+++ b/Sources/WebInspectorUINetwork/NetworkRequest+Display.swift
@@ -8,6 +8,25 @@ extension NetworkRequest {
 
 extension NetworkRequest.Display {
     package typealias MediaPreviewClassifier = @Sendable (String?, String?) -> NetworkRequest.Display.MediaPreviewClassification
+
+    package struct Projection {
+        package var requestURLSummary: NetworkRequest.Display.URLSummary
+        package var responseURLSummary: NetworkRequest.Display.URLSummary?
+        package var fileTypeLabel: String
+        package var searchTokens: [String]
+
+        package init(
+            requestURLSummary: NetworkRequest.Display.URLSummary,
+            responseURLSummary: NetworkRequest.Display.URLSummary?,
+            fileTypeLabel: String,
+            searchTokens: [String]
+        ) {
+            self.requestURLSummary = requestURLSummary
+            self.responseURLSummary = responseURLSummary
+            self.fileTypeLabel = fileTypeLabel
+            self.searchTokens = searchTokens
+        }
+    }
 }
 
 extension NetworkRequest {
@@ -65,75 +84,44 @@ extension NetworkRequest {
         guard query.isEmpty == false else {
             return true
         }
-        return displaySearchTokens.contains { $0.localizedStandardContains(query) }
+        return displayProjection().searchTokens.contains { $0.localizedStandardContains(query) }
     }
 
     package func displayResourceFilter(
         mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
     ) -> NetworkRequest.Display.ResourceFilter {
         let requestURLSummary = NetworkRequest.Display.URLSummary(url: request.url)
-        guard let response else {
-            if let resourceType {
-                return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
-            }
-            return NetworkRequest.Display.ResourceFilter.inferred(
-                mimeType: nil,
-                pathExtension: requestURLSummary.pathExtension,
-                mediaPreviewClassification: mediaPreviewClassifier(nil, requestURLSummary.rawURL)
-            )
-        }
-
-        let responseMIMEType = NetworkRequest.Display.displayMIMEType(
-            mimeType: response.mimeType,
-            headers: response.headers
-        )
-        if let resourceType,
-           NetworkRequest.Display.shouldKeepResourceTypeForURLInferredMedia(resourceType) {
-            if case .previewable = mediaPreviewClassifier(responseMIMEType, nil) {
-                return .media
-            }
-            return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
-        }
-
-        let responseURLSummary = NetworkRequest.Display.URLSummary(url: response.url)
-        switch mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL) {
-        case .previewable:
-            return .media
-        case .notPreviewable:
-            if resourceType == .image || resourceType == .media {
-                return .media
-            }
-            return NetworkRequest.Display.ResourceFilter.inferred(
-                mimeType: responseMIMEType,
-                pathExtension: responseURLSummary.pathExtension,
-                mediaPreviewClassification: mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL)
-            )
-        case .unknown:
-            break
-        }
-        if let resourceType {
-            return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
-        }
-        return NetworkRequest.Display.ResourceFilter.inferred(
-            mimeType: responseMIMEType,
-            pathExtension: responseURLSummary.pathExtension,
-            mediaPreviewClassification: mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL)
+        let responseURLSummary = response.map { NetworkRequest.Display.URLSummary(url: $0.url) }
+        return NetworkRequest.Display.resourceFilter(
+            resourceType: resourceType,
+            response: response,
+            requestURLSummary: requestURLSummary,
+            responseURLSummary: responseURLSummary,
+            mediaPreviewClassifier: mediaPreviewClassifier
         )
     }
 
-    private var displaySearchTokens: [String] {
+    package func displayProjection() -> NetworkRequest.Display.Projection {
         let requestURLSummary = NetworkRequest.Display.URLSummary(url: request.url)
         let responseURLSummary = response.map { NetworkRequest.Display.URLSummary(url: $0.url) }
+        let fileTypeLabel = NetworkRequest.Display.fileTypeLabel(
+            mimeType: response?.mimeType,
+            resourceType: resourceType,
+            urlSummary: requestURLSummary
+        )
         let statusCodeLabel = response.map { String($0.status) } ?? ""
-        return NetworkRequest.Display.uniqueNonEmpty(
-            requestURLSummary.searchTokens
-            + (responseURLSummary?.searchTokens ?? [])
-            + [
-                request.method,
-                statusCodeLabel,
-                response?.statusText ?? "",
-                fileTypeLabel,
-            ]
+        return NetworkRequest.Display.Projection(
+            requestURLSummary: requestURLSummary,
+            responseURLSummary: responseURLSummary,
+            fileTypeLabel: fileTypeLabel,
+            searchTokens: NetworkRequest.Display.searchTokens(
+                requestURLSummary: requestURLSummary,
+                responseURLSummary: responseURLSummary,
+                requestMethod: request.method,
+                statusCodeLabel: statusCodeLabel,
+                statusText: response?.statusText ?? "",
+                fileTypeLabel: fileTypeLabel
+            )
         )
     }
 
@@ -166,6 +154,62 @@ extension NetworkRequest {
 }
 
 extension NetworkRequest.Display {
+    package static func resourceFilter(
+        resourceType: NetworkRequest.ResourceType?,
+        response: NetworkRequest.Response.Payload?,
+        requestURLSummary: NetworkRequest.Display.URLSummary,
+        responseURLSummary: NetworkRequest.Display.URLSummary?,
+        mediaPreviewClassifier: NetworkRequest.Display.MediaPreviewClassifier
+    ) -> NetworkRequest.Display.ResourceFilter {
+        guard let response else {
+            if let resourceType {
+                return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
+            }
+            return NetworkRequest.Display.ResourceFilter.inferred(
+                mimeType: nil,
+                pathExtension: requestURLSummary.pathExtension,
+                mediaPreviewClassification: mediaPreviewClassifier(nil, requestURLSummary.rawURL)
+            )
+        }
+
+        let responseMIMEType = NetworkRequest.Display.displayMIMEType(
+            mimeType: response.mimeType,
+            headers: response.headers
+        )
+        if let resourceType,
+           NetworkRequest.Display.shouldKeepResourceTypeForURLInferredMedia(resourceType) {
+            if case .previewable = mediaPreviewClassifier(responseMIMEType, nil) {
+                return .media
+            }
+            return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
+        }
+
+        let responseURLSummary = responseURLSummary ?? NetworkRequest.Display.URLSummary(url: response.url)
+        switch mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL) {
+        case .previewable:
+            return .media
+        case .notPreviewable:
+            if resourceType == .image || resourceType == .media {
+                return .media
+            }
+            return NetworkRequest.Display.ResourceFilter.inferred(
+                mimeType: responseMIMEType,
+                pathExtension: responseURLSummary.pathExtension,
+                mediaPreviewClassification: mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL)
+            )
+        case .unknown:
+            break
+        }
+        if let resourceType {
+            return NetworkRequest.Display.ResourceFilter(resourceType: resourceType)
+        }
+        return NetworkRequest.Display.ResourceFilter.inferred(
+            mimeType: responseMIMEType,
+            pathExtension: responseURLSummary.pathExtension,
+            mediaPreviewClassification: mediaPreviewClassifier(responseMIMEType, responseURLSummary.rawURL)
+        )
+    }
+
     package static func fileTypeLabel(
         mimeType: String?,
         resourceType: NetworkRequest.ResourceType?,
@@ -201,6 +245,26 @@ extension NetworkRequest.Display {
             return nil
         }
         return mimeType
+    }
+
+    package static func searchTokens(
+        requestURLSummary: NetworkRequest.Display.URLSummary,
+        responseURLSummary: NetworkRequest.Display.URLSummary?,
+        requestMethod: String,
+        statusCodeLabel: String,
+        statusText: String,
+        fileTypeLabel: String
+    ) -> [String] {
+        uniqueNonEmpty(
+            requestURLSummary.searchTokens
+            + (responseURLSummary?.searchTokens ?? [])
+            + [
+                requestMethod,
+                statusCodeLabel,
+                statusText,
+                fileTypeLabel,
+            ]
+        )
     }
 
     fileprivate static func shouldKeepResourceTypeForURLInferredMedia(_ resourceType: NetworkRequest.ResourceType) -> Bool {

--- a/Tests/WebInspectorCoreTests/NetworkModelTests.swift
+++ b/Tests/WebInspectorCoreTests/NetworkModelTests.swift
@@ -73,6 +73,84 @@ func networkRequestIdentityDoesNotIncludeRedirectIndex() async throws {
 }
 
 @Test
+@MainActor
+func requestDisplayChangesTrackOnlyDisplayAffectingRequestIDs() throws {
+    let session = NetworkSession()
+    let targetID = ProtocolTarget.ID("page")
+    let requestID = NetworkRequest.ProtocolID("0.display")
+    let key = session.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: requestID,
+        frameID: .init("main-frame"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: .init(url: "https://example.com/data.json"),
+        resourceType: .xhr,
+        timestamp: 1
+    )
+
+    var displayChanges = session.requestDisplayChanges(after: 0)
+    #expect(displayChanges.revision == session.requestDisplayRevision)
+    #expect(displayChanges.changedRequestIDs == [key])
+    #expect(displayChanges.requiresFullReconcile == false)
+
+    let displayRevisionAfterRequest = session.requestDisplayRevision
+    session.applyDataReceived(
+        targetID: targetID,
+        requestID: requestID,
+        dataLength: 1024,
+        encodedDataLength: 512,
+        timestamp: 2
+    )
+    session.applyLoadingFinished(targetID: targetID, requestID: requestID, timestamp: 3)
+    #expect(session.requestDisplayRevision == displayRevisionAfterRequest)
+    displayChanges = session.requestDisplayChanges(after: displayRevisionAfterRequest)
+    #expect(displayChanges.changedRequestIDs.isEmpty)
+    #expect(displayChanges.requiresFullReconcile == false)
+
+    session.applyResponseReceived(
+        targetID: targetID,
+        requestID: requestID,
+        resourceType: .fetch,
+        response: .init(
+            url: "https://example.com/data-v2.json",
+            status: 200,
+            mimeType: "application/json"
+        ),
+        timestamp: 4
+    )
+    displayChanges = session.requestDisplayChanges(after: displayRevisionAfterRequest)
+    #expect(displayChanges.changedRequestIDs == [key])
+    #expect(displayChanges.requiresFullReconcile == false)
+}
+
+@Test
+@MainActor
+func requestDisplayChangesRequireFullReconcileAfterReset() throws {
+    let session = NetworkSession()
+    let targetID = ProtocolTarget.ID("page")
+    let requestID = NetworkRequest.ProtocolID("0.reset")
+    session.applyRequestWillBeSent(
+        targetID: targetID,
+        requestID: requestID,
+        frameID: .init("main-frame"),
+        loaderID: "loader",
+        documentURL: "https://example.com",
+        request: .init(url: "https://example.com/app.js"),
+        resourceType: .script,
+        timestamp: 1
+    )
+    let revisionBeforeReset = session.requestDisplayRevision
+
+    session.reset()
+
+    let displayChanges = session.requestDisplayChanges(after: revisionBeforeReset)
+    #expect(displayChanges.revision == session.requestDisplayRevision)
+    #expect(displayChanges.changedRequestIDs.isEmpty)
+    #expect(displayChanges.requiresFullReconcile)
+}
+
+@Test
 func requestKeepsEnvelopeTargetOriginatingTargetAndBackendResourceIdentitySeparate() async throws {
     let session = await NetworkSession()
     let pageProxyTargetID = ProtocolTarget.ID("page-proxy")

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -513,7 +513,7 @@ func requestFileTypeAndSearchUpdateWhenRawMIMETypeAppears() async throws {
 
 @Test
 @MainActor
-func displayResourceFilteringClassifiesEachFilteredEvaluation() async throws {
+func displayResourceFilteringCachesDisplayEntriesAcrossRepeatedReads() async throws {
     let network = NetworkSession()
     let requestID = applyRequest(
         to: network,
@@ -535,12 +535,15 @@ func displayResourceFilteringClassifiesEachFilteredEvaluation() async throws {
 
     #expect(model.displayRequestIDs == [requestID])
     #expect(classificationCount.withLock { $0 } == 1)
+    #expect(model.displayEntryBuildCountForTesting == 1)
 
+    model.resetDisplayIndexTestingCounters()
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount.withLock { $0 } == 2)
+    #expect(classificationCount.withLock { $0 } == 1)
+    #expect(model.displayEntryBuildCountForTesting == 0)
 
     #expect(model.displayRequests.map(\.id) == [requestID])
-    #expect(classificationCount.withLock { $0 } == 3)
+    #expect(classificationCount.withLock { $0 } == 1)
 
     network.applyDataReceived(
         targetID: requestID.targetID,
@@ -550,7 +553,152 @@ func displayResourceFilteringClassifiesEachFilteredEvaluation() async throws {
         timestamp: 2
     )
     #expect(model.displayRequestIDs == [requestID])
-    #expect(classificationCount.withLock { $0 } == 4)
+    #expect(classificationCount.withLock { $0 } == 1)
+    #expect(model.displayEntryBuildCountForTesting == 0)
+}
+
+@Test
+@MainActor
+func displayIndexRebuildsOnlyDirtyRequestDisplayEntry() async throws {
+    let network = NetworkSession()
+    let firstID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://cdn.example.com/app.js",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 1
+    )
+    let secondID = applyRequest(
+        to: network,
+        requestID: "2",
+        url: "https://cdn.example.com/data.json",
+        resourceType: .xhr,
+        mimeType: "application/json",
+        timestamp: 2
+    )
+    let thirdID = applyRequest(
+        to: network,
+        requestID: "3",
+        url: "https://cdn.example.com/photo.png",
+        resourceType: .image,
+        mimeType: "image/png",
+        timestamp: 3
+    )
+    let model = NetworkPanelModel(network: network)
+    model.setSearchText("cdn")
+
+    #expect(model.displayRequestIDs == [thirdID, secondID, firstID])
+    model.resetDisplayIndexTestingCounters()
+
+    network.applyResponseReceived(
+        targetID: secondID.targetID,
+        requestID: secondID.requestID,
+        resourceType: .xhr,
+        response: NetworkRequest.Response.Payload(
+            url: "https://api.example.com/data-v2.json",
+            status: 200,
+            mimeType: "application/json"
+        ),
+        timestamp: 4
+    )
+
+    #expect(model.displayRequestIDs == [thirdID, secondID, firstID])
+    #expect(model.displayEntryBuildCountForTesting == 1)
+    #expect(model.rebuiltDisplayRequestIDsForTesting == [secondID])
+}
+
+@Test
+@MainActor
+func displayIndexIgnoresContentOnlyUpdatesDuringActiveFiltering() async throws {
+    let network = NetworkSession()
+    let requestID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://media.example.com/clip.mp4",
+        resourceType: .fetch,
+        mimeType: "application/octet-stream",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+    model.setSearchText("clip")
+    model.setResourceFilter(.media, enabled: true)
+
+    #expect(model.displayRequestIDs == [requestID])
+    model.resetDisplayIndexTestingCounters()
+
+    network.applyDataReceived(
+        targetID: requestID.targetID,
+        requestID: requestID.requestID,
+        dataLength: 1024,
+        encodedDataLength: 512,
+        timestamp: 2
+    )
+    network.applyLoadingFinished(
+        targetID: requestID.targetID,
+        requestID: requestID.requestID,
+        timestamp: 3
+    )
+
+    #expect(model.displayRequestIDs == [requestID])
+    #expect(model.displayEntryBuildCountForTesting == 0)
+    #expect(model.rebuiltDisplayRequestIDsForTesting.isEmpty)
+}
+
+@Test
+@MainActor
+func displayIndexReusesEntriesWhenCriteriaChanges() async throws {
+    let network = NetworkSession()
+    let scriptID = applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://cdn.example.com/app.js",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 1
+    )
+    applyRequest(
+        to: network,
+        requestID: "2",
+        url: "https://cdn.example.com/photo.png",
+        resourceType: .image,
+        mimeType: "image/png",
+        timestamp: 2
+    )
+    let model = NetworkPanelModel(network: network)
+    model.setSearchText("cdn")
+
+    #expect(model.displayRequestIDs.count == 2)
+    model.resetDisplayIndexTestingCounters()
+
+    model.setResourceFilter(.script, enabled: true)
+    #expect(model.displayRequestIDs == [scriptID])
+    #expect(model.displayEntryBuildCountForTesting == 0)
+    #expect(model.fullMembershipEvaluationCountForTesting == 1)
+}
+
+@Test
+@MainActor
+func displayIndexClearsStaleCacheAfterReset() async throws {
+    let network = NetworkSession()
+    applyRequest(
+        to: network,
+        requestID: "1",
+        url: "https://cdn.example.com/app.js",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(network: network)
+    model.setSearchText("cdn")
+
+    #expect(model.displayRequestIDs.count == 1)
+    #expect(model.displayEntryCacheCountForTesting == 1)
+
+    network.reset()
+
+    #expect(model.displayRequestIDs.isEmpty)
+    #expect(model.displayEntryCacheCountForTesting == 0)
 }
 
 @Test


### PR DESCRIPTION
## Purpose

Fix the Network list hang caused by rebuilding display search tokens and resource classification for every request whenever filtered rows are read.

## Changes

- Add display-change history to `NetworkSession` so UI code can ask which request IDs changed since a display revision.
- Add a rebuildable `NetworkPanelDisplayIndex` cache for newest-first IDs, filtered membership, URL summaries, file type labels, resource filters, and search tokens.
- Reuse display projection logic from `NetworkRequest+Display` while keeping cells observing `NetworkRequest` directly.
- Add Core and UI tests for dirty-ID reconciliation, content-only updates, criteria changes, reset behavior, and cache reuse.

## Testing

- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `codex-review` self-review: clean, no findings
