### PR TITLE
Move network request diffing off the main actor

### DIFF
--- a/Sources/WebInspectorDataKit/Fetching.swift
+++ b/Sources/WebInspectorDataKit/Fetching.swift
@@ -256,7 +256,9 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
         WebInspectorFetchedResultsTransaction<Model>
     >()
     @ObservationIgnored weak var modelContext: WebInspectorContext?
+    @ObservationIgnored private var networkQueryPlan: NetworkRequestQueryPlan?
     @ObservationIgnored private var networkQueryState: NetworkRequestQueryState?
+    @ObservationIgnored private var networkResultSnapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>?
 
     init(
         fetchDescriptor: WebInspectorFetchDescriptor<Model>,
@@ -270,7 +272,9 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
         sections = Self.sections(for: items, sectionBy: sectionBy)
         self.modelContext = modelContext
         topologyRevision = 0
+        networkQueryPlan = nil
         networkQueryState = nil
+        networkResultSnapshot = nil
     }
 
     deinit {
@@ -442,11 +446,30 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
 }
 
 extension WebInspectorFetchedResults where Model == NetworkRequest {
+    var networkSnapshotForDelta: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID> {
+        if let networkResultSnapshot {
+            return networkResultSnapshot
+        }
+        let snapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
+        networkResultSnapshot = snapshot
+        return snapshot
+    }
+
+    func currentNetworkQueryPlan(context: WebInspectorContext) -> NetworkRequestQueryPlan {
+        if let networkQueryPlan {
+            return networkQueryPlan
+        }
+        let plan = NetworkRequestQueryPlan(descriptor: fetchDescriptor, context: context)
+        networkQueryPlan = plan
+        return plan
+    }
+
     func setNetworkItems(
         _ requests: [NetworkRequest],
         plan: NetworkRequestQueryPlan,
         lookup: (NetworkRequest.ID) -> NetworkRequest?
     ) {
+        networkQueryPlan = plan
         if plan.requiresQuery {
             let state = NetworkRequestQueryState(plan: plan, requests: requests)
             networkQueryState = state
@@ -455,6 +478,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             networkQueryState = nil
             setItems(requests)
         }
+        networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
     }
 
     func applyNetworkFetchDescriptor(
@@ -464,6 +488,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
         lookup: (NetworkRequest.ID) -> NetworkRequest?
     ) {
         fetchDescriptor = descriptor
+        networkQueryPlan = plan
         if plan.requiresQuery {
             let state = NetworkRequestQueryState(plan: plan, requests: requests)
             networkQueryState = state
@@ -472,6 +497,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             networkQueryState = nil
             resetItems(requests)
         }
+        networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
     }
 
     func resetNetworkItems() {
@@ -479,6 +505,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             networkQueryState = NetworkRequestQueryState(plan: state.plan, requests: [])
         }
         resetItems([])
+        networkResultSnapshot = WebInspectorFetchedResultsSnapshot()
     }
 
     func insertNetworkRequest(
@@ -487,11 +514,13 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
     ) {
         guard var state = networkQueryState else {
             insertItem(request)
+            networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
             return
         }
         state.upsert(request: request)
         networkQueryState = state
         setItems(state.visibleRequests(lookup: lookup))
+        networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
     }
 
     func refreshNetworkRequestAfterMutation(
@@ -500,10 +529,37 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
     ) {
         guard var state = networkQueryState else {
             refreshAfterItemMutation(request)
+            networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
             return
         }
         state.upsert(request: request)
         networkQueryState = state
         setItems(state.visibleRequests(lookup: lookup), updatedItemIDs: [request.id])
+        networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
+    }
+
+    func applyNetworkDelta(
+        _ delta: NetworkResultSetDelta,
+        lookup: (NetworkRequest.ID) -> NetworkRequest?
+    ) {
+        let oldSnapshot = networkSnapshotForDelta
+        items = delta.snapshot.itemIDs.compactMap(lookup)
+        sections = delta.snapshot.sections.map { section in
+            WebInspectorFetchSection(
+                id: section.id,
+                title: section.title,
+                items: section.itemIDs.compactMap(lookup)
+            )
+        }
+        networkResultSnapshot = delta.snapshot
+        if oldSnapshot != delta.snapshot {
+            bumpTopologyRevision()
+        }
+        guard transactionRelay.hasContinuations,
+              let transaction = delta.transaction,
+              transaction.hasChanges else {
+            return
+        }
+        transactionRelay.yield(transaction)
     }
 }

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -987,7 +987,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         requestBody.updateHints(kind: hints.kind, sourceSyntaxKind: hints.syntaxKind)
     }
 
-    private static func resourceCategory(
+    package static func resourceCategory(
         resourceType: Network.ResourceType?,
         mimeType: String?,
         url: String,
@@ -1063,7 +1063,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         return .other
     }
 
-    private static func effectiveMIMEType(mimeType: String?, headers: [String: String]) -> String? {
+    package static func effectiveMIMEType(mimeType: String?, headers: [String: String]) -> String? {
         if let mimeType, mimeType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
             return mimeType
         }
@@ -1105,7 +1105,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         }
     }
 
-    private static func urlSearchText(_ rawURL: String) -> String {
+    package static func urlSearchText(_ rawURL: String) -> String {
         guard rawURL.range(of: "data:", options: [.anchored, .caseInsensitive]) == nil,
               let components = URLComponents(string: rawURL, encodingInvalidCharacters: false)
                 ?? URLComponents(string: rawURL, encodingInvalidCharacters: true) else {
@@ -1119,7 +1119,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         .joined(separator: "\n")
     }
 
-    private static func pathExtension(in rawURL: String) -> String {
+    package static func pathExtension(in rawURL: String) -> String {
         guard rawURL.range(of: "data:", options: [.anchored, .caseInsensitive]) == nil else {
             return ""
         }
@@ -1190,7 +1190,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         "wav",
     ]
 
-    private static func uniqueNonEmpty(_ values: [String?]) -> [String] {
+    package static func uniqueNonEmpty(_ values: [String?]) -> [String] {
         var seen = Set<String>()
         var results: [String] = []
         for value in values {

--- a/Sources/WebInspectorDataKit/NetworkRequestCollectionState.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestCollectionState.swift
@@ -1,0 +1,29 @@
+import Observation
+
+@Observable
+package final class NetworkRequestCollectionState {
+    package private(set) var requestCount: Int
+    package private(set) var topologyRevision: Int
+
+    package init(requestCount: Int = 0) {
+        self.requestCount = requestCount
+        topologyRevision = 0
+    }
+
+    package var hasRequests: Bool {
+        requestCount > 0
+    }
+
+    package func replaceCount(_ count: Int) {
+        guard requestCount != count else {
+            return
+        }
+        requestCount = count
+        topologyRevision &+= 1
+    }
+
+    package func didInsertRequest() {
+        requestCount &+= 1
+        topologyRevision &+= 1
+    }
+}

--- a/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
@@ -1,0 +1,403 @@
+import Foundation
+
+package struct NetworkResultSetDelta: Sendable {
+    package var snapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>
+    package var transaction: WebInspectorFetchedResultsTransaction<NetworkRequest>?
+}
+
+package actor NetworkRequestIndex {
+    private var recordsByID: [NetworkRequest.ID: NetworkRequestRecord] = [:]
+    private var orderedIDs: [NetworkRequest.ID] = []
+    private var lastAppliedSequence: UInt64 = 0
+
+    package init() {}
+
+    package func replace(with inputs: [NetworkRequestRecordInput], sequence: UInt64) {
+        guard apply(sequence: sequence) else {
+            return
+        }
+        recordsByID = [:]
+        recordsByID.reserveCapacity(inputs.count)
+        orderedIDs = []
+        orderedIDs.reserveCapacity(inputs.count)
+        for input in inputs {
+            upsertRecord(input)
+        }
+    }
+
+    package func upsert(_ input: NetworkRequestRecordInput, sequence: UInt64) {
+        guard apply(sequence: sequence) else {
+            return
+        }
+        upsertRecord(input)
+    }
+
+    private func apply(sequence: UInt64) -> Bool {
+        guard sequence > lastAppliedSequence else {
+            return false
+        }
+        lastAppliedSequence = sequence
+        return true
+    }
+
+    private func upsertRecord(_ input: NetworkRequestRecordInput) {
+        let isNewRecord = recordsByID[input.id] == nil
+        let record = NetworkRequestRecord(input: input)
+        recordsByID[record.id] = record
+        if isNewRecord {
+            orderedIDs.append(record.id)
+        }
+    }
+
+    package func delta(
+        plan: NetworkRequestQueryPlan,
+        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>?,
+        oldSnapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>,
+        changedID: NetworkRequest.ID?
+    ) -> NetworkResultSetDelta? {
+        guard plan.requiresModelPredicate == false else {
+            return nil
+        }
+        let newSnapshot = snapshot(plan: plan, sectionBy: sectionBy)
+        guard oldSnapshot != newSnapshot else {
+            return nil
+        }
+        let transaction = NetworkResultSetTransactionBuilder.transaction(
+            oldSnapshot: oldSnapshot,
+            newSnapshot: newSnapshot,
+            changedID: changedID
+        )
+        return NetworkResultSetDelta(snapshot: newSnapshot, transaction: transaction)
+    }
+
+    private func snapshot(
+        plan: NetworkRequestQueryPlan,
+        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>?
+    ) -> WebInspectorFetchedResultsSnapshot<NetworkRequest.ID> {
+        let matchingRecords = visibleRecords(plan: plan)
+        guard matchingRecords.isEmpty == false else {
+            return WebInspectorFetchedResultsSnapshot()
+        }
+        guard let sectionBy else {
+            return WebInspectorFetchedResultsSnapshot(itemIDs: matchingRecords.map(\.id))
+        }
+
+        var sections: [(
+            id: WebInspectorFetchSectionID,
+            title: String?,
+            itemIDs: [NetworkRequest.ID]
+        )] = []
+        for record in matchingRecords {
+            let identity = sectionIdentity(for: record, sectionBy: sectionBy)
+            if let index = sections.firstIndex(where: { $0.id == identity.id }) {
+                sections[index].itemIDs.append(record.id)
+            } else {
+                sections.append((
+                    id: identity.id,
+                    title: identity.title,
+                    itemIDs: [record.id]
+                ))
+            }
+        }
+        return WebInspectorFetchedResultsSnapshot(sections: sections.map { section in
+            WebInspectorFetchedResultsSnapshot.Section(
+                id: section.id,
+                title: section.title,
+                itemIDs: section.itemIDs
+            )
+        })
+    }
+
+    private func visibleRecords(plan: NetworkRequestQueryPlan) -> [NetworkRequestRecord] {
+        var records: [NetworkRequestRecord] = []
+        records.reserveCapacity(orderedIDs.count)
+        for id in orderedIDs {
+            guard let record = recordsByID[id] else {
+                continue
+            }
+            guard plan.matches(record: record) == true else {
+                continue
+            }
+            records.append(record)
+        }
+
+        if plan.sortComparators.isEmpty == false {
+            records.sort { lhs, rhs in
+                plan.ordersBefore(lhs, rhs)
+            }
+        }
+
+        let lowerBound = min(plan.fetchOffset, records.count)
+        let upperBound: Int
+        if let fetchLimit = plan.fetchLimit {
+            upperBound = min(lowerBound + fetchLimit, records.count)
+        } else {
+            upperBound = records.count
+        }
+        return Array(records[lowerBound..<upperBound])
+    }
+
+    private func sectionIdentity(
+        for record: NetworkRequestRecord,
+        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>
+    ) -> (id: WebInspectorFetchSectionID, title: String?) {
+        let value: String?
+        switch sectionBy.key {
+        case .networkMethod:
+            value = record.method
+        case .networkResourceType:
+            value = record.resourceTypeRawValue
+        case .networkResourceCategory:
+            value = record.resourceCategory.rawValue
+        case .networkMIMEType:
+            value = record.mimeType
+        case .consoleSource,
+             .consoleLevel,
+             .consoleKind,
+             .consoleURL:
+            preconditionFailure("Console section descriptors cannot be applied to NetworkRequest results.")
+        }
+
+        let title = value ?? ""
+        return (WebInspectorFetchSectionID(rawValue: title), title)
+    }
+}
+
+private enum NetworkResultSetTransactionBuilder {
+    typealias Snapshot = WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>
+    typealias ItemID = NetworkRequest.ID
+
+    static func transaction(
+        oldSnapshot: Snapshot,
+        newSnapshot: Snapshot,
+        changedID: ItemID?
+    ) -> WebInspectorFetchedResultsTransaction<NetworkRequest>? {
+        let sectionChanges = sectionChanges(from: oldSnapshot, to: newSnapshot)
+        let itemChanges = itemChanges(from: oldSnapshot, to: newSnapshot, changedID: changedID)
+        let transaction = WebInspectorFetchedResultsTransaction<NetworkRequest>(
+            oldSnapshot: oldSnapshot,
+            newSnapshot: newSnapshot,
+            isReset: false,
+            sectionChanges: sectionChanges,
+            itemChanges: itemChanges
+        )
+        return transaction.hasChanges ? transaction : nil
+    }
+
+    private static func sectionChanges(
+        from oldSnapshot: Snapshot,
+        to newSnapshot: Snapshot
+    ) -> [WebInspectorFetchedResultsSectionChange] {
+        let oldIndexes = indexSections(oldSnapshot.sections)
+        let newIndexes = indexSections(newSnapshot.sections)
+
+        let deletes = oldSnapshot.sections.enumerated()
+            .filter { _, section in newIndexes[section.id] == nil }
+            .sorted { lhs, rhs in lhs.offset > rhs.offset }
+            .map { index, section in
+                WebInspectorFetchedResultsSectionChange.delete(sectionID: section.id, index: index)
+            }
+
+        let inserts = newSnapshot.sections.enumerated()
+            .filter { _, section in oldIndexes[section.id] == nil }
+            .map { index, section in
+                WebInspectorFetchedResultsSectionChange.insert(sectionID: section.id, index: index)
+            }
+
+        let moves = newSnapshot.sections.enumerated()
+            .compactMap { newIndex, section -> WebInspectorFetchedResultsSectionChange? in
+                guard let oldIndex = oldIndexes[section.id], oldIndex != newIndex else {
+                    return nil
+                }
+                return .move(sectionID: section.id, from: oldIndex, to: newIndex)
+            }
+
+        let updates = newSnapshot.sections.enumerated()
+            .compactMap { newIndex, section -> WebInspectorFetchedResultsSectionChange? in
+                guard let oldIndex = oldIndexes[section.id] else {
+                    return nil
+                }
+                guard oldSnapshot.sections[oldIndex].title != section.title else {
+                    return nil
+                }
+                return .update(sectionID: section.id, index: newIndex)
+            }
+
+        return deletes + inserts + moves + updates
+    }
+
+    private static func itemChanges(
+        from oldSnapshot: Snapshot,
+        to newSnapshot: Snapshot,
+        changedID: ItemID?
+    ) -> [WebInspectorFetchedResultsItemChange<ItemID>] {
+        let oldPositions = indexItems(oldSnapshot)
+        let newPositions = indexItems(newSnapshot)
+
+        let deletes = oldPositions.values
+            .filter { newPositions[$0.itemID] == nil }
+            .sorted { lhs, rhs in lhs.indexPath > rhs.indexPath }
+            .map {
+                WebInspectorFetchedResultsItemChange.delete(
+                    itemID: $0.itemID,
+                    indexPath: $0.indexPath
+                )
+            }
+
+        let inserts = newPositions.values
+            .filter { oldPositions[$0.itemID] == nil }
+            .sorted { lhs, rhs in lhs.indexPath < rhs.indexPath }
+            .map {
+                WebInspectorFetchedResultsItemChange.insert(
+                    itemID: $0.itemID,
+                    indexPath: $0.indexPath
+                )
+            }
+
+        let sectionMembershipChanges = sectionMembershipChanges(
+            from: oldSnapshot,
+            to: newSnapshot,
+            oldPositions: oldPositions,
+            newPositions: newPositions
+        )
+
+        let moves = moveChanges(
+            from: oldSnapshot,
+            to: newSnapshot,
+            oldPositions: oldPositions,
+            newPositions: newPositions,
+            changedID: changedID,
+            excludedItemIDs: Set(sectionMembershipChanges.map(itemID))
+        )
+
+        return deletes + inserts + sectionMembershipChanges + moves
+    }
+
+    private static func sectionMembershipChanges(
+        from oldSnapshot: Snapshot,
+        to newSnapshot: Snapshot,
+        oldPositions: [ItemID: ItemPosition],
+        newPositions: [ItemID: ItemPosition]
+    ) -> [WebInspectorFetchedResultsItemChange<ItemID>] {
+        let oldSectionIDs = Set(oldSnapshot.sectionIDs)
+        let newSectionIDs = Set(newSnapshot.sectionIDs)
+        let deletedSectionIDs = oldSectionIDs.subtracting(newSectionIDs)
+        let insertedSectionIDs = newSectionIDs.subtracting(oldSectionIDs)
+
+        return newSnapshot.itemIDs.compactMap { itemID -> WebInspectorFetchedResultsItemChange<ItemID>? in
+            guard let oldPosition = oldPositions[itemID],
+                  let newPosition = newPositions[itemID],
+                  oldPosition.sectionID != newPosition.sectionID else {
+                return nil
+            }
+            let oldSectionDeleted = deletedSectionIDs.contains(oldPosition.sectionID)
+            let newSectionInserted = insertedSectionIDs.contains(newPosition.sectionID)
+            switch (oldSectionDeleted, newSectionInserted) {
+            case (true, true):
+                return nil
+            case (true, false):
+                return .insert(itemID: itemID, indexPath: newPosition.indexPath)
+            case (false, true):
+                return .delete(itemID: itemID, indexPath: oldPosition.indexPath)
+            case (false, false):
+                return .move(
+                    itemID: itemID,
+                    from: oldPosition.indexPath,
+                    to: newPosition.indexPath
+                )
+            }
+        }
+    }
+
+    private static func moveChanges(
+        from oldSnapshot: Snapshot,
+        to newSnapshot: Snapshot,
+        oldPositions: [ItemID: ItemPosition],
+        newPositions: [ItemID: ItemPosition],
+        changedID: ItemID?,
+        excludedItemIDs: Set<ItemID>
+    ) -> [WebInspectorFetchedResultsItemChange<ItemID>] {
+        let oldCommonOrder = oldSnapshot.itemIDs.filter { newPositions[$0] != nil }
+        let newCommonOrder = newSnapshot.itemIDs.filter { oldPositions[$0] != nil }
+        guard oldCommonOrder != newCommonOrder else {
+            return []
+        }
+
+        if let changedID,
+           excludedItemIDs.contains(changedID) == false,
+           let oldPosition = oldPositions[changedID],
+           let newPosition = newPositions[changedID],
+           oldPosition.sectionID == newPosition.sectionID,
+           oldPosition.indexPath != newPosition.indexPath {
+            return [
+                .move(
+                    itemID: changedID,
+                    from: oldPosition.indexPath,
+                    to: newPosition.indexPath
+                ),
+            ]
+        }
+
+        return newCommonOrder.compactMap { itemID -> WebInspectorFetchedResultsItemChange<ItemID>? in
+            guard excludedItemIDs.contains(itemID) == false else {
+                return nil
+            }
+            guard let oldPosition = oldPositions[itemID],
+                  let newPosition = newPositions[itemID],
+                  oldPosition.sectionID == newPosition.sectionID,
+                  oldPosition.indexPath != newPosition.indexPath else {
+                return nil
+            }
+            return .move(
+                itemID: itemID,
+                from: oldPosition.indexPath,
+                to: newPosition.indexPath
+            )
+        }
+    }
+
+    private static func indexSections(
+        _ sections: [Snapshot.Section]
+    ) -> [WebInspectorFetchSectionID: Int] {
+        Dictionary(
+            uniqueKeysWithValues: sections.enumerated().map { index, section in
+                (section.id, index)
+            }
+        )
+    }
+
+    private struct ItemPosition {
+        var itemID: ItemID
+        var sectionID: WebInspectorFetchSectionID
+        var indexPath: WebInspectorFetchedResultsIndexPath
+    }
+
+    private static func indexItems(_ snapshot: Snapshot) -> [ItemID: ItemPosition] {
+        var positions: [ItemID: ItemPosition] = [:]
+        for (sectionIndex, section) in snapshot.sections.enumerated() {
+            for (itemIndex, itemID) in section.itemIDs.enumerated() where positions[itemID] == nil {
+                positions[itemID] = ItemPosition(
+                    itemID: itemID,
+                    sectionID: section.id,
+                    indexPath: WebInspectorFetchedResultsIndexPath(
+                        section: sectionIndex,
+                        item: itemIndex
+                    )
+                )
+            }
+        }
+        return positions
+    }
+
+    private static func itemID(
+        for change: WebInspectorFetchedResultsItemChange<ItemID>
+    ) -> ItemID {
+        switch change {
+        case let .insert(itemID, _),
+             let .delete(itemID, _),
+             let .update(itemID, _),
+             let .move(itemID, _, _):
+            return itemID
+        }
+    }
+}

--- a/Sources/WebInspectorDataKit/NetworkRequestQuery.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestQuery.swift
@@ -1,25 +1,86 @@
 import Foundation
 import WebInspectorProxyKit
 
-package struct NetworkRequestRecord: Hashable, Sendable {
+package struct NetworkRequestRecordInput: Hashable, Sendable {
     package var id: NetworkRequest.ID
     package var orderIndex: Int
     package var url: String
     package var method: String
-    package var resourceCategory: NetworkRequest.ResourceCategory
-    package var searchableText: String
+    package var resourceTypeRawValue: String?
+    package var mimeType: String?
+    package var responseURL: String?
+    package var responseHeaders: [String: String]
     package var statusCode: Int?
+    package var statusText: String?
     package var requestSentTimestamp: Double?
+    package var hasResponse: Bool
 
     package init(request: NetworkRequest, orderIndex: Int) {
         id = request.id
         self.orderIndex = orderIndex
         url = request.url
         method = request.method
-        resourceCategory = request.resourceCategory
-        searchableText = request.searchableText
+        resourceTypeRawValue = request.resourceType?.rawValue
+        mimeType = request.mimeType
+        responseURL = request.responseURL
+        responseHeaders = request.responseHeaders
         statusCode = request.statusCode
+        statusText = request.statusText
         requestSentTimestamp = request.requestSentTimestamp
+        hasResponse = request.hasResponse
+    }
+}
+
+package struct NetworkRequestRecord: Hashable, Sendable {
+    package var id: NetworkRequest.ID
+    package var orderIndex: Int
+    package var url: String
+    package var method: String
+    package var resourceTypeRawValue: String?
+    package var mimeType: String?
+    package var resourceCategory: NetworkRequest.ResourceCategory
+    package var searchableText: String
+    package var statusCode: Int?
+    package var requestSentTimestamp: Double?
+
+    package init(input: NetworkRequestRecordInput) {
+        id = input.id
+        orderIndex = input.orderIndex
+        url = input.url
+        method = input.method
+        resourceTypeRawValue = input.resourceTypeRawValue
+        mimeType = input.mimeType
+        let resourceType = input.resourceTypeRawValue.map(Network.ResourceType.init(rawValue:))
+        let effectiveMIMEType = NetworkRequest.effectiveMIMEType(
+            mimeType: input.mimeType,
+            headers: input.responseHeaders
+        )
+        let category = NetworkRequest.resourceCategory(
+            resourceType: resourceType,
+            mimeType: effectiveMIMEType,
+            url: input.responseURL ?? input.url,
+            hasResponse: input.hasResponse
+        )
+        resourceCategory = category
+        searchableText = NetworkRequest.uniqueNonEmpty([
+            input.url,
+            input.responseURL,
+            NetworkRequest.urlSearchText(input.url),
+            input.responseURL.map(NetworkRequest.urlSearchText),
+            input.method,
+            input.statusCode.map(String.init),
+            input.statusText,
+            input.mimeType,
+            input.resourceTypeRawValue,
+            category.rawValue,
+        ])
+        .joined(separator: "\n")
+        statusCode = input.statusCode
+        requestSentTimestamp = input.requestSentTimestamp
+    }
+
+    package init(request: NetworkRequest, orderIndex: Int) {
+        self.init(input: NetworkRequestRecordInput(request: request, orderIndex: orderIndex))
     }
 }
 
@@ -29,6 +90,15 @@ package struct NetworkRequestQueryPlan: Sendable {
     package enum Filter: Sendable {
         case record(RecordPredicate)
         case model(Predicate<NetworkRequest>)
+
+        package func matches(record: NetworkRequestRecord) -> Bool? {
+            switch self {
+            case let .record(predicate):
+                return predicate(record)
+            case .model:
+                return nil
+            }
+        }
 
         package func matches(record: NetworkRequestRecord, request: NetworkRequest) -> Bool {
             switch self {
@@ -63,6 +133,17 @@ package struct NetworkRequestQueryPlan: Sendable {
 
     package var requiresQuery: Bool {
         filter != nil || sortComparators.isEmpty == false || fetchLimit != nil || fetchOffset > 0
+    }
+
+    package var requiresModelPredicate: Bool {
+        guard case .model = filter else {
+            return false
+        }
+        return true
+    }
+
+    package func matches(record: NetworkRequestRecord) -> Bool? {
+        filter?.matches(record: record) ?? true
     }
 
     package func matches(record: NetworkRequestRecord, request: NetworkRequest) -> Bool {
@@ -303,6 +384,7 @@ private protocol NetworkRequestRecordResourceCategorySequenceExpression {
 
 private enum NetworkRequestRecordPredicateValue: Equatable, Sendable {
     case string(String)
+    case optionalString(String?)
     case resourceCategory(NetworkRequest.ResourceCategory)
 }
 
@@ -358,8 +440,30 @@ extension PredicateExpressions.Equal: NetworkRequestRecordPredicateExpression
         let lhsExpression = try lhs.networkRequestEquatableExpression()
         let rhsExpression = try rhs.networkRequestEquatableExpression()
         return { record in
-            lhsExpression(record) == rhsExpression(record)
+            networkRequestRecordPredicateValuesEqual(lhsExpression(record), rhsExpression(record))
         }
+    }
+}
+
+private func networkRequestRecordPredicateValuesEqual(
+    _ lhs: NetworkRequestRecordPredicateValue,
+    _ rhs: NetworkRequestRecordPredicateValue
+) -> Bool {
+    switch (lhs, rhs) {
+    case let (.string(lhs), .string(rhs)):
+        return lhs == rhs
+    case let (.optionalString(lhs), .optionalString(rhs)):
+        return lhs == rhs
+    case let (.optionalString(lhs), .string(rhs)):
+        return lhs == rhs
+    case let (.string(lhs), .optionalString(rhs)):
+        return lhs == rhs
+    case let (.resourceCategory(lhs), .resourceCategory(rhs)):
+        return lhs == rhs
+    case (.string, _),
+         (.optionalString, _),
+         (.resourceCategory, _):
+        return false
     }
 }
 
@@ -430,6 +534,9 @@ extension PredicateExpressions.KeyPath: NetworkRequestRecordStringExpression
     where Root == PredicateExpressions.Variable<NetworkRequest>, Output == String
 {
     fileprivate func networkRequestStringExpression() throws -> @Sendable (NetworkRequestRecord) -> String {
+        if keyPath == \NetworkRequest.url {
+            return { $0.url }
+        }
         if keyPath == \NetworkRequest.method {
             return { $0.method }
         }
@@ -444,15 +551,22 @@ extension PredicateExpressions.KeyPath: NetworkRequestRecordEquatableExpression
     where Root == PredicateExpressions.Variable<NetworkRequest>
 {
     fileprivate func networkRequestEquatableExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequestRecordPredicateValue {
-        if keyPath == \NetworkRequest.method || keyPath == \NetworkRequest.searchableText {
+        if keyPath == \NetworkRequest.url || keyPath == \NetworkRequest.method || keyPath == \NetworkRequest.searchableText {
             let stringExpression: @Sendable (NetworkRequestRecord) -> String
-            if keyPath == \NetworkRequest.method {
+            if keyPath == \NetworkRequest.url {
+                stringExpression = { $0.url }
+            } else if keyPath == \NetworkRequest.method {
                 stringExpression = { $0.method }
             } else {
                 stringExpression = { $0.searchableText }
             }
             return { record in
                 .string(stringExpression(record))
+            }
+        }
+        if keyPath == \NetworkRequest.mimeType {
+            return { record in
+                .optionalString(record.mimeType)
             }
         }
         if keyPath == \NetworkRequest.resourceCategory {
@@ -497,6 +611,10 @@ extension PredicateExpressions.Value: NetworkRequestRecordEquatableExpression {
     fileprivate func networkRequestEquatableExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequestRecordPredicateValue {
         if let value = value as? String {
             return { _ in .string(value) }
+        }
+        if Output.self == Optional<String>.self {
+            let value = value as! String?
+            return { _ in .optionalString(value) }
         }
         if let value = value as? NetworkRequest.ResourceCategory {
             return { _ in .resourceCategory(value) }

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -111,7 +111,12 @@ public final class WebInspectorContext {
     private let statusRelay: WebInspectorAsyncStreamRelay<Status>
     private var requestsByID: [NetworkRequest.ID: NetworkRequest]
     private var orderedRequestIDs: [NetworkRequest.ID]
+    private var networkRequestOrderIndicesByID: [NetworkRequest.ID: Int]
     private var clearedNetworkRequestIDs: Set<NetworkRequest.ID>
+    private let networkRequestIndex: NetworkRequestIndex
+    private var networkRequestIndexSequence: UInt64
+    private var networkRequestIndexNeedsRebuild: Bool
+    private let networkCollectionState: NetworkRequestCollectionState
     private var networkFetchedResults: [WeakWebInspectorFetchedResults<NetworkRequest>]
     private var consoleMessagesByID: [ConsoleMessage.ID: ConsoleMessage]
     private var orderedConsoleMessageIDs: [ConsoleMessage.ID]
@@ -169,7 +174,12 @@ public final class WebInspectorContext {
         statusRelay = WebInspectorAsyncStreamRelay()
         requestsByID = [:]
         orderedRequestIDs = []
+        networkRequestOrderIndicesByID = [:]
         clearedNetworkRequestIDs = []
+        networkRequestIndex = NetworkRequestIndex()
+        networkRequestIndexSequence = 0
+        networkRequestIndexNeedsRebuild = false
+        networkCollectionState = NetworkRequestCollectionState()
         networkFetchedResults = []
         consoleMessagesByID = [:]
         orderedConsoleMessageIDs = []
@@ -277,6 +287,10 @@ public final class WebInspectorContext {
     ) -> NetworkRequest? {
         requireOwner(isolation)
         return requestsByID[id]
+    }
+
+    package var networkRequestsCollectionState: NetworkRequestCollectionState {
+        networkCollectionState
     }
 
     package func registeredRequest(
@@ -1384,6 +1398,10 @@ public final class WebInspectorContext {
         clearedNetworkRequestIDs = []
         requestsByID = [:]
         orderedRequestIDs = []
+        networkRequestOrderIndicesByID = [:]
+        networkRequestIndexNeedsRebuild = true
+        clearNetworkRequestIndex()
+        networkCollectionState.replaceCount(0)
         resetNetworkFetchedResults()
     }
 
@@ -1482,7 +1500,7 @@ public final class WebInspectorContext {
         }
 
         let networkPump = WebInspectorEventPump(stream: target.network.events, isolation: isolation) { [weak self] event in
-            self?.apply(event, isolation: isolation)
+            await self?.apply(event, isolation: isolation)
         }
 
         let cssPump = WebInspectorEventPump(stream: target.css.events, isolation: isolation) { [weak self] event in
@@ -3372,65 +3390,81 @@ extension WebInspectorContext {
         requireOwner(isolation)
         let requestID = Network.Request.ID(rawRequestID)
         let resourceType = resourceTypeRawValue.map(Network.ResourceType.init(rawValue:))
-        apply(
-            .requestWillBeSent(
-                id: requestID,
-                request: Network.Request(
-                    id: requestID,
-                    url: url,
-                    method: method,
-                    headers: requestHeaders,
-                    postData: postData
-                ),
+        let payload = Network.Request(
+            id: requestID,
+            url: url,
+            method: method,
+            headers: requestHeaders,
+            postData: postData
+        )
+        let id = NetworkRequest.ID(requestID)
+        let request: NetworkRequest
+        let inserted: Bool
+        if let existing = requestsByID[id] {
+            request = existing
+            request.applyRequestWillBeSent(
+                request: payload,
                 resourceType: resourceType,
-                redirectResponse: nil,
                 timestamp: timestamp
-            ),
-            isolation: isolation
-        )
-        apply(
-            .responseReceived(
-                id: requestID,
-                response: Network.Response(
-                    url: url,
-                    status: responseStatus,
-                    statusText: responseStatusText,
-                    mimeType: responseMIMEType,
-                    headers: responseHeaders,
-                    source: Network.Source(rawValue: "network"),
-                    requestHeaders: requestHeaders
-                ),
-                resourceType: resourceType ?? .other,
-                timestamp: timestamp + 0.1
-            ),
-            isolation: isolation
-        )
-        apply(
-            .dataReceived(
-                id: requestID,
-                dataLength: encodedBodyLength,
-                encodedDataLength: encodedBodyLength,
-                timestamp: timestamp + 0.11
-            ),
-            isolation: isolation
-        )
-        apply(
-            .loadingFinished(
-                id: requestID,
-                timestamp: timestamp + 0.2,
-                sourceMapURL: nil,
-                metrics: Network.Metrics(
-                    encodedDataLength: encodedBodyLength,
-                    decodedBodyLength: encodedBodyLength
-                )
-            ),
-            isolation: isolation
-        )
-        guard let request = networkRequest(for: requestID, method: "seedNetworkRequest") else {
-            preconditionFailure("Seeded NetworkRequest disappeared during preview seeding.")
+            )
+            inserted = false
+        } else {
+            request = NetworkRequest(
+                request: payload,
+                resourceType: resourceType,
+                timestamp: timestamp,
+                modelContext: self
+            )
+            requestsByID[id] = request
+            appendNetworkRequestID(id)
+            inserted = true
         }
+        request.applyResponse(
+            Network.Response(
+                url: url,
+                status: responseStatus,
+                statusText: responseStatusText,
+                mimeType: responseMIMEType,
+                headers: responseHeaders,
+                source: Network.Source(rawValue: "network"),
+                requestHeaders: requestHeaders
+            ),
+            resourceType: resourceType ?? .other,
+            timestamp: timestamp + 0.1
+        )
+        request.applyDataReceived(
+            dataLength: encodedBodyLength,
+            encodedDataLength: encodedBodyLength,
+            timestamp: timestamp + 0.11
+        )
+        request.finish(
+            timestamp: timestamp + 0.2,
+            sourceMapURL: nil,
+            metrics: Network.Metrics(
+                encodedDataLength: encodedBodyLength,
+                decodedBodyLength: encodedBodyLength
+            )
+        )
         if let responseBody {
             request.responseBody.load(Network.Body(data: responseBody, base64Encoded: false))
+        }
+        networkRequestIndexNeedsRebuild = true
+        networkFetchedResults.removeAll { $0.value == nil }
+        if inserted {
+            networkCollectionState.didInsertRequest()
+            for registration in networkFetchedResults {
+                registration.value?.insertNetworkRequest(
+                    request,
+                    lookup: { id in self.requestsByID[id] }
+                )
+            }
+        } else {
+            for registration in networkFetchedResults {
+                registration.value?.refreshNetworkRequestAfterMutation(
+                    request,
+                    lookup: { id in self.requestsByID[id] }
+                )
+            }
         }
         return request.id
     }
@@ -3455,19 +3489,26 @@ extension WebInspectorContext {
         ))
     }
 
-    package func apply(_ event: Network.Event, isolation: isolated (any Actor) = #isolation) {
+    package func apply(_ event: Network.Event, isolation: isolated (any Actor) = #isolation) async {
         requireOwner(isolation)
         switch event {
         case let .requestWillBeSent(id, request, resourceType, redirectResponse, timestamp):
-            applyRequestWillBeSent(
+            await applyRequestWillBeSent(
                 id: id,
                 request: request,
                 resourceType: resourceType,
                 redirectResponse: redirectResponse,
-                timestamp: timestamp
+                timestamp: timestamp,
+                isolation: isolation
             )
         case let .responseReceived(id, response, resourceType, timestamp):
-            applyResponseReceived(id: id, response: response, resourceType: resourceType, timestamp: timestamp)
+            await applyResponseReceived(
+                id: id,
+                response: response,
+                resourceType: resourceType,
+                timestamp: timestamp,
+                isolation: isolation
+            )
         case let .dataReceived(id, dataLength, encodedDataLength, timestamp):
             guard let request = networkRequest(for: id, method: "dataReceived") else {
                 return
@@ -3477,27 +3518,28 @@ extension WebInspectorContext {
                 encodedDataLength: encodedDataLength,
                 timestamp: timestamp
             )
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         case let .loadingFinished(id, timestamp, sourceMapURL, metrics):
             guard let request = networkRequest(for: id, method: "loadingFinished") else {
                 return
             }
             request.finish(timestamp: timestamp, sourceMapURL: sourceMapURL, metrics: metrics)
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         case let .loadingFailed(id, errorText, canceled, timestamp):
             guard let request = networkRequest(for: id, method: "loadingFailed") else {
                 return
             }
             request.fail(errorText: errorText, canceled: canceled, timestamp: timestamp)
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         case let .webSocket(event):
-            apply(event)
+            await apply(event, isolation: isolation)
         case let .requestServedFromMemoryCache(id, response, resourceType, timestamp):
-            applyRequestServedFromMemoryCache(
+            await applyRequestServedFromMemoryCache(
                 id: id,
                 response: response,
                 resourceType: resourceType,
-                timestamp: timestamp
+                timestamp: timestamp,
+                isolation: isolation
             )
         case .unknown:
             break
@@ -3509,8 +3551,10 @@ extension WebInspectorContext {
         request payload: Network.Request,
         resourceType: Network.ResourceType?,
         redirectResponse: Network.Response?,
-        timestamp: Double
-    ) {
+        timestamp: Double,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
         let id = NetworkRequest.ID(proxyID)
         guard clearedNetworkRequestIDs.contains(id) == false || redirectResponse == nil else {
             return
@@ -3536,13 +3580,13 @@ extension WebInspectorContext {
         } else {
             request = NetworkRequest(request: payload, resourceType: resourceType, timestamp: timestamp, modelContext: self)
             requestsByID[id] = request
-            orderedRequestIDs.append(id)
+            appendNetworkRequestID(id)
             inserted = true
         }
         if inserted {
-            notifyNetworkRequestInserted(request)
+            await notifyNetworkRequestInserted(request, isolation: isolation)
         } else if topologyMayHaveChanged {
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         }
     }
 
@@ -3550,8 +3594,10 @@ extension WebInspectorContext {
         id proxyID: Network.Request.ID,
         response: Network.Response,
         resourceType: Network.ResourceType?,
-        timestamp: Double
-    ) {
+        timestamp: Double,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
         let id = NetworkRequest.ID(proxyID)
         guard clearedNetworkRequestIDs.contains(id) == false else {
             return
@@ -3572,21 +3618,23 @@ extension WebInspectorContext {
             )
             request = NetworkRequest(request: payload, resourceType: resourceType, timestamp: timestamp, modelContext: self)
             requestsByID[id] = request
-            orderedRequestIDs.append(id)
+            appendNetworkRequestID(id)
             request.applyMemoryCache(response: response, resourceType: resourceType, timestamp: timestamp)
-            notifyNetworkRequestInserted(request)
+            await notifyNetworkRequestInserted(request, isolation: isolation)
             return
         }
         request.applyMemoryCache(response: response, resourceType: resourceType, timestamp: timestamp)
-        notifyNetworkRequestMutated(request)
+        await notifyNetworkRequestMutated(request, isolation: isolation)
     }
 
     private func applyResponseReceived(
         id proxyID: Network.Request.ID,
         response: Network.Response,
         resourceType: Network.ResourceType?,
-        timestamp: Double
-    ) {
+        timestamp: Double,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
         let id = NetworkRequest.ID(proxyID)
         guard clearedNetworkRequestIDs.contains(id) == false else {
             return
@@ -3612,63 +3660,69 @@ extension WebInspectorContext {
             )
             request = NetworkRequest(request: payload, resourceType: resourceType, timestamp: timestamp, modelContext: self)
             requestsByID[id] = request
-            orderedRequestIDs.append(id)
+            appendNetworkRequestID(id)
             inserted = true
         }
         request.applyResponse(response, resourceType: resourceType, timestamp: timestamp)
         if inserted {
-            notifyNetworkRequestInserted(request)
+            await notifyNetworkRequestInserted(request, isolation: isolation)
         } else {
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         }
     }
 
-    private func apply(_ event: Network.WebSocketEvent) {
+    private func apply(_ event: Network.WebSocketEvent, isolation: isolated (any Actor)) async {
+        _ = isolation
         switch event {
         case let .created(id, url):
-            applyWebSocketCreated(id: id, url: url)
+            await applyWebSocketCreated(id: id, url: url, isolation: isolation)
         case let .handshakeRequest(id, request, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketWillSendHandshakeRequest") else {
                 return
             }
             networkRequest.applyWebSocketHandshakeRequest(request, timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .handshakeResponse(id, response, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketHandshakeResponseReceived") else {
                 return
             }
             networkRequest.applyWebSocketHandshakeResponse(response, timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .frameSent(id, frame, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketFrameSent") else {
                 return
             }
             networkRequest.appendWebSocketFrame(frame, direction: .sent, timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .frameReceived(id, frame, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketFrameReceived") else {
                 return
             }
             networkRequest.appendWebSocketFrame(frame, direction: .received, timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .error(id, message, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketFrameError") else {
                 return
             }
             networkRequest.appendWebSocketError(message, timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .closed(id, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketClosed") else {
                 return
             }
             networkRequest.closeWebSocket(timestamp: timestamp)
-            notifyNetworkRequestMutated(networkRequest)
+            await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case .other:
             break
         }
     }
 
-    private func applyWebSocketCreated(id proxyID: Network.Request.ID, url: String) {
+    private func applyWebSocketCreated(
+        id proxyID: Network.Request.ID,
+        url: String,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
         let id = NetworkRequest.ID(proxyID)
         clearedNetworkRequestIDs.remove(id)
         let request: NetworkRequest
@@ -3679,14 +3733,14 @@ extension WebInspectorContext {
             let payload = Network.Request(id: proxyID, url: url, method: "GET")
             request = NetworkRequest(request: payload, resourceType: .webSocket, timestamp: nil, modelContext: self)
             requestsByID[id] = request
-            orderedRequestIDs.append(id)
+            appendNetworkRequestID(id)
             inserted = true
         }
         request.applyWebSocketCreated(url: url)
         if inserted {
-            notifyNetworkRequestInserted(request)
+            await notifyNetworkRequestInserted(request, isolation: isolation)
         } else {
-            notifyNetworkRequestMutated(request)
+            await notifyNetworkRequestMutated(request, isolation: isolation)
         }
     }
 
@@ -3708,6 +3762,10 @@ extension WebInspectorContext {
         clearedNetworkRequestIDs.formUnion(requestsByID.keys)
         requestsByID = [:]
         orderedRequestIDs = []
+        networkRequestOrderIndicesByID = [:]
+        networkRequestIndexNeedsRebuild = true
+        clearNetworkRequestIndex()
+        networkCollectionState.replaceCount(0)
         resetNetworkFetchedResults()
     }
 
@@ -3715,23 +3773,103 @@ extension WebInspectorContext {
         orderedRequestIDs.compactMap { requestsByID[$0] }
     }
 
-    private func notifyNetworkRequestInserted(_ request: NetworkRequest) {
-        networkFetchedResults.removeAll { $0.value == nil }
-        for registration in networkFetchedResults {
-            registration.value?.insertNetworkRequest(
-                request,
-                lookup: { id in self.requestsByID[id] }
-            )
+    private func appendNetworkRequestID(_ id: NetworkRequest.ID) {
+        networkRequestOrderIndicesByID[id] = orderedRequestIDs.count
+        orderedRequestIDs.append(id)
+    }
+
+    private func clearNetworkRequestIndex() {
+        let index = networkRequestIndex
+        let sequence = nextNetworkRequestIndexSequence()
+        Task {
+            await index.replace(with: [], sequence: sequence)
         }
     }
 
-    private func notifyNetworkRequestMutated(_ request: NetworkRequest) {
+    private func currentNetworkRecordInputs() -> [NetworkRequestRecordInput] {
+        orderedRequestIDs.enumerated().compactMap { index, id in
+            requestsByID[id].map { NetworkRequestRecordInput(request: $0, orderIndex: index) }
+        }
+    }
+
+    private func networkRecordInput(for request: NetworkRequest) -> NetworkRequestRecordInput {
+        let orderIndex = networkRequestOrderIndicesByID[request.id] ?? orderedRequestIDs.count
+        return NetworkRequestRecordInput(request: request, orderIndex: orderIndex)
+    }
+
+    private func nextNetworkRequestIndexSequence() -> UInt64 {
+        networkRequestIndexSequence &+= 1
+        return networkRequestIndexSequence
+    }
+
+    private func syncNetworkRequestIndexIfNeeded(isolation: isolated (any Actor)) async {
+        _ = isolation
+        guard networkRequestIndexNeedsRebuild else {
+            return
+        }
+        networkRequestIndexNeedsRebuild = false
+        let sequence = nextNetworkRequestIndexSequence()
+        await networkRequestIndex.replace(with: currentNetworkRecordInputs(), sequence: sequence)
+    }
+
+    private func notifyNetworkRequestInserted(
+        _ request: NetworkRequest,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
+        networkCollectionState.didInsertRequest()
+        await syncNetworkRequestIndexIfNeeded(isolation: isolation)
+        let sequence = nextNetworkRequestIndexSequence()
+        await networkRequestIndex.upsert(networkRecordInput(for: request), sequence: sequence)
+        await applyNetworkResultDeltas(for: request, inserted: true, isolation: isolation)
+    }
+
+    private func notifyNetworkRequestMutated(
+        _ request: NetworkRequest,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
+        await syncNetworkRequestIndexIfNeeded(isolation: isolation)
+        let sequence = nextNetworkRequestIndexSequence()
+        await networkRequestIndex.upsert(networkRecordInput(for: request), sequence: sequence)
+        await applyNetworkResultDeltas(for: request, inserted: false, isolation: isolation)
+    }
+
+    private func applyNetworkResultDeltas(
+        for request: NetworkRequest,
+        inserted: Bool,
+        isolation: isolated (any Actor)
+    ) async {
+        _ = isolation
         networkFetchedResults.removeAll { $0.value == nil }
         for registration in networkFetchedResults {
-            registration.value?.refreshNetworkRequestAfterMutation(
-                request,
-                lookup: { id in self.requestsByID[id] }
-            )
+            guard let results = registration.value else {
+                continue
+            }
+            let plan = results.currentNetworkQueryPlan(context: self)
+            if plan.requiresModelPredicate {
+                if inserted {
+                    results.insertNetworkRequest(
+                        request,
+                        lookup: { id in self.requestsByID[id] }
+                    )
+                } else {
+                    results.refreshNetworkRequestAfterMutation(
+                        request,
+                        lookup: { id in self.requestsByID[id] }
+                    )
+                }
+                continue
+            }
+            guard let delta = await networkRequestIndex.delta(
+                plan: plan,
+                sectionBy: results.sectionBy,
+                oldSnapshot: results.networkSnapshotForDelta,
+                changedID: request.id
+            ) else {
+                continue
+            }
+            results.applyNetworkDelta(delta, lookup: { id in self.requestsByID[id] })
         }
     }
 

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -3861,12 +3861,20 @@ extension WebInspectorContext {
                 }
                 continue
             }
+            let oldSnapshot = results.networkSnapshotForDelta
+            let resultTopologyRevision = results.topologyRevision
+            let indexSequence = networkRequestIndexSequence
             guard let delta = await networkRequestIndex.delta(
                 plan: plan,
                 sectionBy: results.sectionBy,
-                oldSnapshot: results.networkSnapshotForDelta,
+                oldSnapshot: oldSnapshot,
                 changedID: request.id
             ) else {
+                continue
+            }
+            guard networkRequestIndexSequence == indexSequence,
+                  results.topologyRevision == resultTopologyRevision,
+                  results.networkSnapshotForDelta == oldSnapshot else {
                 continue
             }
             results.applyNetworkDelta(delta, lookup: { id in self.requestsByID[id] })

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -3797,6 +3797,10 @@ extension WebInspectorContext {
         return NetworkRequestRecordInput(request: request, orderIndex: orderIndex)
     }
 
+    private func isCurrentNetworkRequest(_ request: NetworkRequest) -> Bool {
+        requestsByID[request.id] === request
+    }
+
     private func nextNetworkRequestIndexSequence() -> UInt64 {
         networkRequestIndexSequence &+= 1
         return networkRequestIndexSequence
@@ -3819,8 +3823,14 @@ extension WebInspectorContext {
         _ = isolation
         networkCollectionState.didInsertRequest()
         await syncNetworkRequestIndexIfNeeded(isolation: isolation)
+        guard isCurrentNetworkRequest(request) else {
+            return
+        }
         let sequence = nextNetworkRequestIndexSequence()
         await networkRequestIndex.upsert(networkRecordInput(for: request), sequence: sequence)
+        guard isCurrentNetworkRequest(request) else {
+            return
+        }
         await applyNetworkResultDeltas(for: request, inserted: true, isolation: isolation)
     }
 
@@ -3830,8 +3840,14 @@ extension WebInspectorContext {
     ) async {
         _ = isolation
         await syncNetworkRequestIndexIfNeeded(isolation: isolation)
+        guard isCurrentNetworkRequest(request) else {
+            return
+        }
         let sequence = nextNetworkRequestIndexSequence()
         await networkRequestIndex.upsert(networkRecordInput(for: request), sequence: sequence)
+        guard isCurrentNetworkRequest(request) else {
+            return
+        }
         await applyNetworkResultDeltas(for: request, inserted: false, isolation: isolation)
     }
 

--- a/Sources/WebInspectorDataKit/WebInspectorEventPump.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorEventPump.swift
@@ -6,7 +6,7 @@ struct WebInspectorEventPump: Sendable {
     init<Event: Sendable, Events: AsyncSequence & Sendable>(
         stream: Events,
         isolation: isolated (any Actor),
-        apply: @escaping (Event) -> Void
+        apply: @escaping (Event) async -> Void
     ) where Events.Element == Event, Events.Failure == Never {
         let target = WebInspectorEventPumpTarget(apply: apply)
         task = Task.detached(priority: .userInitiated) {
@@ -28,14 +28,14 @@ struct WebInspectorEventPump: Sendable {
 // the non-Sendable apply closure directly; apply(_:isolation:) runs on the
 // WebInspectorContext owner actor passed to the pump initializer.
 private final class WebInspectorEventPumpTarget<Event: Sendable>: @unchecked Sendable {
-    private let applyEvent: (Event) -> Void
+    private let applyEvent: (Event) async -> Void
 
-    init(apply: @escaping (Event) -> Void) {
+    init(apply: @escaping (Event) async -> Void) {
         applyEvent = apply
     }
 
-    func apply(_ event: Event, isolation: isolated (any Actor)) {
+    func apply(_ event: Event, isolation: isolated (any Actor)) async {
         _ = isolation
-        applyEvent(event)
+        await applyEvent(event)
     }
 }

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -29,7 +29,7 @@ private final class NetworkResponseBodyFetchCoordinator {
 package final class NetworkPanelModel {
     package let context: WebInspectorContext
     package let requests: WebInspectorFetchedResults<NetworkRequest>
-    private let clearableRequests: WebInspectorFetchedResults<NetworkRequest>
+    private let collectionState: NetworkRequestCollectionState
     package var selectedRequestID: NetworkRequest.ID?
     package var searchText: String = ""
     package var activeResourceFilters: Set<NetworkDisplay.ResourceFilter> = [] {
@@ -47,7 +47,7 @@ package final class NetworkPanelModel {
     package init(context: WebInspectorContext) {
         self.context = context
         self.requests = context.network.fetchedResults(for: Self.makeNetworkFetchDescriptor(searchText: "", filters: []))
-        self.clearableRequests = context.network.fetchedResults()
+        self.collectionState = context.networkRequestsCollectionState
         self.responseBodyFetchCoordinator = NetworkResponseBodyFetchCoordinator()
     }
 
@@ -64,7 +64,7 @@ package final class NetworkPanelModel {
     }
 
     package var hasClearableRequests: Bool {
-        clearableRequests.items.isEmpty == false
+        collectionState.hasRequests
     }
 
     package var selectedRequest: NetworkRequest? {
@@ -73,7 +73,7 @@ package final class NetworkPanelModel {
         }
         // Observe the unfiltered request topology so registry removals invalidate
         // the selection without tying selection lifetime to display filters.
-        _ = clearableRequests.topologyRevision
+        _ = collectionState.topologyRevision
         return request(for: selectedRequestID)
     }
 

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -3140,7 +3140,7 @@ func setChildNodesReplacementPublishesSelectionClearingForRemovedDescendant() as
 
 @MainActor
 @Test
-func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async throws {
+func fetchedResultsControllerPublishesNetworkTopologyTransactionsOnly() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
@@ -3183,8 +3183,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { request.status == 200 }
     #expect(results.items.first === request)
-    try await recorder.waitForTransactionCount(2)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: modelID, indexPath: firstIndexPath)])
+    #expect(recorder.transactions.count == 1)
 
     await runtime.backend.emit(
         .dataReceived(id: requestID, dataLength: 7, encodedDataLength: 3, timestamp: 3),
@@ -3193,8 +3192,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { request.decodedDataLength == 7 && request.encodedDataLength == 3 }
     #expect(results.items.first === request)
-    try await recorder.waitForTransactionCount(3)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: modelID, indexPath: firstIndexPath)])
+    #expect(recorder.transactions.count == 1)
 
     await runtime.backend.emit(
         .loadingFinished(id: requestID, timestamp: 4, sourceMapURL: nil, metrics: nil),
@@ -3203,8 +3201,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { request.state == .finished }
     #expect(results.items.first === request)
-    try await recorder.waitForTransactionCount(4)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: modelID, indexPath: firstIndexPath)])
+    #expect(recorder.transactions.count == 1)
 
     await runtime.backend.emit(
         .requestServedFromMemoryCache(
@@ -3218,8 +3215,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { request.finishedOrFailedTimestamp == 5 }
     #expect(results.items.first === request)
-    try await recorder.waitForTransactionCount(5)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: modelID, indexPath: firstIndexPath)])
+    #expect(recorder.transactions.count == 1)
 
     let failedRequestID = Network.Request.ID("controller-failed-request")
     let failedModelID = NetworkRequest.ID(failedRequestID)
@@ -3235,7 +3231,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
         target: target
     )
 
-    try await recorder.waitForTransactionCount(6)
+    try await recorder.waitForTransactionCount(2)
     #expect(recorder.transactions.last?.itemChanges == [.insert(itemID: failedModelID, indexPath: failedIndexPath)])
     let failedRequest = try #require(results.items.last)
 
@@ -3251,8 +3247,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
         return false
     }
     #expect(results.items.last === failedRequest)
-    try await recorder.waitForTransactionCount(7)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: failedModelID, indexPath: failedIndexPath)])
+    #expect(recorder.transactions.count == 2)
 
     let socketRequestID = Network.Request.ID("controller-socket-request")
     let socketModelID = NetworkRequest.ID(socketRequestID)
@@ -3262,7 +3257,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
         target: target
     )
 
-    try await recorder.waitForTransactionCount(8)
+    try await recorder.waitForTransactionCount(3)
     #expect(recorder.transactions.last?.itemChanges == [.insert(itemID: socketModelID, indexPath: socketIndexPath)])
     let socketRequest = try #require(results.items.last)
 
@@ -3282,8 +3277,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.webSocket?.handshakeRequest?.headers["Upgrade"] == "websocket" }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(9)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 
     await runtime.backend.emit(
         .webSocket(.handshakeResponse(
@@ -3296,8 +3290,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.status == 101 }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(10)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 
     await runtime.backend.emit(
         .webSocket(.frameSent(
@@ -3310,8 +3303,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.webSocket?.frames.count == 1 }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(11)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 
     await runtime.backend.emit(
         .webSocket(.frameReceived(
@@ -3324,8 +3316,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.webSocket?.frames.count == 2 }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(12)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 
     await runtime.backend.emit(
         .webSocket(.error(id: socketRequestID, message: "decode failed", timestamp: 12)),
@@ -3334,8 +3325,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.webSocket?.frames.count == 3 }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(13)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 
     await runtime.backend.emit(
         .webSocket(.closed(id: socketRequestID, timestamp: 13)),
@@ -3344,8 +3334,7 @@ func fetchedResultsControllerPublishesNetworkInsertAndUpdateTransactions() async
 
     try await waitUntil { socketRequest.state == .finished && socketRequest.webSocket?.readyState == .closed }
     #expect(results.items.last === socketRequest)
-    try await recorder.waitForTransactionCount(14)
-    #expect(recorder.transactions.last?.itemChanges == [.update(itemID: socketModelID, indexPath: socketIndexPath)])
+    #expect(recorder.transactions.count == 3)
 }
 
 @MainActor
@@ -3406,23 +3395,89 @@ func sectionedNetworkResultsPublishTopologyWhenSectionKeyChanges() async throws 
 
 @MainActor
 @Test
+func sectionedNetworkResultsPublishItemMoveWhenSectionKeyChangesBetweenExistingSections() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(sectionBy: \.resourceCategory)
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
+    defer { recorder.cancel() }
+    try await recorder.waitUntilStarted()
+
+    let imageID = Network.Request.ID("existing-image-section")
+    let movingID = Network.Request.ID("moving-xhr-to-image")
+    let remainingXHRID = Network.Request.ID("remaining-xhr-section")
+    await context.apply(.requestWillBeSent(
+        id: imageID,
+        request: Network.Request(id: imageID, url: "https://cdn.example.com/photo.png", method: "GET"),
+        resourceType: .image,
+        redirectResponse: nil,
+        timestamp: 1
+    ))
+    await context.apply(.requestWillBeSent(
+        id: movingID,
+        request: Network.Request(id: movingID, url: "https://api.example.com/avatar", method: "GET"),
+        resourceType: .xhr,
+        redirectResponse: nil,
+        timestamp: 2
+    ))
+    await context.apply(.requestWillBeSent(
+        id: remainingXHRID,
+        request: Network.Request(id: remainingXHRID, url: "https://api.example.com/data", method: "GET"),
+        resourceType: .xhr,
+        redirectResponse: nil,
+        timestamp: 3
+    ))
+    try await recorder.waitForTransactionCount(3)
+
+    let movingModelID = NetworkRequest.ID(movingID)
+    await context.apply(.responseReceived(
+        id: movingID,
+        response: Network.Response(
+            url: "https://api.example.com/avatar",
+            status: 200,
+            mimeType: "image/png"
+        ),
+        resourceType: .xhr,
+        timestamp: 4
+    ))
+
+    try await recorder.waitForTransactionCount(4)
+    #expect(controller.snapshot.sections.map(\.id) == [
+        WebInspectorFetchSectionID(rawValue: "image"),
+        WebInspectorFetchSectionID(rawValue: "xhrFetch"),
+    ])
+    #expect(controller.snapshot.sections.map(\.itemIDs) == [
+        [NetworkRequest.ID(imageID), movingModelID],
+        [NetworkRequest.ID(remainingXHRID)],
+    ])
+    #expect(recorder.transactions.last?.itemChanges == [
+        .move(
+            itemID: movingModelID,
+            from: WebInspectorFetchedResultsIndexPath(section: 1, item: 0),
+            to: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
+        ),
+    ])
+}
+
+@MainActor
+@Test
 func networkFetchDescriptorAppliesPredicateSortAndLimit() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("graphql-old"),
         request: Network.Request(id: Network.Request.ID("graphql-old"), url: "https://api.example.com/graphql?older", method: "POST"),
         resourceType: .fetch,
         redirectResponse: nil,
         timestamp: 1
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("image"),
         request: Network.Request(id: Network.Request.ID("image"), url: "https://static.example.com/photo.png", method: "GET"),
         resourceType: .image,
         redirectResponse: nil,
         timestamp: 2
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("graphql-new"),
         request: Network.Request(id: Network.Request.ID("graphql-new"), url: "https://api.example.com/graphql?newer", method: "POST"),
         resourceType: .fetch,
@@ -3448,23 +3503,23 @@ func networkFetchDescriptorAppliesPredicateSortAndLimit() async throws {
 
 @MainActor
 @Test
-func networkFetchDescriptorFallsBackForUnsupportedPublicPredicates() async throws {
+func networkFetchDescriptorPlansURLAndMIMETypePredicates() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("api"),
         request: Network.Request(id: Network.Request.ID("api"), url: "https://api.example.com/data.json", method: "GET"),
         resourceType: .fetch,
         redirectResponse: nil,
         timestamp: 1
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("image"),
         request: Network.Request(id: Network.Request.ID("image"), url: "https://static.example.com/photo", method: "GET"),
         resourceType: .image,
         redirectResponse: nil,
         timestamp: 2
     ))
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: Network.Request.ID("image"),
         response: Network.Response(
             url: "https://static.example.com/photo",
@@ -3474,7 +3529,7 @@ func networkFetchDescriptorFallsBackForUnsupportedPublicPredicates() async throw
         resourceType: .image,
         timestamp: 3
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("script"),
         request: Network.Request(id: Network.Request.ID("script"), url: "https://cdn.example.com/app.js", method: "GET"),
         resourceType: .script,
@@ -3508,7 +3563,7 @@ func clearNetworkRequestsResetsDescriptorBackedQueryState() async throws {
     let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
 
     for (index, name) in ["stale-a", "stale-b", "stale-c"].enumerated() {
-        context.apply(.requestWillBeSent(
+        await context.apply(.requestWillBeSent(
             id: Network.Request.ID(name),
             request: Network.Request(id: Network.Request.ID(name), url: "https://example.com/\(name)", method: "GET"),
             resourceType: .fetch,
@@ -3525,7 +3580,7 @@ func clearNetworkRequestsResetsDescriptorBackedQueryState() async throws {
     #expect(results.items.isEmpty)
 
     let freshID = Network.Request.ID("fresh-after-clear")
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: freshID,
         request: Network.Request(id: freshID, url: "https://example.com/fresh", method: "GET"),
         resourceType: .fetch,
@@ -3590,7 +3645,7 @@ func networkFetchDescriptorOrdersEqualTimestampsByNewestInsertionFirst() async t
     let firstModelID = NetworkRequest.ID(firstID)
     let secondModelID = NetworkRequest.ID(secondID)
 
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: firstID,
         request: Network.Request(id: firstID, url: "https://example.com/first", method: "GET"),
         resourceType: .fetch,
@@ -3600,7 +3655,7 @@ func networkFetchDescriptorOrdersEqualTimestampsByNewestInsertionFirst() async t
     try await recorder.waitForTransactionCount(1)
     #expect(results.items.map(\.id) == [firstModelID])
 
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: secondID,
         request: Network.Request(id: secondID, url: "https://example.com/second", method: "GET"),
         resourceType: .fetch,
@@ -3612,11 +3667,6 @@ func networkFetchDescriptorOrdersEqualTimestampsByNewestInsertionFirst() async t
     #expect(results.items.map(\.id) == [secondModelID, firstModelID])
     #expect(recorder.transactions.last?.itemChanges == [
         .insert(itemID: secondModelID, indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)),
-        .move(
-            itemID: firstModelID,
-            from: WebInspectorFetchedResultsIndexPath(section: 0, item: 0),
-            to: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
-        ),
     ])
 }
 
@@ -3637,7 +3687,7 @@ func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
 
     let requestID = Network.Request.ID("status-request")
     let modelID = NetworkRequest.ID(requestID)
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: requestID,
         request: Network.Request(id: requestID, url: "https://api.example.com/status", method: "GET"),
         resourceType: .fetch,
@@ -3650,7 +3700,7 @@ func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
     #expect(results.items.isEmpty)
     #expect(recorder.transactions.isEmpty)
 
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: requestID,
         response: Network.Response(url: "https://api.example.com/status", status: 500),
         resourceType: .fetch,
@@ -3663,7 +3713,7 @@ func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
         .insert(itemID: modelID, indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)),
     ])
 
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: requestID,
         response: Network.Response(url: "https://api.example.com/status", status: 200),
         resourceType: .fetch,
@@ -3683,28 +3733,28 @@ func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
 func networkFetchDescriptorSupportsResourceCategorySets() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
 
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("pending-avatar"),
         request: Network.Request(id: Network.Request.ID("pending-avatar"), url: "https://api.example.com/avatar.png", method: "GET"),
         resourceType: .xhr,
         redirectResponse: nil,
         timestamp: 1
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("script"),
         request: Network.Request(id: Network.Request.ID("script"), url: "https://cdn.example.com/app.js", method: "GET"),
         resourceType: .script,
         redirectResponse: nil,
         timestamp: 2
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("image"),
         request: Network.Request(id: Network.Request.ID("image"), url: "https://cdn.example.com/photo.png", method: "GET"),
         resourceType: .image,
         redirectResponse: nil,
         timestamp: 3
     ))
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: Network.Request.ID("movie"),
         request: Network.Request(id: Network.Request.ID("movie"), url: "https://media.example.com/clip.mp4", method: "GET"),
         resourceType: .fetch,
@@ -3725,7 +3775,7 @@ func networkFetchDescriptorSupportsResourceCategorySets() async throws {
         NetworkRequest.ID(Network.Request.ID("image")),
     ])
 
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: Network.Request.ID("pending-avatar"),
         response: Network.Response(
             url: "https://api.example.com/avatar.png",
@@ -3735,7 +3785,7 @@ func networkFetchDescriptorSupportsResourceCategorySets() async throws {
         resourceType: .xhr,
         timestamp: 5
     ))
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: Network.Request.ID("movie"),
         response: Network.Response(
             url: "https://media.example.com/clip.mp4",
@@ -3758,7 +3808,7 @@ func networkFetchDescriptorSupportsResourceCategorySets() async throws {
 func networkRequestResourceCategoryUsesResponseHeadersWithoutPendingURLInference() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     let requestID = Network.Request.ID("header-avatar")
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: requestID,
         request: Network.Request(id: requestID, url: "https://api.example.com/avatar.png", method: "GET"),
         resourceType: .xhr,
@@ -3769,7 +3819,7 @@ func networkRequestResourceCategoryUsesResponseHeadersWithoutPendingURLInference
 
     #expect(request.resourceCategory == .xhrFetch)
 
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: requestID,
         response: Network.Response(
             url: "https://api.example.com/avatar",
@@ -3785,7 +3835,7 @@ func networkRequestResourceCategoryUsesResponseHeadersWithoutPendingURLInference
     #expect(request.searchableText.localizedStandardContains("image/png") == false)
 
     let scriptVideoID = Network.Request.ID("script-video")
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: scriptVideoID,
         request: Network.Request(id: scriptVideoID, url: "https://cdn.example.com/player.js", method: "GET"),
         resourceType: .script,
@@ -3795,7 +3845,7 @@ func networkRequestResourceCategoryUsesResponseHeadersWithoutPendingURLInference
     let scriptVideoRequest = try #require(context.registeredRequest(forProxyID: scriptVideoID))
     #expect(scriptVideoRequest.resourceCategory == .script)
 
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: scriptVideoID,
         response: Network.Response(
             url: "https://cdn.example.com/player.js",
@@ -5517,14 +5567,14 @@ func responseReceivedWithoutResourceTypePreservesRequestResourceType() async thr
     let requestID = Network.Request.ID("response-type-preserved-request")
     let modelID = NetworkRequest.ID(requestID)
 
-    context.apply(.requestWillBeSent(
+    await context.apply(.requestWillBeSent(
         id: requestID,
         request: Network.Request(id: requestID, url: "https://example.com/image.png", method: "GET"),
         resourceType: .image,
         redirectResponse: nil,
         timestamp: 1
     ))
-    context.apply(.responseReceived(
+    await context.apply(.responseReceived(
         id: requestID,
         response: Network.Response(
             url: "https://example.com/image.png",

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -110,7 +110,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func listLoadDoesNotEvaluateDisplayRequestsUntilAppearing() async throws {
         let context = makeContext()
-        _ = try #require(applyRequest(
+        _ = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://example.com/api/data.json",
@@ -194,7 +194,7 @@ struct NetworkDetailViewControllerTests {
     func detailModeControlSwitchesPreviewAndHeaders() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -265,7 +265,7 @@ struct NetworkDetailViewControllerTests {
     func previewTextBodyUsesAutomaticInsetsAsRegisteredContentScrollView() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.txt",
@@ -304,7 +304,7 @@ struct NetworkDetailViewControllerTests {
     func previewRequestWithoutBodyReplacesPreviousBodyWithUnavailablePlaceholder() async throws {
         let context = makeContext()
         let bodyRequest = try #require(
-            applyRequestWithoutResponse(
+            await applyRequestWithoutResponse(
                 to: context,
                 requestID: "body",
                 url: "https://example.com/form",
@@ -313,7 +313,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         let emptyRequest = try #require(
-            applyRequestWithoutResponse(
+            await applyRequestWithoutResponse(
                 to: context,
                 requestID: "empty",
                 url: "https://example.com/no-body"
@@ -349,7 +349,7 @@ struct NetworkDetailViewControllerTests {
     func responseOnlyPreviewRoleExpandsToBothWithoutChangingLogicalSelection() async throws {
         let context = makeContext()
         let responseOnlyRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "response-only",
                 url: "https://example.com/response.json",
@@ -358,7 +358,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         let requestAndResponse = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "both",
                 url: "https://example.com/both.json",
@@ -395,7 +395,7 @@ struct NetworkDetailViewControllerTests {
     func requestPreviewRoleSurvivesResponseOnlySelection() async throws {
         let context = makeContext()
         let requestAndResponse = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "both",
                 url: "https://example.com/both.json",
@@ -406,7 +406,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         let responseOnlyRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "response-only",
                 url: "https://example.com/response.txt",
@@ -461,7 +461,7 @@ struct NetworkDetailViewControllerTests {
     func previewRequestWithoutBodyRendersPlaceholderWhenBodySurfaceResumes() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequestWithoutResponse(
+            await applyRequestWithoutResponse(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/no-body"
@@ -496,7 +496,7 @@ struct NetworkDetailViewControllerTests {
     func detailUpdatesResponseHeadersAfterSelection() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequestWithoutResponse(
+            await applyRequestWithoutResponse(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json"
@@ -514,7 +514,7 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didRenderRequestHeaders)
 
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "1",
             url: "https://example.com/api/data.json",
@@ -533,7 +533,7 @@ struct NetworkDetailViewControllerTests {
     func detailModeControlUsesCoreBodyAvailabilityAndRendersRequestBody() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/form",
@@ -571,7 +571,7 @@ struct NetworkDetailViewControllerTests {
     func detailModeControlDisablesWhenSelectedRequestDisappears() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/form",
@@ -602,7 +602,7 @@ struct NetworkDetailViewControllerTests {
     func responsePreviewRequestsRuntimeFetchWhenBodyIsAvailable() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -631,7 +631,7 @@ struct NetworkDetailViewControllerTests {
     func responsePreviewPrewarmsSyntaxWhileFetching() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -668,7 +668,7 @@ struct NetworkDetailViewControllerTests {
     func hiddenDetailDoesNotFetchResponseBodyUntilAppearingAgain() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -714,7 +714,7 @@ struct NetworkDetailViewControllerTests {
     func hiddenDetailKeepsDisplayedBodyAndReconcilesBodyOnReturn() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -754,7 +754,7 @@ struct NetworkDetailViewControllerTests {
     func deeplyNestedJSONPreviewFallsBackToRawText() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/deep.json",
@@ -784,7 +784,7 @@ struct NetworkDetailViewControllerTests {
     func jsonPreviewFormatsCRLFWhitespace() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -909,7 +909,7 @@ struct NetworkDetailViewControllerTests {
     func mediaResponsePreviewReleasesPlayerAndTemporaryFileWhenShowingHeaders() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -964,7 +964,7 @@ struct NetworkDetailViewControllerTests {
     func mediaResponsePreviewReusesPlayerAndTemporaryFileWhenRequestUpdateDoesNotChangeBody() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -995,7 +995,7 @@ struct NetworkDetailViewControllerTests {
         let playerIdentity = try #require(viewController.syntaxBodyViewControllerForTesting.mediaPlayerIdentityForTesting)
         #expect(playerFactory.requestedURLs == [temporaryFileURL])
 
-        applyDataReceived(
+        await applyDataReceived(
             to: context,
             requestID: "1",
             dataLength: 128,
@@ -1014,7 +1014,7 @@ struct NetworkDetailViewControllerTests {
     func mediaResponsePreviewPausesPlayerButKeepsSurfaceWhenHidden() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -1065,7 +1065,7 @@ struct NetworkDetailViewControllerTests {
     func mediaResponsePreviewReleasesPlayerAndTemporaryFileWhenSelectionClears() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -1110,7 +1110,7 @@ struct NetworkDetailViewControllerTests {
     func hiddenMediaResponsePreviewReleasesPlayerAndTemporaryFileWhenSelectionClearsBeforeReappearing() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -1164,7 +1164,7 @@ struct NetworkDetailViewControllerTests {
         let imageSize = CGSize(width: 600, height: 1400)
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/large.png",
@@ -1232,7 +1232,7 @@ struct NetworkDetailViewControllerTests {
         let imageSize = CGSize(width: 600, height: 1400)
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/large.png",
@@ -1276,7 +1276,7 @@ struct NetworkDetailViewControllerTests {
         let imageSize = CGSize(width: 24, height: 12)
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/icon.png",
@@ -1309,7 +1309,7 @@ struct NetworkDetailViewControllerTests {
     func responsePreviewWaitsForLoadingFinishedBeforeFetching() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1327,7 +1327,7 @@ struct NetworkDetailViewControllerTests {
 
         #expect(request.responseBody.phase == .available)
 
-        applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
+        await applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
 
         let didFetch = await waitUntilRendered(in: viewController) {
             guard case .failed = request.responseBody.phase else {
@@ -1342,7 +1342,7 @@ struct NetworkDetailViewControllerTests {
     func failedResponseBodyDoesNotRefetchFromRendering() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1386,7 +1386,7 @@ struct NetworkDetailViewControllerTests {
     func headersModeDoesNotFetchResponseBody() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1413,7 +1413,7 @@ struct NetworkDetailViewControllerTests {
     func headersModePreservesSelectionWhenRequestUpdateDoesNotChangeDocument() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1438,7 +1438,7 @@ struct NetworkDetailViewControllerTests {
         viewController.headersTextViewForTesting.selectedRangeForTesting = selectedRange
         let assignmentCount = viewController.headersTextViewForTesting.attributedTextAssignmentCountForTesting
 
-        applyDataReceived(
+        await applyDataReceived(
             to: context,
             requestID: "1",
             dataLength: 128,
@@ -1455,7 +1455,7 @@ struct NetworkDetailViewControllerTests {
     func hiddenDetailKeepsHeadersAndRebindsSameSelectedRequestOnReturn() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1478,7 +1478,7 @@ struct NetworkDetailViewControllerTests {
 
         viewController.beginAppearanceTransition(false, animated: false)
         viewController.endAppearanceTransition()
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "1",
             url: "https://example.com/api/data.json",
@@ -1502,7 +1502,7 @@ struct NetworkDetailViewControllerTests {
     func requestPreviewRoleDoesNotFetchResponseBodyAfterLoadingFinishes() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1534,7 +1534,7 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didRenderRequestBody)
 
-        applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
+        await applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
 
         let didStayOnRequestBody = await waitUntilRendered(in: viewController) {
             viewController.currentPreviewRoleForTesting == .request
@@ -1548,7 +1548,7 @@ struct NetworkDetailViewControllerTests {
     func selectedRequestRebindingIgnoresOldRequestMutations() async throws {
         let context = makeContext()
         let firstRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/first.json",
@@ -1557,7 +1557,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         let secondRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "2",
                 url: "https://example.com/second.json",
@@ -1583,7 +1583,7 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didRenderSecond)
 
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "1",
             url: "https://example.com/first.json",
@@ -1594,7 +1594,7 @@ struct NetworkDetailViewControllerTests {
 
         #expect(viewController.headersTextViewForTesting.renderedTextForTesting.contains("x-old-request: stale") == false)
 
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "2",
             url: "https://example.com/second.json",
@@ -1615,7 +1615,7 @@ struct NetworkDetailViewControllerTests {
     func previewRoleSwitchPreservesInstalledBodyViews() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.json",
@@ -1661,7 +1661,7 @@ struct NetworkDetailViewControllerTests {
     func rebindingPreviewBodyCancelsOutgoingTextPreparation() async throws {
         let context = makeContext()
         let firstRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/large.json",
@@ -1670,7 +1670,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         let secondRequest = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "2",
                 url: "https://example.com/api/current.json",
@@ -1709,7 +1709,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func compactContainerPushesAndPopsDetailFromSelection() async throws {
         let context = makeContext()
-        let request = try #require(applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
+        let request = try #require(await applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
         let model = NetworkPanelModel(context: context)
         let listViewController = NetworkListViewController(model: model)
         let detailViewController = makeNetworkDetailViewController(model: model)
@@ -1741,7 +1741,7 @@ struct NetworkDetailViewControllerTests {
     func compactProgrammaticPopKeepsDetailSurfaceUntilTransitionCompletes() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.txt",
@@ -1793,7 +1793,7 @@ struct NetworkDetailViewControllerTests {
     func compactUserPopDiscardsDetailSurfaceWhenSelectionClearsBeforeTransitionCompletes() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://example.com/api/data.txt",
@@ -1844,7 +1844,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func compactContainerCanPushSameRequestAfterBackNavigation() async throws {
         let context = makeContext()
-        _ = try #require(applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
+        _ = try #require(await applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
         let model = NetworkPanelModel(context: context)
         let listViewController = NetworkListViewController(model: model)
         let detailViewController = makeNetworkDetailViewController(model: model)
@@ -1887,7 +1887,7 @@ struct NetworkDetailViewControllerTests {
     func compactContainerBackNavigationReleasesDetailMediaPreviewResources() async throws {
         let context = makeContext()
         let request = try #require(
-            applyRequest(
+            await applyRequest(
                 to: context,
                 requestID: "1",
                 url: "https://media.example.com/download.php",
@@ -1945,7 +1945,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func compactContainerPopsDetailWhenSelectedRequestDisappears() async throws {
         let context = makeContext()
-        let request = try #require(applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
+        let request = try #require(await applyRequest(to: context, requestID: "1", url: "https://example.com/app.js"))
         let model = NetworkPanelModel(context: context)
         let listViewController = NetworkListViewController(model: model)
         let detailViewController = makeNetworkDetailViewController(model: model)
@@ -1979,7 +1979,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func visibleListAppliesLiveInsertThroughFetchedResultsTransactions() async throws {
         let context = makeContext()
-        let firstRequest = try #require(applyRequest(
+        let firstRequest = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://example.com/first.js"
@@ -1994,7 +1994,7 @@ struct NetworkDetailViewControllerTests {
 
         let evaluationCountBeforeInsert = listViewController.displayRequestIDsEvaluationCountForTesting
         let snapshotApplyCountBeforeInsert = listViewController.snapshotApplyCountForTesting
-        let secondRequest = try #require(applyRequest(
+        let secondRequest = try #require(await applyRequest(
             to: context,
             requestID: "2",
             url: "https://example.com/second.js"
@@ -2012,7 +2012,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func visibleListAppliesDescriptorResetThroughFetchedResultsTransactions() async throws {
         let context = makeContext()
-        _ = try #require(applyRequest(
+        _ = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://media.example.com/clip.mp4",
@@ -2044,7 +2044,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func hiddenListDefersSnapshotEvaluationUntilAppearingAgain() async throws {
         let context = makeContext()
-        _ = try #require(applyRequest(
+        _ = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://media.example.com/clip.mp4",
@@ -2076,7 +2076,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func hiddenListDefersQueuedSnapshotApplyUntilAppearingAgain() async throws {
         let context = makeContext()
-        let request = try #require(applyRequest(
+        let request = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://media.example.com/clip.mp4",
@@ -2114,7 +2114,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func hiddenFilteredListSkipsSnapshotReloadWhenRowsRemainVisible() async throws {
         let context = makeContext()
-        let request = try #require(applyRequest(
+        let request = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://media.example.com/clip.mp4",
@@ -2139,7 +2139,7 @@ struct NetworkDetailViewControllerTests {
 
         listViewController.beginAppearanceTransition(false, animated: false)
         listViewController.endAppearanceTransition()
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "1",
             url: request.url,
@@ -2172,7 +2172,7 @@ struct NetworkDetailViewControllerTests {
     @Test
     func hiddenListSuspendsBoundCellRenderingUntilAppearingAgain() async throws {
         let context = makeContext()
-        let request = try #require(applyRequest(
+        let request = try #require(await applyRequest(
             to: context,
             requestID: "1",
             url: "https://media.example.com/clip.mp4",
@@ -2196,7 +2196,7 @@ struct NetworkDetailViewControllerTests {
         listViewController.endAppearanceTransition()
         #expect(cell.hasActiveRequestObservationForTesting == false)
 
-        applyResponseReceived(
+        await applyResponseReceived(
             to: context,
             requestID: "1",
             url: request.url,
@@ -2248,9 +2248,9 @@ struct NetworkDetailViewControllerTests {
         responseHeaders: [String: String] = ["content-type": "text/javascript"],
         responseMimeType: String = "text/javascript",
         finishes: Bool = true
-    ) -> NetworkRequest? {
+    ) async -> NetworkRequest? {
         let requestID = Network.Request.ID(rawRequestID)
-        context.apply(
+        await context.apply(
             .requestWillBeSent(
                 id: requestID,
                 request: Network.Request(
@@ -2265,7 +2265,7 @@ struct NetworkDetailViewControllerTests {
                 timestamp: 1
             )
         )
-        context.apply(
+        await context.apply(
             .responseReceived(
                 id: requestID,
                 response: Network.Response(
@@ -2282,7 +2282,7 @@ struct NetworkDetailViewControllerTests {
             )
         )
         if finishes {
-            context.apply(
+            await context.apply(
                 .loadingFinished(
                     id: requestID,
                     timestamp: 3,
@@ -2300,9 +2300,9 @@ struct NetworkDetailViewControllerTests {
         url: String,
         requestHeaders: [String: String] = [:],
         postData: String? = nil
-    ) -> NetworkRequest? {
+    ) async -> NetworkRequest? {
         let requestID = Network.Request.ID(rawRequestID)
-        context.apply(
+        await context.apply(
             .requestWillBeSent(
                 id: requestID,
                 request: Network.Request(
@@ -2327,9 +2327,9 @@ struct NetworkDetailViewControllerTests {
         responseHeaders: [String: String],
         responseMimeType: String,
         timestamp: Double
-    ) {
+    ) async {
         let requestID = Network.Request.ID(rawRequestID)
-        context.apply(
+        await context.apply(
             .responseReceived(
                 id: requestID,
                 response: Network.Response(
@@ -2352,8 +2352,8 @@ struct NetworkDetailViewControllerTests {
         dataLength: Int,
         encodedDataLength: Int,
         timestamp: Double
-    ) {
-        context.apply(
+    ) async {
+        await context.apply(
             .dataReceived(
                 id: Network.Request.ID(rawRequestID),
                 dataLength: dataLength,
@@ -2367,8 +2367,8 @@ struct NetworkDetailViewControllerTests {
         to context: WebInspectorContext,
         requestID rawRequestID: String,
         timestamp: Double
-    ) {
-        context.apply(
+    ) async {
+        await context.apply(
             .loadingFinished(
                 id: Network.Request.ID(rawRequestID),
                 timestamp: timestamp,

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -14,7 +14,7 @@ struct NetworkPanelModelTests {
 @MainActor
 func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
     let context = makeContext()
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "1",
         url: "https://example.com/index.html",
@@ -22,7 +22,7 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
         mimeType: "text/html",
         timestamp: 1
     )
-    let scriptID = applyRequest(
+    let scriptID = await applyRequest(
         to: context,
         requestID: "2",
         url: "https://cdn.example.com/app.js",
@@ -30,7 +30,7 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
         mimeType: "text/javascript",
         timestamp: 2
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "3",
         url: "https://cdn.example.com/photo.png",
@@ -50,7 +50,7 @@ func displayRequestsApplySearchFilterAndNewestFirstOrder() async throws {
 @MainActor
 func clearAvailabilityUsesUnfilteredRequestsWhenFiltersHideEveryRequest() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -90,7 +90,7 @@ func clearAvailabilityUsesUnfilteredRequestsWhenFiltersHideEveryRequest() async 
 @MainActor
 func selectedRequestUsesUnfilteredContextWhenFiltersHideRequest() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -113,7 +113,7 @@ func selectedRequestUsesUnfilteredContextWhenFiltersHideRequest() async throws {
 @MainActor
 func selectedRequestInvalidatesWhenUnfilteredRequestDisappears() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -165,7 +165,7 @@ func selectedRequestInvalidatesWhenUnfilteredRequestDisappears() async throws {
 @MainActor
 func requestDisplayUsesReadableURLDisplayName(url: String, expectedDisplayName: String) async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: url,
@@ -182,7 +182,7 @@ func requestDisplayUsesReadableURLDisplayName(url: String, expectedDisplayName: 
 @MainActor
 func requestDisplayUsesEncodingFallbackForURLDerivedLabelsAndFilters() async throws {
     let context = makeContext()
-    let spacedURLRequestID = applyRequest(
+    let spacedURLRequestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/photo 1.png",
@@ -190,7 +190,7 @@ func requestDisplayUsesEncodingFallbackForURLDerivedLabelsAndFilters() async thr
         mimeType: nil,
         timestamp: 1
     )
-    let invalidEscapeRequestID = applyRequest(
+    let invalidEscapeRequestID = await applyRequest(
         to: context,
         requestID: "2",
         url: "https://cdn.example.com/photo%ZZ.png",
@@ -215,7 +215,7 @@ func requestDisplayUsesEncodingFallbackForURLDerivedLabelsAndFilters() async thr
 @MainActor
 func mediaFilterIncludesPreviewableMediaResponses() async throws {
     let context = makeContext()
-    let imageID = applyRequest(
+    let imageID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/photo.png",
@@ -223,7 +223,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "image/png",
         timestamp: 1
     )
-    let movieID = applyRequest(
+    let movieID = await applyRequest(
         to: context,
         requestID: "2",
         url: "https://cdn.example.com/movie.mp4",
@@ -231,7 +231,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "video/mp4",
         timestamp: 2
     )
-    let avifResponseID = applyRequest(
+    let avifResponseID = await applyRequest(
         to: context,
         requestID: "3",
         url: "https://api.example.com/avatar",
@@ -239,7 +239,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "image/avif",
         timestamp: 3
     )
-    let avifURLID = applyRequest(
+    let avifURLID = await applyRequest(
         to: context,
         requestID: "4",
         url: "https://api.example.com/avatar.avif",
@@ -247,7 +247,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 4
     )
-    let hlsID = applyRequest(
+    let hlsID = await applyRequest(
         to: context,
         requestID: "5",
         url: "https://media.example.com/live/master.m3u8",
@@ -255,7 +255,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/vnd.apple.mpegurl",
         timestamp: 5
     )
-    let mp4URLID = applyRequest(
+    let mp4URLID = await applyRequest(
         to: context,
         requestID: "6",
         url: "https://media.example.com/clip.mp4",
@@ -263,7 +263,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 6
     )
-    let mp3URLID = applyRequest(
+    let mp3URLID = await applyRequest(
         to: context,
         requestID: "7",
         url: "https://media.example.com/song.mp3",
@@ -271,7 +271,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 7
     )
-    let apngResponseID = applyRequest(
+    let apngResponseID = await applyRequest(
         to: context,
         requestID: "8",
         url: "https://cdn.example.com/animated.apng",
@@ -279,7 +279,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "image/apng",
         timestamp: 8
     )
-    let svgID = applyRequest(
+    let svgID = await applyRequest(
         to: context,
         requestID: "9",
         url: "https://cdn.example.com/icon.svg",
@@ -287,7 +287,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "image/svg+xml",
         timestamp: 9
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "10",
         url: "https://cdn.example.com/font.woff2",
@@ -295,7 +295,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "font/woff2",
         timestamp: 10
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "11",
         url: "https://api.example.com/data.json",
@@ -303,7 +303,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/json",
         timestamp: 11
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "12",
         url: "https://cdn.example.com/app.js",
@@ -311,7 +311,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "text/javascript",
         timestamp: 12
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "13",
         url: "https://cdn.example.com/player.mp4",
@@ -319,7 +319,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "text/javascript",
         timestamp: 13
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "14",
         url: "https://cdn.example.com/theme.png",
@@ -327,7 +327,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "text/css",
         timestamp: 14
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "15",
         url: "https://api.example.com/download",
@@ -335,7 +335,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 15
     )
-    let apngURLID = applyRequest(
+    let apngURLID = await applyRequest(
         to: context,
         requestID: "16",
         url: "https://cdn.example.com/animated.apng",
@@ -343,7 +343,7 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 16
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "17",
         url: "https://cdn.example.com/player.mp4",
@@ -351,14 +351,14 @@ func mediaFilterIncludesPreviewableMediaResponses() async throws {
         mimeType: "application/octet-stream",
         timestamp: 17
     )
-    applyPendingRequest(
+    await applyPendingRequest(
         to: context,
         requestID: "18",
         url: "https://api.example.com/pending-avatar.png",
         resourceType: .xhr,
         timestamp: 18
     )
-    let headerMediaID = applyRequest(
+    let headerMediaID = await applyRequest(
         to: context,
         requestID: "19",
         url: "https://api.example.com/thumbnail",
@@ -444,7 +444,7 @@ func mediaPreviewSupportClassifiesHLSPlaylists() {
 @MainActor
 func displayResourceFilterUpdatesWhenResponseMIMEBecomesPreviewable() async throws {
     let context = makeContext()
-    let requestID = applyPendingRequest(
+    let requestID = await applyPendingRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/avatar",
@@ -456,7 +456,7 @@ func displayResourceFilterUpdatesWhenResponseMIMEBecomesPreviewable() async thro
 
     #expect(model.displayRequestIDs.isEmpty)
 
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/avatar",
@@ -475,7 +475,7 @@ func displayResourceFilterUpdatesWhenResponseMIMEBecomesPreviewable() async thro
 @MainActor
 func requestStatusSeverityUpdatesWhenResponseChanges() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/data.json",
@@ -489,7 +489,7 @@ func requestStatusSeverityUpdatesWhenResponseChanges() async throws {
 
     #expect(request.statusSeverity == .error)
 
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/data.json",
@@ -506,7 +506,7 @@ func requestStatusSeverityUpdatesWhenResponseChanges() async throws {
 @MainActor
 func displaySearchFieldsUpdateWhenRequestChanges() async throws {
     let context = makeContext()
-    let requestID = applyPendingRequest(
+    let requestID = await applyPendingRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/old",
@@ -519,7 +519,7 @@ func displaySearchFieldsUpdateWhenRequestChanges() async throws {
     model.setSearchText("new-endpoint")
     #expect(model.displayRequestIDs.isEmpty)
 
-    applyRedirectRequest(
+    await applyRedirectRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/new-endpoint",
@@ -535,7 +535,7 @@ func displaySearchFieldsUpdateWhenRequestChanges() async throws {
     model.setSearchText("json")
     #expect(model.displayRequestIDs.isEmpty)
 
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/new-endpoint",
@@ -554,14 +554,14 @@ func displaySearchFieldsUpdateWhenRequestChanges() async throws {
 @MainActor
 func requestFileTypeAndSearchUpdateWhenRawMIMETypeAppears() async throws {
     let context = makeContext()
-    let requestID = applyPendingRequest(
+    let requestID = await applyPendingRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/resource",
         resourceType: .xhr,
         timestamp: 1
     )
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/resource",
@@ -577,7 +577,7 @@ func requestFileTypeAndSearchUpdateWhenRawMIMETypeAppears() async throws {
     model.setSearchText("json")
     #expect(model.displayRequestIDs.isEmpty)
 
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/resource",
@@ -594,7 +594,7 @@ func requestFileTypeAndSearchUpdateWhenRawMIMETypeAppears() async throws {
 @MainActor
 func displayRequestsIgnoreContentOnlyUpdatesDuringActiveFiltering() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://media.example.com/clip.mp4",
@@ -608,8 +608,8 @@ func displayRequestsIgnoreContentOnlyUpdatesDuringActiveFiltering() async throws
 
     #expect(model.displayRequestIDs == [requestID])
 
-    applyDataReceived(to: context, requestID: "1", dataLength: 1024, encodedDataLength: 512, timestamp: 2)
-    applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
+    await applyDataReceived(to: context, requestID: "1", dataLength: 1024, encodedDataLength: 512, timestamp: 2)
+    await applyLoadingFinished(to: context, requestID: "1", timestamp: 3)
 
     #expect(model.displayRequestIDs == [requestID])
 }
@@ -618,7 +618,7 @@ func displayRequestsIgnoreContentOnlyUpdatesDuringActiveFiltering() async throws
 @MainActor
 func displayRequestsUpdateWhenCriteriaChanges() async throws {
     let context = makeContext()
-    let scriptID = applyRequest(
+    let scriptID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -626,7 +626,7 @@ func displayRequestsUpdateWhenCriteriaChanges() async throws {
         mimeType: "text/javascript",
         timestamp: 1
     )
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "2",
         url: "https://cdn.example.com/photo.png",
@@ -647,7 +647,7 @@ func displayRequestsUpdateWhenCriteriaChanges() async throws {
 @MainActor
 func displayRequestsClearAfterReset() async throws {
     let context = makeContext()
-    applyRequest(
+    await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -669,7 +669,7 @@ func displayRequestsClearAfterReset() async throws {
 @MainActor
 func displayRequestsUpdateWhenResourceCategoryChanges() async throws {
     let context = makeContext()
-    let jsonID = applyRequest(
+    let jsonID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/data.json",
@@ -677,7 +677,7 @@ func displayRequestsUpdateWhenResourceCategoryChanges() async throws {
         mimeType: "application/json",
         timestamp: 1
     )
-    let mediaID = applyRequest(
+    let mediaID = await applyRequest(
         to: context,
         requestID: "2",
         url: "https://media.example.com/clip.mp4",
@@ -690,10 +690,10 @@ func displayRequestsUpdateWhenResourceCategoryChanges() async throws {
 
     #expect(model.displayRequestIDs == [mediaID])
 
-    applyDataReceived(to: context, requestID: "1", dataLength: 1024, encodedDataLength: 512, timestamp: 3)
+    await applyDataReceived(to: context, requestID: "1", dataLength: 1024, encodedDataLength: 512, timestamp: 3)
     #expect(model.displayRequestIDs == [mediaID])
 
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: "1",
         url: "https://api.example.com/data.mp4",
@@ -708,7 +708,7 @@ func displayRequestsUpdateWhenResourceCategoryChanges() async throws {
 @MainActor
 func displayRequestIDsUseDataKitClassificationForMediaFiltering() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://media.example.com/clip.mp4",
@@ -733,7 +733,7 @@ func displayRequestIDsUseDataKitClassificationForMediaFiltering() async throws {
 @MainActor
 func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://cdn.example.com/app.js",
@@ -759,7 +759,7 @@ func clearRequestsClearsSelectionButPreservesDisplayCriteria() async throws {
 @MainActor
 func responseBodyFetchMovesUnavailablePreviewContextToFailedPhase() async throws {
     let context = makeContext()
-    let requestID = applyRequest(
+    let requestID = await applyRequest(
         to: context,
         requestID: "1",
         url: "https://api.example.com/data.json",
@@ -800,8 +800,8 @@ private func applyRequest(
     status: Int = 200,
     statusText: String = "OK",
     timestamp: Double
-) -> NetworkRequest.ID {
-    let requestID = applyPendingRequest(
+) async -> NetworkRequest.ID {
+    let requestID = await applyPendingRequest(
         to: context,
         requestID: rawRequestID,
         url: url,
@@ -809,7 +809,7 @@ private func applyRequest(
         resourceType: resourceType,
         timestamp: timestamp
     )
-    applyResponseReceived(
+    await applyResponseReceived(
         to: context,
         requestID: rawRequestID,
         url: url,
@@ -820,7 +820,7 @@ private func applyRequest(
         statusText: statusText,
         timestamp: timestamp + 0.1
     )
-    applyLoadingFinished(to: context, requestID: rawRequestID, timestamp: timestamp + 0.2)
+    await applyLoadingFinished(to: context, requestID: rawRequestID, timestamp: timestamp + 0.2)
     return requestID
 }
 
@@ -833,9 +833,9 @@ private func applyPendingRequest(
     method: String = "GET",
     resourceType: Network.ResourceType,
     timestamp: Double
-) -> NetworkRequest.ID {
+) async -> NetworkRequest.ID {
     let requestID = Network.Request.ID(rawRequestID)
-    context.apply(
+    await context.apply(
         .requestWillBeSent(
             id: requestID,
             request: Network.Request(id: requestID, url: url, method: method),
@@ -856,9 +856,9 @@ private func applyRedirectRequest(
     resourceType: Network.ResourceType,
     redirectURL: String,
     timestamp: Double
-) {
+) async {
     let requestID = Network.Request.ID(rawRequestID)
-    context.apply(
+    await context.apply(
         .requestWillBeSent(
             id: requestID,
             request: Network.Request(id: requestID, url: url, method: method),
@@ -880,9 +880,9 @@ private func applyResponseReceived(
     status: Int = 200,
     statusText: String = "OK",
     timestamp: Double
-) {
+) async {
     let requestID = Network.Request.ID(rawRequestID)
-    context.apply(
+    await context.apply(
         .responseReceived(
             id: requestID,
             response: Network.Response(
@@ -906,8 +906,8 @@ private func applyDataReceived(
     dataLength: Int,
     encodedDataLength: Int,
     timestamp: Double
-) {
-    context.apply(
+) async {
+    await context.apply(
         .dataReceived(
             id: Network.Request.ID(rawRequestID),
             dataLength: dataLength,
@@ -922,8 +922,8 @@ private func applyLoadingFinished(
     to context: WebInspectorContext,
     requestID rawRequestID: String,
     timestamp: Double
-) {
-    context.apply(
+) async {
+    await context.apply(
         .loadingFinished(
             id: Network.Request.ID(rawRequestID),
             timestamp: timestamp,

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -902,7 +902,7 @@ struct ParentContainerTests {
     func networkPanelModelSelectionIsSharedAcrossParentHosts() async throws {
         let context = makeContext()
         let session = WebInspectorSession(context: context)
-        let requestID = applyRequest(
+        let requestID = await applyRequest(
             to: context,
             requestID: "1",
             url: "https://example.com/app.js"
@@ -988,9 +988,9 @@ struct ParentContainerTests {
         to context: WebInspectorContext,
         requestID rawRequestID: String,
         url: String
-    ) -> WebInspectorDataKit.NetworkRequest.ID {
+    ) async -> WebInspectorDataKit.NetworkRequest.ID {
         let requestID = WebInspectorProxyKit.Network.Request.ID(rawRequestID)
-        context.apply(
+        await context.apply(
             .requestWillBeSent(
                 id: requestID,
                 request: WebInspectorProxyKit.Network.Request(
@@ -1003,7 +1003,7 @@ struct ParentContainerTests {
                 timestamp: 1
             )
         )
-        context.apply(
+        await context.apply(
             .responseReceived(
                 id: requestID,
                 response: WebInspectorProxyKit.Network.Response(
@@ -1017,7 +1017,7 @@ struct ParentContainerTests {
                 timestamp: 2
             )
         )
-        context.apply(
+        await context.apply(
             .loadingFinished(
                 id: requestID,
                 timestamp: 3,


### PR DESCRIPTION
## Purpose
Move Network query, sort, diff, and transaction generation off the main actor while keeping `WebInspectorContext` as the owner of observable `NetworkRequest` identity and models.

## Changes
- Add a package-internal `NetworkRequestIndex` actor that stores Sendable network records and builds result snapshots/deltas off-main.
- Route Network event application through async model mutation, actor diffing, and main-actor delta application.
- Add a Network-specific fetched-results delta path that avoids the generic full-snapshot diff for hot updates.
- Align Network fetched-results transactions with topology semantics: content-only updates do not emit transactions, predicate enter/leave emits insert/delete, and index-shift moves are suppressed.
- Replace `NetworkPanelModel.clearableRequests` with O(1) package-only collection state.
- Cache searchable/resource classification fields in Network records.

## Testing
- `git diff --check`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`