### PR TITLE
Optimize iOS CI test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,22 +387,54 @@ jobs:
               -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
               | tee -a "${log_path}"
           elif [ -n "${TEST_WORKSPACE}" ]; then
-            xcodebuild test \
+            derived_data="${RUNNER_TEMP}/${TEST_SCHEME}-DerivedData"
+            log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
+
+            rm -rf "${derived_data}" "${log_path}"
+
+            xcodebuild build-for-testing \
               -workspace "${TEST_WORKSPACE}" \
               -scheme "${TEST_SCHEME}" \
               -destination "${DESTINATION}" \
               -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
               -disableAutomaticPackageResolution \
               -skipPackageUpdates \
+              -derivedDataPath "${derived_data}" \
               -enableCodeCoverage NO \
-              -parallel-testing-enabled NO \
-              -maximum-concurrent-test-simulator-destinations 1 \
-              -test-timeouts-enabled YES \
-              -default-test-execution-time-allowance 30 \
-              -maximum-test-execution-time-allowance 60 \
+              ARCHS=arm64 \
+              ONLY_ACTIVE_ARCH=YES \
               -showBuildTimingSummary \
-              -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
-              | tee "${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
+              | tee "${log_path}"
+
+            xctestrun="$(find "${derived_data}/Build/Products" -name '*.xctestrun' -print -quit)"
+            if [ -z "${xctestrun}" ]; then
+              echo "No .xctestrun generated under ${derived_data}/Build/Products" >&2
+              exit 1
+            fi
+
+            test_filters=(
+              WebInspectorProxyKitTests
+              WebInspectorDataKitTests
+              WebInspectorUITests
+              MonoclyTests/WebInspectorProxyKitIntegrationTests
+            )
+            for test_filter in "${test_filters[@]}"; do
+              result_name="${test_filter//\//-}"
+              echo "::group::Run ${test_filter}"
+              bash Scripts/ci-xcodebuild-watchdog.sh \
+                xcodebuild test-without-building \
+                -xctestrun "${xctestrun}" \
+                -destination "${DESTINATION}" \
+                "-only-testing:${test_filter}" \
+                -parallel-testing-enabled NO \
+                -maximum-concurrent-test-simulator-destinations 1 \
+                -test-timeouts-enabled YES \
+                -default-test-execution-time-allowance 30 \
+                -maximum-test-execution-time-allowance 60 \
+                -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}-${result_name}.xcresult" \
+                | tee -a "${log_path}"
+              echo "::endgroup::"
+            done
           else
             (
               cd "${TEST_PACKAGE_PATH}"
@@ -430,5 +462,5 @@ jobs:
           name: ios-test-diagnostics-${{ matrix.name }}
           path: |
             ${{ runner.temp }}/xcodebuild-${{ env.TEST_SCHEME }}.log
-            ${{ runner.temp }}/${{ env.TEST_SCHEME }}.xcresult
+            ${{ runner.temp }}/${{ env.TEST_SCHEME }}*.xcresult
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
     env:
       XCODE_MAJOR: '26'
       TEST_SCHEME: WebInspectorKitTests
-      DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
+      SIMULATOR_DEVICE: iPhone 17 Pro
       TEST_DERIVED_DATA: ${{ github.workspace }}/.ci/derived-data/WebInspectorKitTests
     steps:
       - name: Check out repository
@@ -575,6 +575,37 @@ jobs:
           end
           puts "Resolved Xcode: #{selected}"
           puts version_output
+          RUBY
+
+      - name: Resolve owned simulator
+        run: |
+          ruby <<'RUBY'
+          require "json"
+
+          requested_device = ENV.fetch("SIMULATOR_DEVICE")
+          runtimes = JSON.parse(`xcrun simctl list devices available --json`).fetch("devices")
+          candidates = runtimes.flat_map do |runtime, devices|
+            match = runtime.match(/SimRuntime\.iOS-(\d+(?:-\d+)*)$/)
+            next [] unless match
+
+            version = match[1].tr("-", ".")
+            devices.filter_map do |device|
+              next unless device.fetch("isAvailable", true)
+              next unless device.fetch("name") == requested_device
+
+              [version.split(".").map(&:to_i), version, device.fetch("udid")]
+            end
+          end
+
+          selected = candidates.max_by(&:first)
+          abort("No available #{requested_device} simulator found") unless selected
+
+          _, version, udid = selected
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "DESTINATION=platform=iOS Simulator,id=#{udid}"
+            env.puts "WATCHDOG_SIMULATOR_UDID=#{udid}"
+          end
+          puts "Owned simulator: #{requested_device} iOS #{version} (#{udid})"
           RUBY
 
       - name: Restore built workspace tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run consumer contract package tests
         run: swift test --package-path ContractTests
 
-  ios-tests:
+  native-bridge-tests:
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -76,24 +76,13 @@ jobs:
             runner: macos-15
             xcode_major: '26.3'
             ios_major: '18'
-            test_mode: native-package
             test_scheme: WebInspectorNativeBridgeTests
             test_package_path: Packages/WebInspectorNativeBridge
             test_workspace: Packages/WebInspectorNativeBridge/WebInspectorNativeBridge.xcworkspace
-          - name: WebInspectorKitTests (iOS 26)
-            runner: macos-26
-            xcode_major: '26'
-            ios_major: '26'
-            test_mode: workspace
-            test_scheme: WebInspectorKitTests
-            test_package_path: .
-            test_workspace: WebInspectorKit.xcworkspace
-            simulator_device: iPhone 17 Pro
           - name: WebInspectorNativeBridgeTests (iOS 26)
             runner: macos-26
             xcode_major: '26'
             ios_major: '26'
-            test_mode: native-package
             test_scheme: WebInspectorNativeBridgeTests
             test_package_path: Packages/WebInspectorNativeBridge
             test_workspace: Packages/WebInspectorNativeBridge/WebInspectorNativeBridge.xcworkspace
@@ -103,7 +92,6 @@ jobs:
     env:
       XCODE_MAJOR: ${{ matrix.xcode_major }}
       IOS_MAJOR: ${{ matrix.ios_major }}
-      TEST_MODE: ${{ matrix.test_mode }}
       TEST_SCHEME: ${{ matrix.test_scheme }}
       TEST_PACKAGE_PATH: ${{ matrix.test_package_path }}
       TEST_WORKSPACE: ${{ matrix.test_workspace }}
@@ -293,7 +281,6 @@ jobs:
           xcodebuild -showsdks
           echo "Destination: ${DESTINATION}"
           echo "Resolved iOS: ${RESOLVED_IOS_VERSION}"
-          echo "Test mode: ${TEST_MODE}"
           echo "Test scheme: ${TEST_SCHEME}"
           echo "Test package path: ${TEST_PACKAGE_PATH}"
           echo "Test workspace: ${TEST_WORKSPACE}"
@@ -308,152 +295,83 @@ jobs:
             exit 0
           fi
 
-          if [ "${TEST_MODE}" = "native-package" ]; then
-            derived_data="${RUNNER_TEMP}/${TEST_SCHEME}-DerivedData"
-            log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
+          derived_data="${RUNNER_TEMP}/${TEST_SCHEME}-DerivedData"
+          log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
 
-            rm -rf "${derived_data}" "${log_path}"
+          rm -rf "${derived_data}" "${log_path}"
 
-            xcodebuild build-for-testing \
-              -workspace "${TEST_WORKSPACE}" \
-              -scheme "${TEST_SCHEME}" \
-              -sdk iphonesimulator \
-              -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
-              -disableAutomaticPackageResolution \
-              -skipPackageUpdates \
-              -derivedDataPath "${derived_data}" \
-              -enableCodeCoverage NO \
-              ARCHS=arm64 \
-              ONLY_ACTIVE_ARCH=YES \
-              -showBuildTimingSummary \
-              | tee "${log_path}"
+          xcodebuild build-for-testing \
+            -workspace "${TEST_WORKSPACE}" \
+            -scheme "${TEST_SCHEME}" \
+            -sdk iphonesimulator \
+            -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
+            -disableAutomaticPackageResolution \
+            -skipPackageUpdates \
+            -derivedDataPath "${derived_data}" \
+            -enableCodeCoverage NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            -showBuildTimingSummary \
+            | tee "${log_path}"
 
-            xctestrun="$(find "${derived_data}/Build/Products" -name '*.xctestrun' -print -quit)"
-            if [ -z "${xctestrun}" ]; then
-              echo "No .xctestrun generated under ${derived_data}/Build/Products" >&2
-              exit 1
-            fi
+          xctestrun="$(find "${derived_data}/Build/Products" -name '*.xctestrun' -print -quit)"
+          if [ -z "${xctestrun}" ]; then
+            echo "No .xctestrun generated under ${derived_data}/Build/Products" >&2
+            exit 1
+          fi
 
-            patched_xctestrun="${xctestrun%.xctestrun}-iphonesimulator.xctestrun"
-            rm -f "${patched_xctestrun}"
-            cp "${xctestrun}" "${patched_xctestrun}"
-            plutil -convert xml1 "${patched_xctestrun}"
+          patched_xctestrun="${xctestrun%.xctestrun}-iphonesimulator.xctestrun"
+          rm -f "${patched_xctestrun}"
+          cp "${xctestrun}" "${patched_xctestrun}"
+          plutil -convert xml1 "${patched_xctestrun}"
 
-            PATCHED_XCTESTRUN="${patched_xctestrun}" ruby <<'RUBY'
-            path = ENV.fetch("PATCHED_XCTESTRUN")
-            scheme = ENV.fetch("TEST_SCHEME")
-            test_bundle = "#{scheme}.xctest"
+          PATCHED_XCTESTRUN="${patched_xctestrun}" ruby <<'RUBY'
+          path = ENV.fetch("PATCHED_XCTESTRUN")
+          scheme = ENV.fetch("TEST_SCHEME")
+          test_bundle = "#{scheme}.xctest"
 
-            data = File.read(path)
-            macos_bundle_path = "__TESTROOT__/Debug/#{test_bundle}"
-            simulator_bundle_path = "__TESTROOT__/Debug-iphonesimulator/#{test_bundle}"
-            macos_xctest_agent = "__PLATFORMS__/MacOSX.platform/Developer/Library/Xcode/Agents/xctest"
-            simulator_xctest_agent = "__PLATFORMS__/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/xctest"
+          data = File.read(path)
+          macos_bundle_path = "__TESTROOT__/Debug/#{test_bundle}"
+          simulator_bundle_path = "__TESTROOT__/Debug-iphonesimulator/#{test_bundle}"
+          macos_xctest_agent = "__PLATFORMS__/MacOSX.platform/Developer/Library/Xcode/Agents/xctest"
+          simulator_xctest_agent = "__PLATFORMS__/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/xctest"
 
-            already_simulator = data.include?(simulator_bundle_path) && data.include?(simulator_xctest_agent)
-            exit if already_simulator
+          already_simulator = data.include?(simulator_bundle_path) && data.include?(simulator_xctest_agent)
+          exit if already_simulator
 
-            required = [macos_bundle_path, macos_xctest_agent]
-            missing = required.reject { |needle| data.include?(needle) }
-            abort("Unexpected xctestrun layout for #{scheme}: missing #{missing.join(", ")}") unless missing.empty?
+          required = [macos_bundle_path, macos_xctest_agent]
+          missing = required.reject { |needle| data.include?(needle) }
+          abort("Unexpected xctestrun layout for #{scheme}: missing #{missing.join(", ")}") unless missing.empty?
 
-            replacements = {
-              macos_bundle_path => simulator_bundle_path,
-              macos_xctest_agent => simulator_xctest_agent,
-              "__PLATFORMS__/MacOSX.platform/Developer/Library/Frameworks" => "__PLATFORMS__/iPhoneSimulator.platform/Developer/Library/Frameworks",
-              "__PLATFORMS__/MacOSX.platform/Developer/usr/lib" => "__PLATFORMS__/iPhoneSimulator.platform/Developer/usr/lib",
-              "<string>arm64e</string>" => "<string>arm64</string>",
-            }
+          replacements = {
+            macos_bundle_path => simulator_bundle_path,
+            macos_xctest_agent => simulator_xctest_agent,
+            "__PLATFORMS__/MacOSX.platform/Developer/Library/Frameworks" => "__PLATFORMS__/iPhoneSimulator.platform/Developer/Library/Frameworks",
+            "__PLATFORMS__/MacOSX.platform/Developer/usr/lib" => "__PLATFORMS__/iPhoneSimulator.platform/Developer/usr/lib",
+            "<string>arm64e</string>" => "<string>arm64</string>",
+          }
 
-            replacements.each do |from, to|
-              data = data.gsub(from, to)
-            end
-            data = data.gsub("__TESTROOT__/Debug:", "__TESTROOT__/Debug-iphonesimulator:")
-            data = data.gsub("__TESTROOT__/Debug<", "__TESTROOT__/Debug-iphonesimulator<")
+          replacements.each do |from, to|
+            data = data.gsub(from, to)
+          end
+          data = data.gsub("__TESTROOT__/Debug:", "__TESTROOT__/Debug-iphonesimulator:")
+          data = data.gsub("__TESTROOT__/Debug<", "__TESTROOT__/Debug-iphonesimulator<")
 
-            File.write(path, data)
+          File.write(path, data)
           RUBY
 
-            plutil -lint "${patched_xctestrun}"
+          plutil -lint "${patched_xctestrun}"
 
-            xcodebuild test-without-building \
-              -xctestrun "${patched_xctestrun}" \
-              -destination "${DESTINATION}" \
-              -parallel-testing-enabled NO \
-              -maximum-concurrent-test-simulator-destinations 1 \
-              -test-timeouts-enabled YES \
-              -default-test-execution-time-allowance 30 \
-              -maximum-test-execution-time-allowance 60 \
-              -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
-              | tee -a "${log_path}"
-          elif [ -n "${TEST_WORKSPACE}" ]; then
-            derived_data="${RUNNER_TEMP}/${TEST_SCHEME}-DerivedData"
-            log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
-
-            rm -rf "${derived_data}" "${log_path}"
-
-            xcodebuild build-for-testing \
-              -workspace "${TEST_WORKSPACE}" \
-              -scheme "${TEST_SCHEME}" \
-              -destination "${DESTINATION}" \
-              -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
-              -disableAutomaticPackageResolution \
-              -skipPackageUpdates \
-              -derivedDataPath "${derived_data}" \
-              -enableCodeCoverage NO \
-              ARCHS=arm64 \
-              ONLY_ACTIVE_ARCH=YES \
-              -showBuildTimingSummary \
-              | tee "${log_path}"
-
-            xctestrun="$(find "${derived_data}/Build/Products" -name '*.xctestrun' -print -quit)"
-            if [ -z "${xctestrun}" ]; then
-              echo "No .xctestrun generated under ${derived_data}/Build/Products" >&2
-              exit 1
-            fi
-
-            test_filters=(
-              WebInspectorProxyKitTests
-              WebInspectorDataKitTests
-              WebInspectorUITests
-              MonoclyTests/WebInspectorProxyKitIntegrationTests
-            )
-            for test_filter in "${test_filters[@]}"; do
-              result_name="${test_filter//\//-}"
-              echo "::group::Run ${test_filter}"
-              bash Scripts/ci-xcodebuild-watchdog.sh \
-                xcodebuild test-without-building \
-                -xctestrun "${xctestrun}" \
-                -destination "${DESTINATION}" \
-                "-only-testing:${test_filter}" \
-                -parallel-testing-enabled NO \
-                -maximum-concurrent-test-simulator-destinations 1 \
-                -test-timeouts-enabled YES \
-                -default-test-execution-time-allowance 30 \
-                -maximum-test-execution-time-allowance 60 \
-                -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}-${result_name}.xcresult" \
-                | tee -a "${log_path}"
-              echo "::endgroup::"
-            done
-          else
-            (
-              cd "${TEST_PACKAGE_PATH}"
-              xcodebuild test \
-                -scheme "${TEST_SCHEME}" \
-                -destination "${DESTINATION}" \
-                -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
-                -disableAutomaticPackageResolution \
-                -skipPackageUpdates \
-                -enableCodeCoverage NO \
-                -parallel-testing-enabled NO \
-                -maximum-concurrent-test-simulator-destinations 1 \
-                -test-timeouts-enabled YES \
-                -default-test-execution-time-allowance 30 \
-                -maximum-test-execution-time-allowance 60 \
-                -showBuildTimingSummary \
-                -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult"
-            ) | tee "${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}.log"
-          fi
+          xcodebuild test-without-building \
+            -xctestrun "${patched_xctestrun}" \
+            -destination "${DESTINATION}" \
+            -parallel-testing-enabled NO \
+            -maximum-concurrent-test-simulator-destinations 1 \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 30 \
+            -maximum-test-execution-time-allowance 60 \
+            -resultBundlePath "${RUNNER_TEMP}/${TEST_SCHEME}.xcresult" \
+            | tee -a "${log_path}"
 
       - name: Upload iOS test diagnostics
         if: always()
@@ -463,4 +381,246 @@ jobs:
           path: |
             ${{ runner.temp }}/xcodebuild-${{ env.TEST_SCHEME }}.log
             ${{ runner.temp }}/${{ env.TEST_SCHEME }}*.xcresult
+          if-no-files-found: ignore
+
+  webinspector-build:
+    name: WebInspectorKit Build (iOS 26)
+    runs-on: macos-26
+    timeout-minutes: 10
+    env:
+      XCODE_MAJOR: '26'
+      TEST_SCHEME: WebInspectorKitTests
+      TEST_WORKSPACE: WebInspectorKit.xcworkspace
+      DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
+      SPM_CACHE_DIR: ${{ github.workspace }}/.ci/spm-cache/26-WebInspectorKitTests
+      TEST_DERIVED_DATA: ${{ github.workspace }}/.ci/derived-data/WebInspectorKitTests
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve Xcode
+        id: toolchain
+        run: |
+          ruby <<'RUBY'
+          xcode_major = ENV.fetch("XCODE_MAJOR")
+
+          candidates = Dir["/Applications/Xcode*.app"].select { |path| File.directory?(path) }
+          candidates = candidates.select do |path|
+            File.basename(path).match?(/Xcode_#{Regexp.escape(xcode_major)}(?:[_.-]|\z)/)
+          end
+
+          def prerelease_xcode_path?(path)
+            labels = [path, File.realpath(path)].map { |candidate| File.basename(candidate).downcase }
+            labels.any? do |label|
+              label.match?(/beta|release[ _-]?candidate|(?:^|[_. -])rc(?:$|[_. -])/)
+            end
+          end
+
+          candidates = candidates.reject { |path| prerelease_xcode_path?(path) }
+
+          def version_components(path)
+            version = File.basename(path)[/Xcode[_-](\d+(?:[._]\d+)*)/, 1]
+            version.to_s.tr("_", ".").split(".").map(&:to_i)
+          end
+
+          selected = candidates.max_by { |path| version_components(path) }
+          abort("No stable Xcode #{xcode_major} installation found") unless selected
+
+          developer_dir = "#{selected}/Contents/Developer"
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "DEVELOPER_DIR=#{developer_dir}"
+          end
+
+          version_output = IO.popen(
+            { "DEVELOPER_DIR" => developer_dir },
+            ["xcodebuild", "-version"],
+            &:read
+          )
+          abort("Unable to read Xcode version") unless $?.success?
+          cache_id = version_output.tr("\n ", "--").gsub(/[^[:alnum:]._-]/, "")
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
+            output.puts "cache-id=#{cache_id}"
+          end
+          puts "Resolved Xcode: #{selected}"
+          puts version_output
+          RUBY
+
+      - name: Restore Swift package cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ env.SPM_CACHE_DIR }}
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-${{ hashFiles('Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-
+
+      - name: Restore test build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.TEST_DERIVED_DATA }}/Build/Products
+          key: webinspector-test-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-${{ hashFiles('Package.swift', 'Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorKitTests.xcscheme', 'Monocly/Monocly.xcodeproj/project.pbxproj') }}-${{ github.sha }}
+          restore-keys: |
+            webinspector-test-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-${{ hashFiles('Package.swift', 'Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorKitTests.xcscheme', 'Monocly/Monocly.xcodeproj/project.pbxproj') }}-
+
+      - name: Build workspace tests
+        run: |
+          set -e -o pipefail
+          log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}-build.log"
+
+          xcodebuild build-for-testing \
+            -workspace "${TEST_WORKSPACE}" \
+            -scheme "${TEST_SCHEME}" \
+            -destination "${DESTINATION}" \
+            -clonedSourcePackagesDirPath "${SPM_CACHE_DIR}" \
+            -disableAutomaticPackageResolution \
+            -skipPackageUpdates \
+            -derivedDataPath "${TEST_DERIVED_DATA}" \
+            -enableCodeCoverage NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            -showBuildTimingSummary \
+            | tee "${log_path}"
+
+          xctestrun_count="$(
+            find "${TEST_DERIVED_DATA}/Build/Products" -maxdepth 1 -name '*.xctestrun' -print \
+              | wc -l \
+              | tr -d '[:space:]'
+          )"
+          if [ "${xctestrun_count}" -ne 1 ]; then
+            echo "Expected exactly one .xctestrun, found ${xctestrun_count}" >&2
+            exit 1
+          fi
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: webinspector-test-build-diagnostics
+          path: ${{ runner.temp }}/xcodebuild-${{ env.TEST_SCHEME }}-build.log
+          if-no-files-found: ignore
+
+  webinspector-tests:
+    name: WebInspectorKit Tests (iOS 26, ${{ matrix.name }})
+    needs: webinspector-build
+    runs-on: macos-26
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ProxyKit
+            test_filter: WebInspectorProxyKitTests
+            result_name: proxy
+          - name: DataKit
+            test_filter: WebInspectorDataKitTests
+            result_name: data
+          - name: UI
+            test_filter: WebInspectorUITests
+            result_name: ui
+          - name: Monocly
+            test_filter: MonoclyTests/WebInspectorProxyKitIntegrationTests
+            result_name: monocly
+    env:
+      XCODE_MAJOR: '26'
+      TEST_SCHEME: WebInspectorKitTests
+      DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
+      TEST_DERIVED_DATA: ${{ github.workspace }}/.ci/derived-data/WebInspectorKitTests
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve Xcode
+        id: toolchain
+        run: |
+          ruby <<'RUBY'
+          xcode_major = ENV.fetch("XCODE_MAJOR")
+
+          candidates = Dir["/Applications/Xcode*.app"].select { |path| File.directory?(path) }
+          candidates = candidates.select do |path|
+            File.basename(path).match?(/Xcode_#{Regexp.escape(xcode_major)}(?:[_.-]|\z)/)
+          end
+
+          def prerelease_xcode_path?(path)
+            labels = [path, File.realpath(path)].map { |candidate| File.basename(candidate).downcase }
+            labels.any? do |label|
+              label.match?(/beta|release[ _-]?candidate|(?:^|[_. -])rc(?:$|[_. -])/)
+            end
+          end
+
+          candidates = candidates.reject { |path| prerelease_xcode_path?(path) }
+
+          def version_components(path)
+            version = File.basename(path)[/Xcode[_-](\d+(?:[._]\d+)*)/, 1]
+            version.to_s.tr("_", ".").split(".").map(&:to_i)
+          end
+
+          selected = candidates.max_by { |path| version_components(path) }
+          abort("No stable Xcode #{xcode_major} installation found") unless selected
+
+          developer_dir = "#{selected}/Contents/Developer"
+          File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
+            env.puts "DEVELOPER_DIR=#{developer_dir}"
+          end
+
+          version_output = IO.popen(
+            { "DEVELOPER_DIR" => developer_dir },
+            ["xcodebuild", "-version"],
+            &:read
+          )
+          abort("Unable to read Xcode version") unless $?.success?
+          cache_id = version_output.tr("\n ", "--").gsub(/[^[:alnum:]._-]/, "")
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
+            output.puts "cache-id=#{cache_id}"
+          end
+          puts "Resolved Xcode: #{selected}"
+          puts version_output
+          RUBY
+
+      - name: Restore built workspace tests
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.TEST_DERIVED_DATA }}/Build/Products
+          key: webinspector-test-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-${{ hashFiles('Package.swift', 'Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorKitTests.xcscheme', 'Monocly/Monocly.xcodeproj/project.pbxproj') }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Run ${{ matrix.name }} tests
+        run: |
+          set -e -o pipefail
+          log_path="${RUNNER_TEMP}/xcodebuild-${TEST_SCHEME}-${{ matrix.result_name }}.log"
+          result_path="${RUNNER_TEMP}/${TEST_SCHEME}-${{ matrix.result_name }}.xcresult"
+          xctestrun_count="$(
+            find "${TEST_DERIVED_DATA}/Build/Products" -maxdepth 1 -name '*.xctestrun' -print \
+              | wc -l \
+              | tr -d '[:space:]'
+          )"
+          if [ "${xctestrun_count}" -ne 1 ]; then
+            echo "Expected exactly one .xctestrun, found ${xctestrun_count}" >&2
+            exit 1
+          fi
+          xctestrun="$(
+            find "${TEST_DERIVED_DATA}/Build/Products" -maxdepth 1 -name '*.xctestrun' -print
+          )"
+
+          bash Scripts/ci-xcodebuild-watchdog.sh \
+            xcodebuild test-without-building \
+            -xctestrun "${xctestrun}" \
+            -destination "${DESTINATION}" \
+            "-only-testing:${{ matrix.test_filter }}" \
+            -parallel-testing-enabled NO \
+            -maximum-concurrent-test-simulator-destinations 1 \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 30 \
+            -maximum-test-execution-time-allowance 60 \
+            -resultBundlePath "${result_path}" \
+            | tee "${log_path}"
+
+      - name: Upload test diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: webinspector-test-diagnostics-${{ matrix.result_name }}
+          path: |
+            ${{ runner.temp }}/xcodebuild-${{ env.TEST_SCHEME }}-${{ matrix.result_name }}.log
+            ${{ runner.temp }}/${{ env.TEST_SCHEME }}-${{ matrix.result_name }}.xcresult
           if-no-files-found: ignore

--- a/Monocly/MonoclyTests/WebInspectorProxyKitIntegrationTests.swift
+++ b/Monocly/MonoclyTests/WebInspectorProxyKitIntegrationTests.swift
@@ -7,6 +7,24 @@ import XCTest
 #if os(iOS)
 final class WebInspectorProxyKitIntegrationTests: XCTestCase {
     @MainActor
+    func testNativeInspectablePageRestoresOriginalInspectability() {
+        let webView = WKWebView(frame: .zero)
+        webView.isInspectable = false
+
+        let page = NativeInspectablePage(webView: webView)
+
+        XCTAssertTrue(webView.isInspectable)
+
+        page.restoreInspectabilityIfNeeded()
+
+        XCTAssertFalse(webView.isInspectable)
+
+        page.restoreInspectabilityIfNeeded()
+
+        XCTAssertFalse(webView.isInspectable)
+    }
+
+    @MainActor
     func testNativeInspectorReconnectsAfterWebContentProcessTermination() async throws {
         let fixture = try HostedWebViewFixture()
         defer { fixture.cleanup() }
@@ -54,6 +72,25 @@ final class WebInspectorProxyKitIntegrationTests: XCTestCase {
             await proxy.close()
             throw error
         }
+    }
+
+    @MainActor
+    func testOverlappingNativeInspectablePagesRestoreOnlyAfterLastOwner() {
+        let webView = WKWebView(frame: .zero)
+        webView.isInspectable = false
+
+        let firstPage = NativeInspectablePage(webView: webView)
+        let secondPage = NativeInspectablePage(webView: webView)
+
+        XCTAssertTrue(webView.isInspectable)
+
+        secondPage.restoreInspectabilityIfNeeded()
+
+        XCTAssertTrue(webView.isInspectable)
+
+        firstPage.restoreInspectabilityIfNeeded()
+
+        XCTAssertFalse(webView.isInspectable)
     }
 
     @MainActor

--- a/Scripts/ci-xcodebuild-watchdog.sh
+++ b/Scripts/ci-xcodebuild-watchdog.sh
@@ -7,10 +7,6 @@ poll_seconds="${POLL_SECONDS:-1}"
 resume_recheck_seconds="${RESUME_RECHECK_SECONDS:-5}"
 sample_seconds="${SAMPLE_SECONDS:-5}"
 log="$(mktemp -t ci-command-watchdog)"
-process_pattern='xcodebuild|xctest|Monocly|WebContent'
-# A developer may already have simulator tests running locally. Diagnostics and
-# termination must remain scoped to processes created after this command starts.
-baseline_process_ids=" $(pgrep -f "${process_pattern}" 2>/dev/null | tr '\n' ' ') "
 
 cleanup() {
     rm -f "${log}"
@@ -59,15 +55,12 @@ wait_for_output_or_exit() {
     return 1
 }
 
-test_process_ids() {
-    local pid
-    for pid in $(pgrep -f "${process_pattern}" 2>/dev/null); do
-        case "${baseline_process_ids}" in
-            *" ${pid} "*)
-                continue
-                ;;
-        esac
-        echo "${pid}"
+descendant_process_ids() {
+    local root_pid=$1
+    local child_pid
+    for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null); do
+        descendant_process_ids "${child_pid}"
+        echo "${child_pid}"
     done
 }
 
@@ -75,20 +68,14 @@ dump_stall_diagnostics() {
     echo "::error::xcodebuild produced no output for ${stall_seconds}s; dumping process state"
 
     local pid
-    for pid in $(test_process_ids); do
-        [ "${pid}" -eq "${runner}" ] && continue
+    for pid in $(descendant_process_ids "${runner}"); do
         sample_process "${pid}"
     done
     sample_process "${runner}"
 }
 
 terminate_test_processes() {
-    local pid
     terminate_process_tree "${runner}"
-    for pid in $(test_process_ids); do
-        [ "${pid}" -eq "$$" ] && continue
-        kill -9 "${pid}" 2>/dev/null || true
-    done
 }
 
 terminate_process_tree() {

--- a/Scripts/ci-xcodebuild-watchdog.sh
+++ b/Scripts/ci-xcodebuild-watchdog.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -uo pipefail
+
+stall_seconds="${STALL_SECONDS:-120}"
+poll_seconds="${POLL_SECONDS:-1}"
+resume_recheck_seconds="${RESUME_RECHECK_SECONDS:-5}"
+sample_seconds="${SAMPLE_SECONDS:-5}"
+log="$(mktemp -t ci-command-watchdog)"
+process_pattern='xcodebuild|xctest|Monocly|WebContent'
+# A developer may already have simulator tests running locally. Diagnostics and
+# termination must remain scoped to processes created after this command starts.
+baseline_process_ids=" $(pgrep -f "${process_pattern}" 2>/dev/null | tr '\n' ' ') "
+
+cleanup() {
+    rm -f "${log}"
+}
+trap cleanup EXIT
+
+"$@" > >(tee -a "${log}") 2>&1 &
+runner=$!
+
+log_size() {
+    stat -f%z "${log}" 2>/dev/null || echo 0
+}
+
+sample_process() {
+    local pid=$1
+    local command
+    command="$(ps -o comm= -p "${pid}" 2>/dev/null)"
+    [ -n "${command}" ] || return
+
+    echo "===== sample of pid ${pid} (${command}) ====="
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        sudo sample "${pid}" "${sample_seconds}" -mayDie 2>&1 || true
+    else
+        sample "${pid}" "${sample_seconds}" -mayDie 2>&1 || true
+    fi
+}
+
+wait_for_output_or_exit() {
+    local stalled_size=$1
+    local remaining=${resume_recheck_seconds}
+    local size
+
+    while [ "${remaining}" -gt 0 ]; do
+        sleep 1
+        if ! kill -0 "${runner}" 2>/dev/null; then
+            return 0
+        fi
+        size="$(log_size)"
+        if [ "${size}" -ne "${stalled_size}" ]; then
+            stalled_for=0
+            last_size="${size}"
+            return 0
+        fi
+        remaining=$((remaining - 1))
+    done
+    return 1
+}
+
+test_process_ids() {
+    local pid
+    for pid in $(pgrep -f "${process_pattern}" 2>/dev/null); do
+        case "${baseline_process_ids}" in
+            *" ${pid} "*)
+                continue
+                ;;
+        esac
+        echo "${pid}"
+    done
+}
+
+dump_stall_diagnostics() {
+    echo "::error::xcodebuild produced no output for ${stall_seconds}s; dumping process state"
+
+    local pid
+    for pid in $(test_process_ids); do
+        [ "${pid}" -eq "${runner}" ] && continue
+        sample_process "${pid}"
+    done
+    sample_process "${runner}"
+}
+
+terminate_test_processes() {
+    local pid
+    terminate_process_tree "${runner}"
+    for pid in $(test_process_ids); do
+        [ "${pid}" -eq "$$" ] && continue
+        kill -9 "${pid}" 2>/dev/null || true
+    done
+}
+
+terminate_process_tree() {
+    local root_pid=$1
+    local child_pid
+    for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null); do
+        terminate_process_tree "${child_pid}"
+    done
+    kill -9 "${root_pid}" 2>/dev/null || true
+}
+
+last_size=-1
+stalled_for=0
+while kill -0 "${runner}" 2>/dev/null; do
+    sleep "${poll_seconds}"
+    size="$(log_size)"
+    if [ "${size}" -eq "${last_size}" ]; then
+        stalled_for=$((stalled_for + poll_seconds))
+    else
+        stalled_for=0
+        last_size=${size}
+    fi
+
+    if [ "${stalled_for}" -lt "${stall_seconds}" ]; then
+        continue
+    fi
+
+    stalled_size="${size}"
+    if wait_for_output_or_exit "${stalled_size}"; then
+        continue
+    fi
+
+    dump_stall_diagnostics
+    if ! kill -0 "${runner}" 2>/dev/null; then
+        break
+    fi
+    if wait_for_output_or_exit "${stalled_size}"; then
+        echo "::warning::xcodebuild output resumed while diagnostics were collected; continuing"
+        continue
+    fi
+
+    terminate_test_processes
+    exit 70
+done
+
+wait "${runner}"

--- a/Scripts/ci-xcodebuild-watchdog.sh
+++ b/Scripts/ci-xcodebuild-watchdog.sh
@@ -6,7 +6,14 @@ stall_seconds="${STALL_SECONDS:-120}"
 poll_seconds="${POLL_SECONDS:-1}"
 resume_recheck_seconds="${RESUME_RECHECK_SECONDS:-5}"
 sample_seconds="${SAMPLE_SECONDS:-5}"
+simulator_udid="${WATCHDOG_SIMULATOR_UDID:-}"
 log="$(mktemp -t ci-command-watchdog)"
+
+if [ -n "${simulator_udid}" ] \
+    && [[ ! "${simulator_udid}" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]]; then
+    echo "Invalid WATCHDOG_SIMULATOR_UDID: ${simulator_udid}" >&2
+    exit 64
+fi
 
 cleanup() {
     rm -f "${log}"
@@ -64,6 +71,19 @@ descendant_process_ids() {
     done
 }
 
+simulator_test_process_ids() {
+    [ -n "${simulator_udid}" ] || return
+
+    xcrun simctl spawn "${simulator_udid}" launchctl print user/501 2>/dev/null \
+        | awk '
+            /^[[:space:]]*[0-9]+[[:space:]]/ &&
+            $1 != "0" &&
+            $0 ~ /(xctest|Monocly|WebContent)/ {
+                print $1
+            }
+        '
+}
+
 dump_stall_diagnostics() {
     echo "::error::xcodebuild produced no output for ${stall_seconds}s; dumping process state"
 
@@ -71,10 +91,16 @@ dump_stall_diagnostics() {
     for pid in $(descendant_process_ids "${runner}"); do
         sample_process "${pid}"
     done
+    for pid in $(simulator_test_process_ids); do
+        sample_process "${pid}"
+    done
     sample_process "${runner}"
 }
 
 terminate_test_processes() {
+    if [ -n "${simulator_udid}" ]; then
+        xcrun simctl shutdown "${simulator_udid}" 2>/dev/null || true
+    fi
     terminate_process_tree "${runner}"
 }
 

--- a/Tests/WebInspectorProxyKitTests/NativeInspectablePageTests.swift
+++ b/Tests/WebInspectorProxyKitTests/NativeInspectablePageTests.swift
@@ -1,47 +1,6 @@
 #if canImport(UIKit)
 import Testing
-import UIKit
-import WebKit
 @testable import WebInspectorProxyKit
-
-@MainActor
-@Test
-func nativeInspectablePageRestoresOriginalInspectability() {
-    let webView = WKWebView(frame: .zero)
-    webView.isInspectable = false
-
-    let page = NativeInspectablePage(webView: webView)
-
-    #expect(webView.isInspectable == true)
-
-    page.restoreInspectabilityIfNeeded()
-
-    #expect(webView.isInspectable == false)
-
-    page.restoreInspectabilityIfNeeded()
-
-    #expect(webView.isInspectable == false)
-}
-
-@MainActor
-@Test
-func overlappingNativeInspectablePagesRestoreOnlyAfterLastOwner() {
-    let webView = WKWebView(frame: .zero)
-    webView.isInspectable = false
-
-    let firstPage = NativeInspectablePage(webView: webView)
-    let secondPage = NativeInspectablePage(webView: webView)
-
-    #expect(webView.isInspectable == true)
-
-    secondPage.restoreInspectabilityIfNeeded()
-
-    #expect(webView.isInspectable == true)
-
-    firstPage.restoreInspectabilityIfNeeded()
-
-    #expect(webView.isInspectable == false)
-}
 
 @MainActor
 @Test

--- a/WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorKitTests.xcscheme
+++ b/WebInspectorKit.xcworkspace/xcshareddata/xcschemes/WebInspectorKitTests.xcscheme
@@ -123,7 +123,13 @@
             </BuildableReference>
             <SelectedTests>
                <Test
+                  Identifier = "WebInspectorProxyKitIntegrationTests/testNativeInspectablePageRestoresOriginalInspectability()">
+               </Test>
+               <Test
                   Identifier = "WebInspectorProxyKitIntegrationTests/testNativeInspectorReconnectsAfterWebContentProcessTermination()">
+               </Test>
+               <Test
+                  Identifier = "WebInspectorProxyKitIntegrationTests/testOverlappingNativeInspectablePagesRestoreOnlyAfterLastOwner()">
                </Test>
                <Test
                   Identifier = "WebInspectorProxyKitIntegrationTests/testSecondNativeInspectorAttachmentFailsWithoutReplacingDelegate()">


### PR DESCRIPTION
## Purpose

Reduce the over-10-minute `WebInspectorKitTests (iOS 26)` lane by building its test products once and distributing the iOS test targets across independent runners, while keeping native WebKit lifecycle coverage at the app-hosted boundary.

## Changes

- Split the long workspace lane into `WebInspectorKit Build (iOS 26)` and a four-entry `WebInspectorKit Tests` matrix for ProxyKit, DataKit, UI, and Monocly.
- Share only relocatable `Build/Products` through an exact OS, architecture, Xcode, source, and commit cache key; every test job fails on a cache miss and runs `test-without-building`.
- Keep Consumer Contract and NativeBridge lanes independent and unchanged in coverage.
- Scope watchdog diagnostics and cleanup to the watched `xcodebuild` process tree and the simulator UDID explicitly selected by each test job.
- Move the two real-`WKWebView` inspectability ownership tests from the package process into the app-hosted Monocly integration bundle.

## Testing

- GitHub Actions run [30365318068](https://github.com/lynnswap/WebInspectorKit/actions/runs/30365318068) — all jobs succeeded in 8m27s.
  - Build: 4m46s.
  - Four iOS matrix jobs started concurrently after the build: ProxyKit 3m33s, DataKit 3m06s, UI 2m55s, Monocly 3m08s.
  - All 722 workspace tests passed: 195 ProxyKit, 231 DataKit, 292 UI, and 4 Monocly.
  - Every matrix job restored the same approximately 43 MB exact-key build cache.
- `swift test --package-path ContractTests` — 7 tests passed.
- Relocated-cache `test-without-building` validation — all 722 tests passed.
- Simulator ownership probes — Monocly and xctest processes were discovered within the selected UDID; forced stall shut down only that simulator and left an unrelated process alive.
- `actionlint`, `shellcheck Scripts/ci-xcodebuild-watchdog.sh`, `bash -n Scripts/ci-xcodebuild-watchdog.sh`, and external Action full-SHA audit.
- Branch-wide `codex-review` against pinned `main` after the successful CI run — no findings.
