### PR TITLE
Fix native inspector resolution on older iOS

### DIFF
--- a/Docs/WebKitVersionMapping.md
+++ b/Docs/WebKitVersionMapping.md
@@ -1,0 +1,84 @@
+# WebKit Version Mapping Notes
+
+Last checked: 2026-07-08.
+
+This note records how iOS WebKit framework versions map back to public WebKit
+source refs.
+
+## Local Reference Checkouts
+
+The `reference/` directory is intentionally ignored by Git. It contains
+shared/sparse clones so the WebKit object store is not duplicated:
+
+| Path | Ref | Purpose |
+| --- | --- | --- |
+| `reference/WebKit-iOS18.5-7621.2.5.10.10` | `WebKit-7621.2.5.10.10` / `4bdf67c5c75` | Known iOS 18.5-era public source drop. |
+| `reference/WebKit-iOS26.5-7624.2.5.10-branch` | `safari-7624.2.5.10-branch` / `eafd2a9b9776` | Public source branch with `Version.xcconfig` matching WebKit source version `624.2.5.10.4`. |
+| `reference/WebKit-main` | `main` / `9d2c43b4dc9d` | Current upstream reference. |
+
+The sparse checkout includes:
+
+- `Configurations/Version.xcconfig`
+- `Source/WebKit/UIProcess/Inspector/**`
+- `Source/WebKit/UIProcess/WebPageProxy.*`
+- `Source/WebKit/UIProcess/API/Cocoa/WKWebView*`
+- `Source/JavaScriptCore/inspector/InspectorAgentRegistry.*`
+- `Source/JavaScriptCore/inspector/InspectorAgentBase.*`
+- `Source/JavaScriptCore/inspector/InspectorFrontendRouter.*`
+- `Source/JavaScriptCore/inspector/InspectorBackendDispatcher.*`
+- `Source/WTF/wtf/Vector.h`
+- `Source/WTF/wtf/WeakRef.h`
+
+## Mapping Rule
+
+Do not compare the iOS runtime `CFBundleVersion` to WebKit public source refs as
+an exact string. WebKit defines the platform prefix in
+`Configurations/Version.xcconfig`.
+
+For iPhone SDK builds:
+
+```xcconfig
+SYSTEM_VERSION_PREFIX[sdk=iphone*] = 8
+BUNDLE_VERSION_Production = $(SYSTEM_VERSION_PREFIX)$(FULL_VERSION)
+SHORT_VERSION_STRING_Production = $(SYSTEM_VERSION_PREFIX)$(MAJOR_VERSION)
+```
+
+That means an iOS WebKit framework version like `8624.2.5.10.4` maps to WebKit
+source version `624.2.5.10.4`. Public WebKit refs use the `WebKit-7...` naming
+family, so the practical public-ref search key is usually `WebKit-7624.2.5.10.4`
+or a matching `safari-7624.2.5.10*` branch.
+
+The leading digit is therefore meaningful:
+
+| Runtime framework version | Strip iOS prefix | Public WebKit search key |
+| --- | --- | --- |
+| `8621.3.11.10.3` | `621.3.11.10.3` | `WebKit-7621.3.11.10.3` / `safari-7621.3.11.10*` |
+| `8624.2.5.10.4` | `624.2.5.10.4` | `WebKit-7624.2.5.10.4` / `safari-7624.2.5.10*` |
+| `8625.1.22.10.2` | `625.1.22.10.2` | `WebKit-7625.1.22.10.2` / `safari-7625.1.22*` |
+
+## Checked Runtimes
+
+| Simulator runtime | WebKit `CFBundleVersion` | `CFBundleShortVersionString` | Public source status |
+| --- | --- | --- | --- |
+| iOS 18.6 `22G86` | `8621.3.11.10.3` | `8621` | Exact public tag/branch was not found by `git ls-remote`. |
+| iOS 26.5 `23F77` | `8624.2.5.10.4` | `8624` | Exact tag was not found; `safari-7624.2.5.10-branch` exists and matches `Version.xcconfig`. |
+| iOS 27.0 `24A5380g` | `8625.1.22.10.2` | `8625` | Exact public tag/branch was not found by `git ls-remote`. |
+
+## Commands
+
+Read the WebKit version from a simulator runtime:
+
+```sh
+/usr/libexec/PlistBuddy \
+  -c 'Print :CFBundleVersion' \
+  -c 'Print :CFBundleShortVersionString' \
+  -c 'Print :DTPlatformVersion' \
+  "$SIMULATOR_ROOT/System/Library/Frameworks/WebKit.framework/Info.plist"
+```
+
+Search public WebKit refs:
+
+```sh
+git ls-remote --heads https://github.com/WebKit/WebKit.git 'refs/heads/safari-7624.2.5.10*'
+git ls-remote --tags https://github.com/WebKit/WebKit.git 'refs/tags/WebKit-7624.2.5.10*'
+```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ For implementation work, [`ArchitectureOverview.md`](Docs/ArchitectureOverview.m
 is the top-level map for module boundaries, runtime ownership, and WebKit
 communication flow. The current SDK split is:
 
+Runtime WebKit version mapping notes live in
+[`WebKitVersionMapping.md`](Docs/WebKitVersionMapping.md).
+
 - `WebInspectorProxyKit` for custom UIs that want typed domain commands and
   events directly over an inspected `WKWebView`.
 - `WebInspectorDataKit` for custom UIs that want observable DOM, Network,

--- a/Sources/WebInspectorNativeBridge/WebInspectorNativeBridge.mm
+++ b/Sources/WebInspectorNativeBridge/WebInspectorNativeBridge.mm
@@ -25,6 +25,9 @@ static constexpr ptrdiff_t invalidControllerOffset = -1;
 static constexpr ptrdiff_t webPageInspectorControllerOffset = 0x4C0;
 static constexpr size_t frontendRouterStorageIndex = 0;
 static constexpr size_t backendDispatcherStorageIndex = 1;
+static constexpr size_t agentRegistryStorageIndex = 2;
+static constexpr uint32_t maximumExpectedInspectorAgentCount = 64;
+static constexpr size_t backendDispatcherFrontendRouterScanBytes = 0x100;
 static constexpr ptrdiff_t preferredControllerSearchRadius = 0x100;
 static constexpr size_t fallbackControllerScanBytes = 0x1000;
 static std::atomic<ptrdiff_t> cachedControllerOffset { invalidControllerOffset };
@@ -160,6 +163,29 @@ static BOOL safeReadWord(const void *address, uintptr_t *valueOut)
     return YES;
 }
 
+static BOOL safeReadUInt32(const void *address, uint32_t *valueOut)
+{
+    if (!address || !valueOut)
+        return NO;
+
+    uint32_t rawValue = 0;
+    vm_size_t bytesRead = 0;
+    kern_return_t result = vm_read_overwrite(
+        mach_task_self(),
+        reinterpret_cast<vm_address_t>(address),
+        sizeof(rawValue),
+        reinterpret_cast<vm_address_t>(&rawValue),
+        &bytesRead
+    );
+    if (result != KERN_SUCCESS || bytesRead != sizeof(rawValue)) {
+        *valueOut = 0;
+        return NO;
+    }
+
+    *valueOut = rawValue;
+    return YES;
+}
+
 struct ControllerResolutionStats {
     size_t attemptedOffsetCount { 0 };
     size_t validCandidateCount { 0 };
@@ -256,6 +282,52 @@ static BOOL backendDispatcherPointer(void *controller, void **backendDispatcherO
     return safeReadPointer(slot, backendDispatcherOut) && *backendDispatcherOut;
 }
 
+static BOOL controllerHasValidAgentRegistry(void *controller)
+{
+    if (!controller)
+        return NO;
+
+    auto *agentRegistry = reinterpret_cast<uint8_t *>(controller) + (agentRegistryStorageIndex * sizeof(void *));
+
+    void *agentsBuffer = nullptr;
+    if (!safeReadPointer(agentRegistry, &agentsBuffer) || !agentsBuffer || !pointerIsWritableMapped(agentsBuffer))
+        return NO;
+
+    uint32_t agentCapacity = 0;
+    if (!safeReadUInt32(agentRegistry + sizeof(void *), &agentCapacity))
+        return NO;
+
+    uint32_t agentCount = 0;
+    if (!safeReadUInt32(agentRegistry + sizeof(void *) + sizeof(uint32_t), &agentCount))
+        return NO;
+
+    if (!agentCount || agentCapacity < agentCount || agentCapacity > maximumExpectedInspectorAgentCount)
+        return NO;
+
+    void *firstAgent = nullptr;
+    if (!safeReadPointer(agentsBuffer, &firstAgent) || !firstAgent || !pointerIsWritableMapped(firstAgent))
+        return NO;
+
+    return YES;
+}
+
+static BOOL backendDispatcherReferencesFrontendRouter(void *backendDispatcher, void *frontendRouter)
+{
+    if (!backendDispatcher || !frontendRouter)
+        return NO;
+
+    auto *storage = reinterpret_cast<uint8_t *>(backendDispatcher);
+    for (size_t offset = 0; offset + sizeof(void *) <= backendDispatcherFrontendRouterScanBytes; offset += sizeof(void *)) {
+        void *candidate = nullptr;
+        if (!safeReadPointer(storage + offset, &candidate))
+            continue;
+        if (candidate == frontendRouter)
+            return YES;
+    }
+
+    return NO;
+}
+
 static BOOL controllerCandidateAtOffset(void *pageProxy, ptrdiff_t offset, void **controllerOut, void **backendDispatcherOut)
 {
     if (!pageProxy)
@@ -274,6 +346,12 @@ static BOOL controllerCandidateAtOffset(void *pageProxy, ptrdiff_t offset, void 
 
     void *backendDispatcher = nullptr;
     if (!backendDispatcherPointer(controller, &backendDispatcher) || !backendDispatcher || !pointerIsWritableMapped(backendDispatcher))
+        return NO;
+
+    if (!backendDispatcherReferencesFrontendRouter(backendDispatcher, frontendRouter))
+        return NO;
+
+    if (!controllerHasValidAgentRegistry(controller))
         return NO;
 
     if (controllerOut)
@@ -443,7 +521,9 @@ static BOOL installSyntheticControllerAtOffset(
     void *pageBuffer,
     size_t pageByteCount,
     NSInteger offset,
-    std::vector<void *>& allocations
+    std::vector<void *>& allocations,
+    bool hasValidAgentRegistry,
+    bool backendReferencesFrontendRouter
 )
 {
     if (!pageBuffer || offset < 0)
@@ -455,17 +535,33 @@ static BOOL installSyntheticControllerAtOffset(
 
     void *controller = allocateZeroedBlock(sizeof(uintptr_t) * 5, allocations);
     void *frontendRouter = allocateZeroedBlock(sizeof(uint64_t), allocations);
-    void *backendDispatcher = allocateZeroedBlock(sizeof(uint64_t), allocations);
-    void *agentsBuffer = allocateZeroedBlock(sizeof(uint64_t), allocations);
-    if (!controller || !frontendRouter || !backendDispatcher || !agentsBuffer)
+    void *backendDispatcher = allocateZeroedBlock(backendDispatcherFrontendRouterScanBytes, allocations);
+    if (!controller || !frontendRouter || !backendDispatcher)
         return NO;
 
     auto *controllerWords = reinterpret_cast<uintptr_t *>(controller);
     controllerWords[0] = reinterpret_cast<uintptr_t>(frontendRouter);
     controllerWords[1] = reinterpret_cast<uintptr_t>(backendDispatcher);
-    controllerWords[2] = reinterpret_cast<uintptr_t>(agentsBuffer);
-    controllerWords[3] = 1;
-    controllerWords[4] = 1;
+
+    if (backendReferencesFrontendRouter) {
+        auto *backendDispatcherWords = reinterpret_cast<uintptr_t *>(backendDispatcher);
+        backendDispatcherWords[2] = reinterpret_cast<uintptr_t>(frontendRouter);
+    }
+
+    if (hasValidAgentRegistry) {
+        void *firstAgent = allocateZeroedBlock(sizeof(uint64_t), allocations);
+        void *agentsBuffer = allocateZeroedBlock(sizeof(uintptr_t), allocations);
+        if (!firstAgent || !agentsBuffer)
+            return NO;
+
+        auto *agentPointers = reinterpret_cast<uintptr_t *>(agentsBuffer);
+        agentPointers[0] = reinterpret_cast<uintptr_t>(firstAgent);
+        controllerWords[2] = reinterpret_cast<uintptr_t>(agentsBuffer);
+
+        auto *agentVectorMetadata = reinterpret_cast<uint32_t *>(controllerWords + 3);
+        agentVectorMetadata[0] = 1;
+        agentVectorMetadata[1] = 1;
+    }
 
     auto *slot = reinterpret_cast<void **>(reinterpret_cast<uint8_t *>(pageBuffer) + normalizedOffset);
     *slot = controller;
@@ -850,8 +946,54 @@ WebInspectorNativeControllerDiscoveryTestResult WebInspectorNativeRunControllerD
         };
     }
 
-    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, primaryControllerOffset, allocations);
-    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, secondaryControllerOffset, allocations);
+    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, primaryControllerOffset, allocations, true, true);
+    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, secondaryControllerOffset, allocations, true, true);
+
+    auto resolution = WebInspectorNativeBridgePrivate::resolveControllerInPageProxy(
+        pageBuffer,
+        scanByteCount,
+        pageAllocationSize == 0,
+        cachedOffset >= 0 ? cachedOffset : WebInspectorNativeBridgePrivate::invalidControllerOffset
+    );
+
+    WebInspectorNativeBridgePrivate::freeAllocatedBlocks(allocations);
+
+    return {
+        .found = resolution.stats.resolvedOffset != WebInspectorNativeBridgePrivate::invalidControllerOffset,
+        .usedFallbackRange = resolution.stats.usedFallbackRange,
+        .resolvedOffset = resolution.stats.resolvedOffset,
+        .attemptedOffsetCount = resolution.stats.attemptedOffsetCount,
+        .validCandidateCount = resolution.stats.validCandidateCount,
+        .scannedByteCount = resolution.stats.scannedByteCount,
+    };
+}
+
+WebInspectorNativeControllerDiscoveryTestResult WebInspectorNativeRunControllerDiscoveryScenarioWithInvalidCandidatesForTesting(
+    NSUInteger pageAllocationSize,
+    NSInteger cachedOffset,
+    NSInteger primaryControllerOffset,
+    NSInteger invalidControllerOffset,
+    NSInteger secondaryInvalidControllerOffset
+)
+{
+    size_t scanByteCount = pageAllocationSize ? pageAllocationSize : WebInspectorNativeBridgePrivate::fallbackControllerScanBytes;
+    std::vector<void *> allocations;
+
+    void *pageBuffer = WebInspectorNativeBridgePrivate::allocateZeroedBlock(scanByteCount, allocations);
+    if (!pageBuffer) {
+        return {
+            .found = NO,
+            .usedFallbackRange = NO,
+            .resolvedOffset = WebInspectorNativeBridgePrivate::invalidControllerOffset,
+            .attemptedOffsetCount = 0,
+            .validCandidateCount = 0,
+            .scannedByteCount = 0,
+        };
+    }
+
+    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, primaryControllerOffset, allocations, true, true);
+    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, invalidControllerOffset, allocations, true, false);
+    WebInspectorNativeBridgePrivate::installSyntheticControllerAtOffset(pageBuffer, scanByteCount, secondaryInvalidControllerOffset, allocations, false, true);
 
     auto resolution = WebInspectorNativeBridgePrivate::resolveControllerInPageProxy(
         pageBuffer,
@@ -946,6 +1088,29 @@ WebInspectorNativeControllerDiscoveryTestResult WebInspectorNativeRunControllerD
     (void)cachedOffset;
     (void)primaryControllerOffset;
     (void)secondaryControllerOffset;
+    return {
+        .found = NO,
+        .usedFallbackRange = NO,
+        .resolvedOffset = -1,
+        .attemptedOffsetCount = 0,
+        .validCandidateCount = 0,
+        .scannedByteCount = 0,
+    };
+}
+
+WebInspectorNativeControllerDiscoveryTestResult WebInspectorNativeRunControllerDiscoveryScenarioWithInvalidCandidatesForTesting(
+    NSUInteger pageAllocationSize,
+    NSInteger cachedOffset,
+    NSInteger primaryControllerOffset,
+    NSInteger invalidControllerOffset,
+    NSInteger secondaryInvalidControllerOffset
+)
+{
+    (void)pageAllocationSize;
+    (void)cachedOffset;
+    (void)primaryControllerOffset;
+    (void)invalidControllerOffset;
+    (void)secondaryInvalidControllerOffset;
     return {
         .found = NO,
         .usedFallbackRange = NO,

--- a/Sources/WebInspectorNativeBridge/include/WebInspectorNativeBridge.h
+++ b/Sources/WebInspectorNativeBridge/include/WebInspectorNativeBridge.h
@@ -54,4 +54,12 @@ FOUNDATION_EXPORT WebInspectorNativeControllerDiscoveryTestResult WebInspectorNa
     NSInteger secondaryControllerOffset
 );
 
+FOUNDATION_EXPORT WebInspectorNativeControllerDiscoveryTestResult WebInspectorNativeRunControllerDiscoveryScenarioWithInvalidCandidatesForTesting(
+    NSUInteger pageAllocationSize,
+    NSInteger cachedOffset,
+    NSInteger primaryControllerOffset,
+    NSInteger invalidControllerOffset,
+    NSInteger secondaryInvalidControllerOffset
+);
+
 NS_ASSUME_NONNULL_END

--- a/Sources/WebInspectorNativeSymbols/NativeInspectorLoadedImageLookup.swift
+++ b/Sources/WebInspectorNativeSymbols/NativeInspectorLoadedImageLookup.swift
@@ -133,7 +133,10 @@ extension NativeInspectorSymbolResolverCore {
         text: SegmentCommand64,
         bucket: inout NativeInspectorResolvedSymbolBucket
     ) {
-        guard offset >= 0 else {
+        guard loadedImageSymbolOffsetIsUsable(offset, textVirtualMemorySize: UInt64(text.virtualMemorySize)) else {
+            if offset > 0, bucket.outsideTextAddress == nil {
+                bucket.outsideTextAddress = imageBaseAddress + UInt64(offset)
+            }
             return
         }
 
@@ -146,6 +149,16 @@ extension NativeInspectorSymbolResolverCore {
             return
         }
         bucket.insertCandidate(address)
+    }
+
+    static func loadedImageSymbolOffsetIsUsable(
+        _ offset: Int,
+        textVirtualMemorySize: UInt64
+    ) -> Bool {
+        guard offset > 0 else {
+            return false
+        }
+        return UInt64(offset) < textVirtualMemorySize
     }
 
     static func resolvedAddress(

--- a/Tests/WebInspectorNativeBridgeTests/WebInspectorNativeBridgeTests.swift
+++ b/Tests/WebInspectorNativeBridgeTests/WebInspectorNativeBridgeTests.swift
@@ -51,6 +51,36 @@ struct WebInspectorNativeBridgeTests {
     }
 
     @Test
+    func invalidControllerShapeCandidatesDoNotBlockResolution() {
+        let result = WebInspectorNativeRunControllerDiscoveryScenarioWithInvalidCandidatesForTesting(
+            0x1000,
+            -1,
+            0x540,
+            0x580,
+            0x5A0
+        )
+
+        #expect(result.found.boolValue)
+        #expect(result.resolvedOffset == 0x540)
+        #expect(result.validCandidateCount == 1)
+    }
+
+    @Test
+    func invalidCachedOffsetFallsBackToValidController() {
+        let result = WebInspectorNativeRunControllerDiscoveryScenarioWithInvalidCandidatesForTesting(
+            0x1000,
+            0x580,
+            0x540,
+            0x580,
+            -1
+        )
+
+        #expect(result.found.boolValue)
+        #expect(result.resolvedOffset == 0x540)
+        #expect(result.validCandidateCount == 1)
+    }
+
+    @Test
     func zeroAllocationSizeUsesFallbackRange() {
         let result = WebInspectorNativeRunControllerDiscoveryScenarioForTesting(
             0,

--- a/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
+++ b/Tests/WebInspectorNativeSymbolsTests/NativeInspectorSymbolResolverTests.swift
@@ -113,6 +113,14 @@ struct NativeInspectorSymbolResolverTests {
     }
 
     @Test
+    func loadedImageSymbolOffsetRejectsMachHeaderAddress() {
+        #expect(!NativeInspectorSymbolResolverCore.loadedImageSymbolOffsetIsUsable(-1, textVirtualMemorySize: 0x1000))
+        #expect(!NativeInspectorSymbolResolverCore.loadedImageSymbolOffsetIsUsable(0, textVirtualMemorySize: 0x1000))
+        #expect(NativeInspectorSymbolResolverCore.loadedImageSymbolOffsetIsUsable(8, textVirtualMemorySize: 0x1000))
+        #expect(!NativeInspectorSymbolResolverCore.loadedImageSymbolOffsetIsUsable(0x1000, textVirtualMemorySize: 0x1000))
+    }
+
+    @Test
     func cStringSwiftMangledNameDetectionRejectsShortNames() {
         for symbolName in ["", "_", "_$", "$"] {
             let isLikelySwiftMangled = unsafe symbolName.withCString { symbolNameC in


### PR DESCRIPTION
## Purpose
Fix native WebInspector attachment on older iOS runtimes where controller discovery can accept invalid candidates and symbol resolution can target the Mach-O header instead of the real backend dispatcher implementation.

## Changes
- Harden native controller discovery by validating the FrontendRouter/BackendDispatcher relationship and AgentRegistry vector shape.
- Reject loaded-image symbol offsets that resolve to the Mach-O header so dispatch resolves to a usable implementation address.
- Add focused bridge and symbol resolver tests.
- Document iOS WebKit framework version mapping and local WebKit reference checkouts.

## Testing
- Codex review against `main`: no findings.
- `git diff --check`
- `WebInspectorKit` simulator tests: 494 passed, 0 failed, 2 skipped.
- Manually verified Monocly inspector display on iOS 26.5 and iOS 18.6 simulators.