### PR TITLE
Preserve Monocly history button images

### DIFF
--- a/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
+++ b/Monocly/Monocly/Controllers/BrowserPageViewController+UIKit.swift
@@ -27,6 +27,11 @@ final class BrowserPageViewController: UIViewController {
         ]
     }
 
+    private enum NavigationSymbolName {
+        static let back = "chevron.backward"
+        static let forward = "chevron.forward"
+    }
+
     private let browserWindow: BrowserWindow
     private let inspectorSession: WebInspectorSession
     private let launchConfiguration: BrowserLaunchConfiguration
@@ -46,21 +51,27 @@ final class BrowserPageViewController: UIViewController {
         action: nil
     )
     private let backButtonItem = UIBarButtonItem(
-        image: UIImage(systemName: "chevron.left"),
+        image: UIImage(systemName: NavigationSymbolName.back),
         style: .plain,
         target: nil,
         action: nil
     )
     private let forwardButtonItem = UIBarButtonItem(
-        image: UIImage(systemName: "chevron.right"),
+        image: UIImage(systemName: NavigationSymbolName.forward),
         style: .plain,
         target: nil,
         action: nil
     )
-    private lazy var backNavigationAction = UIAction { [weak self] _ in
+    private lazy var backNavigationAction = UIAction(
+        title: "",
+        image: UIImage(systemName: NavigationSymbolName.back)
+    ) { [weak self] _ in
         self?.browserWindow.goBack()
     }
-    private lazy var forwardNavigationAction = UIAction { [weak self] _ in
+    private lazy var forwardNavigationAction = UIAction(
+        title: "",
+        image: UIImage(systemName: NavigationSymbolName.forward)
+    ) { [weak self] _ in
         self?.browserWindow.goForward()
     }
     private var hostedWebView: WKWebView?

--- a/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
+++ b/Monocly/MonoclyTests/BrowserSessionRestoreTests.swift
@@ -882,6 +882,33 @@ struct BrowserSessionRestoreTests {
     }
 
     @Test
+    func historyButtonItemsKeepImagesWhenPrimaryActionsAreInstalled() throws {
+        let initialURL = try #require(URL(string: "about:blank"))
+        let store = BrowserWindow(
+            initialState: .fresh(
+                url: initialURL,
+                automaticallyLoadsInitialRequest: false
+            ),
+            sessionPersistence: .ephemeral
+        )
+        let pageViewController = BrowserPageViewController(
+            browserWindow: store,
+            inspectorSession: WebInspectorSession(),
+            launchConfiguration: BrowserLaunchConfiguration(initialURL: initialURL),
+            progressHideScheduler: ManualDelayScheduler()
+        )
+
+        pageViewController.loadViewIfNeeded()
+        let backButtonItem = pageViewController.backButtonItemForTesting
+        let forwardButtonItem = pageViewController.forwardButtonItemForTesting
+
+        #expect(backButtonItem.image != nil)
+        #expect(backButtonItem.primaryAction?.image != nil)
+        #expect(forwardButtonItem.image != nil)
+        #expect(forwardButtonItem.primaryAction?.image != nil)
+    }
+
+    @Test
     func toolbarItemsAreNotRecreatedForSelectedTabRenderingChanges() async throws {
         let initialURL = try #require(URL(string: "about:blank"))
         let store = BrowserWindow(
@@ -912,9 +939,13 @@ struct BrowserSessionRestoreTests {
         #expect(pageViewController.backButtonItemForTesting === backButtonItem)
         #expect(pageViewController.forwardButtonItemForTesting === forwardButtonItem)
         #expect(pageViewController.inspectorButtonItemForTesting === inspectorButtonItem)
-        #expect(pageViewController.toolbarItems?.contains { $0 === backButtonItem } == true)
-        #expect(pageViewController.toolbarItems?.contains { $0 === forwardButtonItem } == true)
-        #expect(pageViewController.toolbarItems?.contains { $0 === inspectorButtonItem } == true)
+
+        let installedChromeItems = pageViewController.toolbarItems
+            ?? pageViewController.navigationItem.leadingItemGroups.flatMap(\.barButtonItems)
+            + pageViewController.navigationItem.trailingItemGroups.flatMap(\.barButtonItems)
+        #expect(installedChromeItems.contains { $0 === backButtonItem })
+        #expect(installedChromeItems.contains { $0 === forwardButtonItem })
+        #expect(installedChromeItems.contains { $0 === inspectorButtonItem })
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Fix Monocly history navigation buttons disappearing on iOS 18 when `UIBarButtonItem.primaryAction` is installed.

## Changes
- Use directional `chevron.backward` and `chevron.forward` symbols for history navigation.
- Provide the same symbols on the `UIAction` instances so iOS 18 does not clear the bar button item images.
- Add regression coverage for history button item and primary action images.
- Make the chrome item reuse test work for both compact toolbar and regular navigation bar placement.

## Testing
- `Monocly` tests on iPhone 15 / iOS 18.6: 60 passed
- `Monocly` tests on iPad Air 13-inch (M2) / iOS 18.6: 60 passed
- `git diff --check`
- `codex-review` on uncommitted changes: no findings