### PR TITLE
Add explicit request selection to Network details

### DIFF
--- a/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
@@ -13,18 +13,15 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     private enum SelectionCommit {
         case none
-        case clearIfStillSelected(NetworkListEntry.ID)
+        case clearIfStillSelected(NetworkPanelSelection)
 
         @MainActor
         func apply(to model: NetworkPanelModel) {
             switch self {
             case .none:
                 return
-            case .clearIfStillSelected(let entryID):
-                guard model.selectedEntryID == entryID else {
-                    return
-                }
-                model.selectEntry(nil)
+            case .clearIfStillSelected(let selection):
+                model.clearSelection(ifUnchanged: selection)
             }
         }
     }
@@ -252,7 +249,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     private func finishUntrackedDetailRemovalIfNeeded(shownTarget: StackTarget?) {
         guard shownTarget == .list,
-              model.selectedEntryID != nil else {
+              model.selection != nil else {
             return
         }
         commit(
@@ -273,7 +270,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func desiredStackTarget() -> StackTarget {
-        model.selectedRequest == nil ? .list : .detail
+        model.selection == nil ? .list : .detail
     }
 
     private func currentStackTarget() -> StackTarget {
@@ -291,10 +288,10 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func userPopSelectionCommit() -> SelectionCommit {
-        guard let selectedEntryID = model.selectedEntryID else {
+        guard let selection = model.selection else {
             return .none
         }
-        return .clearIfStillSelected(selectedEntryID)
+        return .clearIfStillSelected(selection)
     }
 
     private func applyBackgroundFromTraits() {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerCell.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerCell.swift
@@ -1,0 +1,156 @@
+#if canImport(UIKit)
+import ObservationBridge
+import UIKit
+import WebInspectorDataKit
+import WebInspectorUIBase
+
+@MainActor
+final class NetworkDetailRequestPickerCell: UICollectionViewListCell {
+    private weak var observedRequest: NetworkRequest?
+    private var requestObservation: PortableObservationTracking.Token?
+    private var isRenderingActive = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentConfiguration = Self.makeContentConfiguration()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    isolated deinit {
+        requestObservation?.cancel()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        unbind()
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        accessories = state.isSelected ? [.checkmark()] : []
+    }
+
+    func bind(request: NetworkRequest, renderingActive: Bool) {
+        if observedRequest !== request {
+            cancelRequestObservation()
+            observedRequest = request
+        }
+        render(request: request)
+        setRenderingActive(renderingActive)
+    }
+
+    func bindAllRequests(renderingActive: Bool) {
+        cancelRequestObservation()
+        observedRequest = nil
+        isRenderingActive = renderingActive
+        render(
+            title: String(
+                localized: "network.filter.all",
+                bundle: WebInspectorUILocalization.bundle
+            ),
+            subtitle: nil
+        )
+    }
+
+    func setRenderingActive(_ isActive: Bool) {
+        guard isRenderingActive != isActive else {
+            if isActive {
+                renderObservedRequest()
+                startRequestObservationIfNeeded()
+            }
+            return
+        }
+
+        isRenderingActive = isActive
+        if isActive {
+            renderObservedRequest()
+            startRequestObservationIfNeeded()
+        } else {
+            cancelRequestObservation()
+        }
+    }
+
+    func unbind() {
+        cancelRequestObservation()
+        observedRequest = nil
+        isRenderingActive = false
+        render(title: nil, subtitle: nil)
+    }
+
+    private func startRequestObservationIfNeeded() {
+        guard requestObservation == nil,
+              let observedRequest else {
+            return
+        }
+        requestObservation = withPortableContinuousObservation { [weak self, weak observedRequest] _ in
+            guard let self,
+                  let observedRequest,
+                  isRenderingActive,
+                  self.observedRequest === observedRequest else {
+                return
+            }
+            render(request: observedRequest)
+        }
+    }
+
+    private func renderObservedRequest() {
+        guard let observedRequest else {
+            return
+        }
+        render(request: observedRequest)
+    }
+
+    private func render(request: NetworkRequest) {
+        render(title: request.displayName, subtitle: request.url)
+    }
+
+    private func render(title: String?, subtitle: String?) {
+        var content = (contentConfiguration as? UIListContentConfiguration)
+            ?? Self.makeContentConfiguration()
+        guard content.text != title || content.secondaryText != subtitle else {
+            return
+        }
+        content.text = title
+        content.secondaryText = subtitle
+        contentConfiguration = content
+    }
+
+    private func cancelRequestObservation() {
+        requestObservation?.cancel()
+        requestObservation = nil
+    }
+
+    private static func makeContentConfiguration() -> UIListContentConfiguration {
+        var content = UIListContentConfiguration.subtitleCell()
+        content.textProperties.numberOfLines = 1
+        content.textProperties.lineBreakMode = .byTruncatingMiddle
+        content.secondaryTextProperties.numberOfLines = 1
+        content.secondaryTextProperties.lineBreakMode = .byTruncatingMiddle
+        return content
+    }
+}
+
+#if DEBUG
+extension NetworkDetailRequestPickerCell {
+    var titleForTesting: String? {
+        (contentConfiguration as? UIListContentConfiguration)?.text
+    }
+
+    var subtitleForTesting: String? {
+        (contentConfiguration as? UIListContentConfiguration)?.secondaryText
+    }
+
+    var requestObservationForTesting: PortableObservationTracking.Token? {
+        requestObservation
+    }
+
+    var observedRequestForTesting: NetworkRequest? {
+        observedRequest
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -19,7 +19,7 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     }
 
     private let model: NetworkPanelModel
-    private var boundEntryID: NetworkListEntry.ID
+    private let boundEntryID: NetworkListEntry.ID
     private var modelObservation: PortableObservationTracking.Token?
     private var isRenderingActive = false
     private var searchText = ""
@@ -176,11 +176,14 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
             return
         }
 
-        guard selection.entryID == entry.id else {
+        guard selection.entryID == boundEntryID else {
+            dismissPicker(animated: true)
+            return
+        }
+        guard entry.id == boundEntryID else {
             preconditionFailure("The Network request picker must render the selected entry.")
         }
 
-        boundEntryID = entry.id
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let visibleRequests = requests.filter { request in
             request.matchesDisplaySearchText(query)

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -200,8 +200,17 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         snapshot.appendSections([.requests])
         snapshot.appendItems([.entry(entry.id)])
         snapshot.appendItems(visibleRequests.map { .request($0.id) })
+        let preservesVisibleItemIdentity = dataSource.snapshot().itemIdentifiers
+            == snapshot.itemIdentifiers
         dataSource.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
-            self?.renderSelection(selection)
+            guard let self else {
+                return
+            }
+            rebindVisibleRequestCells()
+            renderSelection(selection)
+        }
+        if preservesVisibleItemIdentity {
+            rebindVisibleRequestCells()
         }
     }
 
@@ -233,21 +242,7 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
                 cell.unbind()
                 return
             }
-
-            switch itemID {
-            case .entry(let entryID):
-                guard entryID == boundEntryID else {
-                    preconditionFailure("The Network request picker received an entry from another binding.")
-                }
-                cell.bindAllRequests(renderingActive: isRenderingActive)
-            case .request(let requestID):
-                guard model.entryID(containing: requestID) == boundEntryID,
-                      let request = model.request(for: requestID) else {
-                    cell.unbind()
-                    return
-                }
-                cell.bind(request: request, renderingActive: isRenderingActive)
-            }
+            bind(cell, to: itemID)
         }
 
         return UICollectionViewDiffableDataSource<Section, ItemID>(
@@ -258,6 +253,34 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
                 for: indexPath,
                 item: itemID
             )
+        }
+    }
+
+    private func rebindVisibleRequestCells() {
+        for case let cell as NetworkDetailRequestPickerCell in collectionView.visibleCells {
+            guard let indexPath = collectionView.indexPath(for: cell),
+                  let itemID = dataSource.itemIdentifier(for: indexPath) else {
+                cell.unbind()
+                continue
+            }
+            bind(cell, to: itemID)
+        }
+    }
+
+    private func bind(_ cell: NetworkDetailRequestPickerCell, to itemID: ItemID) {
+        switch itemID {
+        case .entry(let entryID):
+            guard entryID == boundEntryID else {
+                preconditionFailure("The Network request picker received an entry from another binding.")
+            }
+            cell.bindAllRequests(renderingActive: isRenderingActive)
+        case .request(let requestID):
+            guard model.entryID(containing: requestID) == boundEntryID,
+                  let request = model.request(for: requestID) else {
+                cell.unbind()
+                return
+            }
+            cell.bind(request: request, renderingActive: isRenderingActive)
         }
     }
 
@@ -296,6 +319,16 @@ extension NetworkDetailRequestPickerViewController {
 
     var boundEntryIDForTesting: NetworkListEntry.ID {
         boundEntryID
+    }
+
+    func requestCellForTesting(
+        requestID: NetworkRequest.ID
+    ) -> NetworkDetailRequestPickerCell? {
+        collectionView.layoutIfNeeded()
+        guard let indexPath = dataSource.indexPath(for: .request(requestID)) else {
+            return nil
+        }
+        return collectionView.cellForItem(at: indexPath) as? NetworkDetailRequestPickerCell
     }
 
     func resumeRenderingForTesting() {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -86,11 +86,7 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
 
     func updateSearchResults(for searchController: UISearchController) {
         let nextSearchText = searchController.searchBar.text ?? ""
-        guard searchText != nextSearchText else {
-            return
-        }
-        searchText = nextSearchText
-        renderCurrentEntry(animatingDifferences: true)
+        setSearchText(nextSearchText)
     }
 
     override func collectionView(
@@ -150,6 +146,17 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         setVisibleCellRenderingActive(false)
         modelObservation?.cancel()
         modelObservation = nil
+    }
+
+    private func setSearchText(_ text: String) {
+        guard searchText != text else {
+            return
+        }
+        searchText = text
+        guard isRenderingActive else {
+            return
+        }
+        startObservingSelection()
     }
 
     private func renderCurrentEntry(animatingDifferences: Bool) {
@@ -301,8 +308,7 @@ extension NetworkDetailRequestPickerViewController {
     }
 
     func setSearchTextForTesting(_ text: String) {
-        searchText = text
-        renderCurrentEntry(animatingDifferences: false)
+        setSearchText(text)
     }
 }
 #endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -1,0 +1,312 @@
+#if canImport(UIKit)
+import ObservationBridge
+import UIKit
+import WebInspectorDataKit
+import WebInspectorUIBase
+
+@MainActor
+final class NetworkDetailRequestPickerViewController: UICollectionViewController,
+    UISearchResultsUpdating,
+    UIPopoverPresentationControllerDelegate
+{
+    enum ItemID: Hashable {
+        case entry(NetworkListEntry.ID)
+        case request(NetworkRequest.ID)
+    }
+
+    private enum Section: Hashable {
+        case requests
+    }
+
+    private let model: NetworkPanelModel
+    private var boundEntryID: NetworkListEntry.ID
+    private var modelObservation: PortableObservationTracking.Token?
+    private var searchText = ""
+    private lazy var dataSource = makeDataSource()
+
+    init(model: NetworkPanelModel, entryID: NetworkListEntry.ID) {
+        self.model = model
+        boundEntryID = entryID
+
+        var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        configuration.showsSeparators = true
+        super.init(collectionViewLayout: UICollectionViewCompositionalLayout.list(using: configuration))
+        preferredContentSize = CGSize(width: 440, height: 560)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    isolated deinit {
+        modelObservation?.cancel()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        _ = dataSource
+        title = String(
+            localized: "network.section.request",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        collectionView.alwaysBounceVertical = true
+        collectionView.keyboardDismissMode = .onDrag
+        collectionView.accessibilityIdentifier = "WebInspector.Network.DetailRequestPicker"
+        collectionView.allowsMultipleSelection = false
+
+        let searchController = UISearchController(searchResultsController: nil)
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = String(
+            localized: "network.search.placeholder",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        searchController.searchResultsUpdater = self
+        navigationItem.searchController = searchController
+        navigationItem.preferredSearchBarPlacement = .stacked
+        navigationItem.hidesSearchBarWhenScrolling = false
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            systemItem: .close,
+            primaryAction: UIAction { [weak self] _ in
+                self?.dismissPicker(animated: true)
+            }
+        )
+    }
+
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        startObservingSelection()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        stopObservingSelection()
+        super.viewDidDisappear(animated)
+    }
+
+    func updateSearchResults(for searchController: UISearchController) {
+        let nextSearchText = searchController.searchBar.text ?? ""
+        guard searchText != nextSearchText else {
+            return
+        }
+        searchText = nextSearchText
+        renderCurrentEntry(animatingDifferences: true)
+    }
+
+    override func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        guard let itemID = dataSource.itemIdentifier(for: indexPath) else {
+            return
+        }
+        switch itemID {
+        case .entry(let entryID):
+            guard entryID == boundEntryID,
+                  model.entry(for: entryID) != nil else {
+                renderCurrentEntry(animatingDifferences: false)
+                return
+            }
+            model.selectEntry(entryID)
+        case .request(let requestID):
+            guard model.entryID(containing: requestID) == boundEntryID else {
+                renderCurrentEntry(animatingDifferences: false)
+                return
+            }
+            model.selectRequest(id: requestID)
+        }
+        dismissPicker(animated: true)
+    }
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        traitCollection.horizontalSizeClass == .compact ? .pageSheet : .none
+    }
+
+    private func startObservingSelection() {
+        modelObservation?.cancel()
+        modelObservation = withPortableContinuousObservation { [weak self] event in
+            guard let self else {
+                return
+            }
+            let selection = model.selection
+            let entry = model.selectedEntry
+            let requests = entry?.requests ?? []
+            render(
+                selection: selection,
+                entry: entry,
+                requests: requests,
+                animatingDifferences: event.kind != .initial
+            )
+        }
+    }
+
+    private func stopObservingSelection() {
+        modelObservation?.cancel()
+        modelObservation = nil
+    }
+
+    private func renderCurrentEntry(animatingDifferences: Bool) {
+        let selection = model.selection
+        let entry = model.selectedEntry
+        render(
+            selection: selection,
+            entry: entry,
+            requests: entry?.requests ?? [],
+            animatingDifferences: animatingDifferences
+        )
+    }
+
+    private func render(
+        selection: NetworkPanelSelection?,
+        entry: NetworkListEntry?,
+        requests: [NetworkRequest],
+        animatingDifferences: Bool
+    ) {
+        guard let selection,
+              let entry,
+              requests.count > 1 else {
+            dismissPicker(animated: true)
+            return
+        }
+
+        guard selection.entryID == entry.id else {
+            preconditionFailure("The Network request picker must render the selected entry.")
+        }
+
+        boundEntryID = entry.id
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let visibleRequests = requests.filter { request in
+            request.matchesDisplaySearchText(query)
+        }
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ItemID>()
+        snapshot.appendSections([.requests])
+        snapshot.appendItems([.entry(entry.id)])
+        snapshot.appendItems(visibleRequests.map { .request($0.id) })
+        dataSource.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
+            self?.renderSelection(selection)
+        }
+    }
+
+    private func renderSelection(_ selection: NetworkPanelSelection) {
+        let selectedItemID: ItemID
+        switch selection {
+        case .entry(let entryID):
+            selectedItemID = .entry(entryID)
+        case .request(_, let requestID):
+            selectedItemID = .request(requestID)
+        }
+
+        for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
+            guard dataSource.itemIdentifier(for: indexPath) != selectedItemID else {
+                continue
+            }
+            collectionView.deselectItem(at: indexPath, animated: false)
+        }
+        guard let indexPath = dataSource.indexPath(for: selectedItemID) else {
+            return
+        }
+        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+    }
+
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<Section, ItemID> {
+        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+            [weak self] cell, _, itemID in
+            guard let self else {
+                cell.contentConfiguration = nil
+                cell.accessories = []
+                return
+            }
+
+            var content = UIListContentConfiguration.subtitleCell()
+            switch itemID {
+            case .entry(let entryID):
+                guard entryID == boundEntryID else {
+                    preconditionFailure("The Network request picker received an entry from another binding.")
+                }
+                content.text = String(
+                    localized: "network.filter.all",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+                content.secondaryText = nil
+            case .request(let requestID):
+                guard model.entryID(containing: requestID) == boundEntryID,
+                      let request = model.request(for: requestID) else {
+                    cell.contentConfiguration = nil
+                    cell.accessories = []
+                    return
+                }
+                content.text = request.displayName
+                content.secondaryText = request.url
+                content.secondaryTextProperties.numberOfLines = 1
+            }
+            cell.contentConfiguration = content
+            cell.configurationUpdateHandler = { cell, state in
+                guard let cell = cell as? UICollectionViewListCell else {
+                    return
+                }
+                cell.accessories = state.isSelected ? [.checkmark()] : []
+            }
+            cell.setNeedsUpdateConfiguration()
+        }
+
+        return UICollectionViewDiffableDataSource<Section, ItemID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, itemID in
+            collectionView.dequeueConfiguredReusableCell(
+                using: registration,
+                for: indexPath,
+                item: itemID
+            )
+        }
+    }
+
+    private func dismissPicker(animated: Bool) {
+        stopObservingSelection()
+        navigationController?.dismiss(animated: animated)
+    }
+}
+
+#if DEBUG
+extension NetworkDetailRequestPickerViewController {
+    var itemIDsForTesting: [ItemID] {
+        dataSource.snapshot().itemIdentifiers
+    }
+
+    var selectedItemIDForTesting: ItemID? {
+        guard let indexPath = collectionView.indexPathsForSelectedItems?.first else {
+            return nil
+        }
+        return dataSource.itemIdentifier(for: indexPath)
+    }
+
+    var isObservingModelForTesting: Bool {
+        modelObservation?.isActive == true
+    }
+
+    var modelObservationDeliveryForTesting: PortableObservationTracking.Token? {
+        modelObservation
+    }
+
+    var boundEntryIDForTesting: NetworkListEntry.ID {
+        boundEntryID
+    }
+
+    func resumeRenderingForTesting() {
+        loadViewIfNeeded()
+        startObservingSelection()
+    }
+
+    func suspendRenderingForTesting() {
+        stopObservingSelection()
+    }
+
+    func setSearchTextForTesting(_ text: String) {
+        searchText = text
+        renderCurrentEntry(animatingDifferences: false)
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -21,6 +21,7 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     private let model: NetworkPanelModel
     private var boundEntryID: NetworkListEntry.ID
     private var modelObservation: PortableObservationTracking.Token?
+    private var isRenderingActive = false
     private var searchText = ""
     private lazy var dataSource = makeDataSource()
 
@@ -125,6 +126,8 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     }
 
     private func startObservingSelection() {
+        isRenderingActive = true
+        setVisibleCellRenderingActive(true)
         modelObservation?.cancel()
         modelObservation = withPortableContinuousObservation { [weak self] event in
             guard let self else {
@@ -143,6 +146,8 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     }
 
     private func stopObservingSelection() {
+        isRenderingActive = false
+        setVisibleCellRenderingActive(false)
         modelObservation?.cancel()
         modelObservation = nil
     }
@@ -212,44 +217,27 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     }
 
     private func makeDataSource() -> UICollectionViewDiffableDataSource<Section, ItemID> {
-        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+        let registration = UICollectionView.CellRegistration<NetworkDetailRequestPickerCell, ItemID> {
             [weak self] cell, _, itemID in
             guard let self else {
-                cell.contentConfiguration = nil
-                cell.accessories = []
+                cell.unbind()
                 return
             }
 
-            var content = UIListContentConfiguration.subtitleCell()
             switch itemID {
             case .entry(let entryID):
                 guard entryID == boundEntryID else {
                     preconditionFailure("The Network request picker received an entry from another binding.")
                 }
-                content.text = String(
-                    localized: "network.filter.all",
-                    bundle: WebInspectorUILocalization.bundle
-                )
-                content.secondaryText = nil
+                cell.bindAllRequests(renderingActive: isRenderingActive)
             case .request(let requestID):
                 guard model.entryID(containing: requestID) == boundEntryID,
                       let request = model.request(for: requestID) else {
-                    cell.contentConfiguration = nil
-                    cell.accessories = []
+                    cell.unbind()
                     return
                 }
-                content.text = request.displayName
-                content.secondaryText = request.url
-                content.secondaryTextProperties.numberOfLines = 1
+                cell.bind(request: request, renderingActive: isRenderingActive)
             }
-            cell.contentConfiguration = content
-            cell.configurationUpdateHandler = { cell, state in
-                guard let cell = cell as? UICollectionViewListCell else {
-                    return
-                }
-                cell.accessories = state.isSelected ? [.checkmark()] : []
-            }
-            cell.setNeedsUpdateConfiguration()
         }
 
         return UICollectionViewDiffableDataSource<Section, ItemID>(
@@ -260,6 +248,12 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
                 for: indexPath,
                 item: itemID
             )
+        }
+    }
+
+    private func setVisibleCellRenderingActive(_ isActive: Bool) {
+        for case let cell as NetworkDetailRequestPickerCell in collectionView.visibleCells {
+            cell.setRenderingActive(isActive)
         }
     }
 

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -97,11 +97,27 @@ package final class NetworkDetailViewController: UIViewController {
         }
         return controller
     }()
+    private lazy var requestPickerItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(
+            image: UIImage(systemName: "list.bullet"),
+            style: .plain,
+            target: self,
+            action: #selector(presentRequestPicker)
+        )
+        item.accessibilityIdentifier = "WebInspector.Network.DetailRequestPickerButton"
+        item.accessibilityLabel = String(
+            localized: "network.section.request",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        return item
+    }()
     private var previewRoles: [NetworkBody.Role] = []
-    private var hasBoundSelectedRequest = false
+    private var hasBoundSelection = false
+    private var observedSelection: NetworkPanelSelection?
     private weak var observedEntry: NetworkListEntry?
     private weak var observedRequest: NetworkRequest?
     private var observedRequests: [NetworkRequest] = []
+    private weak var presentedRequestPicker: NetworkDetailRequestPickerViewController?
     private var bodyTopToPreviewContainerConstraint: NSLayoutConstraint?
     private var bodyTopToPreviewRoleControlConstraint: NSLayoutConstraint?
 #if DEBUG
@@ -164,6 +180,13 @@ package final class NetworkDetailViewController: UIViewController {
         suspendRendering()
     }
 
+    override package func willMove(toParent parent: UIViewController?) {
+        if parent == nil {
+            dismissRequestPicker(animated: false)
+        }
+        super.willMove(toParent: parent)
+    }
+
     override package func contentScrollView(for edge: NSDirectionalRectEdge) -> UIScrollView? {
         if edge == .top || edge == .bottom {
             return scrollEdgeController.contentScrollView ?? super.contentScrollView(for: edge)
@@ -182,10 +205,14 @@ package final class NetworkDetailViewController: UIViewController {
         modelObservation?.cancel()
         let token = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
+            let selection = model.selection
             let selectedEntry = model.selectedEntry
             _ = selectedEntry?.requests
-            bindSelectedEntry(
-                selectedEntry,
+            let selectedRequest = model.selectedRequest
+            bindSelection(
+                selection,
+                entry: selectedEntry,
+                selectedRequest: selectedRequest,
                 force: selectedRequestRenderObservation == nil
             )
         }
@@ -197,12 +224,22 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func resumeRendering() {
         guard isRenderingActive == false else {
-            bindSelectedEntry(model.selectedEntry, force: selectedRequestRenderObservation == nil)
+            bindSelection(
+                model.selection,
+                entry: model.selectedEntry,
+                selectedRequest: model.selectedRequest,
+                force: selectedRequestRenderObservation == nil
+            )
             updateBodyRenderingActiveForCurrentSurface()
             return
         }
         isRenderingActive = true
-        bindSelectedEntry(model.selectedEntry, force: true)
+        bindSelection(
+            model.selection,
+            entry: model.selectedEntry,
+            selectedRequest: model.selectedRequest,
+            force: true
+        )
         startObservingModel()
         updateBodyRenderingActiveForCurrentSurface()
     }
@@ -314,31 +351,55 @@ package final class NetworkDetailViewController: UIViewController {
         renderModeControl()
     }
 
-    private func bindSelectedEntry(_ entry: NetworkListEntry?, force: Bool = false) {
+    private func bindSelection(
+        _ selection: NetworkPanelSelection?,
+        entry: NetworkListEntry?,
+        selectedRequest: NetworkRequest?,
+        force: Bool = false
+    ) {
         guard isRenderingActive else {
             return
         }
-        let requests = entry?.requests ?? []
+
+        let requests: [NetworkRequest]
+        switch selection {
+        case .entry:
+            requests = entry?.requests ?? []
+        case .request:
+            requests = selectedRequest.map { [$0] } ?? []
+        case nil:
+            requests = []
+        }
+        renderRequestPickerItem(entry: entry)
+
         guard force
-            || hasBoundSelectedRequest == false
+            || hasBoundSelection == false
+            || observedSelection != selection
             || observedEntry !== entry
-            || observedRequests.map(\.id) != requests.map(\.id) else {
-            renderModeControl(selectedRequest: requests.first)
+            || requestInstancesMatch(observedRequests, requests) == false else {
+            renderModeControl(selectedRequest: selectedRequest)
             return
         }
 
-        guard let entry,
-              let request = requests.first else {
+        guard let selection,
+              let entry,
+              let selectedRequest,
+              requests.isEmpty == false else {
             clearSelectedRequestPresentation(bodySurface: .none)
             return
         }
 
-        hasBoundSelectedRequest = true
+        guard selection.entryID == entry.id else {
+            preconditionFailure("A Network detail selection must reference its selected entry.")
+        }
+
+        hasBoundSelection = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
         unbindResponseBodyFetchObservation()
+        observedSelection = selection
         observedEntry = entry
-        observedRequest = request
+        observedRequest = selectedRequest
         observedRequests = requests
 #if DEBUG
         selectedRequestRenderObservationDelivery = nil
@@ -347,8 +408,8 @@ package final class NetworkDetailViewController: UIViewController {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
-        renderModeControl(selectedRequest: request)
-        bindSelectedRequestRendering(requests)
+        renderModeControl(selectedRequest: selectedRequest)
+        bindSelectedRequestRendering(selection: selection, requests: requests)
     }
 
     private func rebindSelectedRequestRendering() {
@@ -361,23 +422,27 @@ package final class NetworkDetailViewController: UIViewController {
         guard isRenderingActive else {
             return
         }
-        guard observedRequests.isEmpty == false else {
+        guard let observedSelection,
+              observedRequests.isEmpty == false else {
             return
         }
-        bindSelectedRequestRendering(observedRequests)
+        bindSelectedRequestRendering(selection: observedSelection, requests: observedRequests)
     }
 
-    private func bindSelectedRequestRendering(_ requests: [NetworkRequest]) {
+    private func bindSelectedRequestRendering(
+        selection: NetworkPanelSelection,
+        requests: [NetworkRequest]
+    ) {
         guard isRenderingActive else {
             return
         }
-        let requestIDs = requests.map(\.id)
         let token = withPortableContinuousObservation { [weak self] _ in
             guard let self,
-                  observedRequests.map(\.id) == requestIDs else {
+                  observedSelection == selection,
+                  requestInstancesMatch(observedRequests, requests) else {
                 return
             }
-            renderSelectedRequests(observedRequests)
+            renderSelection(selection, requests: observedRequests)
         }
         selectedRequestRenderObservation = token
 #if DEBUG
@@ -385,18 +450,41 @@ package final class NetworkDetailViewController: UIViewController {
 #endif
     }
 
-    private func renderSelectedRequests(_ requests: [NetworkRequest]) {
+    private func renderSelection(
+        _ selection: NetworkPanelSelection,
+        requests: [NetworkRequest]
+    ) {
         guard isRenderingActive else {
             return
         }
         switch mode {
         case .preview:
-            guard let candidate = previewCandidate(in: requests) else {
-                return
+            let candidate: PreviewCandidate
+            switch selection {
+            case .entry:
+                guard let groupedCandidate = previewCandidate(in: requests) else {
+                    preconditionFailure("A selected Network entry must contain at least one request.")
+                }
+                candidate = groupedCandidate
+            case .request:
+                guard requests.count == 1,
+                      let request = requests.first else {
+                    preconditionFailure("An explicit Network request selection must render exactly one request.")
+                }
+                candidate = previewCandidate(for: request) ?? .standard(request)
             }
             renderPreviewSurface(candidate: candidate)
         case .headers:
-            renderHeadersSurface(selectedRequests: requests)
+            switch selection {
+            case .entry:
+                renderHeadersSurface(entryRequests: requests)
+            case .request:
+                guard requests.count == 1,
+                      let request = requests.first else {
+                    preconditionFailure("An explicit Network request selection must render exactly one request.")
+                }
+                renderHeadersSurface(request: request)
+            }
         }
     }
 
@@ -409,7 +497,7 @@ package final class NetworkDetailViewController: UIViewController {
         updateBodyRenderingActiveForCurrentSurface()
     }
 
-    private func renderHeadersSurface(selectedRequests requests: [NetworkRequest]) {
+    private func renderHeadersSurface(entryRequests requests: [NetworkRequest]) {
         guard let representativeRequest = requests.first else {
             preconditionFailure("A selected Network entry must contain at least one request.")
         }
@@ -417,6 +505,13 @@ package final class NetworkDetailViewController: UIViewController {
         title = representativeRequest.displayName
         showHeaders()
         headersTextView.render(requests: requests)
+    }
+
+    private func renderHeadersSurface(request: NetworkRequest) {
+        observedRequest = request
+        title = request.displayName
+        showHeaders()
+        headersTextView.render(request: request)
     }
 
     private func setMode(_ nextMode: NetworkDetailViewController.Mode) {
@@ -453,10 +548,11 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func clearSelectedRequestPresentation(bodySurface: NetworkBodySurface) {
-        hasBoundSelectedRequest = true
+        hasBoundSelection = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
         unbindResponseBodyFetchObservation()
+        observedSelection = nil
         observedEntry = nil
         observedRequest = nil
         observedRequests = []
@@ -464,8 +560,58 @@ package final class NetworkDetailViewController: UIViewController {
         selectedRequestRenderObservationDelivery = nil
 #endif
         title = nil
+        renderRequestPickerItem(entry: nil)
         showEmptySelection(bodySurface: bodySurface)
         renderModeControl(selectedRequest: nil)
+    }
+
+    private func requestInstancesMatch(
+        _ lhs: [NetworkRequest],
+        _ rhs: [NetworkRequest]
+    ) -> Bool {
+        lhs.count == rhs.count && zip(lhs, rhs).allSatisfy { $0 === $1 }
+    }
+
+    private func renderRequestPickerItem(entry: NetworkListEntry?) {
+        guard let entry,
+              entry.requests.count > 1 else {
+            navigationItem.rightBarButtonItem = nil
+            dismissRequestPicker(animated: false)
+            return
+        }
+        navigationItem.rightBarButtonItem = requestPickerItem
+        requestPickerItem.accessibilityValue = String(entry.requests.count)
+    }
+
+    @objc private func presentRequestPicker() {
+        guard presentedRequestPicker == nil,
+              let entry = model.selectedEntry,
+              entry.requests.count > 1 else {
+            return
+        }
+
+        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entry.id)
+        let navigationController = UINavigationController(rootViewController: picker)
+        navigationController.modalPresentationStyle = .popover
+        navigationController.preferredContentSize = picker.preferredContentSize
+        guard let popoverPresentationController = navigationController.popoverPresentationController else {
+            preconditionFailure("A popover presentation must provide a popover presentation controller.")
+        }
+        popoverPresentationController.sourceItem = requestPickerItem
+        popoverPresentationController.delegate = picker
+        popoverPresentationController.adaptiveSheetPresentationController.detents = [
+            .medium(),
+            .large(),
+        ]
+        presentedRequestPicker = picker
+        present(navigationController, animated: true)
+    }
+
+    private func dismissRequestPicker(animated: Bool) {
+        guard let picker = presentedRequestPicker else {
+            return
+        }
+        picker.navigationController?.dismiss(animated: animated)
     }
 
     private func showEmptySelection(bodySurface: NetworkBodySurface) {
@@ -935,6 +1081,14 @@ extension NetworkDetailViewController {
         observedRequest?.id
     }
 
+    var requestPickerItemForTesting: UIBarButtonItem? {
+        navigationItem.rightBarButtonItem
+    }
+
+    var presentedRequestPickerForTesting: NetworkDetailRequestPickerViewController? {
+        presentedRequestPicker
+    }
+
     func isDetailModeEnabledForTesting(_ mode: NetworkDetailViewController.Mode) -> Bool {
         modeControlController.isModeEnabledForTesting(mode)
     }
@@ -954,6 +1108,10 @@ extension NetworkDetailViewController {
 
     func selectPreviewRoleForTesting(_ role: NetworkBody.Role) {
         previewRoleControlController.selectRoleForTesting(role)
+    }
+
+    func presentRequestPickerForTesting() {
+        presentRequestPicker()
     }
 }
 #endif

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -165,6 +165,18 @@ package struct NetworkPanelListProjection: Equatable, Sendable {
     package let entryIDs: [NetworkListEntry.ID]
 }
 
+package enum NetworkPanelSelection: Equatable, Sendable {
+    case entry(NetworkListEntry.ID)
+    case request(entryID: NetworkListEntry.ID, requestID: NetworkRequest.ID)
+
+    package var entryID: NetworkListEntry.ID {
+        switch self {
+        case .entry(let entryID), .request(let entryID, _):
+            entryID
+        }
+    }
+}
+
 private final class NetworkPanelListInvalidationRelay: Sendable {
     private struct State {
         var continuations: [UUID: AsyncStream<NetworkPanelListInvalidation>.Continuation] = [:]
@@ -242,7 +254,7 @@ package final class NetworkPanelModel {
     private let fetchedResultsController: WebInspectorFetchedResultsController<NetworkRequest>
     private let collectionState: NetworkRequestCollectionState
 
-    package private(set) var selectedEntryID: NetworkListEntry.ID?
+    package private(set) var selection: NetworkPanelSelection?
     package private(set) var searchText = ""
     package private(set) var activeResourceFilters: Set<NetworkDisplay.ResourceFilter> = []
 
@@ -258,7 +270,6 @@ package final class NetworkPanelModel {
     @ObservationIgnored private var visibleEntryIDSet: Set<NetworkListEntry.ID> = []
     @ObservationIgnored private var nextListTransactionRevision: UInt64 = 0
     @ObservationIgnored private var listEntryIdentityGeneration: UInt64 = 0
-    @ObservationIgnored private var selectedRequestAnchorID: NetworkRequest.ID?
 #if DEBUG
     private struct RawTransactionDeliveryWaiter {
         var id: Int
@@ -350,15 +361,31 @@ package final class NetworkPanelModel {
     }
 
     package var selectedRequest: NetworkRequest? {
-        selectedEntry?.representativeRequest
+        guard let selection else {
+            return nil
+        }
+        switch selection {
+        case .entry:
+            return selectedEntry?.representativeRequest
+        case let .request(entryID, requestID):
+            guard entryIDByRequestID[requestID] == entryID,
+                  let request = requestsByID[requestID] else {
+                preconditionFailure("A selected Network request must belong to its selected entry.")
+            }
+            return request
+        }
     }
 
-    package var selectedRequests: [NetworkRequest] {
+    package var selectedEntryRequests: [NetworkRequest] {
         selectedEntry?.requests ?? []
     }
 
+    package var selectedEntryID: NetworkListEntry.ID? {
+        selection?.entryID
+    }
+
     package var selectedRequestID: NetworkRequest.ID? {
-        selectedRequestAnchorID
+        selectedRequest?.id
     }
 
     package func entry(for id: NetworkListEntry.ID) -> NetworkListEntry? {
@@ -375,28 +402,35 @@ package final class NetworkPanelModel {
 
     package func selectEntry(_ id: NetworkListEntry.ID?) {
         guard let id else {
-            selectedEntryID = nil
-            selectedRequestAnchorID = nil
+            selection = nil
             return
         }
-        guard let entry = entriesByID[id] else {
-            selectedEntryID = nil
-            selectedRequestAnchorID = nil
+        guard entriesByID[id] != nil else {
+            selection = nil
             return
         }
-        selectedEntryID = id
-        selectedRequestAnchorID = entry.representativeRequest.id
+        selection = .entry(id)
     }
 
     package func selectRequest(_ request: NetworkRequest?) {
-        guard let request,
-              let entryID = entryIDByRequestID[request.id] else {
-            selectedEntryID = nil
-            selectedRequestAnchorID = nil
+        selectRequest(id: request?.id)
+    }
+
+    package func selectRequest(id requestID: NetworkRequest.ID?) {
+        guard let requestID,
+              requestsByID[requestID] != nil,
+              let entryID = entryIDByRequestID[requestID] else {
+            selection = nil
             return
         }
-        selectedEntryID = entryID
-        selectedRequestAnchorID = request.id
+        selection = .request(entryID: entryID, requestID: requestID)
+    }
+
+    package func clearSelection(ifUnchanged expectedSelection: NetworkPanelSelection) {
+        guard selection == expectedSelection else {
+            return
+        }
+        selection = nil
     }
 
     package func setSearchText(_ text: String) {
@@ -431,8 +465,7 @@ package final class NetworkPanelModel {
     }
 
     package func clearRequests() {
-        selectedEntryID = nil
-        selectedRequestAnchorID = nil
+        selection = nil
         context.network.clearRequests()
     }
 
@@ -462,15 +495,10 @@ package final class NetworkPanelModel {
         rawTransactionDeliveryCountStorageForTesting &+= 1
         resolveRawTransactionDeliveryWaitersForTesting(result: true)
 #endif
+        let selectionBeforeTransaction = selection
         if transaction.isReset {
             rebuildEntries(from: requests.items)
-            if let selectedRequestAnchorID,
-               let entryID = entryIDByRequestID[selectedRequestAnchorID] {
-                selectedEntryID = entryID
-            } else {
-                selectedEntryID = nil
-                selectedRequestAnchorID = nil
-            }
+            reconcileSelection(selectionBeforeTransaction, forceRebind: true)
             publishListTransaction(
                 topologyChangedEntryIDs: Set(visibleEntryIDs),
                 rebindsStableEntries: true
@@ -516,6 +544,8 @@ package final class NetworkPanelModel {
                 topologyChangedEntryIDs: &topologyChangedEntryIDs
             )
         }
+
+        reconcileSelection(selectionBeforeTransaction)
 
         publishListTransaction(
             topologyChangedEntryIDs: topologyChangedEntryIDs,
@@ -587,7 +617,6 @@ package final class NetworkPanelModel {
         affectedEntryIDs: inout Set<NetworkListEntry.ID>,
         topologyChangedEntryIDs: inout Set<NetworkListEntry.ID>
     ) {
-        let wasSelectedRequest = selectedRequestAnchorID == request.id
         let previousRequest = requestsByID[request.id]
         let previousStatusSeverity = requestStatusSeverityByID[request.id]
         let lifecycleRestarted: Bool
@@ -648,9 +677,6 @@ package final class NetworkPanelModel {
             if hasActiveDisplayCriteria {
                 affectedEntryIDs.insert(currentEntryID)
             }
-            if selectedRequestAnchorID == request.id {
-                selectedEntryID = currentEntryID
-            }
             return
         }
 
@@ -693,10 +719,6 @@ package final class NetworkPanelModel {
             affectedEntryIDs.insert(nextEntryID)
         }
 
-        if wasSelectedRequest {
-            selectedEntryID = nextEntryID
-            selectedRequestAnchorID = request.id
-        }
     }
 
     private func removeRequest(
@@ -720,13 +742,6 @@ package final class NetworkPanelModel {
             topologyChangedEntryIDs: &topologyChangedEntryIDs
         )
 
-        if selectedRequestAnchorID == requestID {
-            if let entry = entriesByID[entryID] {
-                selectedRequestAnchorID = entry.representativeRequest.id
-            } else {
-                selectedRequestAnchorID = nil
-            }
-        }
     }
 
     private func removeRequestFromEntry(
@@ -747,10 +762,6 @@ package final class NetworkPanelModel {
                 visibleEntryIDs.removeAll { $0 == entryID }
                 topologyChangedEntryIDs.insert(entryID)
             }
-            if selectedEntryID == entryID {
-                selectedEntryID = nil
-                selectedRequestAnchorID = nil
-            }
         } else {
 #if DEBUG
             memberTraversalCountStorageForTesting += entry.requests.count
@@ -765,6 +776,30 @@ package final class NetworkPanelModel {
                 affectedEntryIDs.insert(entryID)
             }
         }
+    }
+
+    private func reconcileSelection(
+        _ previousSelection: NetworkPanelSelection?,
+        forceRebind: Bool = false
+    ) {
+        let reconciledSelection: NetworkPanelSelection?
+        switch previousSelection {
+        case .entry(let entryID):
+            reconciledSelection = entriesByID[entryID] == nil ? nil : previousSelection
+        case .request(_, let requestID):
+            guard requestsByID[requestID] != nil,
+                  let entryID = entryIDByRequestID[requestID] else {
+                reconciledSelection = nil
+                break
+            }
+            reconciledSelection = .request(entryID: entryID, requestID: requestID)
+        case nil:
+            reconciledSelection = nil
+        }
+        guard forceRebind || selection != reconciledSelection else {
+            return
+        }
+        selection = reconciledSelection
     }
 
     private func reapplyDisplayCriteria() {
@@ -1041,7 +1076,9 @@ package final class NetworkPanelModel {
 #if DEBUG
 extension NetworkPanelModel {
     package func rebuildEntriesForTesting() {
+        let selectionBeforeRebuild = selection
         rebuildEntries(from: requests.items)
+        reconcileSelection(selectionBeforeRebuild, forceRebind: true)
         publishListTransaction(
             topologyChangedEntryIDs: Set(visibleEntryIDs),
             rebindsStableEntries: true

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -1075,6 +1075,28 @@ package final class NetworkPanelModel {
 
 #if DEBUG
 extension NetworkPanelModel {
+    package func upsertRequestForTesting(_ request: NetworkRequest) {
+        let selectionBeforeTransaction = selection
+        var affectedEntryIDs: Set<NetworkListEntry.ID> = []
+        var topologyChangedEntryIDs: Set<NetworkListEntry.ID> = []
+        upsertRequest(
+            request,
+            affectedEntryIDs: &affectedEntryIDs,
+            topologyChangedEntryIDs: &topologyChangedEntryIDs
+        )
+        for entryID in affectedEntryIDs {
+            reconcileVisibility(
+                of: entryID,
+                topologyChangedEntryIDs: &topologyChangedEntryIDs
+            )
+        }
+        reconcileSelection(selectionBeforeTransaction)
+        publishListTransaction(
+            topologyChangedEntryIDs: topologyChangedEntryIDs,
+            rebindsStableEntries: false
+        )
+    }
+
     package func rebuildEntriesForTesting() {
         let selectionBeforeRebuild = selection
         rebuildEntries(from: requests.items)

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -730,7 +730,7 @@ struct NetworkDetailViewControllerTests {
             base64Encoded: false
         )
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(errorRequest)
+        try selectEntry(containing: errorRequest, in: model)
         let viewController = makeNetworkDetailViewController(
             model: model,
             initialMode: .preview
@@ -743,7 +743,7 @@ struct NetworkDetailViewControllerTests {
                 && viewController.syntaxBodyViewControllerForTesting
                     .syntaxViewForTesting.text.contains(#""error" : "not found""#)
         })
-        #expect(model.selectedRequests.map(\.id) == [successfulRequest.id, errorRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [successfulRequest.id, errorRequest.id])
     }
 
     @Test
@@ -2474,6 +2474,51 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func compactBackPreservesReplacementRequestInTheSameEntry() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("compact-replacement")
+        installNavigationVisit(in: context, frameID: frameID)
+        let firstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "compact-first",
+            url: "https://example.com/compact-first.js",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        let secondRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "compact-second",
+            url: "https://example.com/compact-second.js",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: firstRequest.id))
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(firstRequest)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+            model.selectRequest(secondRequest)
+            navigationController.syncStackForTesting()
+        }
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.selection == .request(entryID: entryID, requestID: secondRequest.id))
+        #expect(model.selectedRequest === secondRequest)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
     func compactContainerReleasesDetailMediaPreviewResourcesWhenDetailIsRemoved() async throws {
         let context = makeContext()
         let request = try #require(
@@ -3761,7 +3806,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 4
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(secondRequest)
+        try selectEntry(containing: secondRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
@@ -3779,7 +3824,47 @@ struct NetworkDetailViewControllerTests {
         let secondHeading = try #require(renderedText.range(of: "2. second.js"))
         #expect(firstHeading.lowerBound < secondHeading.lowerBound)
         #expect(model.selectedRequest === firstRequest)
-        #expect(model.selectedRequests.map(\.id) == [firstRequest.id, secondRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [firstRequest.id, secondRequest.id])
+    }
+
+    @Test
+    func explicitGroupedMemberHeadersRenderOnlyThatRequest() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("explicit-headers")
+        installNavigationVisit(in: context, frameID: frameID)
+        let firstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "first-explicit-header",
+            url: "https://example.com/first-explicit.js",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            requestHeaders: ["x-member": "first"],
+            timestamp: 1
+        ))
+        let secondRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "second-explicit-header",
+            url: "https://example.com/second-explicit.js",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            requestHeaders: ["x-member": "second"],
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(secondRequest)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            let text = viewController.headersTextViewForTesting.renderedTextForTesting
+            return viewController.previewRequestIDForTesting == secondRequest.id
+                && text.contains("x-member: second")
+                && text.contains("x-member: first") == false
+        })
+        #expect(model.selectedRequest === secondRequest)
+        #expect(model.selectedRequest !== firstRequest)
     }
 
     @Test
@@ -3815,7 +3900,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 4
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(partialSegmentRequest)
+        try selectEntry(containing: partialSegmentRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
@@ -3827,7 +3912,201 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didSelectHLSPreview)
         #expect(model.selectedRequest?.id == hlsRequest.id)
-        #expect(model.selectedRequests.map(\.id) == [hlsRequest.id, partialSegmentRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [hlsRequest.id, partialSegmentRequest.id])
+    }
+
+    @Test
+    func explicitGroupedMemberPreviewDoesNotJumpToAnotherMember() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("explicit-preview")
+        installNavigationVisit(in: context, frameID: frameID)
+        let hlsRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "explicit-playlist",
+            url: "https://media.example.com/live/explicit.m3u8",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            responseHeaders: ["content-type": "application/vnd.apple.mpegurl"],
+            responseMIMEType: "application/vnd.apple.mpegurl",
+            resourceType: .media,
+            timestamp: 1
+        ))
+        let partialSegmentRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "explicit-partial-segment",
+            url: "https://media.example.com/explicit-segment.mp4",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            responseHeaders: [
+                "content-type": "video/mp4",
+                "content-range": "bytes 0-1023/4096",
+            ],
+            responseMIMEType: "video/mp4",
+            responseStatus: 206,
+            resourceType: .media,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(partialSegmentRequest)
+        let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.previewRequestIDForTesting == partialSegmentRequest.id
+                && viewController.previewViewForTesting.isHidden == false
+        })
+        #expect(model.selectedRequest === partialSegmentRequest)
+        #expect(viewController.previewRequestIDForTesting != hlsRequest.id)
+    }
+
+    @Test
+    func requestPickerUsesStableEntryAndRequestItemsWithSearch() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("picker")
+        installNavigationVisit(in: context, frameID: frameID)
+        let firstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-first",
+            url: "https://example.com/alpha.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        let secondRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-second",
+            url: "https://example.com/beta.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let otherNodeID = DOM.Node.ID("picker-other")
+        let otherFirstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-other-first",
+            url: "https://example.com/other-alpha.json",
+            frameID: frameID,
+            initiatorNodeID: otherNodeID,
+            timestamp: 7
+        ))
+        let otherSecondRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-other-second",
+            url: "https://example.com/other-beta.json",
+            frameID: frameID,
+            initiatorNodeID: otherNodeID,
+            timestamp: 10
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: firstRequest.id))
+        model.selectEntry(entryID)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(detailViewController)
+        defer { window.isHidden = true }
+        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        let presentationController = UIPresentationController(
+            presentedViewController: picker,
+            presenting: nil
+        )
+
+        picker.resumeRenderingForTesting()
+
+        #expect(
+            detailViewController.requestPickerItemForTesting?.accessibilityIdentifier
+                == "WebInspector.Network.DetailRequestPickerButton"
+        )
+        #expect(picker.isObservingModelForTesting)
+        #expect(
+            picker.adaptivePresentationStyle(
+                for: presentationController,
+                traitCollection: UITraitCollection(horizontalSizeClass: .compact)
+            ) == .pageSheet
+        )
+        #expect(
+            picker.adaptivePresentationStyle(
+                for: presentationController,
+                traitCollection: UITraitCollection(horizontalSizeClass: .regular)
+            ) == .none
+        )
+        #expect(picker.itemIDsForTesting == [
+            .entry(entryID),
+            .request(firstRequest.id),
+            .request(secondRequest.id),
+        ])
+
+        picker.setSearchTextForTesting("beta")
+
+        #expect(picker.itemIDsForTesting == [
+            .entry(entryID),
+            .request(secondRequest.id),
+        ])
+
+        picker.collectionView(
+            picker.collectionView,
+            didSelectItemAt: IndexPath(item: 1, section: 0)
+        )
+
+        #expect(model.selection == .request(entryID: entryID, requestID: secondRequest.id))
+        #expect(picker.isObservingModelForTesting == false)
+
+        picker.setSearchTextForTesting("")
+        picker.resumeRenderingForTesting()
+        picker.collectionView(
+            picker.collectionView,
+            didSelectItemAt: IndexPath(item: 0, section: 0)
+        )
+
+        #expect(model.selection == .entry(entryID))
+
+        picker.resumeRenderingForTesting()
+        let observation = try #require(picker.modelObservationDeliveryForTesting)
+        let observedEntryID = await observation.values {
+            picker.boundEntryIDForTesting
+        }
+        defer { observedEntryID.cancel() }
+        let otherEntryID = try #require(model.entryID(containing: otherFirstRequest.id))
+
+        model.selectEntry(otherEntryID)
+
+        #expect(await observedEntryID.waitUntilValue(otherEntryID))
+        #expect(picker.itemIDsForTesting == [
+            .entry(otherEntryID),
+            .request(otherFirstRequest.id),
+            .request(otherSecondRequest.id),
+        ])
+
+        picker.suspendRenderingForTesting()
+        #expect(picker.isObservingModelForTesting == false)
+    }
+
+    @Test
+    func requestPickerVirtualizesLargeGroupedMembership() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("large-picker")
+        installNavigationVisit(in: context, frameID: frameID)
+        for index in 0..<2_305 {
+            await applyGroupedPendingRequest(
+                to: context,
+                requestID: "picker-\(index)",
+                frameID: frameID,
+                initiatorNodeID: nodeID,
+                timestamp: Double(index)
+            )
+        }
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.displayEntryIDs.first)
+        model.selectEntry(entryID)
+        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+
+        picker.resumeRenderingForTesting()
+
+        #expect(picker.itemIDsForTesting.count == 2_306)
+        #expect(picker.itemIDsForTesting.first == .entry(entryID))
+        picker.suspendRenderingForTesting()
     }
 
     @Test
@@ -3849,7 +4128,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 1
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(firstRequest)
+        try selectEntry(containing: firstRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let playerFactory = MoviePreviewPlayerFactorySpy()
         viewController.syntaxBodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
@@ -3886,7 +4165,7 @@ struct NetworkDetailViewControllerTests {
             viewController.syntaxBodyViewControllerForTesting.mediaPlayerIdentityForTesting
                 != firstPlayerID
         )
-        #expect(model.selectedRequests.map(\.id) == [firstRequest.id, secondRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [firstRequest.id, secondRequest.id])
     }
 
     @Test
@@ -3907,7 +4186,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 1
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(firstRequest)
+        try selectEntry(containing: firstRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let playerFactory = MoviePreviewPlayerFactorySpy()
         viewController.syntaxBodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
@@ -3941,7 +4220,7 @@ struct NetworkDetailViewControllerTests {
                     .mediaPlayerURLForTesting?.absoluteString == secondRequest.url
                 && playerFactory.players.count == 2
         })
-        #expect(model.selectedRequests.map(\.id) == [firstRequest.id, secondRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [firstRequest.id, secondRequest.id])
     }
 
     @Test
@@ -3998,7 +4277,7 @@ struct NetworkDetailViewControllerTests {
             )
         }
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(partialRequest)
+        try selectEntry(containing: partialRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let playerFactory = MoviePreviewPlayerFactorySpy()
         viewController.syntaxBodyViewControllerForTesting.setMoviePreviewPlayerFactoryForTesting(
@@ -4061,7 +4340,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 7
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(noContentRequest)
+        try selectEntry(containing: noContentRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
@@ -4072,7 +4351,7 @@ struct NetworkDetailViewControllerTests {
                 && viewController.previewViewForTesting.isHidden == false
         }
         #expect(didSelectHealthyPreview)
-        #expect(model.selectedRequests.map(\.id) == [healthyRequest.id, failedRequest.id, noContentRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [healthyRequest.id, failedRequest.id, noContentRequest.id])
     }
 
     @Test
@@ -4106,7 +4385,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 4
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(unavailableMediaRequest)
+        try selectEntry(containing: unavailableMediaRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model, initialMode: .preview)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
@@ -4191,7 +4470,7 @@ struct NetworkDetailViewControllerTests {
             timestamp: 1
         ))
         let model = NetworkPanelModel(context: context)
-        model.selectRequest(firstRequest)
+        try selectEntry(containing: firstRequest, in: model)
         let viewController = makeNetworkDetailViewController(model: model)
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
@@ -4216,7 +4495,7 @@ struct NetworkDetailViewControllerTests {
             return text.contains("first.js") && text.contains("second.js")
         })
         #expect(model.displayEntryIDs.isEmpty)
-        #expect(model.selectedRequests.map(\.id) == [firstRequest.id, secondRequest.id])
+        #expect(model.selectedEntryRequests.map(\.id) == [firstRequest.id, secondRequest.id])
     }
 
     @Test
@@ -4243,6 +4522,16 @@ struct NetworkDetailViewControllerTests {
         WebInspectorContext.preview(isolation: MainActor.shared)
     }
 
+    private func selectEntry(
+        containing request: NetworkRequest,
+        in model: NetworkPanelModel
+    ) throws {
+        let entryID: NetworkListEntry.ID = try #require(
+            model.entryID(containing: request.id)
+        )
+        model.selectEntry(entryID)
+    }
+
     private func installNavigationVisit(
         in context: WebInspectorContext,
         frameID: FrameID
@@ -4257,6 +4546,33 @@ struct NetworkDetailViewControllerTests {
             securityOrigin: "https://example.com",
             mimeType: "text/html"
         )))
+    }
+
+    private func applyGroupedPendingRequest(
+        to context: WebInspectorContext,
+        requestID rawRequestID: String,
+        frameID: FrameID,
+        initiatorNodeID: DOM.Node.ID,
+        timestamp: Double
+    ) async {
+        let requestID = Network.Request.ID(rawRequestID)
+        await context.apply(.requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.com/\(rawRequestID)",
+                method: "GET",
+                origin: Network.Request.Origin(
+                    frameID: frameID,
+                    loaderID: "loader",
+                    targetID: "page"
+                )
+            ),
+            initiator: Network.Initiator(kind: "script", nodeID: initiatorNodeID),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: timestamp
+        ))
     }
 
     private func applyGroupedRequest(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -4133,23 +4133,55 @@ struct NetworkDetailViewControllerTests {
 
         picker.resumeRenderingForTesting()
         let observation = try #require(picker.modelObservationDeliveryForTesting)
-        let observedEntryID = await observation.values {
-            picker.boundEntryIDForTesting
+        let selectedItem = await observation.values {
+            picker.selectedItemIDForTesting
+                == .request(secondRequest.id)
         }
-        defer { observedEntryID.cancel() }
+        let itemCount = await observation.values {
+            picker.itemIDsForTesting.count
+        }
+        let stoppedObserving = await observation.values {
+            picker.isObservingModelForTesting == false
+        }
+        defer {
+            selectedItem.cancel()
+            itemCount.cancel()
+            stoppedObserving.cancel()
+        }
+
+        model.selectRequest(secondRequest)
+
+        #expect(await selectedItem.waitUntilValue(true))
+        #expect(picker.isObservingModelForTesting)
+        #expect(picker.boundEntryIDForTesting == entryID)
+
+        let thirdRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-third",
+            url: "https://example.com/gamma.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 13
+        ))
+
+        #expect(await itemCount.waitUntilValue(4))
+        #expect(picker.itemIDsForTesting == [
+            .entry(entryID),
+            .request(firstRequest.id),
+            .request(secondRequest.id),
+            .request(thirdRequest.id),
+        ])
+        let originalItemIDs = picker.itemIDsForTesting
         let otherEntryID = try #require(model.entryID(containing: otherFirstRequest.id))
 
         model.selectEntry(otherEntryID)
 
-        #expect(await observedEntryID.waitUntilValue(otherEntryID))
-        #expect(picker.itemIDsForTesting == [
-            .entry(otherEntryID),
-            .request(otherFirstRequest.id),
-            .request(otherSecondRequest.id),
-        ])
-
-        picker.suspendRenderingForTesting()
+        #expect(await stoppedObserving.waitUntilValue(true))
         #expect(picker.isObservingModelForTesting == false)
+        #expect(picker.boundEntryIDForTesting == entryID)
+        #expect(picker.itemIDsForTesting == originalItemIDs)
+        #expect(picker.itemIDsForTesting.contains(.request(otherFirstRequest.id)) == false)
+        #expect(picker.itemIDsForTesting.contains(.request(otherSecondRequest.id)) == false)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -4032,6 +4032,124 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func requestPickerRebindsVisibleCellWhenRequestInstanceIsReplaced() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("picker-instance")
+        installNavigationVisit(in: context, frameID: frameID)
+        let firstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-instance-first",
+            url: "https://example.com/first-instance.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        _ = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-instance-second",
+            url: "https://example.com/second-instance.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: firstRequest.id))
+        let entry = try #require(model.entry(for: entryID))
+        model.selectEntry(entryID)
+        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        let window = showInWindow(picker, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        picker.resumeRenderingForTesting()
+        let cell = try #require(picker.requestCellForTesting(requestID: firstRequest.id))
+        let originalCellObservation = try #require(cell.requestObservationForTesting)
+        let originalCellIdentity = ObjectIdentifier(cell)
+        let proxyID = Network.Request.ID("picker-instance-first")
+        let origin = Network.Request.Origin(
+            frameID: frameID,
+            loaderID: "loader",
+            targetID: "page"
+        )
+        let replacementRequest = NetworkRequest(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/replacement-instance.json",
+                method: "GET",
+                origin: origin
+            ),
+            initiator: firstRequest.initiator,
+            navigationVisit: firstRequest.navigationVisit,
+            resourceType: firstRequest.resourceType,
+            timestamp: firstRequest.logicalStartTimestamp,
+            chronologySequence: firstRequest.chronologySequence,
+            modelContext: context
+        )
+        let pickerObservation = try #require(picker.modelObservationDeliveryForTesting)
+        let reboundVisibleCell = await pickerObservation.values {
+            cell.observedRequestForTesting === replacementRequest
+        }
+        defer { reboundVisibleCell.cancel() }
+
+        model.upsertRequestForTesting(replacementRequest)
+
+        #expect(model.request(for: firstRequest.id) === replacementRequest)
+        #expect(model.entry(for: entryID) === entry)
+        #expect(
+            model.entry(for: entryID)?.requests.first { $0.id == firstRequest.id }
+                === replacementRequest
+        )
+        #expect(pickerObservation.isActive)
+        #expect(picker.collectionView.visibleCells.contains { $0 === cell })
+        #expect(await reboundVisibleCell.waitUntilValue(true))
+        #expect(picker.boundEntryIDForTesting == entryID)
+        #expect(
+            picker.requestCellForTesting(requestID: firstRequest.id)
+                .map(ObjectIdentifier.init) == originalCellIdentity
+        )
+        #expect(cell.observedRequestForTesting === replacementRequest)
+        #expect(cell.titleForTesting == "replacement-instance.json")
+        #expect(originalCellObservation.isActive == false)
+        let replacementCellObservation = try #require(cell.requestObservationForTesting)
+        let replacementTitle = await replacementCellObservation.values {
+            cell.titleForTesting
+        }
+        defer { replacementTitle.cancel() }
+
+        firstRequest.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/stale-old-instance.json",
+                method: "GET",
+                origin: origin
+            ),
+            initiator: firstRequest.initiator,
+            navigationVisit: firstRequest.navigationVisit,
+            resourceType: firstRequest.resourceType,
+            timestamp: 20,
+            chronologySequence: 20
+        )
+
+        #expect(firstRequest.displayName == "stale-old-instance.json")
+        #expect(cell.titleForTesting == "replacement-instance.json")
+
+        replacementRequest.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/current-instance.json",
+                method: "GET",
+                origin: origin
+            ),
+            initiator: replacementRequest.initiator,
+            navigationVisit: replacementRequest.navigationVisit,
+            resourceType: replacementRequest.resourceType,
+            timestamp: 21,
+            chronologySequence: 21
+        )
+
+        #expect(await replacementTitle.waitUntilValue("current-instance.json"))
+    }
+
+    @Test
     func requestPickerSearchRestartsObservationAndTracksContentMembership() async throws {
         let context = makeContext()
         let frameID = FrameID("main-frame")

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -4032,6 +4032,83 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func requestPickerSearchRestartsObservationAndTracksContentMembership() async throws {
+        let context = makeContext()
+        let frameID = FrameID("main-frame")
+        let nodeID = DOM.Node.ID("picker-search")
+        installNavigationVisit(in: context, frameID: frameID)
+        let firstRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-search-first",
+            url: "https://example.com/alpha.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        let secondRequest = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-search-second",
+            url: "https://example.com/beta.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: firstRequest.id))
+        let entry = try #require(model.entry(for: entryID))
+        let originalRequestIDs = entry.requests.map(\.id)
+        model.selectEntry(entryID)
+        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        picker.resumeRenderingForTesting()
+        let emptyQueryObservation = try #require(picker.modelObservationDeliveryForTesting)
+
+        picker.setSearchTextForTesting("needle")
+
+        #expect(emptyQueryObservation.isActive == false)
+        #expect(picker.itemIDsForTesting == [.entry(entryID)])
+        let searchObservation = try #require(picker.modelObservationDeliveryForTesting)
+        let includesFirstRequest = await searchObservation.values {
+            picker.itemIDsForTesting.contains(.request(firstRequest.id))
+        }
+        defer {
+            includesFirstRequest.cancel()
+            picker.suspendRenderingForTesting()
+        }
+
+        await applyResponseReceived(
+            to: context,
+            requestID: "picker-search-first",
+            url: "https://example.com/needle.json",
+            responseHeaders: ["content-type": "application/json"],
+            responseMimeType: "application/json",
+            timestamp: 10
+        )
+
+        #expect(await includesFirstRequest.waitUntilValue(true))
+        #expect(picker.itemIDsForTesting == [
+            .entry(entryID),
+            .request(firstRequest.id),
+        ])
+        #expect(model.entry(for: entryID) === entry)
+        #expect(entry.requests.map(\.id) == originalRequestIDs)
+
+        await applyResponseReceived(
+            to: context,
+            requestID: "picker-search-first",
+            url: "https://example.com/miss.json",
+            responseHeaders: ["content-type": "application/json"],
+            responseMimeType: "application/json",
+            timestamp: 11
+        )
+
+        #expect(await includesFirstRequest.waitUntilValue(false))
+        #expect(picker.itemIDsForTesting == [.entry(entryID)])
+        #expect(picker.itemIDsForTesting.contains(.request(secondRequest.id)) == false)
+        #expect(model.entry(for: entryID) === entry)
+        #expect(entry.requests.map(\.id) == originalRequestIDs)
+    }
+
+    @Test
     func requestPickerUsesStableEntryAndRequestItemsWithSearch() async throws {
         let context = makeContext()
         let frameID = FrameID("main-frame")

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -3962,6 +3962,76 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func requestPickerCellTracksLiveRequestAndDetachesOldBinding() async throws {
+        let context = makeContext()
+        let firstRequest = try #require(await applyRequest(
+            to: context,
+            requestID: "picker-cell-first",
+            url: "https://example.com/first.json"
+        ))
+        let secondRequest = try #require(await applyRequest(
+            to: context,
+            requestID: "picker-cell-second",
+            url: "https://example.com/second.json"
+        ))
+        let cell = NetworkDetailRequestPickerCell(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 44)
+        )
+        cell.bind(request: firstRequest, renderingActive: true)
+        let firstObservation = try #require(cell.requestObservationForTesting)
+        let firstRenderedValue = await firstObservation.values {
+            [cell.titleForTesting, cell.subtitleForTesting]
+        }
+        defer { firstRenderedValue.cancel() }
+
+        _ = await applyRequest(
+            to: context,
+            requestID: "picker-cell-first",
+            url: "https://example.com/first-updated.json"
+        )
+
+        #expect(await firstRenderedValue.waitUntilValue([
+            "first-updated.json",
+            "https://example.com/first-updated.json",
+        ]))
+
+        cell.bind(request: secondRequest, renderingActive: true)
+        #expect(firstObservation.isActive == false)
+        #expect(cell.observedRequestForTesting === secondRequest)
+        #expect(cell.titleForTesting == "second.json")
+        let secondObservation = try #require(cell.requestObservationForTesting)
+        let secondRenderedValue = await secondObservation.values {
+            [cell.titleForTesting, cell.subtitleForTesting]
+        }
+        defer { secondRenderedValue.cancel() }
+
+        _ = await applyRequest(
+            to: context,
+            requestID: "picker-cell-first",
+            url: "https://example.com/stale-first.json"
+        )
+
+        #expect(cell.titleForTesting == "second.json")
+        #expect(cell.subtitleForTesting == "https://example.com/second.json")
+
+        _ = await applyRequest(
+            to: context,
+            requestID: "picker-cell-second",
+            url: "https://example.com/second-updated.json"
+        )
+
+        #expect(await secondRenderedValue.waitUntilValue([
+            "second-updated.json",
+            "https://example.com/second-updated.json",
+        ]))
+
+        cell.prepareForReuse()
+        #expect(secondObservation.isActive == false)
+        #expect(cell.observedRequestForTesting == nil)
+        #expect(cell.titleForTesting == nil)
+    }
+
+    @Test
     func requestPickerUsesStableEntryAndRequestItemsWithSearch() async throws {
         let context = makeContext()
         let frameID = FrameID("main-frame")

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ObservationBridge
 import Testing
 @testable import WebInspectorDataKit
@@ -1353,6 +1354,88 @@ func groupedEntryAndExplicitMemberSelectionsHaveDistinctScopes() async throws {
     #expect(model.selectedEntryID == stableID)
     #expect(model.selectedRequest?.id == secondID)
     #expect(model.selectedEntryRequests.map(\.id) == [firstID, secondID])
+}
+
+@Test
+@MainActor
+func removedExplicitRequestClearsSelectionInsteadOfSelectingGroupedSibling() async throws {
+    let context = makeContext()
+    let frameID = FrameID("main-frame")
+    let nodeID = DOM.Node.ID("selection-removal")
+    context.apply(WebInspectorTargetLifecycleEvent.frameNavigated(WebInspectorPageFrameLifecycle(
+        id: frameID,
+        parentID: nil,
+        pageBindingID: "page",
+        loaderID: "loader",
+        name: "Main",
+        url: "https://example.test",
+        securityOrigin: "https://example.test",
+        mimeType: "text/html"
+    )))
+    let firstID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "selection-removal-first",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 1
+    )
+    let secondID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "selection-removal-second",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 2
+    )
+    await applyLoadingFinished(
+        to: context,
+        requestID: "selection-removal-second",
+        timestamp: 2.5
+    )
+    #expect(context.registeredRequest(for: secondID)?.state == .finished)
+    let model = NetworkPanelModel(context: context)
+    let groupedEntryID = try #require(model.entryID(containing: firstID))
+    var rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+    model.requests.updateFetchDescriptor(WebInspectorFetchDescriptor(
+        predicate: #Predicate { request in
+            request.method == "GET"
+        }
+    ))
+    #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
+
+    model.selectRequest(context.registeredRequest(for: secondID))
+    let fullRebuildBaseline = model.fullEntryRebuildCountForTesting
+    rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+    let secondProxyID = Network.Request.ID("selection-removal-second")
+    await context.apply(.requestWillBeSent(
+        id: secondProxyID,
+        request: Network.Request(
+            id: secondProxyID,
+            url: "https://example.test/selection-removal-second",
+            method: "POST",
+            origin: Network.Request.Origin(
+                frameID: frameID,
+                loaderID: "loader",
+                targetID: "page"
+            )
+        ),
+        initiator: Network.Initiator(kind: "other", nodeID: nodeID),
+        resourceType: .fetch,
+        redirectResponse: nil,
+        timestamp: 3
+    ))
+    #expect(context.registeredRequest(for: secondID)?.method == "POST")
+
+    #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
+    #expect(model.fullEntryRebuildCountForTesting == fullRebuildBaseline)
+    #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID])
+    #expect(model.entryID(containing: secondID) == nil)
+    #expect(context.registeredRequest(for: secondID) != nil)
+    #expect(model.selection == nil)
+    #expect(model.selectedRequest == nil)
 }
 
 @Test

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -112,6 +112,27 @@ func selectedRequestUsesUnfilteredContextWhenFiltersHideRequest() async throws {
 
 @Test
 @MainActor
+func selectingSingletonEntryUsesEntryScope() async throws {
+    let context = makeContext()
+    let requestID = await applyRequest(
+        to: context,
+        requestID: "singleton",
+        url: "https://example.test/singleton.js",
+        resourceType: .script,
+        mimeType: "text/javascript",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(context: context)
+    let entryID = try #require(model.entryID(containing: requestID))
+
+    model.selectEntry(entryID)
+
+    #expect(model.selection == .entry(entryID))
+    #expect(model.selectedRequestID == requestID)
+}
+
+@Test
+@MainActor
 func selectedRequestInvalidatesWhenUnfilteredRequestDisappears() async throws {
     let context = makeContext()
     let requestID = await applyRequest(
@@ -1284,7 +1305,7 @@ func groupedFilterRequiresOneMemberToMatchSearchAndResourceFilter() async {
 
 @Test
 @MainActor
-func selectingAnyGroupedMemberUsesStableEntryAndOldestRepresentative() async throws {
+func groupedEntryAndExplicitMemberSelectionsHaveDistinctScopes() async throws {
     let context = makeContext()
     let frameID = FrameID("main-frame")
     let nodeID = DOM.Node.ID("player")
@@ -1319,11 +1340,19 @@ func selectingAnyGroupedMemberUsesStableEntryAndOldestRepresentative() async thr
     let model = NetworkPanelModel(context: context)
     let stableID = try #require(model.displayEntryIDs.first)
 
-    model.selectRequest(context.registeredRequest(for: secondID))
+    model.selectEntry(stableID)
 
+    #expect(model.selection == .entry(stableID))
     #expect(model.selectedEntryID == stableID)
     #expect(model.selectedRequest?.id == firstID)
-    #expect(model.selectedRequests.map(\.id) == [firstID, secondID])
+    #expect(model.selectedEntryRequests.map(\.id) == [firstID, secondID])
+
+    model.selectRequest(context.registeredRequest(for: secondID))
+
+    #expect(model.selection == .request(entryID: stableID, requestID: secondID))
+    #expect(model.selectedEntryID == stableID)
+    #expect(model.selectedRequest?.id == secondID)
+    #expect(model.selectedEntryRequests.map(\.id) == [firstID, secondID])
 }
 
 @Test
@@ -1357,6 +1386,7 @@ func liveGroupedInsertionPreservesEntryIdentityRowPositionAndChronologicalMember
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
     let stableEntryID = try #require(model.entryID(containing: firstID))
     let stableEntry = try #require(model.entry(for: stableEntryID))
+    model.selectEntry(stableEntryID)
 
     rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
     let newerSingletonID = await applyPendingRequest(
@@ -1412,11 +1442,13 @@ func liveGroupedInsertionPreservesEntryIdentityRowPositionAndChronologicalMember
     #expect(model.entry(for: stableEntryID) === stableEntry)
     #expect(stableEntry.representativeRequest.id == lateOlderID)
     #expect(stableEntry.requests.map(\.id) == [lateOlderID, sameTimestampID, firstID, laterID])
+    #expect(model.selection == .entry(stableEntryID))
+    #expect(model.selectedRequestID == lateOlderID)
 }
 
 @Test
 @MainActor
-func groupedSelectionTracksAnchoredMemberAndPreservesSelectionWhenAnotherMemberLeaves() async throws {
+func entrySelectionPersistsWhenMemberLeavesAndExplicitRequestFollowsRegrouping() async throws {
     let context = makeContext()
     let frameID = FrameID("main-frame")
     let nodeID = DOM.Node.ID("player")
@@ -1461,7 +1493,7 @@ func groupedSelectionTracksAnchoredMemberAndPreservesSelectionWhenAnotherMemberL
     let groupedEntryID = try #require(model.entryID(containing: firstID))
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID, secondID, thirdID])
 
-    model.selectRequest(context.registeredRequest(for: firstID))
+    model.selectEntry(groupedEntryID)
     var rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
     await applyLoadingFinished(to: context, requestID: "second", timestamp: 4)
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
@@ -1474,6 +1506,7 @@ func groupedSelectionTracksAnchoredMemberAndPreservesSelectionWhenAnotherMemberL
         timestamp: 5
     )
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
+    #expect(model.selection == .entry(groupedEntryID))
     #expect(model.selectedEntryID == groupedEntryID)
     #expect(model.selectedRequestID == firstID)
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID, thirdID])
@@ -1491,8 +1524,10 @@ func groupedSelectionTracksAnchoredMemberAndPreservesSelectionWhenAnotherMemberL
         timestamp: 7
     )
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
+    let regroupedEntryID = try #require(model.entryID(containing: thirdID))
     #expect(model.selectedRequestID == thirdID)
-    #expect(model.selectedEntryID == model.entryID(containing: thirdID))
+    #expect(model.selectedEntryID == regroupedEntryID)
+    #expect(model.selection == .request(entryID: regroupedEntryID, requestID: thirdID))
     #expect(model.selectedRequest?.id == thirdID)
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID])
 }
@@ -1586,6 +1621,7 @@ func selectedSingletonReusedIntoGroupPreservesSelection() async throws {
     let groupedEntryID = try #require(model.entryID(containing: reusedID))
     #expect(model.selectedRequestID == reusedID)
     #expect(model.selectedEntryID == groupedEntryID)
+    #expect(model.selection == .request(entryID: groupedEntryID, requestID: reusedID))
     #expect(model.selectedRequest?.id == reusedID)
     #expect(model.selectedRequest?.url == "https://example.test/reused")
 }

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -1274,7 +1274,7 @@ struct ParentContainerTests {
     }
 
     @Test
-    func networkPanelModelSelectionIsSharedAcrossParentHosts() async throws {
+    func networkDetailSelectionAndModeSurviveParentHostReplacement() async throws {
         let context = makeContext()
         let session = WebInspectorSession(context: context)
         let contentStore = PresentationContentStore()
@@ -1305,6 +1305,12 @@ struct ParentContainerTests {
             compactNavigationController.viewControllers.last is NetworkDetailViewController
         }
         #expect(didPushDetail)
+        let compactDetailViewController = try #require(
+            compactNavigationController.viewControllers.last as? NetworkDetailViewController
+        )
+        compactDetailViewController.setModeForTesting(.preview)
+        let selectedEntryID = try #require(model.entryID(containing: request.id))
+        #expect(model.selection == .request(entryID: selectedEntryID, requestID: request.id))
 
         let regularRoot = WebInspectorTab.ContentFactory.makeViewController(
             for: .network,
@@ -1325,8 +1331,12 @@ struct ParentContainerTests {
         )
         detailViewController.loadViewIfNeeded()
 
+        #expect(detailViewController === compactDetailViewController)
+        #expect(detailViewController.currentModeForTesting == .preview)
+        #expect(model.selection == .request(entryID: selectedEntryID, requestID: request.id))
+
         let didRenderDetail = await waitUntilNetworkDetailRendered(in: detailViewController) {
-            detailViewController.headersTextViewForTesting.renderedTextForTesting.contains("GET /app.js")
+            detailViewController.previewRequestIDForTesting == request.id
         }
         #expect(didRenderDetail)
     }


### PR DESCRIPTION
## Purpose

Prepare Network request details for request-scoped Cookies and Security panes while preserving the existing grouped-media behavior.

Closes #235

## Changes

- Model Network selection as either an aggregate entry or an explicit request.
- Keep aggregate Headers and grouped HLS Preview behavior for entry selection, while rendering the exact member after request selection.
- Add a searchable, virtualized request picker with adaptive popover and sheet presentation.
- Make compact Back handling, picker observation, filtering, and request-instance replacement identity-safe.
- Add regression coverage for regrouping, removal, search dependency changes, same-ID replacement, and compact-to-regular reparenting.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` (533 tests passed)
- `git diff --check`
- `codex-review` (no findings)

## Screenshots

Not included because grouped request data is not part of the deterministic app fixture; the adaptive picker and detail transitions are covered by UIKit rendering tests.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>