### PR TITLE
Preserve Network security metadata

### DIFF
--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WebInspectorDataKit
 import WebInspectorProxyKit
 import WebInspectorProxyKitTesting
 
@@ -86,10 +87,37 @@ func webInspectorProxySecurityMetadataIsConstructibleAndReadableByConsumers() {
             ipAddresses: []
         )
     )
-    let response = Network.Response(security: security)
-    let metrics = Network.Metrics(
-        securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    let response = Network.Response(
+        url: "https://example.com/",
+        status: 200,
+        statusText: "OK",
+        mimeType: "text/html",
+        headers: ["Content-Type": "text/html"],
+        source: Network.Source(rawValue: "network"),
+        requestHeaders: ["Accept": "text/html"],
+        bodySize: 512
     )
+        .reporting(security: security)
+    let metrics = Network.Metrics(
+        timestamp: 42,
+        networkProtocol: "h2",
+        remoteAddress: "203.0.113.10:443",
+        encodedDataLength: 256,
+        decodedBodyLength: 512
+    )
+        .reporting(
+            securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+        )
+    let snapshot = NetworkResponseSnapshot(
+        url: "https://example.com/",
+        status: 200,
+        statusText: "OK",
+        mimeType: "text/html",
+        headers: ["Content-Type": "text/html"],
+        source: "network",
+        requestHeaders: ["Accept": "text/html"]
+    )
+        .reporting(security: security)
 
     #expect(response.security?.connection?.tlsProtocol == "TLS 1.3")
     #expect(response.security?.connection?.cipher == "AES_128_GCM_SHA256")
@@ -98,30 +126,36 @@ func webInspectorProxySecurityMetadataIsConstructibleAndReadableByConsumers() {
     #expect(response.security?.certificate?.validUntil == validUntil)
     #expect(response.security?.certificate?.dnsNames == ["example.com"])
     #expect(response.security?.certificate?.ipAddresses == [])
+    #expect(response.status == 200)
+    #expect(response.url == "https://example.com/")
+    #expect(response.statusText == "OK")
+    #expect(response.mimeType == "text/html")
+    #expect(response.headers == ["Content-Type": "text/html"])
+    #expect(response.source == Network.Source(rawValue: "network"))
+    #expect(response.requestHeaders == ["Accept": "text/html"])
+    #expect(response.bodySize == 512)
     #expect(metrics.securityConnection?.tlsProtocol == "TLS 1.3")
+    #expect(metrics.timestamp == 42)
+    #expect(metrics.networkProtocol == "h2")
+    #expect(metrics.remoteAddress == "203.0.113.10:443")
+    #expect(metrics.encodedDataLength == 256)
+    #expect(metrics.decodedBodyLength == 512)
+    #expect(snapshot.status == 200)
+    #expect(snapshot.url == "https://example.com/")
+    #expect(snapshot.statusText == "OK")
+    #expect(snapshot.mimeType == "text/html")
+    #expect(snapshot.headers == ["Content-Type": "text/html"])
+    #expect(snapshot.source == "network")
+    #expect(snapshot.requestHeaders == ["Accept": "text/html"])
+    #expect(snapshot.security == security)
 }
 
 @Test
 func webInspectorProxyLegacyNetworkInitializerFunctionReferencesRemainUsable() {
-    let makeResponse: (
-        String?,
-        Int?,
-        String?,
-        String?,
-        [String: String],
-        Network.Source?,
-        [String: String]?,
-        Int?
-    ) -> Network.Response = Network.Response.init
+    let makeResponse = Network.Response.init
     let response = makeResponse(nil, 204, nil, nil, [:], nil, nil, nil)
 
-    let makeMetrics: (
-        Double?,
-        String?,
-        String?,
-        Int?,
-        Int?
-    ) -> Network.Metrics = Network.Metrics.init
+    let makeMetrics = Network.Metrics.init
     let metrics = makeMetrics(42, "h2", "203.0.113.10:443", 128, 256)
 
     #expect(response.status == 204)

--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import WebInspectorProxyKit
 import WebInspectorProxyKitTesting
@@ -66,4 +67,36 @@ func webInspectorProxyNetworkEventsMulticastToConsumerSubscribers() async throws
     #expect(secondType == .fetch)
     #expect(firstTimestamp == 42)
     #expect(secondTimestamp == 42)
+}
+
+@Test
+func webInspectorProxySecurityMetadataIsConstructibleAndReadableByConsumers() {
+    let validFrom = Date(timeIntervalSince1970: 1_700_000_000)
+    let validUntil = Date(timeIntervalSince1970: 1_800_000_000)
+    let security = Network.Security(
+        connection: Network.Security.Connection(
+            tlsProtocol: "TLS 1.3",
+            cipher: "AES_128_GCM_SHA256"
+        ),
+        certificate: Network.Security.Certificate(
+            subject: "example.com",
+            validFrom: validFrom,
+            validUntil: validUntil,
+            dnsNames: ["example.com"],
+            ipAddresses: []
+        )
+    )
+    let response = Network.Response(security: security)
+    let metrics = Network.Metrics(
+        securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
+
+    #expect(response.security?.connection?.tlsProtocol == "TLS 1.3")
+    #expect(response.security?.connection?.cipher == "AES_128_GCM_SHA256")
+    #expect(response.security?.certificate?.subject == "example.com")
+    #expect(response.security?.certificate?.validFrom == validFrom)
+    #expect(response.security?.certificate?.validUntil == validUntil)
+    #expect(response.security?.certificate?.dnsNames == ["example.com"])
+    #expect(response.security?.certificate?.ipAddresses == [])
+    #expect(metrics.securityConnection?.tlsProtocol == "TLS 1.3")
 }

--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
@@ -100,3 +100,32 @@ func webInspectorProxySecurityMetadataIsConstructibleAndReadableByConsumers() {
     #expect(response.security?.certificate?.ipAddresses == [])
     #expect(metrics.securityConnection?.tlsProtocol == "TLS 1.3")
 }
+
+@Test
+func webInspectorProxyLegacyNetworkInitializerFunctionReferencesRemainUsable() {
+    let makeResponse: (
+        String?,
+        Int?,
+        String?,
+        String?,
+        [String: String],
+        Network.Source?,
+        [String: String]?,
+        Int?
+    ) -> Network.Response = Network.Response.init
+    let response = makeResponse(nil, 204, nil, nil, [:], nil, nil, nil)
+
+    let makeMetrics: (
+        Double?,
+        String?,
+        String?,
+        Int?,
+        Int?
+    ) -> Network.Metrics = Network.Metrics.init
+    let metrics = makeMetrics(42, "h2", "203.0.113.10:443", 128, 256)
+
+    #expect(response.status == 204)
+    #expect(response.security == nil)
+    #expect(metrics.networkProtocol == "h2")
+    #expect(metrics.securityConnection == nil)
+}

--- a/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
+++ b/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
@@ -53,6 +53,8 @@ private actor DataKitImportOnlyActor {
         _ = requests.items.first?.hasResponse
         _ = requests.items.first?.hasResponseBody
         _ = requests.items.first?.metrics
+        _ = requests.items.first?.security?.connection?.tlsProtocol
+        _ = requests.items.first?.security?.certificate?.dnsNames
         _ = requestsByMethod.sections.first?.title
         let requestSnapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID> =
             requestController.snapshot
@@ -71,9 +73,14 @@ private actor DataKitImportOnlyActor {
         _ = try await context.evaluate("1 + 1").object.description
 
         let request = NetworkRequestSnapshot(url: "https://example.com", method: "GET")
-        let response = NetworkResponseSnapshot(status: 200, mimeType: "text/html")
+        let response = NetworkResponseSnapshot(
+            status: 200,
+            mimeType: "text/html",
+            security: requests.items.first?.security
+        )
         let redirect = RedirectHop(request: request, response: response, timestamp: 1)
         _ = redirect.request.url
         _ = redirect.response.status
+        _ = redirect.response.security?.certificate?.subject
     }
 }

--- a/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
+++ b/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
@@ -6,6 +6,23 @@ func webInspectorDataKitBaseSurfaceDoesNotRequireProxyKitImport() {
     _ = DataKitImportOnlyActor()
 }
 
+@Test
+func dataKitLegacyNetworkResponseSnapshotInitializerFunctionReferenceRemainsUsable() {
+    let makeResponseSnapshot: (
+        String?,
+        Int?,
+        String?,
+        String?,
+        [String: String],
+        String?,
+        [String: String]?
+    ) -> NetworkResponseSnapshot = NetworkResponseSnapshot.init
+    let response = makeResponseSnapshot(nil, 204, nil, nil, [:], nil, nil)
+
+    #expect(response.status == 204)
+    #expect(response.security == nil)
+}
+
 private actor DataKitImportOnlyActor {
     func consume(_ context: WebInspectorContext) async throws {
         let requests: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()

--- a/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
+++ b/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
@@ -8,15 +8,7 @@ func webInspectorDataKitBaseSurfaceDoesNotRequireProxyKitImport() {
 
 @Test
 func dataKitLegacyNetworkResponseSnapshotInitializerFunctionReferenceRemainsUsable() {
-    let makeResponseSnapshot: (
-        String?,
-        Int?,
-        String?,
-        String?,
-        [String: String],
-        String?,
-        [String: String]?
-    ) -> NetworkResponseSnapshot = NetworkResponseSnapshot.init
+    let makeResponseSnapshot = NetworkResponseSnapshot.init
     let response = makeResponseSnapshot(nil, 204, nil, nil, [:], nil, nil)
 
     #expect(response.status == 204)
@@ -90,11 +82,10 @@ private actor DataKitImportOnlyActor {
         _ = try await context.evaluate("1 + 1").object.description
 
         let request = NetworkRequestSnapshot(url: "https://example.com", method: "GET")
-        let response = NetworkResponseSnapshot(
-            status: 200,
-            mimeType: "text/html",
-            security: requests.items.first?.security
-        )
+        let response = NetworkResponseSnapshot(status: 200, mimeType: "text/html")
+        if let security = requests.items.first?.security {
+            _ = response.reporting(security: security)
+        }
         let redirect = RedirectHop(request: request, response: response, timestamp: 1)
         _ = redirect.request.url
         _ = redirect.response.status

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -85,8 +85,30 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
         mimeType: String? = nil,
         headers: [String: String] = [:],
         source: String? = nil,
+        requestHeaders: [String: String]? = nil
+    ) {
+        self.init(
+            url: url,
+            status: status,
+            statusText: statusText,
+            mimeType: mimeType,
+            headers: headers,
+            source: source,
+            requestHeaders: requestHeaders,
+            security: nil
+        )
+    }
+
+    /// Creates a response snapshot with security metadata.
+    public init(
+        url: String? = nil,
+        status: Int? = nil,
+        statusText: String? = nil,
+        mimeType: String? = nil,
+        headers: [String: String] = [:],
+        source: String? = nil,
         requestHeaders: [String: String]? = nil,
-        security: Network.Security? = nil
+        security: Network.Security?
     ) {
         self.url = url
         self.status = status

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -74,6 +74,9 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
     /// Request headers associated with the response, if reported.
     public let requestHeaders: [String: String]?
 
+    /// Security metadata captured with this response, if WebKit reported it.
+    public let security: Network.Security?
+
     /// Creates a response snapshot.
     public init(
         url: String? = nil,
@@ -82,7 +85,8 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
         mimeType: String? = nil,
         headers: [String: String] = [:],
         source: String? = nil,
-        requestHeaders: [String: String]? = nil
+        requestHeaders: [String: String]? = nil,
+        security: Network.Security? = nil
     ) {
         self.url = url
         self.status = status
@@ -91,6 +95,7 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
         self.headers = headers
         self.source = source
         self.requestHeaders = requestHeaders
+        self.security = security
     }
 
     init(_ response: Network.Response) {
@@ -101,7 +106,8 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
             mimeType: response.mimeType,
             headers: response.headers,
             source: response.source?.rawValue,
-            requestHeaders: response.requestHeaders
+            requestHeaders: response.requestHeaders,
+            security: response.security
         )
     }
 }
@@ -930,6 +936,13 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     /// Final transfer metrics, if WebKit reported them.
     public private(set) var metrics: Network.Metrics?
 
+    /// Security metadata reported by WebKit for the current response.
+    ///
+    /// A missing value means WebKit did not report security metadata. It does
+    /// not imply an unencrypted connection, certificate trust, or certificate
+    /// validity.
+    public private(set) var security: Network.Security?
+
     /// Redirect hops that led to the current request.
     public private(set) var redirects: [RedirectHop]
 
@@ -999,6 +1012,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         decodedDataLength = 0
         encodedDataLength = 0
         metrics = nil
+        security = nil
         redirects = []
         webSocket = resourceType == .webSocket ? WebSocketState() : nil
         requestBody = NetworkBody.makeRequestBody(for: request)
@@ -1168,6 +1182,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         decodedDataLength = 0
         encodedDataLength = 0
         metrics = nil
+        security = nil
         redirects = []
         webSocket = resourceType == .webSocket ? WebSocketState() : nil
         requestBody = NetworkBody.makeRequestBody(for: request)
@@ -1208,6 +1223,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         decodedDataLength = 0
         encodedDataLength = 0
         metrics = nil
+        security = nil
         requestBody = NetworkBody.makeRequestBody(for: request)
         responseBody.resetForResponse(fallbackURL: currentRequest.url)
         allowsMultipartContinuation = false
@@ -1235,6 +1251,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         mimeType = response.mimeType
         responseSource = response.source?.rawValue
         responseHeaders = response.headers
+        security = response.security
         if let requestHeaders = response.requestHeaders {
             self.requestHeaders = requestHeaders
             currentRequest = requestWithHeaders(requestHeaders)
@@ -1263,6 +1280,10 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     func finish(timestamp: Double, sourceMapURL: String?, metrics: Network.Metrics?) {
         self.sourceMapURL = sourceMapURL
         self.metrics = metrics
+        if let securityConnection = metrics?.securityConnection {
+            security = security?.merging(connection: securityConnection)
+                ?? Network.Security(connection: securityConnection)
+        }
         if let encodedDataLength = metrics?.encodedDataLength {
             self.encodedDataLength = max(0, encodedDataLength)
         }
@@ -1313,6 +1334,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         decodedDataLength = bodySize
         encodedDataLength = bodySize
         metrics = nil
+        security = response.security
         redirects = []
         requestBody = NetworkBody.makeRequestBody(for: currentRequest)
         responseBody.resetForResponse(response, fallbackURL: currentRequest.url)
@@ -1348,6 +1370,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         responseURL = nil
         mimeType = nil
         responseSource = nil
+        security = nil
         if let timestamp {
             requestSentTimestamp = timestamp
         }

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -99,8 +99,24 @@ public struct NetworkResponseSnapshot: Equatable, Sendable {
         )
     }
 
-    /// Creates a response snapshot with security metadata.
-    public init(
+    /// Returns a copy that records security metadata reported by WebKit.
+    ///
+    /// The metadata is descriptive and does not represent a trust,
+    /// validity, or encrypted-transport verdict.
+    public func reporting(security: Network.Security) -> NetworkResponseSnapshot {
+        NetworkResponseSnapshot(
+            url: url,
+            status: status,
+            statusText: statusText,
+            mimeType: mimeType,
+            headers: headers,
+            source: source,
+            requestHeaders: requestHeaders,
+            security: security
+        )
+    }
+
+    package init(
         url: String? = nil,
         status: Int? = nil,
         statusText: String? = nil,

--- a/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
+++ b/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
@@ -799,6 +799,7 @@ private struct ResponsePayload: Decodable {
     var mimeType: String?
     var source: String?
     var requestHeaders: [String: String]?
+    var security: SecurityPayload?
 
     func proxyResponse(
         fallbackURL: String?,
@@ -814,7 +815,52 @@ private struct ResponsePayload: Decodable {
             source: source.map(Network.Source.init(rawValue:)),
             requestHeaders: requestHeaders,
             bodySize: bodySize,
+            security: security?.proxySecurity,
             origin: origin
+        )
+    }
+}
+
+private struct SecurityPayload: Decodable {
+    var connection: SecurityConnectionPayload?
+    var certificate: SecurityCertificatePayload?
+
+    var proxySecurity: Network.Security {
+        Network.Security(
+            connection: connection?.proxyConnection,
+            certificate: certificate?.proxyCertificate
+        )
+    }
+}
+
+private struct SecurityConnectionPayload: Decodable {
+    var tlsProtocol: String?
+    var cipher: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case tlsProtocol = "protocol"
+        case cipher
+    }
+
+    var proxyConnection: Network.Security.Connection {
+        Network.Security.Connection(tlsProtocol: tlsProtocol, cipher: cipher)
+    }
+}
+
+private struct SecurityCertificatePayload: Decodable {
+    var subject: String?
+    var validFrom: Double?
+    var validUntil: Double?
+    var dnsNames: [String]?
+    var ipAddresses: [String]?
+
+    var proxyCertificate: Network.Security.Certificate {
+        Network.Security.Certificate(
+            subject: subject,
+            validFrom: validFrom.map { Date(timeIntervalSince1970: $0) },
+            validUntil: validUntil.map { Date(timeIntervalSince1970: $0) },
+            dnsNames: dnsNames,
+            ipAddresses: ipAddresses
         )
     }
 }
@@ -824,12 +870,14 @@ private struct MetricsPayload: Decodable {
     var remoteAddress: String?
     var responseBodyBytesReceived: Int?
     var responseBodyDecodedSize: Int?
+    var securityConnection: SecurityConnectionPayload?
 
     enum CodingKeys: String, CodingKey {
         case networkProtocol = "protocol"
         case remoteAddress
         case responseBodyBytesReceived
         case responseBodyDecodedSize
+        case securityConnection
     }
 
     func proxyMetrics(timestamp: Double) -> Network.Metrics {
@@ -838,7 +886,8 @@ private struct MetricsPayload: Decodable {
             networkProtocol: networkProtocol,
             remoteAddress: remoteAddress,
             encodedDataLength: responseBodyBytesReceived,
-            decodedBodyLength: responseBodyDecodedSize
+            decodedBodyLength: responseBodyDecodedSize,
+            securityConnection: securityConnection?.proxyConnection
         )
     }
 }

--- a/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
+++ b/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
@@ -900,7 +900,7 @@ private struct CachedResourcePayload: Decodable {
 
     func proxyResponse(origin: Network.Request.Origin) -> Network.Response {
         response?.proxyResponse(fallbackURL: url, bodySize: bodySize, origin: origin)
-            ?? Network.Response(url: url, bodySize: bodySize, origin: origin)
+            ?? Network.Response(url: url, bodySize: bodySize, security: nil, origin: origin)
     }
 }
 

--- a/Sources/WebInspectorProxyKit/Network.swift
+++ b/Sources/WebInspectorProxyKit/Network.swift
@@ -189,6 +189,83 @@ public enum Network {
         }
     }
 
+    /// Security metadata reported by WebKit for a network response.
+    ///
+    /// Missing properties remain `nil`, while reported empty strings and
+    /// arrays are preserved. This value does not infer certificate trust,
+    /// certificate validity, or whether a request used an encrypted transport.
+    public struct Security: Equatable, Sendable {
+        /// Security connection metadata reported by WebKit.
+        public struct Connection: Equatable, Sendable {
+            /// The negotiated TLS protocol, if WebKit reported one.
+            public let tlsProtocol: String?
+
+            /// The negotiated cipher, if WebKit reported one.
+            public let cipher: String?
+
+            /// Creates security connection metadata.
+            public init(tlsProtocol: String? = nil, cipher: String? = nil) {
+                self.tlsProtocol = tlsProtocol
+                self.cipher = cipher
+            }
+        }
+
+        /// Certificate metadata reported by WebKit.
+        public struct Certificate: Equatable, Sendable {
+            /// The certificate subject, if WebKit reported one.
+            public let subject: String?
+
+            /// The certificate validity start date, if WebKit reported one.
+            public let validFrom: Date?
+
+            /// The certificate validity end date, if WebKit reported one.
+            public let validUntil: Date?
+
+            /// DNS names listed on the certificate, if WebKit reported them.
+            public let dnsNames: [String]?
+
+            /// IP addresses listed on the certificate, if WebKit reported them.
+            public let ipAddresses: [String]?
+
+            /// Creates certificate metadata.
+            public init(
+                subject: String? = nil,
+                validFrom: Date? = nil,
+                validUntil: Date? = nil,
+                dnsNames: [String]? = nil,
+                ipAddresses: [String]? = nil
+            ) {
+                self.subject = subject
+                self.validFrom = validFrom
+                self.validUntil = validUntil
+                self.dnsNames = dnsNames
+                self.ipAddresses = ipAddresses
+            }
+        }
+
+        /// Connection metadata reported by WebKit, if present.
+        public let connection: Connection?
+
+        /// Certificate metadata reported by WebKit, if present.
+        public let certificate: Certificate?
+
+        /// Creates response security metadata.
+        public init(connection: Connection? = nil, certificate: Certificate? = nil) {
+            self.connection = connection
+            self.certificate = certificate
+        }
+
+        package func merging(connection completion: Connection) -> Security {
+            Security(
+                connection: Connection(
+                    tlsProtocol: completion.tlsProtocol ?? connection?.tlsProtocol,
+                    cipher: completion.cipher ?? connection?.cipher
+                ),
+                certificate: certificate
+            )
+        }
+    }
+
     /// A network response payload reported by WebKit.
     public struct Response: Sendable {
         /// The response URL.
@@ -215,6 +292,12 @@ public enum Network {
         /// The response body size, if reported.
         public let bodySize: Int?
 
+        /// Security metadata for the response, if WebKit reported it.
+        ///
+        /// A missing value is not evidence that the response used an
+        /// unencrypted transport.
+        public let security: Security?
+
         /// Protocol-reported request membership for events that create a
         /// response without a preceding request payload.
         package let origin: Request.Origin?
@@ -228,7 +311,8 @@ public enum Network {
             headers: [String: String] = [:],
             source: Source? = nil,
             requestHeaders: [String: String]? = nil,
-            bodySize: Int? = nil
+            bodySize: Int? = nil,
+            security: Security? = nil
         ) {
             self.url = url
             self.status = status
@@ -238,6 +322,7 @@ public enum Network {
             self.source = source
             self.requestHeaders = requestHeaders
             self.bodySize = bodySize
+            self.security = security
             origin = nil
         }
 
@@ -250,6 +335,7 @@ public enum Network {
             source: Source? = nil,
             requestHeaders: [String: String]? = nil,
             bodySize: Int? = nil,
+            security: Security? = nil,
             origin: Request.Origin?
         ) {
             self.url = url
@@ -260,6 +346,7 @@ public enum Network {
             self.source = source
             self.requestHeaders = requestHeaders
             self.bodySize = bodySize
+            self.security = security
             self.origin = origin
         }
     }
@@ -303,19 +390,24 @@ public enum Network {
         /// Decoded body bytes.
         public let decodedBodyLength: Int?
 
+        /// Security connection metadata observed when loading completed.
+        public let securityConnection: Security.Connection?
+
         /// Creates network transfer metrics.
         public init(
             timestamp: Double? = nil,
             networkProtocol: String? = nil,
             remoteAddress: String? = nil,
             encodedDataLength: Int? = nil,
-            decodedBodyLength: Int? = nil
+            decodedBodyLength: Int? = nil,
+            securityConnection: Security.Connection? = nil
         ) {
             self.timestamp = timestamp
             self.networkProtocol = networkProtocol
             self.remoteAddress = remoteAddress
             self.encodedDataLength = encodedDataLength
             self.decodedBodyLength = decodedBodyLength
+            self.securityConnection = securityConnection
         }
     }
 

--- a/Sources/WebInspectorProxyKit/Network.swift
+++ b/Sources/WebInspectorProxyKit/Network.swift
@@ -311,19 +311,45 @@ public enum Network {
             headers: [String: String] = [:],
             source: Source? = nil,
             requestHeaders: [String: String]? = nil,
-            bodySize: Int? = nil,
-            security: Security? = nil
+            bodySize: Int? = nil
         ) {
-            self.url = url
-            self.status = status
-            self.statusText = statusText
-            self.mimeType = mimeType
-            self.headers = headers
-            self.source = source
-            self.requestHeaders = requestHeaders
-            self.bodySize = bodySize
-            self.security = security
-            origin = nil
+            self.init(
+                url: url,
+                status: status,
+                statusText: statusText,
+                mimeType: mimeType,
+                headers: headers,
+                source: source,
+                requestHeaders: requestHeaders,
+                bodySize: bodySize,
+                security: nil
+            )
+        }
+
+        /// Creates a network response payload with security metadata.
+        public init(
+            url: String? = nil,
+            status: Int? = nil,
+            statusText: String? = nil,
+            mimeType: String? = nil,
+            headers: [String: String] = [:],
+            source: Source? = nil,
+            requestHeaders: [String: String]? = nil,
+            bodySize: Int? = nil,
+            security: Security?
+        ) {
+            self.init(
+                url: url,
+                status: status,
+                statusText: statusText,
+                mimeType: mimeType,
+                headers: headers,
+                source: source,
+                requestHeaders: requestHeaders,
+                bodySize: bodySize,
+                security: security,
+                origin: nil
+            )
         }
 
         package init(
@@ -335,7 +361,7 @@ public enum Network {
             source: Source? = nil,
             requestHeaders: [String: String]? = nil,
             bodySize: Int? = nil,
-            security: Security? = nil,
+            security: Security?,
             origin: Request.Origin?
         ) {
             self.url = url
@@ -399,8 +425,26 @@ public enum Network {
             networkProtocol: String? = nil,
             remoteAddress: String? = nil,
             encodedDataLength: Int? = nil,
+            decodedBodyLength: Int? = nil
+        ) {
+            self.init(
+                timestamp: timestamp,
+                networkProtocol: networkProtocol,
+                remoteAddress: remoteAddress,
+                encodedDataLength: encodedDataLength,
+                decodedBodyLength: decodedBodyLength,
+                securityConnection: nil
+            )
+        }
+
+        /// Creates network transfer metrics with security connection metadata.
+        public init(
+            timestamp: Double? = nil,
+            networkProtocol: String? = nil,
+            remoteAddress: String? = nil,
+            encodedDataLength: Int? = nil,
             decodedBodyLength: Int? = nil,
-            securityConnection: Security.Connection? = nil
+            securityConnection: Security.Connection?
         ) {
             self.timestamp = timestamp
             self.networkProtocol = networkProtocol

--- a/Sources/WebInspectorProxyKit/Network.swift
+++ b/Sources/WebInspectorProxyKit/Network.swift
@@ -322,23 +322,17 @@ public enum Network {
                 source: source,
                 requestHeaders: requestHeaders,
                 bodySize: bodySize,
-                security: nil
+                security: nil,
+                origin: nil
             )
         }
 
-        /// Creates a network response payload with security metadata.
-        public init(
-            url: String? = nil,
-            status: Int? = nil,
-            statusText: String? = nil,
-            mimeType: String? = nil,
-            headers: [String: String] = [:],
-            source: Source? = nil,
-            requestHeaders: [String: String]? = nil,
-            bodySize: Int? = nil,
-            security: Security?
-        ) {
-            self.init(
+        /// Returns a copy that records security metadata reported by WebKit.
+        ///
+        /// The metadata is descriptive and does not represent a trust,
+        /// validity, or encrypted-transport verdict.
+        public func reporting(security: Security) -> Response {
+            Response(
                 url: url,
                 status: status,
                 statusText: statusText,
@@ -348,7 +342,7 @@ public enum Network {
                 requestHeaders: requestHeaders,
                 bodySize: bodySize,
                 security: security,
-                origin: nil
+                origin: origin
             )
         }
 
@@ -437,8 +431,23 @@ public enum Network {
             )
         }
 
-        /// Creates network transfer metrics with security connection metadata.
-        public init(
+        /// Returns a copy that records security connection metadata reported
+        /// by WebKit.
+        ///
+        /// The metadata is descriptive and does not represent a trust,
+        /// validity, or encrypted-transport verdict.
+        public func reporting(securityConnection: Security.Connection) -> Metrics {
+            Metrics(
+                timestamp: timestamp,
+                networkProtocol: networkProtocol,
+                remoteAddress: remoteAddress,
+                encodedDataLength: encodedDataLength,
+                decodedBodyLength: decodedBodyLength,
+                securityConnection: securityConnection
+            )
+        }
+
+        package init(
             timestamp: Double? = nil,
             networkProtocol: String? = nil,
             remoteAddress: String? = nil,

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -2083,7 +2083,7 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
     await runtime.backend.emit(
         .responseReceived(
             id: requestID,
-            response: Network.Response(status: 200, security: requestSecurity),
+            response: Network.Response(status: 200).reporting(security: requestSecurity),
             resourceType: .script,
             timestamp: 1.5
         ),
@@ -6360,7 +6360,7 @@ func clearNetworkRequestsPreservesRetainedSecurityWithoutLeakingIntoReusedID() a
     await runtime.backend.emit(
         .responseReceived(
             id: requestID,
-            response: Network.Response(status: 200, security: initialSecurity),
+            response: Network.Response(status: 200).reporting(security: initialSecurity),
             resourceType: .fetch,
             timestamp: 2
         ),
@@ -6379,7 +6379,7 @@ func clearNetworkRequestsPreservesRetainedSecurityWithoutLeakingIntoReusedID() a
             id: requestID,
             timestamp: 3,
             sourceMapURL: nil,
-            metrics: Network.Metrics(
+            metrics: Network.Metrics().reporting(
                 securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
             )
         ),
@@ -9562,7 +9562,8 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
                 statusText: "OK",
                 mimeType: "application/json",
                 headers: ["Content-Type": "application/json"],
-                source: Network.Source(rawValue: "network"),
+                source: Network.Source(rawValue: "network")
+            ).reporting(
                 security: Network.Security(
                     connection: Network.Security.Connection(
                         tlsProtocol: "TLS 1.2",
@@ -9585,7 +9586,7 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
             id: requestID,
             timestamp: 4,
             sourceMapURL: nil,
-            metrics: Network.Metrics(
+            metrics: Network.Metrics().reporting(
                 securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
             )
         ),
@@ -9641,9 +9642,8 @@ func responseReceivedWithoutRequestWillBeSentCreatesRequest() async throws {
                 mimeType: "text/css",
                 headers: ["Content-Type": "text/css"],
                 source: Network.Source(rawValue: "network"),
-                requestHeaders: ["Accept": "text/css"],
-                security: responseSecurity
-            ),
+                requestHeaders: ["Accept": "text/css"]
+            ).reporting(security: responseSecurity),
             resourceType: .stylesheet,
             timestamp: 2
         ),
@@ -9830,7 +9830,7 @@ func loadingFinishedWithoutSecurityConnectionPreservesResponseSecurity() throws 
     )
 
     request.applyResponse(
-        Network.Response(status: 200, security: security),
+        Network.Response(status: 200).reporting(security: security),
         resourceType: .fetch,
         timestamp: 2
     )
@@ -9853,7 +9853,9 @@ func loadingFinishedWithoutSecurityConnectionPreservesResponseSecurity() throws 
     emptyCompletionRequest.finish(
         timestamp: 5,
         sourceMapURL: nil,
-        metrics: Network.Metrics(securityConnection: Network.Security.Connection())
+        metrics: Network.Metrics().reporting(
+            securityConnection: Network.Security.Connection()
+        )
     )
     let emptyCompletionSecurity = try #require(emptyCompletionRequest.security)
     let emptyConnection = try #require(emptyCompletionSecurity.connection)
@@ -9913,9 +9915,8 @@ func multipartContinuationPreservesFinishedLifecycleAcrossLaterParts() throws {
         Network.Response(
             url: "https://example.com/camera",
             status: 200,
-            mimeType: "MULTIPART/X-MIXED-REPLACE",
-            security: firstSecurity
-        ),
+            mimeType: "MULTIPART/X-MIXED-REPLACE"
+        ).reporting(security: firstSecurity),
         resourceType: .image,
         timestamp: 2
     )
@@ -9984,9 +9985,8 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
                 statusText: "Found",
                 mimeType: "text/html",
                 headers: ["Location": "https://example.com/final"],
-                source: Network.Source(rawValue: "network"),
-                security: redirectSecurity
-            ),
+                source: Network.Source(rawValue: "network")
+            ).reporting(security: redirectSecurity),
             resourceType: .document,
             timestamp: 2
         ),
@@ -10003,7 +10003,7 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
             id: requestID,
             request: Network.Request(id: requestID, url: "https://example.com/final", method: "GET"),
             resourceType: .document,
-            redirectResponse: Network.Response(status: 302, security: redirectSecurity),
+            redirectResponse: Network.Response(status: 302).reporting(security: redirectSecurity),
             timestamp: 3
         ),
         target: target
@@ -10122,7 +10122,8 @@ func completedRequestDoesNotTreatLaterRequestWillBeSentAsRedirect() async throws
             sourceMapURL: "first.map",
             metrics: Network.Metrics(
                 encodedDataLength: 20,
-                decodedBodyLength: 40,
+                decodedBodyLength: 40
+            ).reporting(
                 securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
             )
         ),
@@ -10219,9 +10220,8 @@ func memoryCacheEventCreatesFinishedCachedRequestFromResponse() async throws {
                 headers: ["Content-Type": "text/css"],
                 source: Network.Source(rawValue: "network"),
                 requestHeaders: ["Accept": "text/css"],
-                bodySize: 2048,
-                security: security
-            ),
+                bodySize: 2048
+            ).reporting(security: security),
             initiator: Network.Initiator(kind: "other", nodeID: DOM.Node.ID("23")),
             resourceType: .stylesheet,
             timestamp: 5
@@ -10274,7 +10274,8 @@ func memoryCacheSecurityReplacesExistingResponseSummary() throws {
     )
     request.applyResponse(
         Network.Response(
-            status: 200,
+            status: 200
+        ).reporting(
             security: Network.Security(
                 connection: Network.Security.Connection(tlsProtocol: "TLS 1.2")
             )
@@ -10289,9 +10290,8 @@ func memoryCacheSecurityReplacesExistingResponseSummary() throws {
     request.applyMemoryCache(
         response: Network.Response(
             url: "https://example.com/cached.css",
-            status: 200,
-            security: cachedSecurity
-        ),
+            status: 200
+        ).reporting(security: cachedSecurity),
         initiator: Network.Initiator(kind: "other"),
         resourceType: .stylesheet,
         timestamp: 3
@@ -10399,9 +10399,8 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
                 status: 101,
                 statusText: "Switching Protocols",
                 headers: ["Upgrade": "websocket"],
-                requestHeaders: ["Upgrade": "websocket"],
-                security: responseSecurity
-            ),
+                requestHeaders: ["Upgrade": "websocket"]
+            ).reporting(security: responseSecurity),
             resourceType: .webSocket,
             timestamp: 2
         ),
@@ -10516,9 +10515,8 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
                 status: 101,
                 statusText: "Switching Protocols",
                 headers: ["Upgrade": "websocket"],
-                requestHeaders: ["Upgrade": "websocket"],
-                security: handshakeSecurity
-            ),
+                requestHeaders: ["Upgrade": "websocket"]
+            ).reporting(security: handshakeSecurity),
             timestamp: 2
         )),
         target: target

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -2051,6 +2051,9 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
     let target = try await runtime.proxy.waitForCurrentPage()
     let documentID = DOM.Node.ID("document")
     let requestID = Network.Request.ID("request-1")
+    let requestSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
     let runtimeContextID = Runtime.ExecutionContext.ID("main")
     let networkResults: WebInspectorFetchedResults<NetworkRequest>
     let consoleResults: WebInspectorFetchedResults<ConsoleMessage>
@@ -2078,6 +2081,15 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
         target: target
     )
     await runtime.backend.emit(
+        .responseReceived(
+            id: requestID,
+            response: Network.Response(status: 200, security: requestSecurity),
+            resourceType: .script,
+            timestamp: 1.5
+        ),
+        target: target
+    )
+    await runtime.backend.emit(
         .messageAdded(Console.Message(
             source: Console.Source(rawValue: "console-api"),
             level: Console.Level(rawValue: "warning"),
@@ -2092,6 +2104,7 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
     )
     try await waitUntil {
         networkResults.items.count == 1
+            && networkResults.items.first?.security == requestSecurity
             && consoleResults.items.count == 1
             && context.executionContexts.count == 1
     }
@@ -2111,6 +2124,7 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
     #expect(context.node(for: DOMNode.ID(documentID)) == nil)
     #expect(context.registeredRequest(for: request.id) == nil)
     #expect(networkResults.items.isEmpty)
+    #expect(request.security == requestSecurity)
     #expect(context.registeredMessage(for: message.id) == nil)
     #expect(consoleResults.items.isEmpty)
     #expect(context.executionContexts.isEmpty)
@@ -3026,9 +3040,17 @@ func currentPageProcessTerminationInterruptsPickerAndRetargetsWithoutClearingNet
         method: "Network.requestWillBeSent",
         params: #"{"requestId":"destroy-retained-request","frameId":"main-frame","loaderId":"loader-1","request":{"url":"https://example.test/retained","method":"GET"},"initiator":{"type":"other"},"type":"Fetch","timestamp":1}"#
     )
+    await receiveTransportTargetEvent(
+        transport,
+        targetID: oldTargetID,
+        method: "Network.responseReceived",
+        params: #"{"requestId":"destroy-retained-request","frameId":"main-frame","loaderId":"loader-1","type":"Fetch","response":{"url":"https://example.test/retained","status":200,"headers":{},"security":{"connection":{"protocol":"TLS 1.3"},"certificate":{"subject":"retained.example.test"}}},"timestamp":1.5}"#
+    )
     try await waitUntil {
         networkResults.items.map(\.id) == [NetworkRequest.ID(retainedRequestID)]
+            && networkResults.items.first?.security?.certificate?.subject == "retained.example.test"
     }
+    let retainedRequest = try #require(networkResults.items.first)
 
     let interruptedPickerMessageCount = await backend.sentTargetMessages().count
     let interruptedPickerTask = Task { @MainActor in
@@ -3051,6 +3073,8 @@ func currentPageProcessTerminationInterruptsPickerAndRetargetsWithoutClearingNet
     #expect(context.rootNode?.id == DOMNode.ID(DOM.Node.ID("destroyed-root")))
     #expect(context.isElementPickerEnabled == false)
     #expect(networkResults.items.map(\.id) == [NetworkRequest.ID(retainedRequestID)])
+    #expect(networkResults.items.first === retainedRequest)
+    #expect(retainedRequest.security?.connection?.tlsProtocol == "TLS 1.3")
     await installTransportPageTarget(in: transport, targetID: newTargetID)
 
     try await replyTransportInspectorAndPageInitialization(
@@ -3123,6 +3147,8 @@ func currentPageProcessTerminationInterruptsPickerAndRetargetsWithoutClearingNet
     #expect(context.state == .attached)
     #expect(context.rootNode?.id == DOMNode.ID(DOM.Node.ID("reattached-root")))
     #expect(networkResults.items.map(\.id) == [NetworkRequest.ID(retainedRequestID)])
+    #expect(networkResults.items.first === retainedRequest)
+    #expect(retainedRequest.security?.certificate?.subject == "retained.example.test")
 
     let pickerMessageCount = await backend.sentTargetMessages().count
     let pickerTask = Task { @MainActor in
@@ -3751,9 +3777,12 @@ func frameDetachmentRetainsNetworkHistoryAndLateTerminalEvents() async throws {
         transport,
         targetID: targetID,
         method: "Network.responseReceived",
-        params: #"{"requestId":"detached-request","frameId":"child-frame","loaderId":"child-loader","type":"Fetch","response":{"url":"https://example.test/detached-request","status":200,"statusText":"OK","headers":{},"mimeType":"text/plain","source":"network"},"timestamp":1.5}"#
+        params: #"{"requestId":"detached-request","frameId":"child-frame","loaderId":"child-loader","type":"Fetch","response":{"url":"https://example.test/detached-request","status":200,"statusText":"OK","headers":{},"mimeType":"text/plain","source":"network","security":{"connection":{"protocol":"TLS 1.2","cipher":"AES_128_GCM_SHA256"},"certificate":{"subject":"detached.example.test","dnsNames":["detached.example.test"]}}},"timestamp":1.5}"#
     )
-    try await waitUntil { retainedRequest.status == 200 }
+    try await waitUntil {
+        retainedRequest.status == 200
+            && retainedRequest.security?.certificate?.subject == "detached.example.test"
+    }
 
     await receiveTransportTargetEvent(
         transport,
@@ -3765,12 +3794,16 @@ func frameDetachmentRetainsNetworkHistoryAndLateTerminalEvents() async throws {
         transport,
         targetID: targetID,
         method: "Network.loadingFinished",
-        params: #"{"requestId":"detached-request","timestamp":2}"#
+        params: #"{"requestId":"detached-request","timestamp":2,"metrics":{"securityConnection":{"protocol":"TLS 1.3"}}}"#
     )
     try await waitUntil { retainedRequest.state == .finished }
 
     #expect(results.items == [retainedRequest])
     #expect(retainedRequest.navigationVisit == retainedVisit)
+    #expect(retainedRequest.security?.connection?.tlsProtocol == "TLS 1.3")
+    #expect(retainedRequest.security?.connection?.cipher == "AES_128_GCM_SHA256")
+    #expect(retainedRequest.security?.certificate?.subject == "detached.example.test")
+    #expect(retainedRequest.security?.certificate?.dnsNames == ["detached.example.test"])
 
     await emitTransportNetworkRequest(
         id: "reused-detached-frame",
@@ -6297,6 +6330,84 @@ func clearNetworkRequestsPublishesResetAndIgnoresClearedEvents() async throws {
     #expect(reusedRequest.id == firstModelID)
     #expect(reusedRequest.url == "https://example.com/reused")
     #expect(context.registeredRequest(for: firstModelID) === reusedRequest)
+}
+
+@MainActor
+@Test
+func clearNetworkRequestsPreservesRetainedSecurityWithoutLeakingIntoReusedID() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let requestID = Network.Request.ID("clear-security-request")
+    let initialSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.2")
+    )
+
+    await runtime.backend.emit(
+        .requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.com/before-clear",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 1
+        ),
+        target: target
+    )
+    await runtime.backend.emit(
+        .responseReceived(
+            id: requestID,
+            response: Network.Response(status: 200, security: initialSecurity),
+            resourceType: .fetch,
+            timestamp: 2
+        ),
+        target: target
+    )
+    try await waitUntil { results.items.first?.security == initialSecurity }
+    let retainedRequest = try #require(results.items.first)
+
+    context.clearNetworkRequests()
+    #expect(results.items.isEmpty)
+    #expect(retainedRequest.security == initialSecurity)
+
+    let lateEventBaseline = context.eventPumpAppliedSequenceForTesting
+    await runtime.backend.emit(
+        .loadingFinished(
+            id: requestID,
+            timestamp: 3,
+            sourceMapURL: nil,
+            metrics: Network.Metrics(
+                securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+            )
+        ),
+        target: target
+    )
+    #expect(await context.waitForEventPumpAppliedSequenceForTesting(after: lateEventBaseline))
+    #expect(results.items.isEmpty)
+    #expect(retainedRequest.security == initialSecurity)
+
+    await runtime.backend.emit(
+        .requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.com/after-clear",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 4
+        ),
+        target: target
+    )
+    try await waitUntil { results.items.count == 1 }
+    let reusedRequest = try #require(results.items.first)
+    #expect(reusedRequest !== retainedRequest)
+    #expect(reusedRequest.security == nil)
+    #expect(retainedRequest.security == initialSecurity)
 }
 
 @MainActor
@@ -9419,6 +9530,13 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("request-1")
+    let certificate = Network.Security.Certificate(
+        subject: "example.com",
+        validFrom: Date(timeIntervalSince1970: 1_700_000_000),
+        validUntil: Date(timeIntervalSince1970: 1_800_000_000),
+        dnsNames: ["example.com"],
+        ipAddresses: []
+    )
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -9444,7 +9562,14 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
                 statusText: "OK",
                 mimeType: "application/json",
                 headers: ["Content-Type": "application/json"],
-                source: Network.Source(rawValue: "network")
+                source: Network.Source(rawValue: "network"),
+                security: Network.Security(
+                    connection: Network.Security.Connection(
+                        tlsProtocol: "TLS 1.2",
+                        cipher: "AES_128_GCM_SHA256"
+                    ),
+                    certificate: certificate
+                )
             ),
             resourceType: .fetch,
             timestamp: 2
@@ -9456,7 +9581,14 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
         target: target
     )
     await runtime.backend.emit(
-        .loadingFinished(id: requestID, timestamp: 4, sourceMapURL: nil, metrics: nil),
+        .loadingFinished(
+            id: requestID,
+            timestamp: 4,
+            sourceMapURL: nil,
+            metrics: Network.Metrics(
+                securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+            )
+        ),
         target: target
     )
 
@@ -9483,6 +9615,9 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
     #expect(request.finishedOrFailedTimestamp == 4)
     #expect(request.decodedDataLength == 12)
     #expect(request.encodedDataLength == 5)
+    #expect(request.security?.connection?.tlsProtocol == "TLS 1.3")
+    #expect(request.security?.connection?.cipher == "AES_128_GCM_SHA256")
+    #expect(request.security?.certificate == certificate)
     #expect(context.registeredRequest(for: request.id) === request)
 }
 
@@ -9492,6 +9627,9 @@ func responseReceivedWithoutRequestWillBeSentCreatesRequest() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("response-first-request")
+    let responseSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
 
     await runtime.backend.emit(
         .responseReceived(
@@ -9503,7 +9641,8 @@ func responseReceivedWithoutRequestWillBeSentCreatesRequest() async throws {
                 mimeType: "text/css",
                 headers: ["Content-Type": "text/css"],
                 source: Network.Source(rawValue: "network"),
-                requestHeaders: ["Accept": "text/css"]
+                requestHeaders: ["Accept": "text/css"],
+                security: responseSecurity
             ),
             resourceType: .stylesheet,
             timestamp: 2
@@ -9536,6 +9675,7 @@ func responseReceivedWithoutRequestWillBeSentCreatesRequest() async throws {
     #expect(request.finishedOrFailedTimestamp == 4)
     #expect(request.requestHeaders["Accept"] == "text/css")
     #expect(request.responseHeaders["Content-Type"] == "text/css")
+    #expect(request.security == responseSecurity)
     #expect(request.decodedDataLength == 9)
     #expect(request.encodedDataLength == 4)
 }
@@ -9667,6 +9807,89 @@ func loadingFinishedClampsNegativeMetricTotals() async throws {
 
 @MainActor
 @Test
+func loadingFinishedWithoutSecurityConnectionPreservesResponseSecurity() throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("security-without-completion-connection")
+    let security = Network.Security(
+        connection: Network.Security.Connection(
+            tlsProtocol: "TLS 1.3",
+            cipher: "AES_128_GCM_SHA256"
+        ),
+        certificate: Network.Security.Certificate(subject: "example.com")
+    )
+    let request = NetworkRequest(
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.com/security",
+            method: "GET"
+        ),
+        initiator: nil,
+        resourceType: .fetch,
+        timestamp: 1,
+        modelContext: context
+    )
+
+    request.applyResponse(
+        Network.Response(status: 200, security: security),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    request.finish(timestamp: 3, sourceMapURL: nil, metrics: Network.Metrics())
+
+    #expect(request.security == security)
+
+    let emptyCompletionRequestID = Network.Request.ID("empty-completion-security-connection")
+    let emptyCompletionRequest = NetworkRequest(
+        request: Network.Request(
+            id: emptyCompletionRequestID,
+            url: "https://example.com/empty-completion-security",
+            method: "GET"
+        ),
+        initiator: nil,
+        resourceType: .fetch,
+        timestamp: 4,
+        modelContext: context
+    )
+    emptyCompletionRequest.finish(
+        timestamp: 5,
+        sourceMapURL: nil,
+        metrics: Network.Metrics(securityConnection: Network.Security.Connection())
+    )
+    let emptyCompletionSecurity = try #require(emptyCompletionRequest.security)
+    let emptyConnection = try #require(emptyCompletionSecurity.connection)
+    #expect(emptyConnection.tlsProtocol == nil)
+    #expect(emptyConnection.cipher == nil)
+    #expect(emptyCompletionSecurity.certificate == nil)
+}
+
+@MainActor
+@Test(arguments: [
+    "https://example.com/security-not-reported",
+    "http://example.com/security-not-reported",
+])
+func networkSecurityDoesNotInferTransportStateFromURLScheme(_ url: String) throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID(url)
+    let request = NetworkRequest(
+        request: Network.Request(id: requestID, url: url, method: "GET"),
+        initiator: nil,
+        resourceType: .fetch,
+        timestamp: 1,
+        modelContext: context
+    )
+
+    #expect(request.security == nil)
+    request.applyResponse(
+        Network.Response(url: url, status: 200),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    request.finish(timestamp: 3, sourceMapURL: nil, metrics: Network.Metrics())
+    #expect(request.security == nil)
+}
+
+@MainActor
+@Test
 func multipartContinuationPreservesFinishedLifecycleAcrossLaterParts() throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     let requestID = Network.Request.ID("multipart-continuation")
@@ -9682,18 +9905,23 @@ func multipartContinuationPreservesFinishedLifecycleAcrossLaterParts() throws {
         modelContext: context
     )
     let responseBody = request.responseBody
+    let firstSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
 
     request.applyResponse(
         Network.Response(
             url: "https://example.com/camera",
             status: 200,
-            mimeType: "MULTIPART/X-MIXED-REPLACE"
+            mimeType: "MULTIPART/X-MIXED-REPLACE",
+            security: firstSecurity
         ),
         resourceType: .image,
         timestamp: 2
     )
     request.finish(timestamp: 3, sourceMapURL: nil, metrics: nil)
     responseBody.load(Network.Body(data: "first part", base64Encoded: false))
+    #expect(request.security == firstSecurity)
 
     request.applyResponse(
         Network.Response(
@@ -9712,6 +9940,7 @@ func multipartContinuationPreservesFinishedLifecycleAcrossLaterParts() throws {
     #expect(request.responseReceivedTimestamp == 4)
     #expect(request.mimeType == "image/jpeg")
     #expect(request.responseHeaders["X-Part"] == "2")
+    #expect(request.security == nil)
     #expect(responseBody.phase == .available)
     #expect(responseBody.full == nil)
     #expect(request.canFetchResponseBody)
@@ -9731,6 +9960,10 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("redirected-request")
+    let redirectSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3"),
+        certificate: Network.Security.Certificate(subject: "redirect.example.com")
+    )
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -9751,7 +9984,8 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
                 statusText: "Found",
                 mimeType: "text/html",
                 headers: ["Location": "https://example.com/final"],
-                source: Network.Source(rawValue: "network")
+                source: Network.Source(rawValue: "network"),
+                security: redirectSecurity
             ),
             resourceType: .document,
             timestamp: 2
@@ -9769,7 +10003,7 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
             id: requestID,
             request: Network.Request(id: requestID, url: "https://example.com/final", method: "GET"),
             resourceType: .document,
-            redirectResponse: Network.Response(status: 302),
+            redirectResponse: Network.Response(status: 302, security: redirectSecurity),
             timestamp: 3
         ),
         target: target
@@ -9785,6 +10019,7 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
     #expect(request.mimeType == nil)
     #expect(request.responseSource == nil)
     #expect(request.responseHeaders.isEmpty)
+    #expect(request.security == nil)
     #expect(request.requestSentTimestamp == 3)
     #expect(request.responseReceivedTimestamp == nil)
     #expect(request.lastDataReceivedTimestamp == nil)
@@ -9796,6 +10031,7 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
     #expect(request.redirects.count == 1)
     #expect(request.redirects.first?.request.url == "https://example.com/redirect")
     #expect(request.redirects.first?.response.status == 302)
+    #expect(request.redirects.first?.response.security == redirectSecurity)
     #expect(request.redirects.first?.timestamp == 3)
 }
 
@@ -9884,7 +10120,11 @@ func completedRequestDoesNotTreatLaterRequestWillBeSentAsRedirect() async throws
             id: requestID,
             timestamp: 2,
             sourceMapURL: "first.map",
-            metrics: Network.Metrics(encodedDataLength: 20, decodedBodyLength: 40)
+            metrics: Network.Metrics(
+                encodedDataLength: 20,
+                decodedBodyLength: 40,
+                securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+            )
         ),
         target: target
     )
@@ -9893,6 +10133,7 @@ func completedRequestDoesNotTreatLaterRequestWillBeSentAsRedirect() async throws
     try await waitUntil { results.items.first?.state == .finished }
     let request = try #require(results.items.first)
     #expect(request.lifecycleRevision == 0)
+    #expect(request.security?.connection?.tlsProtocol == "TLS 1.3")
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -9915,6 +10156,7 @@ func completedRequestDoesNotTreatLaterRequestWillBeSentAsRedirect() async throws
     #expect(request.finishedOrFailedTimestamp == nil)
     #expect(request.sourceMapURL == nil)
     #expect(request.metrics == nil)
+    #expect(request.security == nil)
     #expect(request.initiator?.nodeID == DOM.Node.ID("42"))
     #expect(request.lifecycleRevision == 1)
 }
@@ -9961,6 +10203,10 @@ func memoryCacheEventCreatesFinishedCachedRequestFromResponse() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("cached-request")
+    let security = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3"),
+        certificate: Network.Security.Certificate(subject: "example.com")
+    )
 
     await runtime.backend.emit(
         .requestServedFromMemoryCache(
@@ -9973,7 +10219,8 @@ func memoryCacheEventCreatesFinishedCachedRequestFromResponse() async throws {
                 headers: ["Content-Type": "text/css"],
                 source: Network.Source(rawValue: "network"),
                 requestHeaders: ["Accept": "text/css"],
-                bodySize: 2048
+                bodySize: 2048,
+                security: security
             ),
             initiator: Network.Initiator(kind: "other", nodeID: DOM.Node.ID("23")),
             resourceType: .stylesheet,
@@ -10003,9 +10250,64 @@ func memoryCacheEventCreatesFinishedCachedRequestFromResponse() async throws {
     #expect(request.finishedOrFailedTimestamp == 5)
     #expect(request.decodedDataLength == 2048)
     #expect(request.encodedDataLength == 2048)
+    #expect(request.security == security)
     #expect(request.responseBody.phase == .available)
     #expect(request.initiator?.nodeID == DOM.Node.ID("23"))
     #expect(context.registeredRequest(for: request.id) === request)
+}
+
+@MainActor
+@Test
+func memoryCacheSecurityReplacesExistingResponseSummary() throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("memory-cache-security-replacement")
+    let request = NetworkRequest(
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.com/cached.css",
+            method: "GET"
+        ),
+        initiator: nil,
+        resourceType: .stylesheet,
+        timestamp: 1,
+        modelContext: context
+    )
+    request.applyResponse(
+        Network.Response(
+            status: 200,
+            security: Network.Security(
+                connection: Network.Security.Connection(tlsProtocol: "TLS 1.2")
+            )
+        ),
+        resourceType: .stylesheet,
+        timestamp: 2
+    )
+    let cachedSecurity = Network.Security(
+        certificate: Network.Security.Certificate(subject: "cached.example.com")
+    )
+
+    request.applyMemoryCache(
+        response: Network.Response(
+            url: "https://example.com/cached.css",
+            status: 200,
+            security: cachedSecurity
+        ),
+        initiator: Network.Initiator(kind: "other"),
+        resourceType: .stylesheet,
+        timestamp: 3
+    )
+    #expect(request.security == cachedSecurity)
+
+    request.applyMemoryCache(
+        response: Network.Response(
+            url: "https://example.com/cached.css",
+            status: 200
+        ),
+        initiator: Network.Initiator(kind: "other"),
+        resourceType: .stylesheet,
+        timestamp: 4
+    )
+    #expect(request.security == nil)
 }
 
 @MainActor
@@ -10071,6 +10373,9 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("websocket-created-after-request")
+    let responseSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -10094,7 +10399,8 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
                 status: 101,
                 statusText: "Switching Protocols",
                 headers: ["Upgrade": "websocket"],
-                requestHeaders: ["Upgrade": "websocket"]
+                requestHeaders: ["Upgrade": "websocket"],
+                security: responseSecurity
             ),
             resourceType: .webSocket,
             timestamp: 2
@@ -10116,6 +10422,7 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
         target: target
     )
     try await waitUntil { request.url == "wss://example.com/socket?created" }
+    #expect(request.security == responseSecurity)
     await runtime.backend.emit(
         .webSocket(.handshakeRequest(
             id: requestID,
@@ -10129,6 +10436,7 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
         )),
         target: target
     )
+    try await waitUntil { request.state == .pending && request.security == nil }
     await runtime.backend.emit(
         .webSocket(.handshakeResponse(
             id: requestID,
@@ -10167,6 +10475,10 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("websocket-lifecycle")
+    let handshakeSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3"),
+        certificate: Network.Security.Certificate(subject: "example.com")
+    )
 
     await runtime.backend.emit(
         .webSocket(.created(id: requestID, url: "wss://example.com/socket")),
@@ -10204,7 +10516,8 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
                 status: 101,
                 statusText: "Switching Protocols",
                 headers: ["Upgrade": "websocket"],
-                requestHeaders: ["Upgrade": "websocket"]
+                requestHeaders: ["Upgrade": "websocket"],
+                security: handshakeSecurity
             ),
             timestamp: 2
         )),
@@ -10214,6 +10527,8 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
         request.webSocket?.readyState == .open && request.state == .responded
     }
     #expect(request.webSocket?.handshakeResponse?.status == 101)
+    #expect(request.webSocket?.handshakeResponse?.security == handshakeSecurity)
+    #expect(request.security == handshakeSecurity)
     #expect(request.status == 101)
     #expect(request.responseHeaders["Upgrade"] == "websocket")
     #expect(request.requestHeaders["Upgrade"] == "websocket")

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -1809,7 +1809,7 @@ func transportBackendDecodesNetworkResponseEventForTargetRoute() async throws {
         transport,
         targetID: ProtocolTarget.ID("page-main"),
         method: "Network.responseReceived",
-        params: #"{"requestId":"request-1","frameId":"main-frame","loaderId":"main-loader","type":"Document","response":{"url":"https://example.test/","status":200,"statusText":"OK","mimeType":"text/html","headers":{"content-type":"text/html"},"source":"network"},"timestamp":12.5}"#
+        params: #"{"requestId":"request-1","frameId":"main-frame","loaderId":"main-loader","type":"Document","response":{"url":"https://example.test/","status":200,"statusText":"OK","mimeType":"text/html","headers":{"content-type":"text/html"},"source":"network","security":{"connection":{"protocol":"TLS 1.3","cipher":"","futureConnectionField":true},"certificate":{"subject":"","validFrom":1700000000.125,"validUntil":1800000000,"dnsNames":["www.example.test","example.test"],"ipAddresses":[],"futureCertificateField":"ignored"},"futureSecurityField":42}},"timestamp":12.5}"#
     )
 
     let event = try #require(try await value(of: eventTask))
@@ -1822,6 +1822,13 @@ func transportBackendDecodesNetworkResponseEventForTargetRoute() async throws {
     #expect(response.status == 200)
     #expect(response.headers["content-type"] == "text/html")
     #expect(response.source == Network.Source(rawValue: "network"))
+    #expect(response.security?.connection?.tlsProtocol == "TLS 1.3")
+    #expect(response.security?.connection?.cipher == "")
+    #expect(response.security?.certificate?.subject == "")
+    #expect(response.security?.certificate?.validFrom == Date(timeIntervalSince1970: 1_700_000_000.125))
+    #expect(response.security?.certificate?.validUntil == Date(timeIntervalSince1970: 1_800_000_000))
+    #expect(response.security?.certificate?.dnsNames == ["www.example.test", "example.test"])
+    #expect(response.security?.certificate?.ipAddresses == [])
     #expect(
         response.origin == Network.Request.Origin(
             frameID: FrameID("main-frame"),
@@ -1860,8 +1867,85 @@ func transportBackendDecodesNetworkResponseEventWithoutType() async throws {
     }
     #expect(id == Network.Request.ID("request-1"))
     #expect(response.url == "https://example.test/")
+    #expect(response.security == nil)
     #expect(resourceType == nil)
     #expect(timestamp == 12.5)
+}
+
+@Test
+func transportBackendPreservesPresentEmptyNetworkSecurity() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(750))
+    await installPageTarget(in: transport)
+    let target = pageTarget(proxy: WebInspectorProxy(backend: LiveWebInspectorProxyBackend(transport: transport)))
+
+    let eventTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        var events: [Network.Event] = []
+        for _ in 0..<3 {
+            guard let event = await iterator.next() else {
+                break
+            }
+            events.append(event)
+        }
+        return events
+    }
+
+    await waitForEventSubscription(target, domain: .network)
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.responseReceived",
+        params: #"{"requestId":"request-empty-security","frameId":"main-frame","loaderId":"main-loader","response":{"url":"https://example.test/","status":200,"headers":{},"security":{}},"timestamp":12.5}"#
+    )
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.responseReceived",
+        params: #"{"requestId":"request-empty-nested-security","frameId":"main-frame","loaderId":"main-loader","response":{"url":"https://example.test/","status":200,"headers":{},"security":{"connection":{},"certificate":{}}},"timestamp":13}"#
+    )
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: #"{"requestId":"request-empty-security","timestamp":14,"metrics":{"securityConnection":{}}}"#
+    )
+
+    let events = try await value(of: eventTask)
+    #expect(events.count == 3)
+    guard events.count == 3 else {
+        return
+    }
+    guard case let .responseReceived(_, response, _, _) = events[0] else {
+        Issue.record("Expected Network.responseReceived.")
+        return
+    }
+    let security = try #require(response.security)
+    #expect(security.connection == nil)
+    #expect(security.certificate == nil)
+
+    guard case let .responseReceived(_, nestedResponse, _, _) = events[1] else {
+        Issue.record("Expected a second Network.responseReceived.")
+        return
+    }
+    let nestedSecurity = try #require(nestedResponse.security)
+    let emptyConnection = try #require(nestedSecurity.connection)
+    let emptyCertificate = try #require(nestedSecurity.certificate)
+    #expect(emptyConnection.tlsProtocol == nil)
+    #expect(emptyConnection.cipher == nil)
+    #expect(emptyCertificate.subject == nil)
+    #expect(emptyCertificate.validFrom == nil)
+    #expect(emptyCertificate.validUntil == nil)
+    #expect(emptyCertificate.dnsNames == nil)
+    #expect(emptyCertificate.ipAddresses == nil)
+
+    guard case let .loadingFinished(_, _, _, metrics) = events[2] else {
+        Issue.record("Expected Network.loadingFinished.")
+        return
+    }
+    let emptyMetricsConnection = try #require(metrics?.securityConnection)
+    #expect(emptyMetricsConnection.tlsProtocol == nil)
+    #expect(emptyMetricsConnection.cipher == nil)
 }
 
 @Test
@@ -3000,7 +3084,7 @@ func transportBackendFiltersEventsByRoute() async throws {
         transport,
         targetID: ProtocolTarget.ID("frame-target"),
         method: "Network.loadingFinished",
-        params: #"{"requestId":"frame-request","timestamp":4,"sourceMapURL":"frame.js.map","metrics":{"protocol":"h2","remoteAddress":"203.0.113.10:443","responseBodyBytesReceived":128,"responseBodyDecodedSize":256}}"#
+        params: #"{"requestId":"frame-request","timestamp":4,"sourceMapURL":"frame.js.map","metrics":{"protocol":"h2","remoteAddress":"203.0.113.10:443","responseBodyBytesReceived":128,"responseBodyDecodedSize":256,"securityConnection":{"protocol":"TLS 1.3","cipher":"AES_128_GCM_SHA256","futureConnectionField":true}}}"#
     )
 
     let frameEvent = try #require(try await value(of: frameEventTask))
@@ -3015,6 +3099,8 @@ func transportBackendFiltersEventsByRoute() async throws {
     #expect(metrics?.remoteAddress == "203.0.113.10:443")
     #expect(metrics?.encodedDataLength == 128)
     #expect(metrics?.decodedBodyLength == 256)
+    #expect(metrics?.securityConnection?.tlsProtocol == "TLS 1.3")
+    #expect(metrics?.securityConnection?.cipher == "AES_128_GCM_SHA256")
 
     pageEventTask.cancel()
 }

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -1838,6 +1838,18 @@ func transportBackendDecodesNetworkResponseEventForTargetRoute() async throws {
     )
     #expect(resourceType == .document)
     #expect(timestamp == 12.5)
+
+    let copiedResponse = response.reporting(security: Network.Security())
+    #expect(copiedResponse.url == response.url)
+    #expect(copiedResponse.status == response.status)
+    #expect(copiedResponse.statusText == response.statusText)
+    #expect(copiedResponse.mimeType == response.mimeType)
+    #expect(copiedResponse.headers == response.headers)
+    #expect(copiedResponse.source == response.source)
+    #expect(copiedResponse.requestHeaders == response.requestHeaders)
+    #expect(copiedResponse.bodySize == response.bodySize)
+    #expect(copiedResponse.origin == response.origin)
+    #expect(copiedResponse.security == Network.Security())
 }
 
 @Test


### PR DESCRIPTION
## Purpose

Expose WebKit-reported TLS connection and certificate summary metadata to direct ProxyKit consumers and observable DataKit request models.

Closes #236

## Changes

- Add immutable `Network.Security`, `Connection`, and `Certificate` values with explicit reported-metadata semantics.
- Decode `Network.Response.security` and completion-time `Metrics.securityConnection`, including Unix wall-time conversion and present-empty payloads.
- Store one observable `NetworkRequest.security` value, replace it on response updates, and merge completion connection fields without erasing certificate data.
- Reset current security at request lifecycle, redirect, and WebSocket handshake boundaries while preserving redirect and handshake response snapshots.
- Preserve existing public initializer identity and expose security construction through immutable `reporting(...)` copy APIs.
- Add raw-wire, DataKit lifecycle, import-only, and external consumer contract coverage.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` (723 tests passed)
- `swift test --package-path ContractTests` (10 tests passed)
- ProxyKit SwiftPM tests (195 passed)
- DataKit SwiftPM tests (235 passed)
- `Scripts/check-datakit-symbol-boundary.sh`
- DocC generation for WebInspectorProxyKit and WebInspectorDataKit
- `git diff --check`
- `codex-review` (no findings)

## Runtime probe

No live TLS probe is included because the deterministic inspector fixture is loopback HTTP-only and known Network events are not exposed as raw events. The field shape and platform emission paths were checked against the pinned WebKit source, and deterministic raw-wire transport tests cover the protocol-to-DataKit path.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
