### PR TITLE
Publish DocC documentation with GitHub Pages

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -55,7 +55,11 @@ jobs:
 
       - name: Generate DocC documentation
         run: |
-          swift package --allow-writing-to-directory .build/docs \
+          sdk_path="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+          swift package --scratch-path .build/docc-generation \
+            --sdk "$sdk_path" \
+            --triple arm64-apple-ios18.0-simulator \
+            --allow-writing-to-directory .build/docs \
             generate-documentation \
             --target WebInspectorKit \
             --target WebInspectorUI \
@@ -69,10 +73,22 @@ jobs:
             --output-path .build/docs
           touch .build/docs/.nojekyll
 
+      - name: Archive Pages artifact
+        run: |
+          tar \
+            -C .build/docs \
+            -cf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: .build/docs
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     name: Deploy GitHub Pages

--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,0 +1,91 @@
+name: DocC
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Generate DocC
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      XCODE_MAJOR: '26'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve latest stable Xcode
+        run: |
+          xcode_app="$(ruby <<'RUBY'
+          xcode_major = ENV.fetch("XCODE_MAJOR")
+          candidates = Dir["/Applications/Xcode_#{xcode_major}*.app"].select { |path| File.directory?(path) }
+
+          def pre_release_xcode_path?(path)
+            labels = [path, File.realpath(path)].map { |candidate| File.basename(candidate).downcase }
+            labels.any? do |label|
+              label.match?(/beta|release[ _-]?candidate|(?:^|[_. -])rc(?:$|[_. -])/)
+            end
+          end
+
+          candidates = candidates.reject do |path|
+            pre_release_xcode_path?(path)
+          end
+
+          def version_components(path)
+            version = File.basename(path)[/Xcode_(\d+(?:\.\d+)*)/, 1]
+            version.to_s.split(".").map(&:to_i)
+          end
+
+          selected = candidates.max_by { |path| version_components(path) }
+          abort("No stable Xcode #{xcode_major} installation found") unless selected
+          puts selected
+          RUBY
+          )"
+          echo "DEVELOPER_DIR=${xcode_app}/Contents/Developer" >> "$GITHUB_ENV"
+          echo "Resolved Xcode: ${xcode_app}"
+
+      - name: Show Xcode environment
+        run: |
+          xcodebuild -version
+          xcodebuild -showsdks
+
+      - name: Generate DocC documentation
+        run: |
+          swift package --allow-writing-to-directory .build/docs \
+            generate-documentation \
+            --target WebInspectorKit \
+            --target WebInspectorUI \
+            --target WebInspectorDataKit \
+            --target WebInspectorProxyKit \
+            --target WebInspectorProxyKitTesting \
+            --disable-indexing \
+            --enable-experimental-combined-documentation \
+            --transform-for-static-hosting \
+            --hosting-base-path WebInspectorKit \
+            --output-path .build/docs
+          touch .build/docs/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: .build/docs
+
+  deploy:
+    name: Deploy GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7b65d088e01d973900ad8317a166b66130543f816de75ed636fb43c3f6c9d55a",
+  "originHash" : "ae3de8a6b51fe478760fba6af6efb1c879e8c65cad3ca03db74e57ded0373a12",
   "pins" : [
     {
       "identity" : "machokit",
@@ -53,6 +53,24 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,10 @@ let package = Package(
         .package(
             url: "https://github.com/p-x9/MachOKit.git",
             exact: "0.51.0"
+        ),
+        .package(
+            url: "https://github.com/swiftlang/swift-docc-plugin",
+            from: "1.5.0"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ let inspector = WebInspectorViewController(
 
 ## Documentation
 
-Generate DocC documentation from the package when you need symbol-level details
-for `WebInspectorKit`, `WebInspectorDataKit`, `WebInspectorProxyKit`, or
-`WebInspectorUI`.
+The DocC workflow publishes symbol-level documentation to GitHub Pages:
+
+- [WebInspectorKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorkit/)
+- [WebInspectorUI](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorui/)
+- [WebInspectorDataKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectordatakit/)
+- [WebInspectorProxyKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorproxykit/)
+- [WebInspectorProxyKitTesting](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorproxykittesting/)
 
 | Document | Purpose |
 | --- | --- |

--- a/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "31f1f24623d7a62883c4f3c047f9c1a8c1257ed1503f26d7d7a4568e5679322c",
+  "originHash" : "f756f0a41438ce26162b2d1d68b16b18dae99d9af86d495d32302188b8e0159e",
   "pins" : [
     {
       "identity" : "machokit",
@@ -53,6 +53,24 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {


### PR DESCRIPTION
## Purpose
Publish the package DocC documentation through GitHub Pages, following the same shape as ObservationBridge.

## Changes
- Add a `DocC` workflow that builds combined static documentation for `WebInspectorKit`, `WebInspectorUI`, `WebInspectorDataKit`, `WebInspectorProxyKit`, and `WebInspectorProxyKitTesting`.
- Generate DocC with the iOS Simulator SDK/triple so UIKit symbols are included in the published pages.
- Preserve `.nojekyll` by archiving the Pages artifact directly before uploading it with SHA-pinned GitHub Actions.
- Add `swift-docc-plugin` to the package dependencies and update resolved pins.
- Link the published DocC module pages from the root README.

## Testing
- `actionlint`
- external workflow `uses:` non-SHA scan
- `git diff --check`
- `swift build`
- iOS Simulator combined DocC generation with `swift package --sdk ... --triple arm64-apple-ios18.0-simulator generate-documentation`
- Pages artifact tar includes `.nojekyll`
- Codex review against `main` (`ab5780b92e0d6d1993b7346bb22ba22bb29e7522`): no findings
