### PR TITLE
Bound simulator watchdog cleanup

### DIFF
--- a/Scripts/ci-xcodebuild-watchdog.sh
+++ b/Scripts/ci-xcodebuild-watchdog.sh
@@ -62,6 +62,15 @@ wait_for_output_or_exit() {
     return 1
 }
 
+terminate_process_tree() {
+    local root_pid=$1
+    local child_pid
+    for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null); do
+        terminate_process_tree "${child_pid}"
+    done
+    kill -9 "${root_pid}" 2>/dev/null || true
+}
+
 descendant_process_ids() {
     local root_pid=$1
     local child_pid
@@ -71,19 +80,6 @@ descendant_process_ids() {
     done
 }
 
-simulator_test_process_ids() {
-    [ -n "${simulator_udid}" ] || return
-
-    xcrun simctl spawn "${simulator_udid}" launchctl print user/501 2>/dev/null \
-        | awk '
-            /^[[:space:]]*[0-9]+[[:space:]]/ &&
-            $1 != "0" &&
-            $0 ~ /(xctest|Monocly|WebContent)/ {
-                print $1
-            }
-        '
-}
-
 dump_stall_diagnostics() {
     echo "::error::xcodebuild produced no output for ${stall_seconds}s; dumping process state"
 
@@ -91,26 +87,33 @@ dump_stall_diagnostics() {
     for pid in $(descendant_process_ids "${runner}"); do
         sample_process "${pid}"
     done
-    for pid in $(simulator_test_process_ids); do
-        sample_process "${pid}"
-    done
     sample_process "${runner}"
 }
 
-terminate_test_processes() {
-    if [ -n "${simulator_udid}" ]; then
-        xcrun simctl shutdown "${simulator_udid}" 2>/dev/null || true
+shutdown_owned_simulator() {
+    [ -n "${simulator_udid}" ] || return
+
+    local shutdown_pid
+    local timeout_seconds=5
+    local remaining=${timeout_seconds}
+    xcrun simctl shutdown "${simulator_udid}" >/dev/null 2>&1 &
+    shutdown_pid=$!
+
+    while kill -0 "${shutdown_pid}" 2>/dev/null && [ "${remaining}" -gt 0 ]; do
+        sleep 1
+        remaining=$((remaining - 1))
+    done
+
+    if kill -0 "${shutdown_pid}" 2>/dev/null; then
+        echo "::warning::simulator shutdown did not finish within ${timeout_seconds}s; terminating simctl"
+        terminate_process_tree "${shutdown_pid}"
     fi
-    terminate_process_tree "${runner}"
+    wait "${shutdown_pid}" 2>/dev/null || true
 }
 
-terminate_process_tree() {
-    local root_pid=$1
-    local child_pid
-    for child_pid in $(pgrep -P "${root_pid}" 2>/dev/null); do
-        terminate_process_tree "${child_pid}"
-    done
-    kill -9 "${root_pid}" 2>/dev/null || true
+terminate_test_processes() {
+    terminate_process_tree "${runner}"
+    shutdown_owned_simulator
 }
 
 last_size=-1


### PR DESCRIPTION
## Purpose

Keep the CI `xcodebuild` watchdog from being blocked by CoreSimulator while handling a simulator service stall.

The failed [CI run](https://github.com/lynnswap/WebInspectorKit/actions/runs/30368117819/job/90306203216) never entered the Monocly tests: CoreSimulator timed out connecting to `com.apple.instruments.deviceservice.lockdown`, then the watchdog blocked in its own unbounded `simctl spawn` diagnostic until the outer 10-minute job timeout cancelled it.

## Changes

- Remove simulator-side process discovery from stall diagnostics because it depends on the same CoreSimulator transport that may already be wedged.
- Terminate the watched `xcodebuild` process tree before best-effort simulator cleanup.
- Bound owned-simulator shutdown to five seconds and terminate a hung `simctl` process.

This makes simulator stalls fail fast with the watchdog's explicit exit status instead of being reported as an opaque job cancellation.

## Testing

- `bash -n Scripts/ci-xcodebuild-watchdog.sh`
- `shellcheck Scripts/ci-xcodebuild-watchdog.sh`
- `git diff --check main...HEAD`
- Forced-stall probe with a hanging fake `xcrun`: watchdog exited 70 in 10 seconds, terminated both the watched process and fake `simctl`, and preserved an unrelated sentinel process.
- Codex review: no findings.
- [CI rerun attempt 2](https://github.com/lynnswap/WebInspectorKit/actions/runs/30368117819/attempts/2): succeeded; all four Monocly tests passed with zero failures, confirming the original simulator stall was transient.