### PR TITLE
Stabilize network text preview tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             test_scheme: WebInspectorNativeTests
             simulator_device: iPhone 17 Pro
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             test_scheme: WebInspectorNativeTests
             simulator_device: iPhone 17 Pro
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}

--- a/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
+++ b/Sources/WebInspectorUI/Containers/WebInspectorSession.swift
@@ -59,14 +59,47 @@ public final class WebInspectorSession {
     }
 
     public func attach(to webView: WKWebView) async throws {
-        try await attach(to: webView) { webView in
-            try await WebInspectorContainer(attachingTo: webView)
-        }
+        try await attach(
+            makeContainer: {
+                try await WebInspectorContainer(attachingTo: webView)
+            },
+            makePageUserInterfaceStyleObserver: { [makePageUserInterfaceStyleObserver] apply in
+                makePageUserInterfaceStyleObserver(webView, apply)
+            }
+        )
     }
 
     package func attach(
         to webView: WKWebView,
         makeContainer: @MainActor (WKWebView) async throws -> WebInspectorContainer
+    ) async throws {
+        try await attach(
+            makeContainer: {
+                try await makeContainer(webView)
+            },
+            makePageUserInterfaceStyleObserver: { [makePageUserInterfaceStyleObserver] apply in
+                makePageUserInterfaceStyleObserver(webView, apply)
+            }
+        )
+    }
+
+    package func attachForTesting(
+        makeContainer: @escaping @MainActor () async throws -> WebInspectorContainer,
+        makePageUserInterfaceStyleObserver: @escaping @MainActor (
+            @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> (any WebInspectorPageUserInterfaceStyleObserving)? = { _ in nil }
+    ) async throws {
+        try await attach(
+            makeContainer: makeContainer,
+            makePageUserInterfaceStyleObserver: makePageUserInterfaceStyleObserver
+        )
+    }
+
+    private func attach(
+        makeContainer: @MainActor () async throws -> WebInspectorContainer,
+        makePageUserInterfaceStyleObserver: @MainActor (
+            @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> (any WebInspectorPageUserInterfaceStyleObserving)?
     ) async throws {
         let generation = advanceAttachmentGeneration()
         stopPageUserInterfaceStyleObservation()
@@ -76,7 +109,7 @@ public final class WebInspectorSession {
             throw CancellationError()
         }
         do {
-            let container = try await makeContainer(webView)
+            let container = try await makeContainer()
             try Task.checkCancellation()
             guard isCurrentAttachmentGeneration(generation) else {
                 await container.close()
@@ -84,7 +117,7 @@ public final class WebInspectorSession {
             }
             self.container = container
             installDataContext(container.mainContext)
-            startPageUserInterfaceStyleObservation(for: webView)
+            startPageUserInterfaceStyleObservation(makePageUserInterfaceStyleObserver)
         } catch {
             guard isCurrentAttachmentGeneration(generation) else {
                 throw error
@@ -134,9 +167,15 @@ public final class WebInspectorSession {
         try? await context.hideHighlight()
     }
 
-    private func startPageUserInterfaceStyleObservation(for webView: WKWebView) {
-        let observer = makePageUserInterfaceStyleObserver(webView) { [weak self] style in
+    private func startPageUserInterfaceStyleObservation(
+        _ makeObserver: @MainActor (
+            @escaping @MainActor (UIUserInterfaceStyle) -> Void
+        ) -> (any WebInspectorPageUserInterfaceStyleObserving)?
+    ) {
+        guard let observer = makeObserver({ [weak self] style in
             self?.setPageUserInterfaceStyle(style)
+        }) else {
+            return
         }
         pageUserInterfaceStyleObserver = observer
         observer.start()

--- a/Sources/WebInspectorUIDOM/Tree/DOMTreeTextView.swift
+++ b/Sources/WebInspectorUIDOM/Tree/DOMTreeTextView.swift
@@ -2669,6 +2669,20 @@ extension DOMTreeTextView {
         return true
     }
 
+    func waitForPendingDOMInvalidationForTesting(
+        _ minimumRevision: UInt64,
+        timeout: Duration = .seconds(1)
+    ) async -> Bool {
+        let start = ContinuousClock.now
+        while pendingDOMTreeRenderInvalidation?.revision ?? 0 < minimumRevision {
+            if ContinuousClock.now - start >= timeout {
+                return false
+            }
+            await Task.yield()
+        }
+        return true
+    }
+
     func resetPerformanceCountersForTesting() {
         performanceCounters.reset()
     }

--- a/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
+++ b/Tests/WebInspectorUITests/DOMTreeTextViewTests.swift
@@ -689,8 +689,9 @@ struct DOMTreeTextViewTests {
         view.setRenderingActive(false)
         session.applyAttributeModified(visibleDivID, name: "data-visible", value: "deferred")
         let hiddenRevision = session.treeRevision
-        #expect(await view.waitForRowDocumentAppliedTreeRevisionForTesting(hiddenRevision) == false)
+        #expect(await view.waitForPendingDOMInvalidationForTesting(hiddenRevision))
 
+        #expect(view.rowDocumentAppliedTreeRevisionForTesting < hiddenRevision)
         #expect(view.buildRowRenderPlanCallCountForTesting == 0)
         #expect(view.documentTextForTesting == baselineText)
         #expect(!view.documentTextForTesting.contains("data-visible=\"deferred\""))
@@ -827,9 +828,10 @@ struct DOMTreeTextViewTests {
         session.selectNode(inputID)
         let hiddenTreeRevision = session.treeRevision
         let hiddenSelectionRevision = session.selectionRevision
-        #expect(await view.waitForRowDocumentAppliedTreeRevisionForTesting(hiddenTreeRevision) == false)
+        #expect(await view.waitForObservedTreeRevisionForTesting(hiddenSelectionRevision))
         #expect(hiddenSelectionRevision >= hiddenTreeRevision)
 
+        #expect(view.rowDocumentAppliedTreeRevisionForTesting < hiddenTreeRevision)
         #expect(!view.documentTextForTesting.contains("data-visible=\"while-hidden\""))
         #expect(view.multiSelectedRowSnapshotsInDisplayOrderForTesting.count == 3)
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -729,7 +729,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderVisibleBody = await waitUntilRendered(in: viewController) {
+        let didRenderVisibleBody = await waitUntilPreparedTextPreviewRendered(in: viewController) {
             viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""visible" : true"#)
         }
         #expect(didRenderVisibleBody)
@@ -744,7 +744,7 @@ struct NetworkDetailViewControllerTests {
         viewController.beginAppearanceTransition(true, animated: false)
         viewController.endAppearanceTransition()
 
-        let didRenderHiddenBody = await waitUntilRendered(in: viewController) {
+        let didRenderHiddenBody = await waitUntilPreparedTextPreviewRendered(in: viewController) {
             viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text.contains(#""hidden" : true"#)
         }
         #expect(didRenderHiddenBody)
@@ -800,7 +800,7 @@ struct NetworkDetailViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
 
-        let didRenderPrettyBody = await waitUntilRendered(in: viewController) {
+        let didRenderPrettyBody = await waitUntilPreparedTextPreviewRendered(in: viewController) {
             viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == """
             {
               "a" : 1,
@@ -2457,6 +2457,17 @@ struct NetworkDetailViewControllerTests {
                 sampleRenderedCondition(in: viewController, condition: condition)
             }
         )
+    }
+
+    private func waitUntilPreparedTextPreviewRendered(
+        in viewController: NetworkDetailViewController,
+        _ condition: @escaping @MainActor @Sendable () -> Bool
+    ) async -> Bool {
+        if await waitUntilRendered(in: viewController, condition) {
+            return true
+        }
+        await viewController.syntaxBodyViewControllerForTesting.waitUntilTextPreviewPreparationFinishedForTesting()
+        return await waitUntilRendered(in: viewController, condition)
     }
 
     private func waitUntilNetworkBodyPhase(

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -5,7 +5,6 @@ import WebInspectorDataKit
 import WebInspectorProxyKit
 import WebInspectorProxyKitTesting
 import UIKit
-import WebKit
 @testable import WebInspectorUI
 @testable import WebInspectorUISyntaxBody
 @testable import WebInspectorUINetwork
@@ -62,31 +61,33 @@ struct ParentContainerTests {
     }
 
     @Test
-    func sessionUpdatesPageUserInterfaceStyleFromUnderPageBackgroundColor() async throws {
+    func sessionUpdatesPageUserInterfaceStyleFromPageObserver() async throws {
+        let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
         let session = makeSessionWithNoOpAttachment()
-        let webView = WKWebView(frame: .zero)
 
-        try await attach(session, to: webView)
+        try await attach(
+            session,
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
         let styleObservation = await observePageUserInterfaceStyle(in: session)
         defer { styleObservation.cancel() }
 
-        webView.underPageBackgroundColor = .black
-
         #expect(await styleObservation.values.waitUntilValue(UIUserInterfaceStyle.dark.rawValue))
 
-        webView.underPageBackgroundColor = .white
+        let observer = try #require(observerRecorder.observers.first)
+        observer.publish(.light)
         #expect(await styleObservation.values.waitUntilValue(UIUserInterfaceStyle.light.rawValue))
     }
 
     @Test
     func sessionClearsPageUserInterfaceStyleAndStopsObservingOnDetach() async throws {
         let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
-        let session = makeSessionWithNoOpAttachment(
+        let session = makeSessionWithNoOpAttachment()
+
+        try await attach(
+            session,
             makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
         )
-        let webView = WKWebView(frame: .zero)
-
-        try await attach(session, to: webView)
         let observer = try #require(observerRecorder.observers.first)
         #expect(observer.isStarted)
         #expect(session.pageUserInterfaceStyle == .dark)
@@ -102,25 +103,25 @@ struct ParentContainerTests {
 
     @Test
     func sessionClearsPageUserInterfaceStyleAndStopsObservingWhenAttachFails() async throws {
-        let observedWebView = WKWebView(frame: .zero)
-        let observedWebViewID = ObjectIdentifier(observedWebView)
         let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
-        let attachAction: @MainActor (WKWebView) async throws -> Void = { webView in
-            if ObjectIdentifier(webView) != observedWebViewID {
-                throw AttachmentFailure()
-            }
-        }
-        let session = makeSessionWithNoOpAttachment(
+        let session = makeSessionWithNoOpAttachment()
+
+        try await attach(
+            session,
             makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
         )
-
-        try await attach(session, to: observedWebView, perform: attachAction)
         let observer = try #require(observerRecorder.observers.first)
         #expect(observer.isStarted)
         #expect(session.pageUserInterfaceStyle == .dark)
 
         do {
-            try await attach(session, to: WKWebView(frame: .zero), perform: attachAction)
+            try await attach(
+                session,
+                perform: {
+                    throw AttachmentFailure()
+                },
+                makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+            )
             Issue.record("Expected attach to fail")
         } catch {
             #expect(error is AttachmentFailure)
@@ -137,29 +138,31 @@ struct ParentContainerTests {
     @Test
     func staleAttachCompletionDoesNotReplaceNewerAttach() async throws {
         let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
-        let session = makeSessionWithNoOpAttachment(
-            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
-        )
-        let firstWebView = WKWebView(frame: .zero)
-        let secondWebView = WKWebView(frame: .zero)
+        let session = makeSessionWithNoOpAttachment()
         let firstAttachStarted = WebInspectorTestGate()
         let firstAttachGate = WebInspectorTestGate()
 
         let firstAttach = Task { @MainActor in
-            try await session.attach(to: firstWebView) { [self] _ in
-                await firstAttachStarted.open()
-                await firstAttachGate.wait()
-                return try await makeFakeContainer()
-            }
+            try await session.attachForTesting(
+                makeContainer: { [self] in
+                    await firstAttachStarted.open()
+                    await firstAttachGate.wait()
+                    return try await makeFakeContainer()
+                },
+                makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+            )
         }
         await firstAttachStarted.wait()
 
         var secondContext: WebInspectorContext?
-        try await session.attach(to: secondWebView) { [self] _ in
-            let container = try await makeFakeContainer()
-            secondContext = container.mainContext
-            return container
-        }
+        try await session.attachForTesting(
+            makeContainer: { [self] in
+                let container = try await makeFakeContainer()
+                secondContext = container.mainContext
+                return container
+            },
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
         let installedSecondContext = try #require(secondContext)
 
         await firstAttachGate.open()
@@ -179,19 +182,19 @@ struct ParentContainerTests {
     @Test
     func detachInvalidatesInFlightAttachCompletion() async throws {
         let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
-        let session = makeSessionWithNoOpAttachment(
-            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
-        )
-        let webView = WKWebView(frame: .zero)
+        let session = makeSessionWithNoOpAttachment()
         let attachStarted = WebInspectorTestGate()
         let attachGate = WebInspectorTestGate()
 
         let attachTask = Task { @MainActor in
-            try await session.attach(to: webView) { [self] _ in
-                await attachStarted.open()
-                await attachGate.wait()
-                return try await makeFakeContainer()
-            }
+            try await session.attachForTesting(
+                makeContainer: { [self] in
+                    await attachStarted.open()
+                    await attachGate.wait()
+                    return try await makeFakeContainer()
+                },
+                makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+            )
         }
         await attachStarted.wait()
 
@@ -228,7 +231,7 @@ struct ParentContainerTests {
         #expect(session.interface.contentCacheCountForTesting > 0)
 
         var installedContext: WebInspectorContext?
-        try await session.attach(to: WKWebView(frame: .zero)) { [self] _ in
+        try await session.attachForTesting {
             let container = try await makeFakeContainer()
             installedContext = container.mainContext
             return container
@@ -346,15 +349,15 @@ struct ParentContainerTests {
     @Test
     func viewControllerDoesNotApplyPageUserInterfaceStyle() async throws {
         let observerRecorder = PageUserInterfaceStyleObserverRecorder(styleOnStart: .dark)
-        let session = makeSessionWithNoOpAttachment(
-            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
-        )
+        let session = makeSessionWithNoOpAttachment()
         let viewController = WebInspectorViewController(session: session)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
-        let webView = WKWebView(frame: .zero)
 
-        try await attach(session, to: webView)
+        try await attach(
+            session,
+            makePageUserInterfaceStyleObserver: observerRecorder.makeObserver
+        )
 
         #expect(session.pageUserInterfaceStyle == .dark)
         #expect(viewController.overrideUserInterfaceStyle == .unspecified)
@@ -1044,27 +1047,22 @@ struct ParentContainerTests {
 
     private func attach(
         _ session: WebInspectorSession,
-        to webView: WKWebView,
-        perform attachAction: @escaping @MainActor (WKWebView) async throws -> Void = { _ in }
-    ) async throws {
-        try await session.attach(to: webView) { [self] webView in
-            try await attachAction(webView)
-            return try await makeFakeContainer()
-        }
-    }
-
-    private func makeSessionWithNoOpAttachment(
+        perform attachAction: @escaping @MainActor () async throws -> Void = {},
         makePageUserInterfaceStyleObserver: @escaping @MainActor (
-            WKWebView,
             @escaping @MainActor (UIUserInterfaceStyle) -> Void
-        ) -> any WebInspectorPageUserInterfaceStyleObserving = { webView, apply in
-            WebInspectorPageUserInterfaceStyleObserver(webView: webView, apply: apply)
-        }
-    ) -> WebInspectorSession {
-        WebInspectorSession(
-            context: makeContext(),
+        ) -> (any WebInspectorPageUserInterfaceStyleObserving)? = { _ in nil }
+    ) async throws {
+        try await session.attachForTesting(
+            makeContainer: { [self] in
+                try await attachAction()
+                return try await makeFakeContainer()
+            },
             makePageUserInterfaceStyleObserver: makePageUserInterfaceStyleObserver
         )
+    }
+
+    private func makeSessionWithNoOpAttachment() -> WebInspectorSession {
+        WebInspectorSession(context: makeContext())
     }
 
     @MainActor
@@ -1077,9 +1075,8 @@ struct ParentContainerTests {
         }
 
         func makeObserver(
-            webView: WKWebView,
             apply: @escaping @MainActor (UIUserInterfaceStyle) -> Void
-        ) -> any WebInspectorPageUserInterfaceStyleObserving {
+        ) -> (any WebInspectorPageUserInterfaceStyleObserving)? {
             let observer = PageUserInterfaceStyleObserverDouble(
                 styleOnStart: styleOnStart,
                 apply: apply


### PR DESCRIPTION
## Purpose
Fix the iOS 26 CI failure in `NetworkDetailViewControllerTests` and remove the slow test dependencies that made the iOS 26 all job run into the 10-minute job timeout after tests had already succeeded.

## Changes
- Wait for asynchronous network text preview preparation before asserting JSON pretty-preview output.
- Keep the iOS test job timeout at 10 minutes; the previous timeout-only change is reverted in the branch diff.
- Add a package test attach path for `WebInspectorSession` so session lifecycle tests do not instantiate real `WKWebView` instances and trigger WebKit GPU/WebContent process startup.
- Update `ParentContainerTests` to use observer/container doubles for attach, detach, failed attach, and stale attach lifecycle coverage.
- Replace DOMTree hidden-render negative timeout waits with positive owner checks for pending invalidation/selection observation plus row-document revision assertions.

## Testing
- `WebInspectorKitTests` on iPhone 17 Pro simulator: 471 tests, 0 failures
- Per-test duration check on the final local run: 0 tests >2s, 0 tests >5s, max 1.731s; CI-slow ParentContainer cases now report 0.001s locally
- `actionlint .github/workflows/ci.yml`
- external `uses:` full-SHA scan
- `git diff --check`
- Codex review against base `main`: 0 findings