### PR TITLE
Add request-scoped Network Cookies pane

### DIFF
--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
@@ -67,3 +67,18 @@ func webInspectorProxyNetworkEventsMulticastToConsumerSubscribers() async throws
     #expect(firstTimestamp == 42)
     #expect(secondTimestamp == 42)
 }
+
+@Test
+func webInspectorProxyMetricsRequestHeadersPreserveInitializerAndCopyContracts() {
+    let makeMetrics = Network.Metrics.init
+    let base = makeMetrics(42, "h2", "203.0.113.10:443", 128, 256)
+    let reported = base.reporting(requestHeaders: ["Cookie": "session=abc"])
+
+    #expect(base.requestHeaders == nil)
+    #expect(reported.timestamp == 42)
+    #expect(reported.networkProtocol == "h2")
+    #expect(reported.remoteAddress == "203.0.113.10:443")
+    #expect(reported.encodedDataLength == 128)
+    #expect(reported.decodedBodyLength == 256)
+    #expect(reported.requestHeaders == ["Cookie": "session=abc"])
+}

--- a/Sources/WebInspectorDataKit/NetworkCookies.swift
+++ b/Sources/WebInspectorDataKit/NetworkCookies.swift
@@ -406,6 +406,8 @@ package enum NetworkCookieParser {
                 status: .unparsed
             )
         }
+        // Do not split: WebKit's HTTPHeaderMap irreversibly discards Set-Cookie field boundaries,
+        // so commas in Expires or values cannot be safely distinguished from field separators.
         guard containsCombinedCookieCandidate(rawHeaderValue) == false else {
             return NetworkResponseCookieParseReport(
                 cookies: [],

--- a/Sources/WebInspectorDataKit/NetworkCookies.swift
+++ b/Sources/WebInspectorDataKit/NetworkCookies.swift
@@ -485,8 +485,10 @@ package enum NetworkCookieParser {
                 attributeName = trimmedAttribute
                 attributeValue = nil
             }
-            guard containsControlCharacter(attributeName) == false,
-                  attributeValue.map(containsControlCharacter) != true else {
+            guard containsProhibitedAttributeControlCharacter(
+                name: attributeName,
+                value: attributeValue
+            ) == false else {
                 return unparsedResponseReport(
                     rawHeaderValues: rawHeaderValues,
                     diagnostic: NetworkCookieParseDiagnostic(
@@ -622,6 +624,22 @@ fileprivate extension NetworkCookieParser {
         value.unicodeScalars.contains { scalar in
             scalar.value <= 0x1F || scalar.value == 0x7F
         }
+    }
+
+    static func containsProhibitedAttributeControlCharacter(
+        name: String,
+        value: String?
+    ) -> Bool {
+        guard containsControlCharacter(name) == false else {
+            return true
+        }
+        guard let value else {
+            return false
+        }
+        if lowercaseASCII(name) == "expires" {
+            return containsNonOWSControlCharacter(value)
+        }
+        return containsControlCharacter(value)
     }
 
     static func containsCombinedCookieCandidate(_ value: String) -> Bool {

--- a/Sources/WebInspectorDataKit/NetworkCookies.swift
+++ b/Sources/WebInspectorDataKit/NetworkCookies.swift
@@ -333,6 +333,13 @@ package enum NetworkCookieParser {
         for (ordinal, fragment) in fragments.enumerated() {
             let rawFragment = String(fragment)
             let trimmedFragment = trimOptionalWhitespace(rawFragment)
+            guard containsNonOWSControlCharacter(rawFragment) == false else {
+                diagnostics.append(NetworkCookieParseDiagnostic(
+                    kind: .prohibitedControlCharacter,
+                    rawFragment: rawFragment
+                ))
+                continue
+            }
             guard let equalsIndex = trimmedFragment.firstIndex(of: "=") else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
                     kind: .invalidCookieFragment,
@@ -342,6 +349,16 @@ package enum NetworkCookieParser {
             }
 
             let name = trimOptionalWhitespace(String(trimmedFragment[..<equalsIndex]))
+            let valueStart = trimmedFragment.index(after: equalsIndex)
+            let value = trimOptionalWhitespace(String(trimmedFragment[valueStart...]))
+            guard containsControlCharacter(name) == false,
+                  containsControlCharacter(value) == false else {
+                diagnostics.append(NetworkCookieParseDiagnostic(
+                    kind: .prohibitedControlCharacter,
+                    rawFragment: rawFragment
+                ))
+                continue
+            }
             guard isHTTPToken(name) else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
                     kind: .invalidCookieFragment,
@@ -349,8 +366,6 @@ package enum NetworkCookieParser {
                 ))
                 continue
             }
-            let valueStart = trimmedFragment.index(after: equalsIndex)
-            let value = trimOptionalWhitespace(String(trimmedFragment[valueStart...]))
             cookies.append(NetworkRequestCookie(
                 ordinal: ordinal,
                 name: name,
@@ -395,7 +410,7 @@ package enum NetworkCookieParser {
                 status: .complete
             )
         }
-        guard containsProhibitedControlCharacter(rawHeaderValue) == false else {
+        guard containsNonOWSControlCharacter(rawHeaderValue) == false else {
             return NetworkResponseCookieParseReport(
                 cookies: [],
                 rawHeaderValues: rawHeaderValues,
@@ -433,6 +448,18 @@ package enum NetworkCookieParser {
             )
         }
         let name = trimOptionalWhitespace(String(trimmedCookiePair[..<equalsIndex]))
+        let valueStart = trimmedCookiePair.index(after: equalsIndex)
+        let value = trimOptionalWhitespace(String(trimmedCookiePair[valueStart...]))
+        guard containsControlCharacter(name) == false,
+              containsControlCharacter(value) == false else {
+            return unparsedResponseReport(
+                rawHeaderValues: rawHeaderValues,
+                diagnostic: NetworkCookieParseDiagnostic(
+                    kind: .prohibitedControlCharacter,
+                    rawFragment: rawHeaderValue
+                )
+            )
+        }
         guard isHTTPToken(name) else {
             return unparsedResponseReport(
                 rawHeaderValues: rawHeaderValues,
@@ -442,8 +469,6 @@ package enum NetworkCookieParser {
                 )
             )
         }
-        let valueStart = trimmedCookiePair.index(after: equalsIndex)
-        let value = trimOptionalWhitespace(String(trimmedCookiePair[valueStart...]))
 
         var attributes: [NetworkResponseCookieAttribute] = []
         attributes.reserveCapacity(max(fragments.count - 1, 0))
@@ -459,6 +484,16 @@ package enum NetworkCookieParser {
             } else {
                 attributeName = trimmedAttribute
                 attributeValue = nil
+            }
+            guard containsControlCharacter(attributeName) == false,
+                  attributeValue.map(containsControlCharacter) != true else {
+                return unparsedResponseReport(
+                    rawHeaderValues: rawHeaderValues,
+                    diagnostic: NetworkCookieParseDiagnostic(
+                        kind: .prohibitedControlCharacter,
+                        rawFragment: rawHeaderValue
+                    )
+                )
             }
 
             let attribute = NetworkResponseCookieAttribute(
@@ -576,10 +611,16 @@ fileprivate extension NetworkCookieParser {
         )
     }
 
-    static func containsProhibitedControlCharacter(_ value: String) -> Bool {
+    static func containsNonOWSControlCharacter(_ value: String) -> Bool {
         value.unicodeScalars.contains { scalar in
             let codePoint = scalar.value
             return (codePoint <= 0x1F && codePoint != 0x09) || codePoint == 0x7F
+        }
+    }
+
+    static func containsControlCharacter(_ value: String) -> Bool {
+        value.unicodeScalars.contains { scalar in
+            scalar.value <= 0x1F || scalar.value == 0x7F
         }
     }
 

--- a/Sources/WebInspectorDataKit/NetworkCookies.swift
+++ b/Sources/WebInspectorDataKit/NetworkCookies.swift
@@ -1,0 +1,834 @@
+import Foundation
+
+package enum NetworkCookieParseStatus: Hashable, Sendable {
+    case complete
+    case partial
+    case unparsed
+    case ambiguousCombined
+}
+
+package struct NetworkCookieParseDiagnostic: Hashable, Sendable {
+    package enum Kind: Hashable, Sendable {
+        case multipleHeaderFields
+        case invalidCookieFragment
+        case prohibitedControlCharacter
+        case ambiguousCombinedHeader
+        case invalidAttribute
+        case invalidExpires
+        case invalidMaxAge
+    }
+
+    package let kind: Kind
+    package let rawFragment: String
+
+    package init(kind: Kind, rawFragment: String) {
+        self.kind = kind
+        self.rawFragment = rawFragment
+    }
+}
+
+package struct NetworkRequestCookie: Hashable, Sendable {
+    package let ordinal: Int
+    package let name: String
+    package let value: String
+    package let raw: String
+
+    package init(ordinal: Int, name: String, value: String, raw: String) {
+        self.ordinal = ordinal
+        self.name = name
+        self.value = value
+        self.raw = raw
+    }
+}
+
+package struct NetworkResponseCookieAttribute: Hashable, Sendable {
+    package let ordinal: Int
+    package let name: String
+    package let value: String?
+    package let raw: String
+
+    package init(ordinal: Int, name: String, value: String?, raw: String) {
+        self.ordinal = ordinal
+        self.name = name
+        self.value = value
+        self.raw = raw
+    }
+}
+
+package enum NetworkCookieSameSite: Hashable, Sendable {
+    case absent
+    case none
+    case lax
+    case strict
+    case other(String)
+}
+
+package struct NetworkResponseCookie: Hashable, Sendable {
+    package let ordinal: Int
+    package let name: String
+    package let value: String
+    package let raw: String
+    package let attributes: [NetworkResponseCookieAttribute]
+    private let projection: NetworkResponseCookieProjection
+
+    package var domain: String? { projection.domain }
+    package var path: String? { projection.path }
+    package var rawExpires: String? { projection.rawExpires }
+    package var expires: Date? { projection.expires }
+    package var rawMaxAge: String? { projection.rawMaxAge }
+    package var maxAgeSeconds: Int64? { projection.maxAgeSeconds }
+    package var isSecure: Bool { projection.isSecure }
+    package var isHTTPOnly: Bool { projection.isHTTPOnly }
+    package var isPartitioned: Bool { projection.isPartitioned }
+    package var sameSite: NetworkCookieSameSite { projection.sameSite }
+    package var unknownAttributes: [NetworkResponseCookieAttribute] {
+        projection.unknownAttributes
+    }
+
+    fileprivate var projectionDiagnostics: [NetworkCookieParseDiagnostic] {
+        projection.diagnostics
+    }
+
+    fileprivate init(
+        ordinal: Int,
+        name: String,
+        value: String,
+        raw: String,
+        attributes: [NetworkResponseCookieAttribute]
+    ) {
+        self.ordinal = ordinal
+        self.name = name
+        self.value = value
+        self.raw = raw
+        self.attributes = attributes
+        projection = NetworkResponseCookieProjection(attributes: attributes)
+    }
+}
+
+private struct NetworkResponseCookieProjection: Hashable, Sendable {
+    let domain: String?
+    let path: String?
+    let rawExpires: String?
+    let expires: Date?
+    let rawMaxAge: String?
+    let maxAgeSeconds: Int64?
+    let isSecure: Bool
+    let isHTTPOnly: Bool
+    let isPartitioned: Bool
+    let sameSite: NetworkCookieSameSite
+    let unknownAttributes: [NetworkResponseCookieAttribute]
+    let diagnostics: [NetworkCookieParseDiagnostic]
+
+    init(attributes: [NetworkResponseCookieAttribute]) {
+        var domain: String?
+        var path: String?
+        var rawExpires: String?
+        var expires: Date?
+        var rawMaxAge: String?
+        var maxAgeSeconds: Int64?
+        var isSecure = false
+        var isHTTPOnly = false
+        var isPartitioned = false
+        var sameSite = NetworkCookieSameSite.absent
+        var unknownAttributes: [NetworkResponseCookieAttribute] = []
+        var diagnostics: [NetworkCookieParseDiagnostic] = []
+
+        for attribute in attributes {
+            guard NetworkCookieParser.isHTTPToken(attribute.name) else {
+                diagnostics.append(NetworkCookieParseDiagnostic(
+                    kind: .invalidAttribute,
+                    rawFragment: attribute.raw
+                ))
+                continue
+            }
+
+            switch NetworkCookieParser.lowercaseASCII(attribute.name) {
+            case "domain":
+                guard let value = attribute.value, value.isEmpty == false else {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                    continue
+                }
+                domain = value
+
+            case "path":
+                guard let value = attribute.value, value.isEmpty == false else {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                    continue
+                }
+                path = value
+
+            case "expires":
+                guard
+                    let value = attribute.value,
+                    value.isEmpty == false,
+                    let parsedDate = NetworkCookieParser.parseCookieDate(value)
+                else {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidExpires,
+                        rawFragment: attribute.raw
+                    ))
+                    continue
+                }
+                rawExpires = value
+                expires = parsedDate
+
+            case "max-age":
+                guard
+                    let value = attribute.value,
+                    let parsedSeconds = NetworkCookieParser.parseMaxAge(value)
+                else {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidMaxAge,
+                        rawFragment: attribute.raw
+                    ))
+                    continue
+                }
+                rawMaxAge = value
+                maxAgeSeconds = parsedSeconds
+
+            case "secure":
+                isSecure = true
+                if attribute.value != nil {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                }
+
+            case "httponly":
+                isHTTPOnly = true
+                if attribute.value != nil {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                }
+
+            case "partitioned":
+                isPartitioned = true
+                if attribute.value != nil {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                }
+
+            case "samesite":
+                guard let value = attribute.value, value.isEmpty == false else {
+                    diagnostics.append(NetworkCookieParseDiagnostic(
+                        kind: .invalidAttribute,
+                        rawFragment: attribute.raw
+                    ))
+                    continue
+                }
+                switch NetworkCookieParser.lowercaseASCII(value) {
+                case "none":
+                    sameSite = .none
+                case "lax":
+                    sameSite = .lax
+                case "strict":
+                    sameSite = .strict
+                default:
+                    sameSite = .other(value)
+                }
+            default:
+                unknownAttributes.append(attribute)
+            }
+        }
+
+        self.domain = domain
+        self.path = path
+        self.rawExpires = rawExpires
+        self.expires = expires
+        self.rawMaxAge = rawMaxAge
+        self.maxAgeSeconds = maxAgeSeconds
+        self.isSecure = isSecure
+        self.isHTTPOnly = isHTTPOnly
+        self.isPartitioned = isPartitioned
+        self.sameSite = sameSite
+        self.unknownAttributes = unknownAttributes
+        self.diagnostics = diagnostics
+    }
+}
+
+package struct NetworkRequestCookieParseReport: Hashable, Sendable {
+    package let cookies: [NetworkRequestCookie]
+    package let rawHeaderValues: [String]
+    package let diagnostics: [NetworkCookieParseDiagnostic]
+    package let status: NetworkCookieParseStatus
+
+    package init(
+        cookies: [NetworkRequestCookie],
+        rawHeaderValues: [String],
+        diagnostics: [NetworkCookieParseDiagnostic],
+        status: NetworkCookieParseStatus
+    ) {
+        self.cookies = cookies
+        self.rawHeaderValues = rawHeaderValues
+        self.diagnostics = diagnostics
+        self.status = status
+    }
+}
+
+package struct NetworkResponseCookieParseReport: Hashable, Sendable {
+    package let cookies: [NetworkResponseCookie]
+    package let rawHeaderValues: [String]
+    package let diagnostics: [NetworkCookieParseDiagnostic]
+    package let status: NetworkCookieParseStatus
+
+    package init(
+        cookies: [NetworkResponseCookie],
+        rawHeaderValues: [String],
+        diagnostics: [NetworkCookieParseDiagnostic],
+        status: NetworkCookieParseStatus
+    ) {
+        self.cookies = cookies
+        self.rawHeaderValues = rawHeaderValues
+        self.diagnostics = diagnostics
+        self.status = status
+    }
+}
+
+package enum NetworkCookieParser {
+    package static func parseRequestHeaders(
+        _ headers: [String: String]
+    ) -> NetworkRequestCookieParseReport? {
+        guard let fields = matchingHeaderFields(named: "Cookie", in: headers) else {
+            return nil
+        }
+        let rawHeaderValues = fields.map(\.value)
+        guard fields.count == 1 else {
+            let diagnostics = rawHeaderValues.map {
+                NetworkCookieParseDiagnostic(kind: .multipleHeaderFields, rawFragment: $0)
+            }
+            return NetworkRequestCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: diagnostics,
+                status: .unparsed
+            )
+        }
+
+        let rawHeaderValue = rawHeaderValues[0]
+        guard trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
+            return NetworkRequestCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: [],
+                status: .complete
+            )
+        }
+
+        var cookies: [NetworkRequestCookie] = []
+        var diagnostics: [NetworkCookieParseDiagnostic] = []
+        let fragments = rawHeaderValue.split(separator: ";", omittingEmptySubsequences: false)
+        cookies.reserveCapacity(fragments.count)
+
+        for (ordinal, fragment) in fragments.enumerated() {
+            let rawFragment = String(fragment)
+            let trimmedFragment = trimOptionalWhitespace(rawFragment)
+            guard let equalsIndex = trimmedFragment.firstIndex(of: "=") else {
+                diagnostics.append(NetworkCookieParseDiagnostic(
+                    kind: .invalidCookieFragment,
+                    rawFragment: rawFragment
+                ))
+                continue
+            }
+
+            let name = trimOptionalWhitespace(String(trimmedFragment[..<equalsIndex]))
+            guard isHTTPToken(name) else {
+                diagnostics.append(NetworkCookieParseDiagnostic(
+                    kind: .invalidCookieFragment,
+                    rawFragment: rawFragment
+                ))
+                continue
+            }
+            let valueStart = trimmedFragment.index(after: equalsIndex)
+            let value = trimOptionalWhitespace(String(trimmedFragment[valueStart...]))
+            cookies.append(NetworkRequestCookie(
+                ordinal: ordinal,
+                name: name,
+                value: value,
+                raw: rawFragment
+            ))
+        }
+
+        return NetworkRequestCookieParseReport(
+            cookies: cookies,
+            rawHeaderValues: rawHeaderValues,
+            diagnostics: diagnostics,
+            status: parseStatus(parsedCount: cookies.count, diagnostics: diagnostics)
+        )
+    }
+
+    package static func parseResponseHeaders(
+        _ headers: [String: String]
+    ) -> NetworkResponseCookieParseReport? {
+        guard let fields = matchingHeaderFields(named: "Set-Cookie", in: headers) else {
+            return nil
+        }
+        let rawHeaderValues = fields.map(\.value)
+        guard fields.count == 1 else {
+            let diagnostics = rawHeaderValues.map {
+                NetworkCookieParseDiagnostic(kind: .multipleHeaderFields, rawFragment: $0)
+            }
+            return NetworkResponseCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: diagnostics,
+                status: .unparsed
+            )
+        }
+
+        let rawHeaderValue = rawHeaderValues[0]
+        guard trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
+            return NetworkResponseCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: [],
+                status: .complete
+            )
+        }
+        guard containsProhibitedControlCharacter(rawHeaderValue) == false else {
+            return NetworkResponseCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: [NetworkCookieParseDiagnostic(
+                    kind: .prohibitedControlCharacter,
+                    rawFragment: rawHeaderValue
+                )],
+                status: .unparsed
+            )
+        }
+        guard containsCombinedCookieCandidate(rawHeaderValue) == false else {
+            return NetworkResponseCookieParseReport(
+                cookies: [],
+                rawHeaderValues: rawHeaderValues,
+                diagnostics: [NetworkCookieParseDiagnostic(
+                    kind: .ambiguousCombinedHeader,
+                    rawFragment: rawHeaderValue
+                )],
+                status: .ambiguousCombined
+            )
+        }
+
+        let fragments = rawHeaderValue.split(separator: ";", omittingEmptySubsequences: false)
+        let rawCookiePair = String(fragments[0])
+        let trimmedCookiePair = trimOptionalWhitespace(rawCookiePair)
+        guard let equalsIndex = trimmedCookiePair.firstIndex(of: "=") else {
+            return unparsedResponseReport(
+                rawHeaderValues: rawHeaderValues,
+                diagnostic: NetworkCookieParseDiagnostic(
+                    kind: .invalidCookieFragment,
+                    rawFragment: rawCookiePair
+                )
+            )
+        }
+        let name = trimOptionalWhitespace(String(trimmedCookiePair[..<equalsIndex]))
+        guard isHTTPToken(name) else {
+            return unparsedResponseReport(
+                rawHeaderValues: rawHeaderValues,
+                diagnostic: NetworkCookieParseDiagnostic(
+                    kind: .invalidCookieFragment,
+                    rawFragment: rawCookiePair
+                )
+            )
+        }
+        let valueStart = trimmedCookiePair.index(after: equalsIndex)
+        let value = trimOptionalWhitespace(String(trimmedCookiePair[valueStart...]))
+
+        var attributes: [NetworkResponseCookieAttribute] = []
+        attributes.reserveCapacity(max(fragments.count - 1, 0))
+        for (ordinal, fragment) in fragments.dropFirst().enumerated() {
+            let rawAttribute = String(fragment)
+            let trimmedAttribute = trimOptionalWhitespace(rawAttribute)
+            let attributeName: String
+            let attributeValue: String?
+            if let equalsIndex = trimmedAttribute.firstIndex(of: "=") {
+                attributeName = trimOptionalWhitespace(String(trimmedAttribute[..<equalsIndex]))
+                let valueStart = trimmedAttribute.index(after: equalsIndex)
+                attributeValue = trimOptionalWhitespace(String(trimmedAttribute[valueStart...]))
+            } else {
+                attributeName = trimmedAttribute
+                attributeValue = nil
+            }
+
+            let attribute = NetworkResponseCookieAttribute(
+                ordinal: ordinal,
+                name: attributeName,
+                value: attributeValue,
+                raw: rawAttribute
+            )
+            attributes.append(attribute)
+        }
+
+        let cookie = NetworkResponseCookie(
+            ordinal: 0,
+            name: name,
+            value: value,
+            raw: rawHeaderValue,
+            attributes: attributes
+        )
+        let diagnostics = cookie.projectionDiagnostics
+        return NetworkResponseCookieParseReport(
+            cookies: [cookie],
+            rawHeaderValues: rawHeaderValues,
+            diagnostics: diagnostics,
+            status: parseStatus(parsedCount: 1, diagnostics: diagnostics)
+        )
+    }
+}
+
+fileprivate extension NetworkCookieParser {
+    struct HeaderField {
+        let name: String
+        let value: String
+    }
+
+    static func matchingHeaderFields(
+        named targetName: String,
+        in headers: [String: String]
+    ) -> [HeaderField]? {
+        let fields = headers.compactMap { name, value -> HeaderField? in
+            guard asciiCaseInsensitiveEqual(name, targetName) else {
+                return nil
+            }
+            return HeaderField(name: name, value: value)
+        }.sorted { lhs, rhs in
+            if lhs.name != rhs.name {
+                return lhs.name < rhs.name
+            }
+            return lhs.value < rhs.value
+        }
+        return fields.isEmpty ? nil : fields
+    }
+
+    static func asciiCaseInsensitiveEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = lhs.utf8
+        let rhsBytes = rhs.utf8
+        guard lhsBytes.count == rhsBytes.count else {
+            return false
+        }
+        return zip(lhsBytes, rhsBytes).allSatisfy { lhsByte, rhsByte in
+            lowercaseASCII(lhsByte) == lowercaseASCII(rhsByte)
+        }
+    }
+
+    static func lowercaseASCII(_ value: String) -> String {
+        String(decoding: value.utf8.map(lowercaseASCII), as: UTF8.self)
+    }
+
+    static func lowercaseASCII(_ byte: UInt8) -> UInt8 {
+        guard (65...90).contains(byte) else {
+            return byte
+        }
+        return byte + 32
+    }
+
+    static func trimOptionalWhitespace(_ value: String) -> String {
+        let bytes = value.utf8
+        var lowerBound = bytes.startIndex
+        var upperBound = bytes.endIndex
+        while lowerBound < upperBound, isOptionalWhitespace(bytes[lowerBound]) {
+            lowerBound = bytes.index(after: lowerBound)
+        }
+        while lowerBound < upperBound {
+            let preceding = bytes.index(before: upperBound)
+            guard isOptionalWhitespace(bytes[preceding]) else {
+                break
+            }
+            upperBound = preceding
+        }
+        return String(decoding: bytes[lowerBound..<upperBound], as: UTF8.self)
+    }
+
+    static func isOptionalWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09
+    }
+
+    static func parseStatus(
+        parsedCount: Int,
+        diagnostics: [NetworkCookieParseDiagnostic]
+    ) -> NetworkCookieParseStatus {
+        guard diagnostics.isEmpty == false else {
+            return .complete
+        }
+        return parsedCount > 0 ? .partial : .unparsed
+    }
+
+    static func unparsedResponseReport(
+        rawHeaderValues: [String],
+        diagnostic: NetworkCookieParseDiagnostic
+    ) -> NetworkResponseCookieParseReport {
+        NetworkResponseCookieParseReport(
+            cookies: [],
+            rawHeaderValues: rawHeaderValues,
+            diagnostics: [diagnostic],
+            status: .unparsed
+        )
+    }
+
+    static func containsProhibitedControlCharacter(_ value: String) -> Bool {
+        value.unicodeScalars.contains { scalar in
+            let codePoint = scalar.value
+            return (codePoint <= 0x1F && codePoint != 0x09) || codePoint == 0x7F
+        }
+    }
+
+    static func containsCombinedCookieCandidate(_ value: String) -> Bool {
+        let bytes = Array(value.utf8)
+        for commaIndex in bytes.indices where bytes[commaIndex] == 0x2C {
+            var index = commaIndex + 1
+            while index < bytes.count, isOptionalWhitespace(bytes[index]) {
+                index += 1
+            }
+            let tokenStart = index
+            while index < bytes.count, isHTTPTokenCharacter(bytes[index]) {
+                index += 1
+            }
+            guard index > tokenStart else {
+                continue
+            }
+            while index < bytes.count, isOptionalWhitespace(bytes[index]) {
+                index += 1
+            }
+            if index < bytes.count, bytes[index] == 0x3D {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func isHTTPTokenCharacter(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 48...57, 65...90, 97...122:
+            return true
+        case 0x21, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2A, 0x2B, 0x2D, 0x2E,
+             0x5E, 0x5F, 0x60, 0x7C, 0x7E:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func isHTTPToken(_ value: String) -> Bool {
+        let bytes = value.utf8
+        return bytes.isEmpty == false && bytes.allSatisfy(isHTTPTokenCharacter)
+    }
+
+    static func parseMaxAge(_ value: String) -> Int64? {
+        let bytes = Array(value.utf8)
+        guard bytes.isEmpty == false else {
+            return nil
+        }
+        let digitsStart: Int
+        if bytes[0] == 0x2D {
+            digitsStart = 1
+        } else {
+            digitsStart = 0
+        }
+        guard digitsStart < bytes.count else {
+            return nil
+        }
+        guard bytes[digitsStart...].allSatisfy({ (48...57).contains($0) }) else {
+            return nil
+        }
+        return Int64(value)
+    }
+
+    static func parseCookieDate(_ value: String) -> Date? {
+        let tokens = cookieDateTokens(value)
+        var time: (hour: Int, minute: Int, second: Int)?
+        var day: Int?
+        var month: Int?
+        var year: Int?
+
+        for token in tokens {
+            if time == nil, let parsedTime = parseTime(token) {
+                time = parsedTime
+                continue
+            }
+            if day == nil, let parsedDay = parseLeadingDecimal(token, minimumDigits: 1, maximumDigits: 2) {
+                day = parsedDay
+                continue
+            }
+            if month == nil, let parsedMonth = parseMonth(token) {
+                month = parsedMonth
+                continue
+            }
+            if year == nil, let parsedYear = parseLeadingDecimal(token, minimumDigits: 2, maximumDigits: 4) {
+                year = parsedYear
+            }
+        }
+
+        guard
+            let time,
+            let day,
+            let month,
+            var year
+        else {
+            return nil
+        }
+        if (70...99).contains(year) {
+            year += 1900
+        } else if (0...69).contains(year) {
+            year += 2000
+        }
+        guard
+            (1...31).contains(day),
+            year >= 1601,
+            (0...23).contains(time.hour),
+            (0...59).contains(time.minute),
+            (0...59).contains(time.second)
+        else {
+            return nil
+        }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        var components = DateComponents()
+        components.calendar = calendar
+        components.timeZone = calendar.timeZone
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = time.hour
+        components.minute = time.minute
+        components.second = time.second
+        guard let date = calendar.date(from: components) else {
+            return nil
+        }
+        let resolved = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        guard
+            resolved.year == year,
+            resolved.month == month,
+            resolved.day == day,
+            resolved.hour == time.hour,
+            resolved.minute == time.minute,
+            resolved.second == time.second
+        else {
+            return nil
+        }
+        return date
+    }
+
+    static func cookieDateTokens(_ value: String) -> [[UInt8]] {
+        let bytes = Array(value.utf8)
+        var tokens: [[UInt8]] = []
+        var index = 0
+        while index < bytes.count {
+            while index < bytes.count, isCookieDateDelimiter(bytes[index]) {
+                index += 1
+            }
+            let tokenStart = index
+            while index < bytes.count, isCookieDateDelimiter(bytes[index]) == false {
+                index += 1
+            }
+            if tokenStart < index {
+                tokens.append(Array(bytes[tokenStart..<index]))
+            }
+        }
+        return tokens
+    }
+
+    static func isCookieDateDelimiter(_ byte: UInt8) -> Bool {
+        byte == 0x09 ||
+            (0x20...0x2F).contains(byte) ||
+            (0x3B...0x40).contains(byte) ||
+            (0x5B...0x60).contains(byte) ||
+            (0x7B...0x7E).contains(byte)
+    }
+
+    static func parseTime(_ token: [UInt8]) -> (hour: Int, minute: Int, second: Int)? {
+        var index = 0
+        guard let hour = parseTimeField(token, index: &index) else {
+            return nil
+        }
+        guard index < token.count, token[index] == 0x3A else {
+            return nil
+        }
+        index += 1
+        guard let minute = parseTimeField(token, index: &index) else {
+            return nil
+        }
+        guard index < token.count, token[index] == 0x3A else {
+            return nil
+        }
+        index += 1
+        guard let second = parseTimeField(token, index: &index) else {
+            return nil
+        }
+        guard index == token.count || isASCIIDigit(token[index]) == false else {
+            return nil
+        }
+        return (hour, minute, second)
+    }
+
+    static func parseTimeField(_ token: [UInt8], index: inout Int) -> Int? {
+        let start = index
+        while index < token.count, isASCIIDigit(token[index]) {
+            index += 1
+        }
+        let digitCount = index - start
+        guard (1...2).contains(digitCount) else {
+            return nil
+        }
+        return decimalValue(token[start..<index])
+    }
+
+    static func parseLeadingDecimal(
+        _ token: [UInt8],
+        minimumDigits: Int,
+        maximumDigits: Int
+    ) -> Int? {
+        var digitCount = 0
+        while digitCount < token.count, isASCIIDigit(token[digitCount]) {
+            digitCount += 1
+        }
+        guard (minimumDigits...maximumDigits).contains(digitCount) else {
+            return nil
+        }
+        return decimalValue(token[0..<digitCount])
+    }
+
+    static func decimalValue(_ digits: ArraySlice<UInt8>) -> Int {
+        digits.reduce(into: 0) { value, digit in
+            value = value * 10 + Int(digit - 48)
+        }
+    }
+
+    static func parseMonth(_ token: [UInt8]) -> Int? {
+        guard token.count >= 3 else {
+            return nil
+        }
+        let prefix = String(decoding: token.prefix(3).map(lowercaseASCII), as: UTF8.self)
+        switch prefix {
+        case "jan": return 1
+        case "feb": return 2
+        case "mar": return 3
+        case "apr": return 4
+        case "may": return 5
+        case "jun": return 6
+        case "jul": return 7
+        case "aug": return 8
+        case "sep": return 9
+        case "oct": return 10
+        case "nov": return 11
+        case "dec": return 12
+        default: return nil
+        }
+    }
+
+    static func isASCIIDigit(_ byte: UInt8) -> Bool {
+        (48...57).contains(byte)
+    }
+}

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -798,6 +798,44 @@ package struct NetworkNavigationVisit: Hashable, Sendable {
     }
 }
 
+package enum NetworkRequestHeaderSource: Equatable, Sendable {
+    case unavailable
+    case requestWillBeSent
+    case response
+    case metrics
+}
+
+package struct NetworkCookieSections: Equatable, Sendable {
+    package let request: NetworkRequestCookieSection
+    package let response: NetworkResponseCookieSection
+
+    package init(
+        request: NetworkRequestCookieSection,
+        response: NetworkResponseCookieSection
+    ) {
+        self.request = request
+        self.response = response
+    }
+}
+
+package enum NetworkRequestCookieSection: Equatable, Sendable {
+    case unavailable(NetworkRequestCookieUnavailableReason)
+    case empty
+    case values(NetworkRequestCookieParseReport)
+}
+
+package enum NetworkRequestCookieUnavailableReason: Equatable, Sendable {
+    case notCaptured
+    case servedFromMemoryCache
+}
+
+package enum NetworkResponseCookieSection: Equatable, Sendable {
+    case loading
+    case noResponse
+    case empty
+    case values(NetworkResponseCookieParseReport)
+}
+
 /// Observable model for one network request.
 @Observable
 public final class NetworkRequest: WebInspectorFetchableModel {
@@ -906,6 +944,9 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     /// Request headers keyed by header name.
     public private(set) var requestHeaders: [String: String]
 
+    /// The most authoritative protocol source for ``requestHeaders``.
+    package private(set) var requestHeaderSource: NetworkRequestHeaderSource
+
     /// Response headers keyed by header name.
     public private(set) var responseHeaders: [String: String]
 
@@ -972,6 +1013,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         resourceType: Network.ResourceType?,
         timestamp: Double?,
         chronologySequence: UInt64 = 0,
+        requestHeaderSource: NetworkRequestHeaderSource = .requestWillBeSent,
         modelContext: WebInspectorContext
     ) {
         id = ID(request.id)
@@ -991,6 +1033,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         responseSource = nil
         sourceMapURL = nil
         requestHeaders = request.headers
+        self.requestHeaderSource = requestHeaderSource
         responseHeaders = [:]
         requestSentTimestamp = timestamp
         responseReceivedTimestamp = nil
@@ -1032,6 +1075,40 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     /// A Boolean value indicating whether the request can have a response body.
     public var hasResponseBody: Bool {
         hasResponse && resourceType != .webSocket
+    }
+
+    package var cookieSections: NetworkCookieSections {
+        NetworkCookieSections(
+            request: requestCookieSection,
+            response: responseCookieSection
+        )
+    }
+
+    private var requestCookieSection: NetworkRequestCookieSection {
+        if responseSource == "memory-cache" {
+            return .unavailable(.servedFromMemoryCache)
+        }
+        guard requestHeaderSource != .unavailable else {
+            return .unavailable(.notCaptured)
+        }
+        guard let report = NetworkCookieParser.parseRequestHeaders(requestHeaders) else {
+            return .empty
+        }
+        return report.cookies.isEmpty && report.diagnostics.isEmpty
+            ? .empty
+            : .values(report)
+    }
+
+    private var responseCookieSection: NetworkResponseCookieSection {
+        guard hasResponse else {
+            return isActive ? .loading : .noResponse
+        }
+        guard let report = NetworkCookieParser.parseResponseHeaders(responseHeaders) else {
+            return .empty
+        }
+        return report.cookies.isEmpty && report.diagnostics.isEmpty
+            ? .empty
+            : .values(report)
     }
 
     /// The coarse category inferred for filtering and display.
@@ -1153,7 +1230,12 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         self.resourceType = resourceType
         logicalStartTimestamp = timestamp
         self.chronologySequence = chronologySequence
-        requestHeaders = request.headers
+        requestBody = NetworkBody.makeRequestBody(for: request)
+        updateRequestHeaders(
+            request.headers,
+            source: .requestWillBeSent,
+            resetsPrecedence: true
+        )
         status = nil
         statusText = nil
         responseURL = nil
@@ -1170,7 +1252,6 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         metrics = nil
         redirects = []
         webSocket = resourceType == .webSocket ? WebSocketState() : nil
-        requestBody = NetworkBody.makeRequestBody(for: request)
         responseBody.resetForResponse(fallbackURL: currentRequest.url)
         allowsMultipartContinuation = false
         state = .pending
@@ -1193,7 +1274,12 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         let resolvedResourceType = resourceType ?? self.resourceType
         self.resourceType = resolvedResourceType
         webSocket = resolvedResourceType == .webSocket ? webSocket ?? WebSocketState() : nil
-        requestHeaders = request.headers
+        requestBody = NetworkBody.makeRequestBody(for: request)
+        updateRequestHeaders(
+            request.headers,
+            source: .requestWillBeSent,
+            resetsPrecedence: true
+        )
         status = nil
         statusText = nil
         responseURL = nil
@@ -1208,7 +1294,6 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         decodedDataLength = 0
         encodedDataLength = 0
         metrics = nil
-        requestBody = NetworkBody.makeRequestBody(for: request)
         responseBody.resetForResponse(fallbackURL: currentRequest.url)
         allowsMultipartContinuation = false
         state = .pending
@@ -1236,9 +1321,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         responseSource = response.source?.rawValue
         responseHeaders = response.headers
         if let requestHeaders = response.requestHeaders {
-            self.requestHeaders = requestHeaders
-            currentRequest = requestWithHeaders(requestHeaders)
-            refreshRequestBodyHints()
+            updateRequestHeaders(requestHeaders, source: .response)
         }
         if let timestamp {
             responseReceivedTimestamp = timestamp
@@ -1263,6 +1346,9 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     func finish(timestamp: Double, sourceMapURL: String?, metrics: Network.Metrics?) {
         self.sourceMapURL = sourceMapURL
         self.metrics = metrics
+        if let requestHeaders = metrics?.requestHeaders {
+            updateRequestHeaders(requestHeaders, source: .metrics)
+        }
         if let encodedDataLength = metrics?.encodedDataLength {
             self.encodedDataLength = max(0, encodedDataLength)
         }
@@ -1302,9 +1388,12 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         sourceMapURL = nil
         responseHeaders = response.headers
         if let requestHeaders = response.requestHeaders {
-            self.requestHeaders = requestHeaders
+            updateRequestHeaders(
+                requestHeaders,
+                source: .response,
+                resetsPrecedence: true
+            )
         }
-        currentRequest = requestWithHeaders(requestHeaders)
         requestSentTimestamp = timestamp
         responseReceivedTimestamp = timestamp
         lastDataReceivedTimestamp = nil
@@ -1339,8 +1428,12 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         url = request.url
         method = request.method
         resourceType = .webSocket
-        requestHeaders = request.headers
         requestBody = NetworkBody.makeRequestBody(for: request)
+        updateRequestHeaders(
+            request.headers,
+            source: .requestWillBeSent,
+            resetsPrecedence: true
+        )
         responseBody.resetForResponse(fallbackURL: currentRequest.url)
         allowsMultipartContinuation = false
         status = nil
@@ -1457,6 +1550,34 @@ public final class NetworkRequest: WebInspectorFetchableModel {
             backendResourceIdentifier: currentRequest.backendResourceIdentifier,
             origin: currentRequest.origin
         )
+    }
+
+    private func updateRequestHeaders(
+        _ headers: [String: String],
+        source: NetworkRequestHeaderSource,
+        resetsPrecedence: Bool = false
+    ) {
+        guard resetsPrecedence
+            || Self.requestHeaderPrecedence(source) >= Self.requestHeaderPrecedence(requestHeaderSource) else {
+            return
+        }
+        requestHeaders = headers
+        currentRequest = requestWithHeaders(headers)
+        requestHeaderSource = source
+        refreshRequestBodyHints()
+    }
+
+    private static func requestHeaderPrecedence(_ source: NetworkRequestHeaderSource) -> Int {
+        switch source {
+        case .unavailable:
+            0
+        case .requestWillBeSent:
+            1
+        case .response:
+            2
+        case .metrics:
+            3
+        }
     }
 
     private func refreshRequestBodyHints() {

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -6184,6 +6184,7 @@ extension WebInspectorContext {
                 resourceType: resourceType,
                 timestamp: timestamp,
                 chronologySequence: chronologySequence,
+                requestHeaderSource: .unavailable,
                 modelContext: self
             )
             requestsByID[id] = request
@@ -6246,6 +6247,7 @@ extension WebInspectorContext {
                 resourceType: resourceType,
                 timestamp: timestamp,
                 chronologySequence: chronologySequence,
+                requestHeaderSource: .unavailable,
                 modelContext: self
             )
             requestsByID[id] = request
@@ -6361,6 +6363,7 @@ extension WebInspectorContext {
                 resourceType: .webSocket,
                 timestamp: nil,
                 chronologySequence: chronologySequence,
+                requestHeaderSource: .unavailable,
                 modelContext: self
             )
             requestsByID[id] = request

--- a/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
+++ b/Sources/WebInspectorProxyKit/LiveProxyEventDecoder.swift
@@ -822,12 +822,14 @@ private struct ResponsePayload: Decodable {
 private struct MetricsPayload: Decodable {
     var networkProtocol: String?
     var remoteAddress: String?
+    var requestHeaders: [String: String]?
     var responseBodyBytesReceived: Int?
     var responseBodyDecodedSize: Int?
 
     enum CodingKeys: String, CodingKey {
         case networkProtocol = "protocol"
         case remoteAddress
+        case requestHeaders
         case responseBodyBytesReceived
         case responseBodyDecodedSize
     }
@@ -838,7 +840,8 @@ private struct MetricsPayload: Decodable {
             networkProtocol: networkProtocol,
             remoteAddress: remoteAddress,
             encodedDataLength: responseBodyBytesReceived,
-            decodedBodyLength: responseBodyDecodedSize
+            decodedBodyLength: responseBodyDecodedSize,
+            requestHeaders: requestHeaders
         )
     }
 }

--- a/Sources/WebInspectorProxyKit/Network.swift
+++ b/Sources/WebInspectorProxyKit/Network.swift
@@ -297,6 +297,9 @@ public enum Network {
         /// The remote address, if WebKit reported one.
         public let remoteAddress: String?
 
+        /// Request headers transmitted over the network, if WebKit reported them.
+        public let requestHeaders: [String: String]?
+
         /// Encoded bytes transferred over the network.
         public let encodedDataLength: Int?
 
@@ -311,11 +314,42 @@ public enum Network {
             encodedDataLength: Int? = nil,
             decodedBodyLength: Int? = nil
         ) {
+            self.init(
+                timestamp: timestamp,
+                networkProtocol: networkProtocol,
+                remoteAddress: remoteAddress,
+                encodedDataLength: encodedDataLength,
+                decodedBodyLength: decodedBodyLength,
+                requestHeaders: nil
+            )
+        }
+
+        /// Returns a copy that records request headers reported by WebKit.
+        public func reporting(requestHeaders: [String: String]) -> Metrics {
+            Metrics(
+                timestamp: timestamp,
+                networkProtocol: networkProtocol,
+                remoteAddress: remoteAddress,
+                encodedDataLength: encodedDataLength,
+                decodedBodyLength: decodedBodyLength,
+                requestHeaders: requestHeaders
+            )
+        }
+
+        package init(
+            timestamp: Double? = nil,
+            networkProtocol: String? = nil,
+            remoteAddress: String? = nil,
+            encodedDataLength: Int? = nil,
+            decodedBodyLength: Int? = nil,
+            requestHeaders: [String: String]?
+        ) {
             self.timestamp = timestamp
             self.networkProtocol = networkProtocol
             self.remoteAddress = remoteAddress
             self.encodedDataLength = encodedDataLength
             self.decodedBodyLength = decodedBodyLength
+            self.requestHeaders = requestHeaders
         }
     }
 

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -3164,6 +3164,448 @@
         }
       }
     },
+    "network.cookies.field.domain" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Domain"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドメイン"
+          }
+        }
+      }
+    },
+    "network.cookies.field.expires" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expires"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
+          }
+        }
+      }
+    },
+    "network.cookies.field.http_only" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "HttpOnly"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HttpOnly"
+          }
+        }
+      }
+    },
+    "network.cookies.field.max_age" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max-Age"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max-Age"
+          }
+        }
+      }
+    },
+    "network.cookies.field.name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
+        }
+      }
+    },
+    "network.cookies.field.partitioned" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Partitioned"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パーティション化"
+          }
+        }
+      }
+    },
+    "network.cookies.field.path" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Path"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パス"
+          }
+        }
+      }
+    },
+    "network.cookies.field.same_site" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SameSite"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SameSite"
+          }
+        }
+      }
+    },
+    "network.cookies.field.secure" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Secure"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secure"
+          }
+        }
+      }
+    },
+    "network.cookies.field.unknown_attribute" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Attribute"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明な属性"
+          }
+        }
+      }
+    },
+    "network.cookies.field.value" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Value"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "値"
+          }
+        }
+      }
+    },
+    "network.cookies.request.empty" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No request cookies"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストCookieなし"
+          }
+        }
+      }
+    },
+    "network.cookies.request.memory_cache" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No request, served from the memory cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストなし（メモリキャッシュから提供）"
+          }
+        }
+      }
+    },
+    "network.cookies.request.not_captured" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Request cookies were not captured"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストCookieは取得されませんでした"
+          }
+        }
+      }
+    },
+    "network.cookies.response.empty" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response cookies"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスCookieなし"
+          }
+        }
+      }
+    },
+    "network.cookies.response.loading" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Waiting for response"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスを待機中"
+          }
+        }
+      }
+    },
+    "network.cookies.response.missing" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response was received"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスを受信しませんでした"
+          }
+        }
+      }
+    },
+    "network.cookies.section.request" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Request Cookies"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストCookie"
+          }
+        }
+      }
+    },
+    "network.cookies.section.response" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Response Cookies"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスCookie"
+          }
+        }
+      }
+    },
+    "network.cookies.value.no" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "いいえ"
+          }
+        }
+      }
+    },
+    "network.cookies.value.unavailable" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未報告"
+          }
+        }
+      }
+    },
+    "network.cookies.value.yes" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "はい"
+          }
+        }
+      }
+    },
+    "network.cookies.warning.ambiguous_combined" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Combined cookie header cannot be parsed safely"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結合されたCookieヘッダーを安全に解析できません"
+          }
+        }
+      }
+    },
+    "network.cookies.warning.partial" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Some cookie data could not be parsed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のCookieデータを解析できませんでした"
+          }
+        }
+      }
+    },
+    "network.cookies.warning.unparsed" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cookie header could not be parsed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookieヘッダーを解析できませんでした"
+          }
+        }
+      }
+    },
+    "network.detail.mode.cookies" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cookies"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookie"
+          }
+        }
+      }
+    },
     "network.detail.mode.preview" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkCookieCell.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkCookieCell.swift
@@ -1,0 +1,209 @@
+#if canImport(UIKit)
+import UIKit
+
+package struct NetworkCookieFieldContent: Hashable, Sendable {
+    package let label: String
+    package let value: String
+    package let isFullWidth: Bool
+
+    package init(label: String, value: String, isFullWidth: Bool = false) {
+        self.label = label
+        self.value = value
+        self.isFullWidth = isFullWidth
+    }
+}
+
+package struct NetworkCookieRowContent: Hashable, Sendable {
+    package let fields: [NetworkCookieFieldContent]
+    package let accessibilityIdentifier: String
+
+    package init(
+        fields: [NetworkCookieFieldContent],
+        accessibilityIdentifier: String
+    ) {
+        self.fields = fields
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+}
+
+@MainActor
+package final class NetworkCookieCell: UICollectionViewListCell {
+    private let fieldRows = UIStackView()
+    private var rowContent: NetworkCookieRowContent?
+    private var usesTwoColumns = false
+
+    override package init(frame: CGRect) {
+        super.init(frame: frame)
+        configureStaticViews()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override package func prepareForReuse() {
+        super.prepareForReuse()
+        clear()
+    }
+
+    package func bind(_ content: NetworkCookieRowContent) {
+        let contentChanged = rowContent != content
+        rowContent = content
+        accessibilityIdentifier = content.accessibilityIdentifier
+        if contentChanged {
+            rebuildFieldsIfNeeded(force: true)
+        } else {
+            rebuildFieldsIfNeeded(force: false)
+        }
+        renderAccessibility(content)
+    }
+
+    package func clear() {
+        rowContent = nil
+        usesTwoColumns = false
+        removeAllArrangedSubviews(from: fieldRows)
+        accessibilityIdentifier = nil
+        accessibilityLabel = nil
+        accessibilityValue = nil
+    }
+
+    private func configureStaticViews() {
+        contentView.preservesSuperviewLayoutMargins = true
+        fieldRows.axis = .vertical
+        fieldRows.alignment = .fill
+        fieldRows.spacing = 12
+        fieldRows.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(fieldRows)
+        NSLayoutConstraint.activate([
+            fieldRows.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            fieldRows.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            fieldRows.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            fieldRows.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+        ])
+
+        isAccessibilityElement = true
+        accessibilityTraits = .staticText
+        registerForTraitChanges([
+            UITraitHorizontalSizeClass.self,
+            UITraitPreferredContentSizeCategory.self,
+        ]) { (cell: NetworkCookieCell, _) in
+            cell.rebuildFieldsIfNeeded(force: true)
+        }
+    }
+
+    private func rebuildFieldsIfNeeded(force: Bool) {
+        guard let rowContent else {
+            removeAllArrangedSubviews(from: fieldRows)
+            return
+        }
+        let nextUsesTwoColumns = traitCollection.horizontalSizeClass == .regular
+            && traitCollection.preferredContentSizeCategory.isAccessibilityCategory == false
+        guard force || usesTwoColumns != nextUsesTwoColumns else {
+            return
+        }
+        usesTwoColumns = nextUsesTwoColumns
+        removeAllArrangedSubviews(from: fieldRows)
+
+        if nextUsesTwoColumns {
+            installTwoColumnFields(rowContent.fields)
+        } else {
+            for field in rowContent.fields {
+                fieldRows.addArrangedSubview(makeFieldView(field))
+            }
+        }
+    }
+
+    private func installTwoColumnFields(_ fields: [NetworkCookieFieldContent]) {
+        var pendingFields: [NetworkCookieFieldContent] = []
+
+        func flushPendingFields() {
+            guard pendingFields.isEmpty == false else {
+                return
+            }
+            let row = UIStackView()
+            row.axis = .horizontal
+            row.alignment = .top
+            row.distribution = .fillEqually
+            row.spacing = 16
+            for field in pendingFields {
+                row.addArrangedSubview(makeFieldView(field))
+            }
+            if pendingFields.count == 1 {
+                row.addArrangedSubview(UIView())
+            }
+            fieldRows.addArrangedSubview(row)
+            pendingFields.removeAll(keepingCapacity: true)
+        }
+
+        for field in fields {
+            if field.isFullWidth {
+                flushPendingFields()
+                fieldRows.addArrangedSubview(makeFieldView(field))
+                continue
+            }
+            pendingFields.append(field)
+            if pendingFields.count == 2 {
+                flushPendingFields()
+            }
+        }
+        flushPendingFields()
+    }
+
+    private func makeFieldView(_ field: NetworkCookieFieldContent) -> UIView {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .caption1)
+        label.textColor = .secondaryLabel
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.text = field.label
+        label.isAccessibilityElement = false
+
+        let value = UILabel()
+        value.font = .preferredFont(forTextStyle: .body)
+        value.textColor = .label
+        value.adjustsFontForContentSizeCategory = true
+        value.numberOfLines = 0
+        value.lineBreakMode = .byCharWrapping
+        value.text = field.value
+        value.isAccessibilityElement = false
+
+        let stack = UIStackView(arrangedSubviews: [label, value])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 2
+        return stack
+    }
+
+    private func renderAccessibility(_ content: NetworkCookieRowContent) {
+        accessibilityLabel = content.fields
+            .map { "\($0.label), \($0.value)" }
+            .joined(separator: ", ")
+        accessibilityValue = nil
+    }
+
+    private func removeAllArrangedSubviews(from stackView: UIStackView) {
+        for view in stackView.arrangedSubviews {
+            stackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+    }
+}
+
+#if DEBUG
+extension NetworkCookieCell {
+    package var renderedFieldsForTesting: [NetworkCookieFieldContent] {
+        rowContent?.fields ?? []
+    }
+
+    package var usesTwoColumnsForTesting: Bool {
+        usesTwoColumns
+    }
+
+    package var fieldRowCountForTesting: Int {
+        fieldRows.arrangedSubviews.count
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkCookiesViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkCookiesViewController.swift
@@ -1,0 +1,693 @@
+#if canImport(UIKit)
+import Foundation
+import WebInspectorDataKit
+import WebInspectorUIBase
+import UIKit
+
+@MainActor
+package final class NetworkCookiesViewController: UICollectionViewController {
+    package struct RequestEpoch: Hashable, Sendable {
+        private enum Storage: Hashable, Sendable {
+            case request(
+                id: NetworkRequest.ID,
+                instance: ObjectIdentifier,
+                lifecycleRevision: UInt64,
+                redirectCount: Int
+            )
+            case testing(ObjectIdentifier)
+        }
+
+        private let storage: Storage
+
+        private init(storage: Storage) {
+            self.storage = storage
+        }
+
+        package init(request: NetworkRequest) {
+            storage = .request(
+                id: request.id,
+                instance: ObjectIdentifier(request),
+                lifecycleRevision: request.lifecycleRevision,
+                redirectCount: request.redirects.count
+            )
+        }
+
+#if DEBUG
+        package static func testing(_ owner: AnyObject) -> RequestEpoch {
+            RequestEpoch(storage: .testing(ObjectIdentifier(owner)))
+        }
+#endif
+    }
+
+    package struct CookieKey: Hashable, Sendable {
+        package let name: String
+        package let duplicateOccurrence: Int
+
+        package init(name: String, duplicateOccurrence: Int) {
+            self.name = name
+            self.duplicateOccurrence = duplicateOccurrence
+        }
+    }
+
+    package enum SectionID: Int, CaseIterable, Hashable, Sendable {
+        case request
+        case response
+    }
+
+    package enum ItemID: Hashable, Sendable {
+        case requestCookie(epoch: RequestEpoch, key: CookieKey)
+        case responseCookie(epoch: RequestEpoch, key: CookieKey)
+        case state(epoch: RequestEpoch, section: SectionID, kind: StateKind)
+        case diagnostic(epoch: RequestEpoch, section: SectionID, ordinal: Int)
+    }
+
+    package enum StateKind: Hashable, Sendable {
+        case requestNotCaptured
+        case requestMemoryCache
+        case requestEmpty
+        case responseLoading
+        case responseMissing
+        case responseEmpty
+    }
+
+    package struct MessageContent: Hashable, Sendable {
+        package enum Kind: Hashable, Sendable {
+            case information
+            case loading
+            case warning
+        }
+
+        package let kind: Kind
+        package let title: String
+        package let detail: String?
+    }
+
+    private enum RowContent: Hashable, Sendable {
+        case cookie(NetworkCookieRowContent)
+        case message(MessageContent)
+    }
+
+    private var rowContents: [ItemID: RowContent] = [:]
+    private lazy var dataSource = makeDataSource()
+
+    package init() {
+        super.init(collectionViewLayout: Self.makeLayout())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override package func viewDidLoad() {
+        super.viewDidLoad()
+        _ = dataSource
+        collectionView.allowsSelection = false
+        collectionView.alwaysBounceVertical = true
+        collectionView.keyboardDismissMode = .onDrag
+        collectionView.accessibilityIdentifier = "WebInspector.Network.CookiesList"
+        applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
+        }
+        applySnapshot(rows: emptyRows(), animatingDifferences: false)
+    }
+
+    package func render(
+        _ sections: NetworkCookieSections,
+        requestEpoch: RequestEpoch,
+        completion: (@MainActor () -> Void)? = nil
+    ) {
+        loadViewIfNeeded()
+        applySnapshot(
+            rows: rows(for: sections, requestEpoch: requestEpoch),
+            animatingDifferences: view.window != nil,
+            completion: completion
+        )
+    }
+
+    package func clear(completion: (@MainActor () -> Void)? = nil) {
+        loadViewIfNeeded()
+        applySnapshot(
+            rows: emptyRows(),
+            animatingDifferences: false,
+            completion: completion
+        )
+    }
+
+    private static func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, environment in
+            let configuration = Self.listLayoutConfiguration
+            let section = NSCollectionLayoutSection.list(
+                using: configuration,
+                layoutEnvironment: environment
+            )
+            var contentInsets = section.contentInsets
+            contentInsets.top = 0
+            section.contentInsets = contentInsets
+            return section
+        }
+    }
+
+    private static var listLayoutConfiguration: UICollectionLayoutListConfiguration {
+        var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        configuration.headerMode = .supplementary
+        configuration.showsSeparators = true
+        return configuration
+    }
+
+    private func applyBackgroundFromTraits() {
+        let backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+        view.backgroundColor = backgroundColor
+        collectionView.backgroundColor = backgroundColor
+    }
+
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionID, ItemID> {
+        let cookieRegistration = UICollectionView.CellRegistration<NetworkCookieCell, ItemID> {
+            [weak self] cell, _, itemID in
+            guard let self,
+                  case let .cookie(content) = rowContents[itemID] else {
+                cell.clear()
+                return
+            }
+            cell.bind(content)
+        }
+        let messageRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+            [weak self] cell, _, itemID in
+            guard let self,
+                  case let .message(content) = rowContents[itemID] else {
+                Self.clearMessageCell(cell)
+                return
+            }
+            configureMessageCell(cell, content: content)
+        }
+
+        let dataSource = UICollectionViewDiffableDataSource<SectionID, ItemID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, itemID in
+            switch itemID {
+            case .requestCookie, .responseCookie:
+                collectionView.dequeueConfiguredReusableCell(
+                    using: cookieRegistration,
+                    for: indexPath,
+                    item: itemID
+                )
+            case .state, .diagnostic:
+                collectionView.dequeueConfiguredReusableCell(
+                    using: messageRegistration,
+                    for: indexPath,
+                    item: itemID
+                )
+            }
+        }
+
+        let headerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(
+            elementKind: UICollectionView.elementKindSectionHeader
+        ) { [weak dataSource] header, _, indexPath in
+            guard let dataSource,
+                  dataSource.snapshot().sectionIdentifiers.indices.contains(indexPath.section) else {
+                header.contentConfiguration = nil
+                header.accessibilityLabel = nil
+                return
+            }
+            let section = dataSource.snapshot().sectionIdentifiers[indexPath.section]
+            var content = UIListContentConfiguration.header()
+            content.text = Self.title(for: section)
+            header.contentConfiguration = content
+            header.isAccessibilityElement = true
+            header.accessibilityLabel = content.text
+            header.accessibilityTraits = .header
+        }
+        dataSource.supplementaryViewProvider = { collectionView, elementKind, indexPath in
+            guard elementKind == UICollectionView.elementKindSectionHeader else {
+                return nil
+            }
+            return collectionView.dequeueConfiguredReusableSupplementary(
+                using: headerRegistration,
+                for: indexPath
+            )
+        }
+        return dataSource
+    }
+
+    private func rows(
+        for sections: NetworkCookieSections,
+        requestEpoch: RequestEpoch
+    ) -> [(SectionID, [(ItemID, RowContent)])] {
+        [
+            (.request, requestRows(for: sections.request, requestEpoch: requestEpoch)),
+            (.response, responseRows(for: sections.response, requestEpoch: requestEpoch)),
+        ]
+    }
+
+    private func emptyRows() -> [(SectionID, [(ItemID, RowContent)])] {
+        [
+            (.request, []),
+            (.response, []),
+        ]
+    }
+
+    private func requestRows(
+        for section: NetworkRequestCookieSection,
+        requestEpoch: RequestEpoch
+    ) -> [(ItemID, RowContent)] {
+        switch section {
+        case .unavailable(.notCaptured):
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .request,
+                kind: .requestNotCaptured,
+                title: localized(
+                    "network.cookies.request.not_captured",
+                    defaultValue: "Request cookies were not captured"
+                )
+            )]
+        case .unavailable(.servedFromMemoryCache):
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .request,
+                kind: .requestMemoryCache,
+                title: localized(
+                    "network.cookies.request.memory_cache",
+                    defaultValue: "No request, served from the memory cache"
+                )
+            )]
+        case .empty:
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .request,
+                kind: .requestEmpty,
+                title: localized(
+                    "network.cookies.request.empty",
+                    defaultValue: "No request cookies"
+                )
+            )]
+        case .values(let report):
+            var rows = identifiedCookies(report.cookies, name: \NetworkRequestCookie.name)
+                .sorted { cookieSort($0.cookie, $1.cookie) }
+                .map { cookie, key in
+                    (
+                        ItemID.requestCookie(epoch: requestEpoch, key: key),
+                        RowContent.cookie(requestRowContent(cookie))
+                    )
+                }
+            rows.append(contentsOf: diagnosticRows(
+                report.diagnostics,
+                status: report.status,
+                rawHeaderValues: report.rawHeaderValues,
+                section: .request,
+                requestEpoch: requestEpoch
+            ))
+            return rows
+        }
+    }
+
+    private func responseRows(
+        for section: NetworkResponseCookieSection,
+        requestEpoch: RequestEpoch
+    ) -> [(ItemID, RowContent)] {
+        switch section {
+        case .loading:
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .response,
+                kind: .responseLoading,
+                title: localized(
+                    "network.cookies.response.loading",
+                    defaultValue: "Waiting for response"
+                ),
+                messageKind: .loading
+            )]
+        case .noResponse:
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .response,
+                kind: .responseMissing,
+                title: localized(
+                    "network.cookies.response.missing",
+                    defaultValue: "No response was received"
+                )
+            )]
+        case .empty:
+            return [stateRow(
+                requestEpoch: requestEpoch,
+                section: .response,
+                kind: .responseEmpty,
+                title: localized(
+                    "network.cookies.response.empty",
+                    defaultValue: "No response cookies"
+                )
+            )]
+        case .values(let report):
+            var rows = identifiedCookies(report.cookies, name: \NetworkResponseCookie.name)
+                .sorted { cookieSort($0.cookie, $1.cookie) }
+                .map { cookie, key in
+                    (
+                        ItemID.responseCookie(epoch: requestEpoch, key: key),
+                        RowContent.cookie(responseRowContent(cookie))
+                    )
+                }
+            rows.append(contentsOf: diagnosticRows(
+                report.diagnostics,
+                status: report.status,
+                rawHeaderValues: report.rawHeaderValues,
+                section: .response,
+                requestEpoch: requestEpoch
+            ))
+            return rows
+        }
+    }
+
+    private func stateRow(
+        requestEpoch: RequestEpoch,
+        section: SectionID,
+        kind: StateKind,
+        title: String,
+        messageKind: MessageContent.Kind = .information
+    ) -> (ItemID, RowContent) {
+        (
+            .state(epoch: requestEpoch, section: section, kind: kind),
+            .message(MessageContent(kind: messageKind, title: title, detail: nil))
+        )
+    }
+
+    private func diagnosticRows(
+        _ diagnostics: [NetworkCookieParseDiagnostic],
+        status: NetworkCookieParseStatus,
+        rawHeaderValues: [String],
+        section: SectionID,
+        requestEpoch: RequestEpoch
+    ) -> [(ItemID, RowContent)] {
+        let title: String
+        switch status {
+        case .ambiguousCombined:
+            title = localized(
+                "network.cookies.warning.ambiguous_combined",
+                defaultValue: "Combined cookie header cannot be parsed safely"
+            )
+        case .partial:
+            title = localized(
+                "network.cookies.warning.partial",
+                defaultValue: "Some cookie data could not be parsed"
+            )
+        case .unparsed:
+            title = localized(
+                "network.cookies.warning.unparsed",
+                defaultValue: "Cookie header could not be parsed"
+            )
+        case .complete:
+            title = localized(
+                "network.cookies.warning.unparsed",
+                defaultValue: "Cookie header could not be parsed"
+            )
+        }
+
+        if diagnostics.isEmpty {
+            guard status != .complete else {
+                return []
+            }
+            return [(
+                .diagnostic(epoch: requestEpoch, section: section, ordinal: 0),
+                .message(MessageContent(
+                    kind: .warning,
+                    title: title,
+                    detail: rawHeaderValues.joined(separator: "\n")
+                ))
+            )]
+        }
+        return diagnostics.enumerated().map { index, diagnostic in
+            (
+                .diagnostic(epoch: requestEpoch, section: section, ordinal: index),
+                .message(MessageContent(
+                    kind: .warning,
+                    title: title,
+                    detail: diagnostic.rawFragment
+                ))
+            )
+        }
+    }
+
+    private func requestRowContent(_ cookie: NetworkRequestCookie) -> NetworkCookieRowContent {
+        NetworkCookieRowContent(
+            fields: [
+                field("network.cookies.field.name", defaultValue: "Name", value: cookie.name),
+                field("network.cookies.field.value", defaultValue: "Value", value: cookie.value),
+            ],
+            accessibilityIdentifier: "WebInspector.Network.RequestCookie.\(cookie.ordinal)"
+        )
+    }
+
+    private func responseRowContent(_ cookie: NetworkResponseCookie) -> NetworkCookieRowContent {
+        let missingValue = localized("network.cookies.value.unavailable", defaultValue: "Not reported")
+        var fields = [
+            field("network.cookies.field.name", defaultValue: "Name", value: cookie.name),
+            field("network.cookies.field.value", defaultValue: "Value", value: cookie.value),
+            field("network.cookies.field.domain", defaultValue: "Domain", value: cookie.domain ?? missingValue),
+            field("network.cookies.field.path", defaultValue: "Path", value: cookie.path ?? missingValue),
+            field(
+                "network.cookies.field.partitioned",
+                defaultValue: "Partitioned",
+                value: booleanText(cookie.isPartitioned)
+            ),
+            field(
+                "network.cookies.field.expires",
+                defaultValue: "Expires",
+                value: expiresText(cookie, missingValue: missingValue)
+            ),
+            field(
+                "network.cookies.field.max_age",
+                defaultValue: "Max-Age",
+                value: cookie.maxAgeSeconds.map(String.init) ?? cookie.rawMaxAge ?? missingValue
+            ),
+            field(
+                "network.cookies.field.secure",
+                defaultValue: "Secure",
+                value: booleanText(cookie.isSecure)
+            ),
+            field(
+                "network.cookies.field.http_only",
+                defaultValue: "HttpOnly",
+                value: booleanText(cookie.isHTTPOnly)
+            ),
+            field(
+                "network.cookies.field.same_site",
+                defaultValue: "SameSite",
+                value: sameSiteText(cookie.sameSite, missingValue: missingValue)
+            ),
+        ]
+        fields.append(contentsOf: cookie.unknownAttributes.map { attribute in
+            field(
+                "network.cookies.field.unknown_attribute",
+                defaultValue: "Unknown Attribute",
+                value: attribute.raw,
+                isFullWidth: true
+            )
+        })
+        return NetworkCookieRowContent(
+            fields: fields,
+            accessibilityIdentifier: "WebInspector.Network.ResponseCookie.\(cookie.ordinal)"
+        )
+    }
+
+    private func field(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue,
+        value: String,
+        isFullWidth: Bool = false
+    ) -> NetworkCookieFieldContent {
+        NetworkCookieFieldContent(
+            label: localized(key, defaultValue: defaultValue),
+            value: value,
+            isFullWidth: isFullWidth
+        )
+    }
+
+    private func expiresText(_ cookie: NetworkResponseCookie, missingValue: String) -> String {
+        if let expires = cookie.expires {
+            return expires.formatted(date: .abbreviated, time: .standard)
+        }
+        return cookie.rawExpires ?? missingValue
+    }
+
+    private func sameSiteText(_ sameSite: NetworkCookieSameSite, missingValue: String) -> String {
+        switch sameSite {
+        case .absent:
+            missingValue
+        case .none:
+            "None"
+        case .lax:
+            "Lax"
+        case .strict:
+            "Strict"
+        case .other(let rawValue):
+            rawValue
+        }
+    }
+
+    private func booleanText(_ value: Bool) -> String {
+        value
+            ? localized("network.cookies.value.yes", defaultValue: "Yes")
+            : localized("network.cookies.value.no", defaultValue: "No")
+    }
+
+    private func cookieSort(_ lhs: NetworkRequestCookie, _ rhs: NetworkRequestCookie) -> Bool {
+        cookieSort(name: lhs.name, ordinal: lhs.ordinal, name: rhs.name, ordinal: rhs.ordinal)
+    }
+
+    private func cookieSort(_ lhs: NetworkResponseCookie, _ rhs: NetworkResponseCookie) -> Bool {
+        cookieSort(name: lhs.name, ordinal: lhs.ordinal, name: rhs.name, ordinal: rhs.ordinal)
+    }
+
+    private func identifiedCookies<Cookie>(
+        _ cookies: [Cookie],
+        name: KeyPath<Cookie, String>
+    ) -> [(cookie: Cookie, key: CookieKey)] {
+        var duplicateOccurrences: [String: Int] = [:]
+        return cookies.map { cookie in
+            let name = cookie[keyPath: name]
+            let duplicateOccurrence = duplicateOccurrences[name, default: 0]
+            duplicateOccurrences[name] = duplicateOccurrence + 1
+            return (
+                cookie,
+                CookieKey(name: name, duplicateOccurrence: duplicateOccurrence)
+            )
+        }
+    }
+
+    private func cookieSort(
+        name lhsName: String,
+        ordinal lhsOrdinal: Int,
+        name rhsName: String,
+        ordinal rhsOrdinal: Int
+    ) -> Bool {
+        switch lhsName.localizedStandardCompare(rhsName) {
+        case .orderedAscending:
+            true
+        case .orderedDescending:
+            false
+        case .orderedSame:
+            lhsOrdinal < rhsOrdinal
+        }
+    }
+
+    private func applySnapshot(
+        rows: [(SectionID, [(ItemID, RowContent)])],
+        animatingDifferences: Bool,
+        completion: (@MainActor () -> Void)? = nil
+    ) {
+        let oldItemIDs = Set(dataSource.snapshot().itemIdentifiers)
+        var snapshot = NSDiffableDataSourceSnapshot<SectionID, ItemID>()
+        var nextRowContents: [ItemID: RowContent] = [:]
+        for (section, items) in rows {
+            snapshot.appendSections([section])
+            let itemIDs = items.map(\.0)
+            snapshot.appendItems(itemIDs, toSection: section)
+            for (itemID, content) in items {
+                nextRowContents[itemID] = content
+            }
+        }
+        let retainedItemIDs = Set(snapshot.itemIdentifiers).intersection(oldItemIDs)
+        snapshot.reconfigureItems(Array(retainedItemIDs))
+        rowContents = nextRowContents
+        dataSource.apply(
+            snapshot,
+            animatingDifferences: animatingDifferences,
+            completion: completion
+        )
+    }
+
+    private func configureMessageCell(
+        _ cell: UICollectionViewListCell,
+        content: MessageContent
+    ) {
+        var configuration = UIListContentConfiguration.subtitleCell()
+        configuration.text = content.title
+        configuration.secondaryText = content.detail
+        configuration.textProperties.numberOfLines = 0
+        configuration.secondaryTextProperties.numberOfLines = 0
+        configuration.secondaryTextProperties.lineBreakMode = .byCharWrapping
+        if content.kind == .warning {
+            configuration.image = UIImage(systemName: "exclamationmark.triangle")
+            configuration.imageProperties.tintColor = .systemOrange
+        }
+        cell.contentConfiguration = configuration
+        cell.accessories = content.kind == .loading ? [Self.loadingAccessory()] : []
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = .staticText
+        cell.accessibilityLabel = content.title
+        cell.accessibilityValue = content.detail
+    }
+
+    private static func clearMessageCell(_ cell: UICollectionViewListCell) {
+        cell.contentConfiguration = nil
+        cell.accessories = []
+        cell.accessibilityLabel = nil
+        cell.accessibilityValue = nil
+    }
+
+    private static func loadingAccessory() -> UICellAccessory {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.startAnimating()
+        return .customView(configuration: .init(
+            customView: indicator,
+            placement: .trailing()
+        ))
+    }
+
+    private static func title(for section: SectionID) -> String {
+        switch section {
+        case .request:
+            String(
+                localized: "network.cookies.section.request",
+                defaultValue: "Request Cookies",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        case .response:
+            String(
+                localized: "network.cookies.section.response",
+                defaultValue: "Response Cookies",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        }
+    }
+
+    private func localized(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        String(localized: key, defaultValue: defaultValue, bundle: WebInspectorUILocalization.bundle)
+    }
+}
+
+#if DEBUG
+extension NetworkCookiesViewController {
+    package static var listLayoutConfigurationForTesting: UICollectionLayoutListConfiguration {
+        listLayoutConfiguration
+    }
+
+    package var snapshotForTesting: NSDiffableDataSourceSnapshot<SectionID, ItemID> {
+        dataSource.snapshot()
+    }
+
+    package func cookieContentForTesting(_ itemID: ItemID) -> NetworkCookieRowContent? {
+        guard case let .cookie(content) = rowContents[itemID] else {
+            return nil
+        }
+        return content
+    }
+
+    package func messageContentForTesting(_ itemID: ItemID) -> MessageContent? {
+        guard case let .message(content) = rowContents[itemID] else {
+            return nil
+        }
+        return content
+    }
+
+    package static func sectionTitleForTesting(_ section: SectionID) -> String {
+        title(for: section)
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailMode.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailMode.swift
@@ -8,9 +8,10 @@ extension NetworkDetailViewController {
     package enum Mode: CaseIterable, Hashable {
         case preview
         case headers
+        case cookies
 
         nonisolated package static var allCases: [NetworkDetailViewController.Mode] {
-            [.headers, .preview]
+            [.headers, .preview, .cookies]
         }
 
         package var title: String {
@@ -19,6 +20,8 @@ extension NetworkDetailViewController {
                 String(localized: "network.detail.mode.preview", defaultValue: "Preview", bundle: WebInspectorUILocalization.bundle)
             case .headers:
                 String(localized: "network.section.headers", defaultValue: "Headers", bundle: WebInspectorUILocalization.bundle)
+            case .cookies:
+                String(localized: "network.detail.mode.cookies", defaultValue: "Cookies", bundle: WebInspectorUILocalization.bundle)
             }
         }
     }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -83,6 +83,7 @@ package final class NetworkDetailViewController: UIViewController {
     private var isRenderingActive = false
     private var isBodyRenderingActive = false
     private lazy var bodyViewController = makeBodyViewController(scrollEdgeController)
+    private lazy var cookiesViewController = NetworkCookiesViewController()
     private lazy var modeControlController: NetworkDetailModeControlController = {
         let controller = NetworkDetailModeControlController(initialMode: mode)
         controller.selectionHandler = { [weak self] mode in
@@ -282,18 +283,24 @@ package final class NetworkDetailViewController: UIViewController {
         view.backgroundColor = backgroundColor
         bodyViewController.view.backgroundColor = backgroundColor
         headersTextView.backgroundColor = backgroundColor
+        cookiesViewController.view.backgroundColor = backgroundColor
     }
 
     private func installContentViews() {
         addChild(bodyViewController)
+        addChild(cookiesViewController)
         view.addSubview(bodyViewController.view)
         view.addSubview(previewRoleControlController.containerView)
         view.addSubview(headersTextView)
+        view.addSubview(cookiesViewController.view)
         bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
         bodyViewController.view.isHidden = true
         bodyViewController.view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
+        cookiesViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        cookiesViewController.view.isHidden = true
         previewRoleControlController.containerView.translatesAutoresizingMaskIntoConstraints = false
         bodyViewController.didMove(toParent: self)
+        cookiesViewController.didMove(toParent: self)
 
         let bodyTopToPreviewContainerConstraint = bodyViewController.view.topAnchor.constraint(
             equalTo: view.topAnchor
@@ -322,6 +329,10 @@ package final class NetworkDetailViewController: UIViewController {
             headersTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             headersTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             headersTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            cookiesViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            cookiesViewController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            cookiesViewController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            cookiesViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
 
@@ -485,6 +496,22 @@ package final class NetworkDetailViewController: UIViewController {
                 }
                 renderHeadersSurface(request: request)
             }
+        case .cookies:
+            let request: NetworkRequest
+            switch selection {
+            case .entry:
+                guard let representativeRequest = requests.first else {
+                    preconditionFailure("A selected Network entry must contain at least one request.")
+                }
+                request = representativeRequest
+            case .request:
+                guard requests.count == 1,
+                      let selectedRequest = requests.first else {
+                    preconditionFailure("An explicit Network request selection must render exactly one request.")
+                }
+                request = selectedRequest
+            }
+            renderCookiesSurface(request: request)
         }
     }
 
@@ -512,6 +539,16 @@ package final class NetworkDetailViewController: UIViewController {
         title = request.displayName
         showHeaders()
         headersTextView.render(request: request)
+    }
+
+    private func renderCookiesSurface(request: NetworkRequest) {
+        observedRequest = request
+        title = request.displayName
+        showCookies()
+        cookiesViewController.render(
+            request.cookieSections,
+            requestEpoch: NetworkCookiesViewController.RequestEpoch(request: request)
+        )
     }
 
     private func setMode(_ nextMode: NetworkDetailViewController.Mode) {
@@ -621,6 +658,8 @@ package final class NetworkDetailViewController: UIViewController {
         previewRoleControlController.containerView.isHidden = true
         headersTextView.isHidden = true
         headersTextView.clear()
+        cookiesViewController.view.isHidden = true
+        cookiesViewController.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
         scrollEdgeController.contentScrollView = nil
 
@@ -636,6 +675,7 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func showPreview() {
         headersTextView.isHidden = true
+        cookiesViewController.view.isHidden = true
         bodyViewController.view.isHidden = false
     }
 
@@ -647,7 +687,20 @@ package final class NetworkDetailViewController: UIViewController {
         scrollEdgeController.isPreviewRoleControlVisible = false
         bodyViewController.setSurface(.none)
         headersTextView.isHidden = false
+        cookiesViewController.view.isHidden = true
         scrollEdgeController.contentScrollView = headersTextView.contentScrollView
+    }
+
+    private func showCookies() {
+        setBodyRenderingActive(false)
+        bodyViewController.view.isHidden = true
+        previewRoleControlController.containerView.isHidden = true
+        updatePreviewRoleControlLayout(isVisible: false)
+        scrollEdgeController.isPreviewRoleControlVisible = false
+        bodyViewController.setSurface(.none)
+        headersTextView.isHidden = true
+        cookiesViewController.view.isHidden = false
+        scrollEdgeController.contentScrollView = cookiesViewController.collectionView
     }
 
     private func renderPreview(candidate: PreviewCandidate) {
@@ -1039,6 +1092,10 @@ extension NetworkDetailViewController {
 
     var headersTextViewForTesting: NetworkHeadersTextView {
         headersTextView
+    }
+
+    var cookiesViewControllerForTesting: NetworkCookiesViewController {
+        cookiesViewController
     }
 
     var bodyViewControllerForTesting: NetworkBodyPreviewViewController {

--- a/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
@@ -391,6 +391,7 @@ struct NetworkCookieParserTests {
         ("Wed, 09 Jun 69 10:18:14 GMT", 2069),
         ("Wed, 09 Jun 70 10:18:14 GMT", 1970),
         ("Wed, 09 Jun 2021 10:18:14 GMT", 2021),
+        ("Wed,\t09 Jun 2021 10:18:14 GMT", 2021),
         ("09th-Jun-2021 10:18:14GMT", 2021),
     ])
     func cookieDatesUseRFCDateTokens(_ rawValue: String, expectedYear: Int) throws {

--- a/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
@@ -113,12 +113,35 @@ struct NetworkCookieParserTests {
         #expect(report.diagnostics.map(\.kind) == [
             .invalidCookieFragment,
             .invalidCookieFragment,
-            .invalidCookieFragment,
+            .prohibitedControlCharacter,
         ])
         #expect(report.diagnostics.map(\.rawFragment) == [
             " bad name=2",
             " naïve=3",
             " \u{1F}control=4",
+        ])
+        #expect(report.status == .partial)
+    }
+
+    @Test
+    func requestControlCharactersRejectOnlyAffectedFragments() throws {
+        let report = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "a=ok\u{1F}; tab=\tallowed\t; embedded=foo\tbar; b=2"
+        ]))
+
+        #expect(report.cookies == [
+            NetworkRequestCookie(ordinal: 1, name: "tab", value: "allowed", raw: " tab=\tallowed\t"),
+            NetworkRequestCookie(ordinal: 3, name: "b", value: "2", raw: " b=2"),
+        ])
+        #expect(report.diagnostics == [
+            NetworkCookieParseDiagnostic(
+                kind: .prohibitedControlCharacter,
+                rawFragment: "a=ok\u{1F}"
+            ),
+            NetworkCookieParseDiagnostic(
+                kind: .prohibitedControlCharacter,
+                rawFragment: " embedded=foo\tbar"
+            ),
         ])
         #expect(report.status == .partial)
     }
@@ -198,6 +221,9 @@ struct NetworkCookieParserTests {
         "a=b\u{0}",
         "a=b\u{1F}",
         "a=b\u{7F}",
+        "a=foo\tbar",
+        "na\tme=value",
+        "a=b; Domain=foo\tbar",
         "\u{1F}name=value",
     ])
     func responseControlCharactersAreFatal(_ rawHeader: String) throws {

--- a/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkCookieParserTests.swift
@@ -1,0 +1,438 @@
+import Foundation
+import Testing
+@testable import WebInspectorDataKit
+
+@Suite
+struct NetworkCookieParserTests {
+    @Test
+    func absentAndBlankHeadersRemainDistinct() throws {
+        #expect(NetworkCookieParser.parseRequestHeaders([:]) == nil)
+        #expect(NetworkCookieParser.parseResponseHeaders([:]) == nil)
+
+        let requestReport = try #require(NetworkCookieParser.parseRequestHeaders([
+            "cOoKiE": " \t "
+        ]))
+        #expect(requestReport.cookies.isEmpty)
+        #expect(requestReport.rawHeaderValues == [" \t "])
+        #expect(requestReport.diagnostics.isEmpty)
+        #expect(requestReport.status == .complete)
+
+        let responseReport = try #require(NetworkCookieParser.parseResponseHeaders([
+            "sEt-CoOkIe": "\t"
+        ]))
+        #expect(responseReport.cookies.isEmpty)
+        #expect(responseReport.rawHeaderValues == ["\t"])
+        #expect(responseReport.diagnostics.isEmpty)
+        #expect(responseReport.status == .complete)
+
+        requireHashableSendable(requestReport)
+        requireHashableSendable(responseReport)
+    }
+
+    @Test
+    func caseVariantHeaderFieldsAreRejectedInDeterministicOrder() throws {
+        let requestHeaders = [
+            "cookie": "lower=1",
+            "COOKIE": "upper=1",
+            "Cookie": "title=1",
+        ]
+        let firstRequestReport = try #require(NetworkCookieParser.parseRequestHeaders(requestHeaders))
+        let secondRequestReport = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "title=1",
+            "cookie": "lower=1",
+            "COOKIE": "upper=1",
+        ]))
+
+        #expect(firstRequestReport == secondRequestReport)
+        #expect(firstRequestReport.rawHeaderValues == ["upper=1", "title=1", "lower=1"])
+        #expect(firstRequestReport.cookies.isEmpty)
+        #expect(firstRequestReport.diagnostics.map(\.kind) == [
+            .multipleHeaderFields,
+            .multipleHeaderFields,
+            .multipleHeaderFields,
+        ])
+        #expect(firstRequestReport.diagnostics.map(\.rawFragment) == firstRequestReport.rawHeaderValues)
+        #expect(firstRequestReport.status == .unparsed)
+
+        let responseReport = try #require(NetworkCookieParser.parseResponseHeaders([
+            "set-cookie": "lower=1",
+            "SET-COOKIE": "upper=1",
+        ]))
+        #expect(responseReport.rawHeaderValues == ["upper=1", "lower=1"])
+        #expect(responseReport.cookies.isEmpty)
+        #expect(responseReport.diagnostics.map(\.rawFragment) == responseReport.rawHeaderValues)
+        #expect(responseReport.status == .unparsed)
+    }
+
+    @Test
+    func requestCookiesPreserveOrderDuplicatesAndUnnormalizedValues() throws {
+        let rawHeader = "\tfirst = a=b== ; quoted=\"x,y\"; encoded=%2F%3D; first=again\t"
+        let report = try #require(NetworkCookieParser.parseRequestHeaders(["COOKIE": rawHeader]))
+
+        #expect(report.status == .complete)
+        #expect(report.rawHeaderValues == [rawHeader])
+        #expect(report.diagnostics.isEmpty)
+        #expect(report.cookies == [
+            NetworkRequestCookie(ordinal: 0, name: "first", value: "a=b==", raw: "\tfirst = a=b== "),
+            NetworkRequestCookie(ordinal: 1, name: "quoted", value: "\"x,y\"", raw: " quoted=\"x,y\""),
+            NetworkRequestCookie(ordinal: 2, name: "encoded", value: "%2F%3D", raw: " encoded=%2F%3D"),
+            NetworkRequestCookie(ordinal: 3, name: "first", value: "again", raw: " first=again\t"),
+        ])
+    }
+
+    @Test
+    func requestCookieDiagnosticsPreserveInvalidFragments() throws {
+        let partial = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "a=1; broken; =missing; b=2;"
+        ]))
+        #expect(partial.cookies.map(\.ordinal) == [0, 3])
+        #expect(partial.cookies.map(\.name) == ["a", "b"])
+        #expect(partial.diagnostics == [
+            NetworkCookieParseDiagnostic(kind: .invalidCookieFragment, rawFragment: " broken"),
+            NetworkCookieParseDiagnostic(kind: .invalidCookieFragment, rawFragment: " =missing"),
+            NetworkCookieParseDiagnostic(kind: .invalidCookieFragment, rawFragment: ""),
+        ])
+        #expect(partial.status == .partial)
+
+        let unparsed = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "broken; =missing"
+        ]))
+        #expect(unparsed.cookies.isEmpty)
+        #expect(unparsed.diagnostics.map(\.rawFragment) == ["broken", " =missing"])
+        #expect(unparsed.status == .unparsed)
+    }
+
+    @Test
+    func requestCookieNamesMustBeHTTPTokens() throws {
+        let report = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "valid=1; bad name=2; naïve=3; \u{1F}control=4; final=5"
+        ]))
+
+        #expect(report.cookies.map(\.ordinal) == [0, 4])
+        #expect(report.cookies.map(\.name) == ["valid", "final"])
+        #expect(report.diagnostics.map(\.kind) == [
+            .invalidCookieFragment,
+            .invalidCookieFragment,
+            .invalidCookieFragment,
+        ])
+        #expect(report.diagnostics.map(\.rawFragment) == [
+            " bad name=2",
+            " naïve=3",
+            " \u{1F}control=4",
+        ])
+        #expect(report.status == .partial)
+    }
+
+    @Test
+    func responseCookiePreservesOWSValuesAttributesAndTypedProjections() throws {
+        let rawHeader = "\tname \t= \"a,b\"==%2F \t; Domain=.Example.COM; Path=/a,b; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Max-Age=-42; Secure; HttpOnly; Partitioned; SameSite=Lax; Priority=High; Flag; X = one=two "
+        let report = try #require(NetworkCookieParser.parseResponseHeaders(["SET-cookie": rawHeader]))
+        let cookie = try #require(report.cookies.first)
+
+        #expect(report.status == .complete)
+        #expect(report.rawHeaderValues == [rawHeader])
+        #expect(report.diagnostics.isEmpty)
+        #expect(cookie.ordinal == 0)
+        #expect(cookie.name == "name")
+        #expect(cookie.value == "\"a,b\"==%2F")
+        #expect(cookie.raw == rawHeader)
+        #expect(cookie.domain == ".Example.COM")
+        #expect(cookie.path == "/a,b")
+        #expect(cookie.rawExpires == "Wed, 09 Jun 2021 10:18:14 GMT")
+        #expect(cookie.expires == utcDate(year: 2021, month: 6, day: 9, hour: 10, minute: 18, second: 14))
+        #expect(cookie.rawMaxAge == "-42")
+        #expect(cookie.maxAgeSeconds == -42)
+        #expect(cookie.isSecure)
+        #expect(cookie.isHTTPOnly)
+        #expect(cookie.isPartitioned)
+        #expect(cookie.sameSite == .lax)
+        #expect(cookie.attributes.map(\.ordinal) == Array(0..<11))
+        #expect(cookie.attributes.map(\.name) == [
+            "Domain", "Path", "Expires", "Max-Age", "Secure", "HttpOnly",
+            "Partitioned", "SameSite", "Priority", "Flag", "X",
+        ])
+        #expect(cookie.attributes.last?.value == "one=two")
+        #expect(cookie.attributes.last?.raw == " X = one=two ")
+        #expect(cookie.unknownAttributes.map(\.name) == ["Priority", "Flag", "X"])
+        #expect(cookie.unknownAttributes.map(\.value) == ["High", nil, "one=two"])
+    }
+
+    @Test
+    func expiresWeekdayCommaIsNotACombinedCookieCandidate() throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "a=b; Expires=Wed, 09 Jun 2021 10:18:14 GMT"
+        ]))
+
+        #expect(report.status == .complete)
+        #expect(report.cookies.count == 1)
+        #expect(report.cookies.first?.expires == utcDate(
+            year: 2021,
+            month: 6,
+            day: 9,
+            hour: 10,
+            minute: 18,
+            second: 14
+        ))
+    }
+
+    @Test(arguments: [
+        "a=b, c=d",
+        "a=b,\t c \t= d",
+        "a=b; Path=/c,d=e",
+    ])
+    func combinedCookieCandidatesRemainRawOnly(_ rawHeader: String) throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": rawHeader
+        ]))
+
+        #expect(report.cookies.isEmpty)
+        #expect(report.rawHeaderValues == [rawHeader])
+        #expect(report.diagnostics == [NetworkCookieParseDiagnostic(
+            kind: .ambiguousCombinedHeader,
+            rawFragment: rawHeader
+        )])
+        #expect(report.status == .ambiguousCombined)
+    }
+
+    @Test(arguments: [
+        "a=b\u{0}",
+        "a=b\u{1F}",
+        "a=b\u{7F}",
+        "\u{1F}name=value",
+    ])
+    func responseControlCharactersAreFatal(_ rawHeader: String) throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": rawHeader
+        ]))
+
+        #expect(report.cookies.isEmpty)
+        #expect(report.rawHeaderValues == [rawHeader])
+        #expect(report.diagnostics == [NetworkCookieParseDiagnostic(
+            kind: .prohibitedControlCharacter,
+            rawFragment: rawHeader
+        )])
+        #expect(report.status == .unparsed)
+    }
+
+    @Test
+    func invalidResponseCookiePairRemainsRawOnly() throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "broken; Path=/"
+        ]))
+
+        #expect(report.cookies.isEmpty)
+        #expect(report.rawHeaderValues == ["broken; Path=/"])
+        #expect(report.diagnostics == [NetworkCookieParseDiagnostic(
+            kind: .invalidCookieFragment,
+            rawFragment: "broken"
+        )])
+        #expect(report.status == .unparsed)
+    }
+
+    @Test(arguments: [
+        "bad name=value",
+        "näme=value",
+    ])
+    func responseCookieNamesMustBeHTTPTokens(_ rawHeader: String) throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": rawHeader
+        ]))
+
+        #expect(report.cookies.isEmpty)
+        #expect(report.diagnostics == [NetworkCookieParseDiagnostic(
+            kind: .invalidCookieFragment,
+            rawFragment: rawHeader
+        )])
+        #expect(report.status == .unparsed)
+    }
+
+    @Test
+    func attributeNamesMustBeTokensAndPresenceValuesAreDiagnosed() throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "a=b; Good=1; Good=2; bad name=x; naïve=y; Secure=x; HttpOnly=0; Partitioned=value"
+        ]))
+        let cookie = try #require(report.cookies.first)
+
+        #expect(cookie.attributes.map(\.ordinal) == Array(0..<7))
+        #expect(cookie.attributes.map(\.name) == [
+            "Good", "Good", "bad name", "naïve", "Secure", "HttpOnly", "Partitioned",
+        ])
+        #expect(cookie.unknownAttributes.map(\.name) == ["Good", "Good"])
+        #expect(cookie.unknownAttributes.map(\.value) == ["1", "2"])
+        #expect(cookie.isSecure)
+        #expect(cookie.isHTTPOnly)
+        #expect(cookie.isPartitioned)
+        #expect(report.diagnostics.map(\.kind) == [
+            .invalidAttribute,
+            .invalidAttribute,
+            .invalidAttribute,
+            .invalidAttribute,
+            .invalidAttribute,
+        ])
+        #expect(report.diagnostics.map(\.rawFragment) == [
+            " bad name=x",
+            " naïve=y",
+            " Secure=x",
+            " HttpOnly=0",
+            " Partitioned=value",
+        ])
+        #expect(report.status == .partial)
+    }
+
+    @Test
+    func invalidKnownDuplicatesDoNotEraseSuccessfulProjections() throws {
+        let validExpires = "Wed, 09 Jun 2021 10:18:14 GMT"
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "a=b; Domain=one.test; Domain=; Domain=two.test; Path=/one; Path; Path=/two; Expires=\(validExpires); Expires=invalid; Max-Age=10; Max-Age=+20; Secure=value; SameSite=None; SameSite; SameSite=Experimental"
+        ]))
+        let cookie = try #require(report.cookies.first)
+
+        #expect(cookie.domain == "two.test")
+        #expect(cookie.path == "/two")
+        #expect(cookie.rawExpires == validExpires)
+        #expect(cookie.expires == utcDate(year: 2021, month: 6, day: 9, hour: 10, minute: 18, second: 14))
+        #expect(cookie.rawMaxAge == "10")
+        #expect(cookie.maxAgeSeconds == 10)
+        #expect(cookie.isSecure)
+        #expect(cookie.sameSite == .other("Experimental"))
+        #expect(cookie.attributes.map(\.ordinal) == Array(0..<14))
+        #expect(cookie.attributes.map(\.name) == [
+            "Domain", "Domain", "Domain", "Path", "Path", "Path", "Expires",
+            "Expires", "Max-Age", "Max-Age", "Secure", "SameSite", "SameSite",
+            "SameSite",
+        ])
+        #expect(cookie.unknownAttributes.isEmpty)
+        #expect(report.diagnostics.map(\.kind) == [
+            .invalidAttribute,
+            .invalidAttribute,
+            .invalidExpires,
+            .invalidMaxAge,
+            .invalidAttribute,
+            .invalidAttribute,
+        ])
+        #expect(report.diagnostics.map(\.rawFragment) == [
+            " Domain=",
+            " Path",
+            " Expires=invalid",
+            " Max-Age=+20",
+            " Secure=value",
+            " SameSite",
+        ])
+        #expect(report.status == .partial)
+    }
+
+    @Test
+    func maxAgeAcceptsZeroAndNegativeValues() throws {
+        let zero = try responseCookie("a=b; Max-Age=0")
+        #expect(zero.rawMaxAge == "0")
+        #expect(zero.maxAgeSeconds == 0)
+
+        let negative = try responseCookie("a=b; Max-Age=-9223372036854775808")
+        #expect(negative.rawMaxAge == "-9223372036854775808")
+        #expect(negative.maxAgeSeconds == Int64.min)
+    }
+
+    @Test(arguments: [
+        "+1",
+        "9223372036854775808",
+        "-9223372036854775809",
+        "1.0",
+        "-",
+    ])
+    func invalidMaxAgeIsDiagnosedWithoutAProjection(_ rawValue: String) throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "a=b; Max-Age=\(rawValue)"
+        ]))
+        let cookie = try #require(report.cookies.first)
+
+        #expect(cookie.rawMaxAge == nil)
+        #expect(cookie.maxAgeSeconds == nil)
+        #expect(report.diagnostics.map(\.kind) == [.invalidMaxAge])
+        #expect(report.diagnostics.map(\.rawFragment) == [" Max-Age=\(rawValue)"])
+        #expect(report.status == .partial)
+    }
+
+    @Test
+    func sameSitePreservesAllSemanticStates() throws {
+        #expect(try responseCookie("a=b").sameSite == .absent)
+        #expect(try responseCookie("a=b; SameSite=None").sameSite == .none)
+        #expect(try responseCookie("a=b; SameSite=lAx").sameSite == .lax)
+        #expect(try responseCookie("a=b; SameSite=STRICT").sameSite == .strict)
+        #expect(try responseCookie("a=b; SameSite=FutureMode").sameSite == .other("FutureMode"))
+    }
+
+    @Test(arguments: [
+        ("Wed, 09 Jun 69 10:18:14 GMT", 2069),
+        ("Wed, 09 Jun 70 10:18:14 GMT", 1970),
+        ("Wed, 09 Jun 2021 10:18:14 GMT", 2021),
+        ("09th-Jun-2021 10:18:14GMT", 2021),
+    ])
+    func cookieDatesUseRFCDateTokens(_ rawValue: String, expectedYear: Int) throws {
+        let cookie = try responseCookie("a=b; Expires=\(rawValue)")
+        let date = try #require(cookie.expires)
+
+        #expect(cookie.rawExpires == rawValue)
+        #expect(utcCalendar.dateComponents([.year], from: date).year == expectedYear)
+    }
+
+    @Test(arguments: [
+        "Wed, 32 Jun 2021 10:18:14 GMT",
+        "Wed, 31 Feb 2021 10:18:14 GMT",
+        "Wed, 09 Jun 1600 10:18:14 GMT",
+        "Wed, 09 Jun 2021 24:18:14 GMT",
+        "Wed, 09 Jun 2021 10:60:14 GMT",
+        "Wed, 09 Jun 2021 10:18:60 GMT",
+        "Wed, 09 Jun 2021 GMT",
+    ])
+    func invalidCookieDateBoundsAreDiagnosed(_ rawValue: String) throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "a=b; Expires=\(rawValue)"
+        ]))
+        let cookie = try #require(report.cookies.first)
+
+        #expect(cookie.rawExpires == nil)
+        #expect(cookie.expires == nil)
+        #expect(report.diagnostics.map(\.kind) == [.invalidExpires])
+        #expect(report.status == .partial)
+    }
+}
+
+private extension NetworkCookieParserTests {
+    func responseCookie(_ rawHeader: String) throws -> NetworkResponseCookie {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": rawHeader
+        ]))
+        #expect(report.status == .complete)
+        #expect(report.diagnostics.isEmpty)
+        return try #require(report.cookies.first)
+    }
+
+    var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    func utcDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+        second: Int
+    ) -> Date? {
+        utcCalendar.date(from: DateComponents(
+            timeZone: utcCalendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        ))
+    }
+
+    func requireHashableSendable<T: Hashable & Sendable>(_ value: T) {
+        _ = value.hashValue
+    }
+}

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -12007,6 +12007,286 @@ func runtimeEventsPopulateContextsAndFallbackSelection() async throws {
 }
 
 @MainActor
+@Test
+func networkRequestHeadersUseWholeSnapshotPrecedence() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("cookie-header-precedence")
+
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/cookies",
+            method: "POST",
+            headers: [
+                "Cookie": "request=1",
+                "Content-Type": "text/plain",
+            ],
+            postData: "body"
+        ),
+        resourceType: .fetch,
+        redirectResponse: nil,
+        timestamp: 1
+    ))
+    let request = try #require(context.registeredRequest(forProxyID: requestID))
+    #expect(request.requestHeaderSource == .requestWillBeSent)
+    #expect(request.requestHeaders["Cookie"] == "request=1")
+
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(
+            status: 200,
+            requestHeaders: [:]
+        ),
+        resourceType: .fetch,
+        timestamp: 2
+    ))
+    #expect(request.requestHeaderSource == .response)
+    #expect(request.requestHeaders == [:])
+    #expect(request.cookieSections.request == .empty)
+
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(
+            status: 200,
+            requestHeaders: [
+                "Cookie": "response=2",
+                "Content-Type": "application/json",
+            ]
+        ),
+        resourceType: .fetch,
+        timestamp: 3
+    ))
+    #expect(request.requestHeaders["Cookie"] == "response=2")
+    #expect(request.requestBody?.sourceSyntaxKind == .json)
+
+    await context.apply(.loadingFinished(
+        id: requestID,
+        timestamp: 4,
+        sourceMapURL: nil,
+        metrics: Network.Metrics()
+    ))
+    #expect(request.requestHeaderSource == .response)
+    #expect(request.requestHeaders["Cookie"] == "response=2")
+
+    await context.apply(.loadingFinished(
+        id: requestID,
+        timestamp: 5,
+        sourceMapURL: nil,
+        metrics: Network.Metrics().reporting(requestHeaders: [:])
+    ))
+    #expect(request.requestHeaderSource == .metrics)
+    #expect(request.requestHeaders == [:])
+
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(
+            status: 200,
+            requestHeaders: ["Cookie": "late-response=3"]
+        ),
+        resourceType: .fetch,
+        timestamp: 6
+    ))
+    #expect(request.requestHeaderSource == .metrics)
+    #expect(request.requestHeaders == [:])
+}
+
+@MainActor
+@Test
+func networkRequestHeaderSourceResetsForReusedAndRedirectedLifecycles() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("cookie-header-reset")
+
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/first",
+            method: "GET",
+            headers: ["Cookie": "first=1"]
+        ),
+        resourceType: .document,
+        redirectResponse: nil,
+        timestamp: 1
+    ))
+    await context.apply(.loadingFinished(
+        id: requestID,
+        timestamp: 2,
+        sourceMapURL: nil,
+        metrics: Network.Metrics().reporting(requestHeaders: ["Cookie": "final=2"])
+    ))
+    let request = try #require(context.registeredRequest(forProxyID: requestID))
+    #expect(request.requestHeaderSource == .metrics)
+
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/reused",
+            method: "GET",
+            headers: ["Cookie": "reused=3"]
+        ),
+        resourceType: .document,
+        redirectResponse: Network.Response(status: 302),
+        timestamp: 3
+    ))
+    #expect(request.requestHeaderSource == .requestWillBeSent)
+    #expect(request.requestHeaders["Cookie"] == "reused=3")
+    #expect(request.redirects.isEmpty)
+
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(
+            status: 302,
+            requestHeaders: ["Cookie": "refined=4"]
+        ),
+        resourceType: .document,
+        timestamp: 4
+    ))
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/redirected",
+            method: "GET",
+            headers: ["Cookie": "redirected=5"]
+        ),
+        resourceType: .document,
+        redirectResponse: Network.Response(status: 302),
+        timestamp: 5
+    ))
+    #expect(request.requestHeaderSource == .requestWillBeSent)
+    #expect(request.requestHeaders["Cookie"] == "redirected=5")
+    #expect(request.redirects.count == 1)
+}
+
+@MainActor
+@Test
+func networkCookieRequestAvailabilityFollowsCaptureBoundary() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+
+    let responseFirstID = Network.Request.ID("cookie-response-first")
+    await context.apply(.responseReceived(
+        id: responseFirstID,
+        response: Network.Response(
+            url: "https://example.test/response-first",
+            status: 200
+        ),
+        resourceType: .fetch,
+        timestamp: 1
+    ))
+    let responseFirst = try #require(context.registeredRequest(forProxyID: responseFirstID))
+    #expect(responseFirst.requestHeaderSource == .unavailable)
+    #expect(responseFirst.cookieSections.request == .unavailable(.notCaptured))
+
+    let cachedID = Network.Request.ID("cookie-memory-cache")
+    await context.apply(.requestServedFromMemoryCache(
+        id: cachedID,
+        response: Network.Response(
+            url: "https://example.test/cached",
+            status: 200,
+            requestHeaders: ["Cookie": "cached=1"]
+        ),
+        resourceType: .fetch,
+        timestamp: 2
+    ))
+    let cached = try #require(context.registeredRequest(forProxyID: cachedID))
+    #expect(cached.responseSource == "memory-cache")
+    #expect(cached.cookieSections.request == .unavailable(.servedFromMemoryCache))
+
+    let webSocketID = Network.Request.ID("cookie-websocket")
+    await context.apply(.webSocket(.created(
+        id: webSocketID,
+        url: "wss://example.test/socket"
+    )))
+    let webSocket = try #require(context.registeredRequest(forProxyID: webSocketID))
+    #expect(webSocket.requestHeaderSource == .unavailable)
+    #expect(webSocket.cookieSections.request == .unavailable(.notCaptured))
+
+    await context.apply(.webSocket(.handshakeRequest(
+        id: webSocketID,
+        request: Network.Request(
+            id: webSocketID,
+            url: "wss://example.test/socket",
+            method: "GET",
+            headers: ["Cookie": "socket=2"]
+        ),
+        timestamp: 3
+    )))
+    #expect(webSocket.requestHeaderSource == .requestWillBeSent)
+    guard case let .values(report) = webSocket.cookieSections.request else {
+        Issue.record("Expected WebSocket handshake request cookies.")
+        return
+    }
+    #expect(report.cookies.map(\.name) == ["socket"])
+    #expect(report.cookies.map(\.value) == ["2"])
+}
+
+@MainActor
+@Test
+func networkResponseCookieSectionDistinguishesLoadingNoResponseEmptyAndValues() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("cookie-response-states")
+
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/states",
+            method: "GET"
+        ),
+        resourceType: .fetch,
+        redirectResponse: nil,
+        timestamp: 1
+    ))
+    let request = try #require(context.registeredRequest(forProxyID: requestID))
+    #expect(request.cookieSections.response == .loading)
+
+    await context.apply(.loadingFailed(
+        id: requestID,
+        errorText: "failed",
+        canceled: false,
+        timestamp: 2
+    ))
+    #expect(request.cookieSections.response == .noResponse)
+
+    await context.apply(.requestWillBeSent(
+        id: requestID,
+        request: Network.Request(
+            id: requestID,
+            url: "https://example.test/empty",
+            method: "GET"
+        ),
+        resourceType: .fetch,
+        redirectResponse: nil,
+        timestamp: 3
+    ))
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(status: 200),
+        resourceType: .fetch,
+        timestamp: 4
+    ))
+    #expect(request.cookieSections.response == .empty)
+
+    await context.apply(.responseReceived(
+        id: requestID,
+        response: Network.Response(
+            status: 200,
+            headers: ["Set-Cookie": "session=abc; HttpOnly"]
+        ),
+        resourceType: .fetch,
+        timestamp: 5
+    ))
+    guard case let .values(report) = request.cookieSections.response else {
+        Issue.record("Expected response cookies.")
+        return
+    }
+    #expect(report.cookies.map(\.name) == ["session"])
+    #expect(report.cookies.first?.isHTTPOnly == true)
+}
+
+@MainActor
 private func startContext(
     runtime: WebInspectorProxyTestRuntime,
     document: DOM.Node = DOM.Node(id: DOM.Node.ID("document"), nodeType: 9, nodeName: "#document")

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -3000,7 +3000,7 @@ func transportBackendFiltersEventsByRoute() async throws {
         transport,
         targetID: ProtocolTarget.ID("frame-target"),
         method: "Network.loadingFinished",
-        params: #"{"requestId":"frame-request","timestamp":4,"sourceMapURL":"frame.js.map","metrics":{"protocol":"h2","remoteAddress":"203.0.113.10:443","responseBodyBytesReceived":128,"responseBodyDecodedSize":256}}"#
+        params: #"{"requestId":"frame-request","timestamp":4,"sourceMapURL":"frame.js.map","metrics":{"protocol":"h2","remoteAddress":"203.0.113.10:443","requestHeaders":{"Cookie":"session=abc"},"responseBodyBytesReceived":128,"responseBodyDecodedSize":256,"futureField":true}}"#
     )
 
     let frameEvent = try #require(try await value(of: frameEventTask))
@@ -3013,10 +3013,39 @@ func transportBackendFiltersEventsByRoute() async throws {
     #expect(sourceMapURL == "frame.js.map")
     #expect(metrics?.networkProtocol == "h2")
     #expect(metrics?.remoteAddress == "203.0.113.10:443")
+    #expect(metrics?.requestHeaders == ["Cookie": "session=abc"])
     #expect(metrics?.encodedDataLength == 128)
     #expect(metrics?.decodedBodyLength == 256)
 
     pageEventTask.cancel()
+}
+
+@Test
+func transportBackendPreservesPresentEmptyMetricsRequestHeaders() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(750))
+    await installPageTarget(in: transport)
+    let target = pageTarget(proxy: WebInspectorProxy(backend: LiveWebInspectorProxyBackend(transport: transport)))
+
+    let eventTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+
+    await waitForEventSubscription(target, domain: .network)
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: #"{"requestId":"empty-request-headers","timestamp":4,"metrics":{"requestHeaders":{}}}"#
+    )
+
+    let event = try #require(try await value(of: eventTask))
+    guard case let .loadingFinished(_, _, _, metrics) = event else {
+        Issue.record("Expected Network.loadingFinished.")
+        return
+    }
+    #expect(metrics?.requestHeaders == [:])
 }
 
 @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -339,16 +339,16 @@ struct NetworkDetailViewControllerTests {
         ])
         #expect(
             NetworkCookiesViewController.sectionTitleForTesting(.request)
-                == String(
-                    localized: "network.cookies.section.request",
-                    bundle: WebInspectorUILocalization.bundle
+                == localized(
+                    "network.cookies.section.request",
+                    defaultValue: "Request Cookies"
                 )
         )
         #expect(
             NetworkCookiesViewController.sectionTitleForTesting(.response)
-                == String(
-                    localized: "network.cookies.section.response",
-                    bundle: WebInspectorUILocalization.bundle
+                == localized(
+                    "network.cookies.section.response",
+                    defaultValue: "Response Cookies"
                 )
         )
         #expect(
@@ -529,29 +529,29 @@ struct NetworkDetailViewControllerTests {
                 key: .init(name: "session", duplicateOccurrence: 0)
             ))
         )
-        let nameLabel = String(
-            localized: "network.cookies.field.name",
-            bundle: WebInspectorUILocalization.bundle
+        let nameLabel = localized(
+            "network.cookies.field.name",
+            defaultValue: "Name"
         )
-        let maxAgeLabel = String(
-            localized: "network.cookies.field.max_age",
-            bundle: WebInspectorUILocalization.bundle
+        let maxAgeLabel = localized(
+            "network.cookies.field.max_age",
+            defaultValue: "Max-Age"
         )
-        let secureLabel = String(
-            localized: "network.cookies.field.secure",
-            bundle: WebInspectorUILocalization.bundle
+        let secureLabel = localized(
+            "network.cookies.field.secure",
+            defaultValue: "Secure"
         )
-        let httpOnlyLabel = String(
-            localized: "network.cookies.field.http_only",
-            bundle: WebInspectorUILocalization.bundle
+        let httpOnlyLabel = localized(
+            "network.cookies.field.http_only",
+            defaultValue: "HttpOnly"
         )
-        let partitionedLabel = String(
-            localized: "network.cookies.field.partitioned",
-            bundle: WebInspectorUILocalization.bundle
+        let partitionedLabel = localized(
+            "network.cookies.field.partitioned",
+            defaultValue: "Partitioned"
         )
-        let yes = String(
-            localized: "network.cookies.value.yes",
-            bundle: WebInspectorUILocalization.bundle
+        let yes = localized(
+            "network.cookies.value.yes",
+            defaultValue: "Yes"
         )
         #expect(content.fields.count == 11)
         #expect(content.fields.map(\.label).contains(nameLabel))
@@ -5909,6 +5909,17 @@ struct NetworkDetailViewControllerTests {
             return nil
         }
         return bundle.localizedString(forKey: key, value: nil, table: nil)
+    }
+
+    private func localized(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        String(
+            localized: key,
+            defaultValue: defaultValue,
+            bundle: WebInspectorUILocalization.bundle
+        )
     }
 
     @MainActor

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -65,6 +65,8 @@ struct NetworkDetailViewControllerTests {
 
         #expect(viewController.previewViewForTesting.isHidden)
         #expect(viewController.headersTextViewForTesting.isHidden)
+        #expect(viewController.cookiesViewControllerForTesting.view.isHidden)
+        #expect(viewController.cookiesViewControllerForTesting.snapshotForTesting.itemIdentifiers.isEmpty)
         #expect(viewController.contentUnavailableConfiguration != nil)
         let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
         #expect(configuration?.text?.isEmpty == false)
@@ -87,6 +89,7 @@ struct NetworkDetailViewControllerTests {
 
         #expect(viewController.view.backgroundColor == .clear)
         #expect(viewController.headersTextViewForTesting.backgroundColor == .clear)
+        #expect(viewController.cookiesViewControllerForTesting.collectionView.backgroundColor == .clear)
         #expect(viewController.syntaxBodyViewControllerForTesting.view.backgroundColor == .clear)
     }
 
@@ -209,9 +212,11 @@ struct NetworkDetailViewControllerTests {
         let topInset = viewController.view.safeAreaLayoutGuide.layoutFrame.minY
         let trailingInset = viewController.view.safeAreaLayoutGuide.layoutFrame.maxX
         let bounds = viewController.view.bounds
+        let cookiesView: UIView = viewController.cookiesViewControllerForTesting.view
         for contentView in [
             viewController.headersTextViewForTesting,
             viewController.previewViewForTesting,
+            cookiesView,
         ] {
             #expect(contentView.frame.minX == leadingInset)
             #expect(contentView.frame.maxX == trailingInset)
@@ -219,11 +224,12 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(viewController.headersTextViewForTesting.frame.minY == bounds.minY)
         #expect(viewController.previewViewForTesting.frame.minY == bounds.minY)
+        #expect(cookiesView.frame.minY == bounds.minY)
         #expect(viewController.previewRoleControlContainerViewForTesting.frame.minY == topInset)
     }
 
     @Test
-    func detailModeControlSwitchesPreviewAndHeaders() async throws {
+    func detailModeControlSwitchesHeadersPreviewAndCookies() async throws {
         let context = makeContext()
         let request = try #require(
             await applyRequest(
@@ -232,10 +238,14 @@ struct NetworkDetailViewControllerTests {
                 url: "https://example.com/api/data.json",
                 requestHeaders: [
                     "accept": "application/json",
+                    "Cookie": "request-cookie=1",
                     "content-type": "application/x-www-form-urlencoded",
                 ],
                 postData: "name=Jane+Doe&city=Tokyo%20East",
-                responseHeaders: ["content-type": "application/json"],
+                responseHeaders: [
+                    "content-type": "application/json",
+                    "Set-Cookie": "response-cookie=2; HttpOnly",
+                ],
                 responseMimeType: "application/json"
             )
         )
@@ -259,6 +269,25 @@ struct NetworkDetailViewControllerTests {
 
         #expect(didRenderHeaders)
         #expect(viewController.contentUnavailableConfiguration == nil)
+        #expect(NetworkDetailViewController.Mode.allCases == [.headers, .preview, .cookies])
+
+        selectMode(.cookies, on: viewController)
+
+        let didRenderCookies = await waitUntilRendered(in: viewController) {
+            let items = viewController.cookiesViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers
+            return viewController.currentModeForTesting == .cookies
+                && viewController.previewViewForTesting.isHidden
+                && viewController.headersTextViewForTesting.isHidden
+                && viewController.cookiesViewControllerForTesting.view.isHidden == false
+                && items.contains(where: isRequestCookieItem)
+                && items.contains(where: isResponseCookieItem)
+        }
+        #expect(didRenderCookies)
+        #expect(
+            viewController.contentScrollView(for: .top)
+                === viewController.cookiesViewControllerForTesting.collectionView
+        )
 
         selectMode(.preview, on: viewController)
 
@@ -266,6 +295,7 @@ struct NetworkDetailViewControllerTests {
             viewController.currentModeForTesting == .preview
                 && viewController.previewViewForTesting.isHidden == false
                 && viewController.headersTextViewForTesting.isHidden
+                && viewController.cookiesViewControllerForTesting.view.isHidden
                 && viewController.isPreviewRoleControlHiddenForTesting == false
         }
         #expect(didRenderPreview)
@@ -277,6 +307,515 @@ struct NetworkDetailViewControllerTests {
                 && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
         }
         #expect(didRenderRequestPreview)
+    }
+
+    @Test
+    func cookiesListUsesNativeInsetGroupedLayoutAndFixedStateSections() async {
+        let viewController = NetworkCookiesViewController()
+        let requestEpoch = NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        await renderCookies(
+            NetworkCookieSections(
+                request: .unavailable(.notCaptured),
+                response: .loading
+            ),
+            in: viewController
+        )
+
+        let configuration = NetworkCookiesViewController.listLayoutConfigurationForTesting
+        #expect(configuration.appearance == .insetGrouped)
+        #expect(configuration.headerMode == .supplementary)
+        #expect(configuration.showsSeparators)
+        #expect(viewController.collectionView.collectionViewLayout is UICollectionViewCompositionalLayout)
+        #expect(viewController.collectionView.allowsSelection == false)
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.request, .response])
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .request) == [
+            .state(epoch: requestEpoch, section: .request, kind: .requestNotCaptured)
+        ])
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
+            .state(epoch: requestEpoch, section: .response, kind: .responseLoading)
+        ])
+        #expect(
+            NetworkCookiesViewController.sectionTitleForTesting(.request)
+                == String(
+                    localized: "network.cookies.section.request",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
+        #expect(
+            NetworkCookiesViewController.sectionTitleForTesting(.response)
+                == String(
+                    localized: "network.cookies.section.response",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
+        #expect(
+            viewController.messageContentForTesting(
+                .state(epoch: requestEpoch, section: .response, kind: .responseLoading)
+            )?.kind == .loading
+        )
+
+        await renderCookies(
+            NetworkCookieSections(
+                request: .unavailable(.servedFromMemoryCache),
+                response: .noResponse
+            ),
+            in: viewController
+        )
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .request) == [
+            .state(epoch: requestEpoch, section: .request, kind: .requestMemoryCache)
+        ])
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
+            .state(epoch: requestEpoch, section: .response, kind: .responseMissing)
+        ])
+
+        await renderCookies(
+            NetworkCookieSections(request: .empty, response: .empty),
+            in: viewController
+        )
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .request) == [
+            .state(epoch: requestEpoch, section: .request, kind: .requestEmpty)
+        ])
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
+            .state(epoch: requestEpoch, section: .response, kind: .responseEmpty)
+        ])
+    }
+
+    @Test
+    func cookiesListKeepsValidRowsWithPartialAndAmbiguousRawWarnings() async throws {
+        let requestReport = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "z=3; broken; a=1; a=2"
+        ]))
+        let responseReport = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "first=1, second=2"
+        ]))
+        #expect(requestReport.status == .partial)
+        #expect(responseReport.status == .ambiguousCombined)
+
+        let viewController = NetworkCookiesViewController()
+        let requestEpoch = NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        await renderCookies(
+            NetworkCookieSections(
+                request: .values(requestReport),
+                response: .values(responseReport)
+            ),
+            in: viewController
+        )
+
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .request) == [
+            .requestCookie(
+                epoch: requestEpoch,
+                key: .init(name: "a", duplicateOccurrence: 0)
+            ),
+            .requestCookie(
+                epoch: requestEpoch,
+                key: .init(name: "a", duplicateOccurrence: 1)
+            ),
+            .requestCookie(
+                epoch: requestEpoch,
+                key: .init(name: "z", duplicateOccurrence: 0)
+            ),
+            .diagnostic(epoch: requestEpoch, section: .request, ordinal: 0),
+        ])
+        #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
+            .diagnostic(epoch: requestEpoch, section: .response, ordinal: 0)
+        ])
+        #expect(
+            viewController.cookieContentForTesting(.requestCookie(
+                epoch: requestEpoch,
+                key: .init(name: "a", duplicateOccurrence: 0)
+            ))?
+                .fields.first?.value == "a"
+        )
+        #expect(
+            viewController.cookieContentForTesting(.requestCookie(
+                epoch: requestEpoch,
+                key: .init(name: "a", duplicateOccurrence: 1)
+            ))?
+                .fields.first?.value == "a"
+        )
+        #expect(
+            viewController.messageContentForTesting(
+                .diagnostic(epoch: requestEpoch, section: .request, ordinal: 0)
+            )?.detail?.contains("broken") == true
+        )
+        #expect(
+            viewController.messageContentForTesting(
+                .diagnostic(epoch: requestEpoch, section: .response, ordinal: 0)
+            )?.detail == "first=1, second=2"
+        )
+    }
+
+    @Test
+    func cookiesListKeepsSemanticIdentityOnlyWithinOneRequestEpoch() async throws {
+        let initialReport = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "b=2; broken; c=3"
+        ]))
+        let refinedReport = try #require(NetworkCookieParser.parseRequestHeaders([
+            "Cookie": "a=1; broken; b=4"
+        ]))
+        let initialSections = NetworkCookieSections(
+            request: .values(initialReport),
+            response: .loading
+        )
+        let refinedSections = NetworkCookieSections(
+            request: .values(refinedReport),
+            response: .loading
+        )
+        let viewController = NetworkCookiesViewController()
+        let firstEpoch = NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        await renderCookies(initialSections, requestEpoch: firstEpoch, in: viewController)
+        let initialRequestIDs = viewController.snapshotForTesting.itemIdentifiers(inSection: .request)
+        let initialB = try #require(initialRequestIDs.first { itemID in
+            guard case let .requestCookie(_, key) = itemID else {
+                return false
+            }
+            return key == .init(name: "b", duplicateOccurrence: 0)
+        })
+        let initialC = try #require(initialRequestIDs.first { itemID in
+            guard case let .requestCookie(_, key) = itemID else {
+                return false
+            }
+            return key == .init(name: "c", duplicateOccurrence: 0)
+        })
+
+        await renderCookies(refinedSections, requestEpoch: firstEpoch, in: viewController)
+        let refinedIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(refinedIDs.contains(initialB))
+        #expect(refinedIDs.contains(initialC) == false)
+
+        let nextEpochOwner = NSObject()
+        let nextEpoch = NetworkCookiesViewController.RequestEpoch.testing(nextEpochOwner)
+        await renderCookies(refinedSections, requestEpoch: nextEpoch, in: viewController)
+        let nextEpochIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(Set(refinedIDs).intersection(nextEpochIDs).isEmpty)
+        #expect(nextEpochIDs.contains(where: isRequestCookieItem))
+        #expect(nextEpochIDs.contains { itemID in
+            if case .diagnostic = itemID {
+                return true
+            }
+            return false
+        })
+        #expect(nextEpochIDs.contains { itemID in
+            isCookieStateItem(itemID, section: .response, kind: .responseLoading)
+        })
+    }
+
+    @Test
+    func responseCookieCellShowsAllFieldsAndAdaptsColumnsAccessibilityAndRTL() async throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "session=abc; Domain=example.test; Path=/; Partitioned; "
+                + "Expires=Wed, 09 Jun 2027 10:18:14 GMT; Max-Age=0; Secure; "
+                + "HttpOnly; SameSite=Lax; Priority=High"
+        ]))
+        let viewController = NetworkCookiesViewController()
+        let requestEpoch = NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        await renderCookies(
+            NetworkCookieSections(request: .empty, response: .values(report)),
+            in: viewController
+        )
+        let content = try #require(
+            viewController.cookieContentForTesting(.responseCookie(
+                epoch: requestEpoch,
+                key: .init(name: "session", duplicateOccurrence: 0)
+            ))
+        )
+        let nameLabel = String(
+            localized: "network.cookies.field.name",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let maxAgeLabel = String(
+            localized: "network.cookies.field.max_age",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let secureLabel = String(
+            localized: "network.cookies.field.secure",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let httpOnlyLabel = String(
+            localized: "network.cookies.field.http_only",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let partitionedLabel = String(
+            localized: "network.cookies.field.partitioned",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let yes = String(
+            localized: "network.cookies.value.yes",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(content.fields.count == 11)
+        #expect(content.fields.map(\.label).contains(nameLabel))
+        #expect(content.fields.map(\.label).contains(maxAgeLabel))
+        #expect(content.fields.first { $0.label == maxAgeLabel }?.value == "0")
+        #expect(content.fields.first { $0.label == secureLabel }?.value == yes)
+        #expect(content.fields.first { $0.label == httpOnlyLabel }?.value == yes)
+        #expect(content.fields.first { $0.label == partitionedLabel }?.value == yes)
+        #expect(content.fields.last?.isFullWidth == true)
+        #expect(content.fields.last?.value.contains("Priority=High") == true)
+
+        let host = UIViewController()
+        let cellHost = UIViewController()
+        host.addChild(cellHost)
+        host.view.addSubview(cellHost.view)
+        cellHost.view.frame = host.view.bounds
+        cellHost.didMove(toParent: host)
+        let cell = NetworkCookieCell(frame: CGRect(x: 0, y: 0, width: 700, height: 200))
+        cellHost.view.addSubview(cell)
+        let cellWindow = showInWindow(host)
+        defer { cellWindow.isHidden = true }
+        cellHost.traitOverrides.horizontalSizeClass = .regular
+        cellHost.traitOverrides.preferredContentSizeCategory = .large
+        cellHost.updateTraitsIfNeeded()
+        cell.updateTraitsIfNeeded()
+        cell.bind(content)
+        host.view.layoutIfNeeded()
+        #expect(cell.usesTwoColumnsForTesting)
+        #expect(cell.fieldRowCountForTesting == 6)
+
+        cellHost.traitOverrides.horizontalSizeClass = .compact
+        cellHost.updateTraitsIfNeeded()
+        cell.updateTraitsIfNeeded()
+        cell.bind(content)
+        #expect(cell.usesTwoColumnsForTesting == false)
+        #expect(cell.fieldRowCountForTesting == content.fields.count)
+
+        cellHost.traitOverrides.horizontalSizeClass = .regular
+        cellHost.traitOverrides.preferredContentSizeCategory = .accessibilityExtraExtraExtraLarge
+        cellHost.updateTraitsIfNeeded()
+        cell.updateTraitsIfNeeded()
+        cell.bind(content)
+        #expect(cell.usesTwoColumnsForTesting == false)
+        #expect(cell.fieldRowCountForTesting == content.fields.count)
+
+        cell.semanticContentAttribute = .forceRightToLeft
+        cell.bind(content)
+        #expect(cell.effectiveUserInterfaceLayoutDirection == .rightToLeft)
+        #expect(cell.accessibilityLabel?.contains("\(secureLabel), \(yes)") == true)
+        #expect(cell.accessibilityLabel?.contains("\(partitionedLabel), \(yes)") == true)
+        #expect(cell.accessibilityValue == nil)
+
+        cell.prepareForReuse()
+        #expect(cell.renderedFieldsForTesting.isEmpty)
+        #expect(cell.accessibilityLabel == nil)
+    }
+
+    @Test
+    func cookiesModeTracksLoadingResponseAndRefinedMetricsHeaders() async throws {
+        let context = makeContext()
+        let request = try #require(await applyRequestWithoutResponse(
+            to: context,
+            requestID: "cookie-live",
+            url: "https://example.com/cookie-live",
+            requestHeaders: ["Cookie": "initial=1"]
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model, initialMode: .cookies)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieValue(in: viewController) == "1"
+                && viewController.cookiesViewControllerForTesting.snapshotForTesting
+                    .itemIdentifiers(inSection: .response)
+                    .contains(where: { isCookieStateItem(
+                        $0,
+                        section: .response,
+                        kind: .responseLoading
+                    ) })
+        })
+
+        await applyResponseReceived(
+            to: context,
+            requestID: "cookie-live",
+            url: request.url,
+            responseHeaders: ["Set-Cookie": "response=2; HttpOnly"],
+            responseMimeType: "text/plain",
+            timestamp: 2
+        )
+
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.cookiesViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers(inSection: .response).filter(isResponseCookieItem).count == 1
+        })
+
+        await applyLoadingFinished(
+            to: context,
+            requestID: "cookie-live",
+            timestamp: 3,
+            requestHeaders: ["Cookie": "refined=3"]
+        )
+
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "refined"
+                && requestCookieValue(in: viewController) == "3"
+        })
+        #expect(viewController.selectedRequestRenderObservationDeliveryForTesting?.isActive == true)
+    }
+
+    @Test
+    func cookiesModeUsesRepresentativeThenExplicitGroupedRequestWithoutAggregation() async throws {
+        let context = makeContext()
+        let frameID = FrameID("cookie-group-frame")
+        let nodeID = DOM.Node.ID("cookie-group-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let first = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "cookie-group-first",
+            url: "https://example.com/first",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            requestHeaders: ["Cookie": "first=1"],
+            timestamp: 1
+        ))
+        let second = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "cookie-group-second",
+            url: "https://example.com/second",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            requestHeaders: ["Cookie": "second=2"],
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        try selectEntry(containing: first, in: model)
+        let viewController = makeNetworkDetailViewController(model: model, initialMode: .cookies)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "first"
+        })
+        let firstCookieItemID = try #require(
+            viewController.cookiesViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers(inSection: .request).first(where: isRequestCookieItem)
+        )
+        #expect(
+            viewController.cookiesViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers(inSection: .request).filter(isRequestCookieItem).count == 1
+        )
+        #expect(viewController.requestPickerItemForTesting != nil)
+
+        model.selectRequest(second)
+
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "second"
+                && requestCookieValue(in: viewController) == "2"
+        })
+        let secondCookieItemID = try #require(
+            viewController.cookiesViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers(inSection: .request).first(where: isRequestCookieItem)
+        )
+        #expect(secondCookieItemID != firstCookieItemID)
+        #expect(
+            viewController.cookiesViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers(inSection: .request).filter(isRequestCookieItem).count == 1
+        )
+        #expect(model.selectedRequest === second)
+        #expect(viewController.requestPickerItemForTesting != nil)
+    }
+
+    @Test
+    func cookiesModeRebindsSameIDInstanceAndIgnoresHiddenAndOldMutations() async throws {
+        let context = makeContext()
+        let request = try #require(await applyRequest(
+            to: context,
+            requestID: "cookie-instance",
+            url: "https://example.com/original",
+            requestHeaders: ["Cookie": "original=1"]
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model, initialMode: .cookies)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "original"
+        })
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        let transactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await applyLoadingFinished(
+            to: context,
+            requestID: "cookie-instance",
+            timestamp: 4,
+            requestHeaders: ["Cookie": "hidden=2"]
+        )
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: transactionBaseline))
+        #expect(requestCookieName(in: viewController) == "original")
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "hidden"
+        })
+
+        let proxyID = Network.Request.ID("cookie-instance")
+        let replacement = NetworkRequest(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/replacement",
+                method: "GET",
+                headers: ["Cookie": "replacement=3"]
+            ),
+            initiator: request.initiator,
+            navigationVisit: request.navigationVisit,
+            resourceType: request.resourceType,
+            timestamp: request.logicalStartTimestamp,
+            chronologySequence: request.chronologySequence,
+            modelContext: context
+        )
+        model.upsertRequestForTesting(replacement)
+
+        #expect(await waitUntilRendered(in: viewController) {
+            model.selectedRequest === replacement
+                && requestCookieName(in: viewController) == "replacement"
+        })
+
+        request.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/stale",
+                method: "GET",
+                headers: ["Cookie": "stale=4"]
+            ),
+            initiator: request.initiator,
+            navigationVisit: request.navigationVisit,
+            resourceType: request.resourceType,
+            timestamp: 5,
+            chronologySequence: 5
+        )
+        #expect(requestCookieName(in: viewController) == "replacement")
+
+        replacement.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/current",
+                method: "GET",
+                headers: ["Cookie": "current=5"]
+            ),
+            initiator: replacement.initiator,
+            navigationVisit: replacement.navigationVisit,
+            resourceType: replacement.resourceType,
+            timestamp: 6,
+            chronologySequence: 6
+        )
+        #expect(await waitUntilRendered(in: viewController) {
+            requestCookieName(in: viewController) == "current"
+                && requestCookieValue(in: viewController) == "5"
+        })
     }
 
     @Test
@@ -5062,14 +5601,17 @@ struct NetworkDetailViewControllerTests {
     private func applyLoadingFinished(
         to context: WebInspectorContext,
         requestID rawRequestID: String,
-        timestamp: Double
+        timestamp: Double,
+        requestHeaders: [String: String]? = nil
     ) async {
         await context.apply(
             .loadingFinished(
                 id: Network.Request.ID(rawRequestID),
                 timestamp: timestamp,
                 sourceMapURL: nil,
-                metrics: nil
+                metrics: requestHeaders.map {
+                    Network.Metrics().reporting(requestHeaders: $0)
+                }
             )
         )
     }
@@ -5081,6 +5623,77 @@ struct NetworkDetailViewControllerTests {
         base64Encoded: Bool = false
     ) {
         context.seedResponseBody(for: request.id, body: body, base64Encoded: base64Encoded)
+    }
+
+    private func renderCookies(
+        _ sections: NetworkCookieSections,
+        requestEpoch: NetworkCookiesViewController.RequestEpoch? = nil,
+        in viewController: NetworkCookiesViewController
+    ) async {
+        let requestEpoch = requestEpoch
+            ?? NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        await withCheckedContinuation { continuation in
+            viewController.render(sections, requestEpoch: requestEpoch) {
+                continuation.resume()
+            }
+        }
+        viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func requestCookieName(in viewController: NetworkDetailViewController) -> String? {
+        requestCookieContent(in: viewController)?.fields.first?.value
+    }
+
+    private func requestCookieValue(in viewController: NetworkDetailViewController) -> String? {
+        guard let fields = requestCookieContent(in: viewController)?.fields,
+              fields.indices.contains(1) else {
+            return nil
+        }
+        return fields[1].value
+    }
+
+    private func isRequestCookieItem(
+        _ itemID: NetworkCookiesViewController.ItemID
+    ) -> Bool {
+        if case .requestCookie = itemID {
+            return true
+        }
+        return false
+    }
+
+    private func isResponseCookieItem(
+        _ itemID: NetworkCookiesViewController.ItemID
+    ) -> Bool {
+        if case .responseCookie = itemID {
+            return true
+        }
+        return false
+    }
+
+    private func isCookieStateItem(
+        _ itemID: NetworkCookiesViewController.ItemID,
+        section: NetworkCookiesViewController.SectionID,
+        kind: NetworkCookiesViewController.StateKind
+    ) -> Bool {
+        guard case let .state(_, itemSection, itemKind) = itemID else {
+            return false
+        }
+        return itemSection == section && itemKind == kind
+    }
+
+    private func requestCookieContent(
+        in viewController: NetworkDetailViewController
+    ) -> NetworkCookieRowContent? {
+        let cookies = viewController.cookiesViewControllerForTesting
+        guard let itemID = cookies.snapshotForTesting.itemIdentifiers(inSection: .request).first(where: {
+            if case .requestCookie = $0 {
+                return true
+            }
+            return false
+        }) else {
+            return nil
+        }
+        return cookies.cookieContentForTesting(itemID)
     }
 
     private func selectMode(


### PR DESCRIPTION
## Purpose

Add a per-request Cookies pane backed by captured Network headers, including refined request headers reported at load completion.

Depends on #241  
Closes #237

## Changes

- Decode `Metrics.requestHeaders` and replace DataKit's best-known request-header snapshot without changing existing initializer identity.
- Parse request and response cookies outside UIKit while preserving raw fragments, unknown attributes, duplicates, invalid values, and case-variant header ambiguity.
- Treat potentially combined `Set-Cookie` values as raw ambiguous data instead of guessing field boundaries around commas.
- Model request/response loading, unavailable, empty, partial, and unparsed states as computed DataKit projections with no cookie cache.
- Add a native inset-grouped Cookies pane for the active request, with adaptive one/two-column fields, stable diffable identity, Dynamic Type, RTL, and accessibility support.
- Render the representative request in entry scope and the exact picker-selected member in request scope.
- Add English and Japanese UI strings for the new pane and states.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` (759 tests passed; 807 invocations)
- Network detail rendering tests on iOS 26.5 (107/107 passed)
- Parser + Detail post-fix tests (126/126 passed)
- Parent container tests (48/48 passed)
- `swift test --package-path ContractTests` (8/8 passed)
- `Scripts/check-datakit-symbol-boundary.sh`
- `xcrun xcstringstool compile` for the complete localization catalog
- DocC generation for WebInspectorProxyKit, WebInspectorDataKit, and WebInspectorUI
- `git diff --check`
- `codex-review` (no findings)

## Screenshots

Not included because the deterministic inspector fixture does not currently emit Cookie / Set-Cookie traffic. The compact, regular, Accessibility Dynamic Type, RTL, and VoiceOver content paths are covered by UIKit rendering tests.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
