### PR TITLE
Pin workflow action runtimes to full SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       SIMULATOR_DEVICE: ${{ matrix.simulator_device }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve Xcode
         run: |
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload iOS test diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-test-diagnostics-${{ matrix.name }}
           path: |


### PR DESCRIPTION
## Purpose

Harden the GitHub Actions supply chain by pinning external workflow actions to full commit SHAs while moving to the Node 24 runtime-compatible action releases.

## Changes

- Update `actions/checkout` to the full SHA for v7.0.0.
- Update `actions/upload-artifact` to the full SHA for v7.0.1.
- Leave the CI workflow structure and test matrix unchanged.

## Testing

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Verified `.github/workflows` has no non-SHA-pinned external `uses:` entries, excluding local and Docker uses.
- Not run: simulator tests from `AGENTS.md`, because this is a workflow-only change.
