### PR TITLE
Finish closed transport event streams

### DIFF
--- a/Sources/WebInspectorProxyKit/Transport/TransportSession.swift
+++ b/Sources/WebInspectorProxyKit/Transport/TransportSession.swift
@@ -44,6 +44,9 @@ package actor TransportSession {
     }
 
     package func events(for domain: ProtocolDomain) -> AsyncStream<ProtocolEvent> {
+        guard !closed else {
+            return finishedStream(of: ProtocolEvent.self)
+        }
         let pair = AsyncStream<ProtocolEvent>.makeStream(bufferingPolicy: .unbounded)
         let subscriberID = eventSubscribers.insert(pair.continuation, domain: domain)
         pair.continuation.onTermination = { [weak self] _ in
@@ -55,6 +58,9 @@ package actor TransportSession {
     }
 
     package func orderedEvents() -> AsyncStream<ProtocolEvent> {
+        guard !closed else {
+            return finishedStream(of: ProtocolEvent.self)
+        }
         let pair = AsyncStream<ProtocolEvent>.makeStream(bufferingPolicy: .unbounded)
         let subscriberID = eventSubscribers.insertOrdered(pair.continuation)
         pair.continuation.onTermination = { [weak self] _ in

--- a/Tests/WebInspectorProxyKitTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorProxyKitTests/TransportSessionTests.swift
@@ -400,6 +400,20 @@ func detachFailsPendingRepliesAndClosesStreams() async throws {
 }
 
 @Test
+func eventStreamsRequestedAfterDetachFinishImmediately() async throws {
+    let backend = FakeTransportBackend()
+    let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
+
+    await session.detach()
+
+    let domainStream = await session.events(for: .dom)
+    let orderedStream = await session.orderedEvents()
+
+    #expect(try await nextEvent(from: domainStream) == nil)
+    #expect(try await nextEvent(from: orderedStream) == nil)
+}
+
+@Test
 func waitForCurrentMainPageTargetFailsAfterDetach() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)
@@ -1298,6 +1312,16 @@ private func waitForRootMessage(_ backend: FakeTransportBackend, timeout: Durati
 private func waitForTargetMessage(_ backend: FakeTransportBackend, timeout: Duration = testWaitTimeout) async throws -> SentTargetMessage {
     try await waitForBackendValue(timeout: timeout) {
         try await backend.waitForTargetMessage()
+    }
+}
+
+private func nextEvent(
+    from stream: AsyncStream<ProtocolEvent>,
+    timeout: Duration = testWaitTimeout
+) async throws -> ProtocolEvent? {
+    try await waitForBackendValue(timeout: timeout) {
+        var iterator = stream.makeAsyncIterator()
+        return await iterator.next()
     }
 }
 


### PR DESCRIPTION
## Purpose
Fix the CI timeout from run 28844995150 by making closed transport event streams terminate deterministically, including streams requested after detach.

## Changes
- Return an already-finished stream from `TransportSession.events(for:)` and `orderedEvents()` when the session is closed.
- Add regression coverage for domain and ordered event streams requested after `detach()`.

## Testing
- Passed: `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKitTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -enableCodeCoverage NO -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1 -test-timeouts-enabled YES -default-test-execution-time-allowance 30 -maximum-test-execution-time-allowance 60 -showBuildTimingSummary`
- Passed: `codex-review --uncommitted`
- Passed: `codex-review --base main`
- Attempted: repo default `WebInspectorKit` scheme on local `iPhone 17, OS=latest`; local latest resolved to iOS 27.0 and `WebInspectorDataKitTests.restartDisablesPreviousDomainTrackingBeforeReenable()` timed out, outside this ProxyKit transport change. The relevant CI-matching `WebInspectorKitTests` run passed.