### PR TITLE
Add DocC preview and module overviews

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -61,7 +61,6 @@ jobs:
             --triple arm64-apple-ios18.0-simulator \
             --allow-writing-to-directory .build/docs \
             generate-documentation \
-            --target WebInspectorKit \
             --target WebInspectorUI \
             --target WebInspectorDataKit \
             --target WebInspectorProxyKit \

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ let inspector = WebInspectorViewController(
 
 The DocC workflow publishes symbol-level documentation to GitHub Pages:
 
-- [WebInspectorKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorkit/)
+- [Package Documentation](https://lynnswap.github.io/WebInspectorKit/documentation/)
 - [WebInspectorUI](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorui/)
 - [WebInspectorDataKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectordatakit/)
 - [WebInspectorProxyKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorproxykit/)

--- a/README.md
+++ b/README.md
@@ -88,13 +88,8 @@ let inspector = WebInspectorViewController(
 
 ## Documentation
 
-The DocC workflow publishes symbol-level documentation to GitHub Pages:
-
-- [Package Documentation](https://lynnswap.github.io/WebInspectorKit/documentation/)
-- [WebInspectorUI](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorui/)
-- [WebInspectorDataKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectordatakit/)
-- [WebInspectorProxyKit](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorproxykit/)
-- [WebInspectorProxyKitTesting](https://lynnswap.github.io/WebInspectorKit/documentation/webinspectorproxykittesting/)
+The DocC workflow publishes [package documentation](https://lynnswap.github.io/WebInspectorKit/documentation/)
+to GitHub Pages.
 
 | Document | Purpose |
 | --- | --- |

--- a/Scripts/preview-docc.py
+++ b/Scripts/preview-docc.py
@@ -45,7 +45,10 @@ def parse_port(value: str) -> int:
     return port
 
 
-def default_port() -> int:
+def resolve_port(parsed_port: int | None) -> int:
+    if parsed_port is not None:
+        return parsed_port
+
     value = os.environ.get("PORT", "8080")
     try:
         return parse_port(value)
@@ -64,7 +67,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--port",
         type=parse_port,
-        default=default_port(),
+        default=None,
         help="preferred local port; increments if the port is already in use",
     )
     parser.add_argument(
@@ -275,6 +278,7 @@ def serve(site_root: Path, port: int, *, open_browser: bool) -> None:
 
 def main() -> None:
     args = parse_arguments()
+    args.port = resolve_port(args.port)
     root = repo_root()
     output_path = root / ".build" / "docs"
     scratch_path = root / ".build" / "docc-preview"

--- a/Scripts/preview-docc.py
+++ b/Scripts/preview-docc.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import functools
+import os
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import webbrowser
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+BASE_PATH = "WebInspectorKit"
+HOST = "127.0.0.1"
+SIMULATOR_TRIPLE = "arm64-apple-ios18.0-simulator"
+TARGETS = [
+    "WebInspectorUI",
+    "WebInspectorDataKit",
+    "WebInspectorProxyKit",
+    "WebInspectorProxyKitTesting",
+]
+MODULE_PATHS = {
+    "webinspectordatakit",
+    "webinspectorproxykit",
+    "webinspectorproxykittesting",
+    "webinspectorui",
+}
+
+
+def parse_port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("must be between 1 and 65535")
+    return port
+
+
+def default_port() -> int:
+    value = os.environ.get("PORT", "8080")
+    try:
+        return parse_port(value)
+    except argparse.ArgumentTypeError as error:
+        print(f"error: invalid PORT value {value!r}: {error}", file=sys.stderr)
+        raise SystemExit(64) from error
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build combined DocC documentation, serve it with the GitHub Pages "
+            "base path, and open the WebInspectorKit documentation root."
+        )
+    )
+    parser.add_argument(
+        "--port",
+        type=parse_port,
+        default=default_port(),
+        help="preferred local port; increments if the port is already in use",
+    )
+    parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="serve without opening a browser",
+    )
+    parser.add_argument(
+        "--no-generate",
+        action="store_true",
+        help="reuse the existing .build/docs output",
+    )
+    parser.add_argument(
+        "--no-serve",
+        action="store_true",
+        help="generate documentation without starting a local server",
+    )
+    return parser.parse_args()
+
+
+def require_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        print(f"error: {name} is required.", file=sys.stderr)
+        raise SystemExit(69)
+
+
+def run(command: list[str], *, cwd: Path) -> None:
+    print("+ " + shlex.join(command), flush=True)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def command_output(command: list[str], *, cwd: Path | None = None) -> str:
+    return subprocess.check_output(command, cwd=cwd, text=True).strip()
+
+
+def repo_root() -> Path:
+    script_root = Path(__file__).resolve().parents[1]
+    if (script_root / "Package.swift").is_file():
+        return script_root
+
+    if shutil.which("git") is not None:
+        try:
+            return Path(command_output(["git", "rev-parse", "--show-toplevel"])).resolve()
+        except subprocess.CalledProcessError:
+            pass
+
+    print("error: could not find the WebInspectorKit repository root.", file=sys.stderr)
+    raise SystemExit(66)
+
+
+@contextlib.contextmanager
+def preview_lock(root: Path):
+    lock_path = root / ".build" / "docc-preview.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock_file:
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(
+                "error: another DocC preview is already running. "
+                "Stop it with Control-C before starting a new one.",
+                file=sys.stderr,
+            )
+            raise SystemExit(75)
+
+        yield
+
+
+def generate_documentation(root: Path, output_path: Path, scratch_path: Path) -> None:
+    shutil.rmtree(output_path, ignore_errors=True)
+    shutil.rmtree(scratch_path, ignore_errors=True)
+    shutil.rmtree(root / ".build" / SIMULATOR_TRIPLE, ignore_errors=True)
+
+    output_argument = str(output_path.relative_to(root))
+    scratch_argument = str(scratch_path.relative_to(root))
+    sdk_path = command_output(["xcrun", "--sdk", "iphonesimulator", "--show-sdk-path"])
+    command = [
+        "swift",
+        "package",
+        "--scratch-path",
+        scratch_argument,
+        "--sdk",
+        sdk_path,
+        "--triple",
+        SIMULATOR_TRIPLE,
+        "--allow-writing-to-directory",
+        output_argument,
+        "generate-documentation",
+    ]
+    for target in TARGETS:
+        command.extend(["--target", target])
+    command.extend(
+        [
+            "--disable-indexing",
+            "--enable-experimental-combined-documentation",
+            "--transform-for-static-hosting",
+            "--hosting-base-path",
+            BASE_PATH,
+            "--warnings-as-errors",
+            "--output-path",
+            output_argument,
+        ]
+    )
+
+    run(command, cwd=root)
+    (output_path / ".nojekyll").touch()
+
+
+def require_generated_documentation(output_path: Path) -> None:
+    if (output_path / "index.html").is_file():
+        return
+
+    print(
+        f"error: generated documentation was not found at {output_path}.",
+        file=sys.stderr,
+    )
+    print("Run without --no-generate to build it first.", file=sys.stderr)
+    raise SystemExit(66)
+
+
+def prepare_site_root(output_path: Path, site_root: Path) -> None:
+    shutil.rmtree(site_root, ignore_errors=True)
+    site_root.mkdir(parents=True, exist_ok=True)
+    (site_root / BASE_PATH).symlink_to(output_path.resolve(), target_is_directory=True)
+
+
+def first_available_port(starting_port: int) -> int:
+    for port in range(starting_port, 65536):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                probe.bind((HOST, port))
+            except OSError:
+                continue
+            return port
+
+    print("error: no available TCP port found.", file=sys.stderr)
+    raise SystemExit(69)
+
+
+def preview_url(port: int) -> str:
+    return f"http://{HOST}:{port}/{BASE_PATH}/documentation/"
+
+
+class DocCPreviewRequestHandler(SimpleHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.redirect_short_docc_path():
+            return
+        super().do_GET()
+
+    def do_HEAD(self) -> None:
+        if self.redirect_short_docc_path():
+            return
+        super().do_HEAD()
+
+    def redirect_short_docc_path(self) -> bool:
+        redirect_path = short_docc_redirect_path(self.path)
+        if redirect_path is None:
+            return False
+
+        self.send_response(302)
+        self.send_header("Location", redirect_path)
+        self.end_headers()
+        return True
+
+
+def short_docc_redirect_path(request_path: str) -> str | None:
+    parsed = urlsplit(request_path)
+    segments = [segment for segment in parsed.path.split("/") if segment]
+
+    if not segments or segments[0] != BASE_PATH:
+        return None
+
+    if len(segments) == 1:
+        return urlunsplit(("", "", f"/{BASE_PATH}/documentation/", parsed.query, parsed.fragment))
+
+    if segments[1] == "webinspectorkit":
+        return urlunsplit(("", "", f"/{BASE_PATH}/documentation/", parsed.query, parsed.fragment))
+
+    if len(segments) >= 3 and segments[1] == "documentation" and segments[2] == "webinspectorkit":
+        return urlunsplit(("", "", f"/{BASE_PATH}/documentation/", parsed.query, parsed.fragment))
+
+    if segments[1] not in MODULE_PATHS:
+        return None
+
+    suffix = "/".join(segments[2:])
+    suffix = f"{suffix}/" if suffix else ""
+    return urlunsplit(
+        ("", "", f"/{BASE_PATH}/documentation/{segments[1]}/{suffix}", parsed.query, parsed.fragment)
+    )
+
+
+def serve(site_root: Path, port: int, *, open_browser: bool) -> None:
+    handler = functools.partial(DocCPreviewRequestHandler, directory=str(site_root))
+
+    with ThreadingHTTPServer((HOST, port), handler) as server:
+        url = preview_url(port)
+        print(f"Serving DocC documentation at {url}", flush=True)
+        print("Press Control-C to stop the server.", flush=True)
+        if open_browser:
+            webbrowser.open(url)
+
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping DocC preview server.", flush=True)
+
+
+def main() -> None:
+    args = parse_arguments()
+    root = repo_root()
+    output_path = root / ".build" / "docs"
+    scratch_path = root / ".build" / "docc-preview"
+    site_root = root / ".build" / "docc-preview-site"
+
+    with preview_lock(root):
+        if not args.no_generate:
+            require_tool("swift")
+            require_tool("xcrun")
+            generate_documentation(root, output_path, scratch_path)
+
+        require_generated_documentation(output_path)
+        prepare_site_root(output_path, site_root)
+
+        if args.no_serve:
+            print(f"Generated DocC documentation: {output_path}", flush=True)
+            print(f"Preview URL when served: {preview_url(args.port)}", flush=True)
+            return
+
+        port = first_available_port(args.port)
+        serve(site_root, port, open_browser=not args.no_open)
+
+
+if __name__ == "__main__":
+    main()

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
@@ -1,4 +1,4 @@
-# WebInspectorDataKit
+# ``WebInspectorDataKit``
 
 Observable Web Inspector models for building custom inspector interfaces.
 

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
@@ -1,0 +1,106 @@
+# WebInspectorDataKit
+
+Observable Web Inspector models for building custom inspector interfaces.
+
+## Overview
+
+Use WebInspectorDataKit when you want WebKit inspector data as identity-preserving
+models instead of sending protocol commands directly. DataKit owns DOM, Network,
+Console, Runtime, and CSS model state for one inspected page and keeps those
+models updated as WebKit emits protocol events.
+
+Attach a ``WebInspectorContainer`` to a `WKWebView`, then read the
+``WebInspectorContext`` for UI-bound model state:
+
+```swift
+import WebKit
+import WebInspectorDataKit
+
+@MainActor
+final class InspectorModel {
+    private var container: WebInspectorContainer?
+    private(set) var context: WebInspectorContext?
+    private var treeTask: Task<Void, Never>?
+
+    func attach(to webView: WKWebView) async throws {
+        let container = try await WebInspectorContainer(attachingTo: webView)
+        let context = container.mainContext
+        let tree = context.dom.treeController()
+
+        treeTask = Task { @MainActor in
+            for await update in tree.updates {
+                render(update)
+            }
+        }
+
+        self.container = container
+        self.context = context
+    }
+
+    func close() async {
+        treeTask?.cancel()
+        await container?.close()
+        container = nil
+        context = nil
+    }
+}
+```
+
+Contexts are actor-owned. Read and mutate context state from the same actor you
+used to create or obtain the context. For UIKit clients, ``WebInspectorContainer``
+provides ``WebInspectorContainer/mainContext`` as a main-actor context.
+
+Use the domain controllers on ``WebInspectorContext`` for high-level operations:
+
+```swift
+try await context.dom.setElementPickerEnabled(true)
+try await context.page.reload()
+
+let result = try await context.runtime.evaluate("document.title")
+print(result.object.description ?? "")
+```
+
+Reach for WebInspectorDataKit when your UI wants stable model identity, undoable
+DOM edits, fetched-results style collection updates, or derived DOM tree
+snapshots. Reach for WebInspectorProxyKit when you need direct typed protocol
+access with no model layer.
+
+## Topics
+
+### Creating a Model Context
+
+- ``WebInspectorContainer``
+- ``WebInspectorContext``
+
+### Reading DOM State
+
+- ``DOMNode``
+- ``DOMTreeController``
+- ``DOMTreeSnapshot``
+- ``DOMTreeUpdate``
+
+### Reading Network and Console State
+
+- ``NetworkRequest``
+- ``ConsoleMessage``
+- ``WebInspectorFetchRequest``
+- ``WebInspectorFetchedResultsController``
+
+### Runtime and CSS Models
+
+- ``RuntimeContext``
+- ``RuntimeObject``
+- ``RuntimeEvaluation``
+- ``CSSStyles``
+- ``CSSStyleSection``
+- ``CSSStyleProperty``
+
+### Domain Operations
+
+- ``DOMModelController``
+- ``NetworkModelController``
+- ``ConsoleModelController``
+- ``RuntimeModelController``
+- ``CSSModelController``
+- ``PageModelController``
+- ``WebInspectorEditHistory``

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
@@ -53,7 +53,7 @@ provides ``WebInspectorContainer/mainContext`` as a main-actor context.
 Use the domain controllers on ``WebInspectorContext`` for high-level operations:
 
 ```swift
-try await context.dom.setElementPickerEnabled(true)
+try await context.dom.setInspectMode(enabled: true)
 try await context.page.reload()
 
 let result = try await context.runtime.evaluate("document.title")

--- a/Sources/WebInspectorProxyKit/WebInspectorProxyKit.docc/WebInspectorProxyKit.md
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxyKit.docc/WebInspectorProxyKit.md
@@ -1,4 +1,4 @@
-# WebInspectorProxyKit
+# ``WebInspectorProxyKit``
 
 Typed Web Inspector protocol transport for an inspected `WKWebView`.
 

--- a/Sources/WebInspectorProxyKit/WebInspectorProxyKit.docc/WebInspectorProxyKit.md
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxyKit.docc/WebInspectorProxyKit.md
@@ -1,0 +1,72 @@
+# WebInspectorProxyKit
+
+Typed Web Inspector protocol transport for an inspected `WKWebView`.
+
+## Overview
+
+Use WebInspectorProxyKit when you want direct access to WebKit's inspector
+protocol commands and events. ProxyKit attaches to a `WKWebView`, tracks the
+current page target, and exposes typed domain clients from ``WebInspectorTarget``.
+
+Create a ``WebInspectorProxy``, wait for the current page, and send protocol
+commands through target-scoped clients:
+
+```swift
+import WebKit
+import WebInspectorProxyKit
+
+@MainActor
+func printPageTitle(from webView: WKWebView) async throws {
+    let proxy = try await WebInspectorProxy(attachingTo: webView)
+    defer {
+        Task {
+            await proxy.close()
+        }
+    }
+
+    let page = try await proxy.waitForCurrentPage()
+    try await page.runtime.enable()
+
+    let evaluation = try await page.runtime.evaluate("document.title")
+    print(evaluation.object.description ?? "")
+}
+```
+
+Domain clients can also expose event streams. Enable the domain before consuming
+events that require WebKit to start reporting that domain:
+
+```swift
+let page = try await proxy.waitForCurrentPage()
+try await page.network.enable()
+
+for await event in page.network.events {
+    handleNetworkEvent(event)
+}
+```
+
+ProxyKit is the lowest public layer in WebInspectorKit. Prefer
+WebInspectorDataKit when you want observable model objects for UI binding,
+selection, collection updates, and DOM tree snapshots.
+
+## Topics
+
+### Attaching to WebKit
+
+- ``WebInspectorProxy``
+- ``WebInspectorProxy/Configuration``
+- ``WebInspectorTarget``
+- ``WebInspectorProxyError``
+
+### Protocol Domains
+
+- ``DOM``
+- ``CSS``
+- ``Network``
+- ``Console``
+- ``Runtime``
+- ``Page``
+
+### Events and Targets
+
+- ``RawEvent``
+- ``FrameID``

--- a/Sources/WebInspectorUI/WebInspectorUI.docc/WebInspectorUI.md
+++ b/Sources/WebInspectorUI/WebInspectorUI.docc/WebInspectorUI.md
@@ -1,4 +1,4 @@
-# WebInspectorUI
+# ``WebInspectorUI``
 
 UIKit Web Inspector components for presenting and extending the built-in inspector.
 

--- a/Sources/WebInspectorUI/WebInspectorUI.docc/WebInspectorUI.md
+++ b/Sources/WebInspectorUI/WebInspectorUI.docc/WebInspectorUI.md
@@ -1,0 +1,66 @@
+# WebInspectorUI
+
+UIKit Web Inspector components for presenting and extending the built-in inspector.
+
+## Overview
+
+Use WebInspectorUI when you want to present the built-in UIKit inspector or add
+UIKit tabs to the inspector surface. Application code normally imports
+`WebInspectorKit`, which re-exports this module, but the symbols documented here
+are the UI entry points behind that product.
+
+Create a ``WebInspectorViewController``, attach it to a `WKWebView`, and present
+it from your app UI:
+
+```swift
+import UIKit
+import WebKit
+import WebInspectorKit
+
+final class BrowserViewController: UIViewController {
+    private let webView = WKWebView(frame: .zero)
+
+    @objc private func showInspector() {
+        let inspector = WebInspectorViewController()
+        inspector.modalPresentationStyle = .pageSheet
+
+        Task { @MainActor in
+            try await inspector.attach(to: webView)
+            present(inspector, animated: true)
+        }
+    }
+}
+```
+
+The default inspector includes DOM and Network tabs. Add a custom tab when your
+app needs a UIKit panel that shares the same inspection session:
+
+```swift
+let consoleTab = WebInspectorTab(
+    id: "app_console",
+    title: "Console",
+    systemImage: "terminal"
+) { session in
+    ConsoleViewController(inspectorSession: session)
+}
+
+let inspector = WebInspectorViewController(
+    tabs: [.dom, .network, consoleTab]
+)
+```
+
+Use ``WebInspectorSession`` when you need explicit access to attachment
+lifecycle, page style observation, or the DataKit context used by custom tabs.
+For custom inspector UIs that do not use the built-in UIKit surface, start with
+WebInspectorDataKit instead.
+
+## Topics
+
+### Presenting the Inspector
+
+- ``WebInspectorViewController``
+- ``WebInspectorSession``
+
+### Configuring Tabs
+
+- ``WebInspectorTab``


### PR DESCRIPTION
## Purpose

Make the generated DocC site easier to inspect locally and give the public modules useful landing content.

## Changes

- Add an executable Python script for generating, serving, and opening the DocC site with the GitHub Pages base path.
- Point README documentation at the package documentation root instead of the removed WebInspectorKit module page.
- Remove the empty WebInspectorKit target from DocC generation.
- Add DocC overview pages for WebInspectorUI, WebInspectorDataKit, and WebInspectorProxyKit.

## Testing

- `python3 -m py_compile Scripts/preview-docc.py`
- `actionlint`
- `git diff --check`
- `Scripts/preview-docc.py --no-serve --port 8765`
- `swift package --scratch-path .build/docc-overview-generation --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)" --triple arm64-apple-ios18.0-simulator --allow-writing-to-directory .build/docc-overview-docs generate-documentation --target WebInspectorUI --target WebInspectorDataKit --target WebInspectorProxyKit --target WebInspectorProxyKitTesting --disable-indexing --enable-experimental-combined-documentation --transform-for-static-hosting --hosting-base-path WebInspectorKit --warnings-as-errors --output-path .build/docc-overview-docs`