### PR TITLE
Add live WebSocket timeline to Network Preview

### DIFF
--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -137,18 +137,62 @@ public struct RedirectHop: Equatable, Sendable {
     }
 }
 
+package struct WebSocketTimelineHandshakeResponse: Equatable, Sendable {
+    package enum Disposition: Equatable, Sendable {
+        case switchingProtocols(statusText: String?)
+        case rejected(statusCode: Int, statusText: String?)
+        case unreported(statusText: String?)
+    }
+
+    package let statusCode: Int?
+    package let statusText: String?
+
+    package var disposition: Disposition {
+        switch statusCode {
+        case 101?:
+            .switchingProtocols(statusText: statusText)
+        case let statusCode?:
+            .rejected(statusCode: statusCode, statusText: statusText)
+        case nil:
+            .unreported(statusText: statusText)
+        }
+    }
+
+    package init(statusCode: Int?, statusText: String?) {
+        self.statusCode = statusCode
+        self.statusText = statusText
+    }
+}
+
 package struct WebSocketTimelineEntry: Identifiable, Equatable, Sendable {
-    package struct ID: Hashable, Sendable {
+    package struct ID: Comparable, Hashable, Sendable {
         package let lifecycleRevision: UInt64
         package let chronologySequence: UInt64
+        package let ordinalWithinEvent: UInt8
 
-        package init(lifecycleRevision: UInt64, chronologySequence: UInt64) {
+        package init(
+            lifecycleRevision: UInt64,
+            chronologySequence: UInt64,
+            ordinalWithinEvent: UInt8 = 0
+        ) {
             self.lifecycleRevision = lifecycleRevision
             self.chronologySequence = chronologySequence
+            self.ordinalWithinEvent = ordinalWithinEvent
+        }
+
+        package static func < (lhs: ID, rhs: ID) -> Bool {
+            if lhs.lifecycleRevision != rhs.lifecycleRevision {
+                return lhs.lifecycleRevision < rhs.lifecycleRevision
+            }
+            if lhs.chronologySequence != rhs.chronologySequence {
+                return lhs.chronologySequence < rhs.chronologySequence
+            }
+            return lhs.ordinalWithinEvent < rhs.ordinalWithinEvent
         }
     }
 
     package enum Kind: Equatable, Sendable {
+        case handshakeResponse(WebSocketTimelineHandshakeResponse)
         case connectionEstablished
         case frame(WebSocketTimelineFrame)
         case error(String)
@@ -213,13 +257,13 @@ package struct WebSocketTimelineFrame: Equatable, Sendable {
 public final class WebSocketState {
     /// WebSocket ready state tracked from network events.
     public enum ReadyState: Equatable, Sendable {
-        /// The WebSocket is connecting.
+        /// No frame has confirmed that the WebSocket connection opened.
         case connecting
 
-        /// The WebSocket handshake completed.
+        /// A WebSocket frame confirmed that the connection opened.
         case open
 
-        /// The WebSocket is closed.
+        /// A WebSocket error or close event was observed.
         case closed
     }
 
@@ -291,7 +335,7 @@ public final class WebSocketState {
     public var frames: [Frame] {
         timelineEntries.compactMap { entry in
             switch entry.kind {
-            case .connectionEstablished, .connectionClosed:
+            case .handshakeResponse, .connectionEstablished, .connectionClosed:
                 return nil
             case let .frame(frame):
                 guard let timestamp = entry.timestamp else {
@@ -352,10 +396,14 @@ public final class WebSocketState {
             return false
         }
         handshakeResponse = NetworkResponseSnapshot(response)
-        readyState = .open
+        // Do not infer an open connection here. WebKit reports this response
+        // before some invalid-101 failure paths and exposes no didConnect event.
         appendTimelineEntry(
             timestamp: timestamp,
-            kind: .connectionEstablished,
+            kind: .handshakeResponse(WebSocketTimelineHandshakeResponse(
+                statusCode: response.status,
+                statusText: response.statusText
+            )),
             lifecycleRevision: lifecycleRevision,
             chronologySequence: chronologySequence
         )
@@ -369,7 +417,25 @@ public final class WebSocketState {
         lifecycleRevision: UInt64,
         chronologySequence: UInt64
     ) {
-        appendTimelineEntry(
+        var entries: [WebSocketTimelineEntry] = []
+        if readyState == .connecting {
+            readyState = .open
+            let switchingProtocolsResponse = timelineEntries.last { entry in
+                guard case let .handshakeResponse(response) = entry.kind,
+                      case .switchingProtocols = response.disposition else {
+                    return false
+                }
+                return true
+            }
+            entries.append(makeTimelineEntry(
+                timestamp: switchingProtocolsResponse?.timestamp ?? timestamp,
+                kind: .connectionEstablished,
+                lifecycleRevision: lifecycleRevision,
+                chronologySequence: chronologySequence,
+                ordinalWithinEvent: 0
+            ))
+        }
+        entries.append(makeTimelineEntry(
             timestamp: timestamp,
             kind: .frame(WebSocketTimelineFrame(
                 direction: direction,
@@ -381,8 +447,10 @@ public final class WebSocketState {
                 isMasked: frame.mask
             )),
             lifecycleRevision: lifecycleRevision,
-            chronologySequence: chronologySequence
-        )
+            chronologySequence: chronologySequence,
+            ordinalWithinEvent: 1
+        ))
+        appendTimelineEntries(entries)
     }
 
     func appendError(
@@ -391,6 +459,7 @@ public final class WebSocketState {
         lifecycleRevision: UInt64,
         chronologySequence: UInt64
     ) {
+        readyState = .closed
         appendTimelineEntry(
             timestamp: timestamp,
             kind: .error(message),
@@ -405,7 +474,12 @@ public final class WebSocketState {
         lifecycleRevision: UInt64,
         chronologySequence: UInt64
     ) -> Bool {
-        guard readyState != .closed else {
+        guard timelineEntries.contains(where: { entry in
+            if case .connectionClosed = entry.kind {
+                return true
+            }
+            return false
+        }) == false else {
             return false
         }
         readyState = .closed
@@ -426,23 +500,65 @@ public final class WebSocketState {
         timestamp: Double?,
         kind: WebSocketTimelineEntry.Kind,
         lifecycleRevision: UInt64,
-        chronologySequence: UInt64
+        chronologySequence: UInt64,
+        ordinalWithinEvent: UInt8 = 0
     ) {
-        let id = WebSocketTimelineEntry.ID(
+        appendTimelineEntries([makeTimelineEntry(
+            timestamp: timestamp,
+            kind: kind,
             lifecycleRevision: lifecycleRevision,
-            chronologySequence: chronologySequence
+            chronologySequence: chronologySequence,
+            ordinalWithinEvent: ordinalWithinEvent
+        )])
+    }
+
+    private func makeTimelineEntry(
+        timestamp: Double?,
+        kind: WebSocketTimelineEntry.Kind,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64,
+        ordinalWithinEvent: UInt8
+    ) -> WebSocketTimelineEntry {
+        WebSocketTimelineEntry(
+            id: WebSocketTimelineEntry.ID(
+                lifecycleRevision: lifecycleRevision,
+                chronologySequence: chronologySequence,
+                ordinalWithinEvent: ordinalWithinEvent
+            ),
+            timestamp: timestamp,
+            kind: kind
         )
-        if let lastID = timelineEntries.last?.id {
-            precondition(
-                lastID.lifecycleRevision == lifecycleRevision,
-                "A WebSocketState cannot span multiple request lifecycle revisions."
-            )
-            precondition(
-                lastID.chronologySequence < chronologySequence,
-                "WebSocket timeline entries must follow owner-issued chronology order."
-            )
+    }
+
+    private func appendTimelineEntries(_ entries: [WebSocketTimelineEntry]) {
+        guard let firstEntry = entries.first else {
+            return
         }
-        timelineEntries.append(WebSocketTimelineEntry(id: id, timestamp: timestamp, kind: kind))
+        let lifecycleRevision = firstEntry.id.lifecycleRevision
+        let existingRevisionMatches = timelineEntries.last.map {
+            $0.id.lifecycleRevision == lifecycleRevision
+        } ?? true
+        precondition(
+            entries.allSatisfy { $0.id.lifecycleRevision == lifecycleRevision }
+                && existingRevisionMatches,
+            "A WebSocketState cannot span multiple request lifecycle revisions."
+        )
+        var lastID = timelineEntries.last?.id
+        for entry in entries {
+            let id = entry.id
+            if let lastID {
+                precondition(
+                    lastID < id,
+                    "WebSocket timeline entries must follow owner-issued chronology order."
+                )
+            }
+            lastID = id
+        }
+        precondition(
+            timelineEntries.count <= Int.max - entries.count,
+            "WebSocket timeline entry count overflowed."
+        )
+        timelineEntries.append(contentsOf: entries)
     }
 }
 

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -510,7 +510,21 @@ public final class WebSocketState {
     }
 
     package func timelineEntry(for id: WebSocketTimelineEntry.ID) -> WebSocketTimelineEntry? {
-        timelineEntries.first { $0.id == id }
+        var lowerBound = 0
+        var upperBound = timelineEntries.count
+        while lowerBound < upperBound {
+            let index = lowerBound + (upperBound - lowerBound) / 2
+            if timelineEntries[index].id < id {
+                lowerBound = index + 1
+            } else {
+                upperBound = index
+            }
+        }
+        guard lowerBound < timelineEntries.count,
+              timelineEntries[lowerBound].id == id else {
+            return nil
+        }
+        return timelineEntries[lowerBound]
     }
 
     private func appendTimelineEntry(
@@ -1834,7 +1848,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     }
 
     func applyWebSocketCreated(url: String, chronologySequence: UInt64) {
-        guard isActive else {
+        guard isActive, webSocket?.readyState != .closed else {
             resetLifecycle(
                 request: Network.Request(
                     id: currentRequest.id,

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -137,6 +137,77 @@ public struct RedirectHop: Equatable, Sendable {
     }
 }
 
+package struct WebSocketTimelineEntry: Identifiable, Equatable, Sendable {
+    package struct ID: Hashable, Sendable {
+        package let lifecycleRevision: UInt64
+        package let chronologySequence: UInt64
+
+        package init(lifecycleRevision: UInt64, chronologySequence: UInt64) {
+            self.lifecycleRevision = lifecycleRevision
+            self.chronologySequence = chronologySequence
+        }
+    }
+
+    package enum Kind: Equatable, Sendable {
+        case connectionEstablished
+        case frame(WebSocketTimelineFrame)
+        case error(String)
+        case connectionClosed
+    }
+
+    package let id: ID
+    package let timestamp: Double?
+    package let kind: Kind
+
+    package init(id: ID, timestamp: Double?, kind: Kind) {
+        self.id = id
+        self.timestamp = timestamp
+        self.kind = kind
+    }
+}
+
+package struct WebSocketTimelineFrame: Equatable, Sendable {
+    package enum Direction: Equatable, Sendable {
+        case sent
+        case received
+    }
+
+    package enum Kind: Equatable, Sendable {
+        case continuation
+        case text
+        case binary
+        case close
+        case ping
+        case pong
+        case unknown(Int)
+    }
+
+    package enum Payload: Equatable, Sendable {
+        case text(String)
+        case base64Encoded(String)
+    }
+
+    package let direction: Direction
+    package let kind: Kind
+    package let payload: Payload
+    package let payloadLength: Int
+    package let isMasked: Bool
+
+    package init(
+        direction: Direction,
+        kind: Kind,
+        payload: Payload,
+        payloadLength: Int,
+        isMasked: Bool
+    ) {
+        self.direction = direction
+        self.kind = kind
+        self.payload = payload
+        self.payloadLength = payloadLength
+        self.isMasked = isMasked
+    }
+}
+
 /// Observable WebSocket state attached to a network request.
 @Observable
 public final class WebSocketState {
@@ -217,58 +288,201 @@ public final class WebSocketState {
     public private(set) var handshakeResponse: NetworkResponseSnapshot?
 
     /// Frames and errors observed for the WebSocket.
-    public private(set) var frames: [Frame]
+    public var frames: [Frame] {
+        timelineEntries.compactMap { entry in
+            switch entry.kind {
+            case .connectionEstablished, .connectionClosed:
+                return nil
+            case let .frame(frame):
+                guard let timestamp = entry.timestamp else {
+                    preconditionFailure("A WebSocket frame timeline entry must have a timestamp.")
+                }
+                let payloadData: String
+                switch frame.payload {
+                case let .text(text), let .base64Encoded(text):
+                    payloadData = text
+                }
+                return Frame(
+                    direction: frame.direction == .sent ? .sent : .received,
+                    opcode: frame.kind.opcode,
+                    mask: frame.isMasked,
+                    payloadData: payloadData,
+                    payloadLength: frame.payloadLength,
+                    timestamp: timestamp
+                )
+            case let .error(message):
+                guard let timestamp = entry.timestamp else {
+                    preconditionFailure("A WebSocket error timeline entry must have a timestamp.")
+                }
+                return Frame(
+                    direction: .error(message),
+                    errorMessage: message,
+                    timestamp: timestamp
+                )
+            }
+        }
+    }
+
+    package private(set) var timelineEntries: [WebSocketTimelineEntry]
 
     init(readyState: ReadyState = .connecting) {
         self.readyState = readyState
         handshakeRequest = nil
         handshakeResponse = nil
-        frames = []
+        timelineEntries = []
     }
 
-    func markConnecting() {
-        readyState = .connecting
-    }
-
-    func markOpen() {
-        readyState = .open
-    }
-
-    func markClosed() {
-        readyState = .closed
-    }
-
-    func applyHandshakeRequest(_ request: Network.Request) {
+    @discardableResult
+    func applyHandshakeRequest(_ request: Network.Request) -> Bool {
+        guard readyState == .connecting, handshakeRequest == nil else {
+            return false
+        }
         handshakeRequest = NetworkRequestSnapshot(request)
-        readyState = .connecting
+        return true
     }
 
-    func applyHandshakeResponse(_ response: Network.Response) {
+    @discardableResult
+    func applyHandshakeResponse(
+        _ response: Network.Response,
+        timestamp: Double?,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64
+    ) -> Bool {
+        guard readyState != .closed, handshakeResponse == nil else {
+            return false
+        }
         handshakeResponse = NetworkResponseSnapshot(response)
         readyState = .open
+        appendTimelineEntry(
+            timestamp: timestamp,
+            kind: .connectionEstablished,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
+        return true
     }
 
     func appendFrame(
         _ frame: Network.WebSocketFrame,
-        direction: FrameDirection,
-        timestamp: Double
+        direction: WebSocketTimelineFrame.Direction,
+        timestamp: Double,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64
     ) {
-        frames.append(Frame(
-            direction: direction,
-            opcode: frame.opcode,
-            mask: frame.mask,
-            payloadData: frame.payloadData,
-            payloadLength: frame.payloadLength,
-            timestamp: timestamp
-        ))
+        appendTimelineEntry(
+            timestamp: timestamp,
+            kind: .frame(WebSocketTimelineFrame(
+                direction: direction,
+                kind: WebSocketTimelineFrame.Kind(opcode: frame.opcode),
+                payload: frame.opcode == 1
+                    ? .text(frame.payloadData)
+                    : .base64Encoded(frame.payloadData),
+                payloadLength: frame.payloadLength,
+                isMasked: frame.mask
+            )),
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
     }
 
-    func appendError(_ message: String, timestamp: Double) {
-        frames.append(Frame(
-            direction: .error(message),
-            errorMessage: message,
-            timestamp: timestamp
-        ))
+    func appendError(
+        _ message: String,
+        timestamp: Double,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64
+    ) {
+        appendTimelineEntry(
+            timestamp: timestamp,
+            kind: .error(message),
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
+    }
+
+    @discardableResult
+    func close(
+        timestamp: Double,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64
+    ) -> Bool {
+        guard readyState != .closed else {
+            return false
+        }
+        readyState = .closed
+        appendTimelineEntry(
+            timestamp: timestamp,
+            kind: .connectionClosed,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
+        return true
+    }
+
+    package func timelineEntry(for id: WebSocketTimelineEntry.ID) -> WebSocketTimelineEntry? {
+        timelineEntries.first { $0.id == id }
+    }
+
+    private func appendTimelineEntry(
+        timestamp: Double?,
+        kind: WebSocketTimelineEntry.Kind,
+        lifecycleRevision: UInt64,
+        chronologySequence: UInt64
+    ) {
+        let id = WebSocketTimelineEntry.ID(
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
+        if let lastID = timelineEntries.last?.id {
+            precondition(
+                lastID.lifecycleRevision == lifecycleRevision,
+                "A WebSocketState cannot span multiple request lifecycle revisions."
+            )
+            precondition(
+                lastID.chronologySequence < chronologySequence,
+                "WebSocket timeline entries must follow owner-issued chronology order."
+            )
+        }
+        timelineEntries.append(WebSocketTimelineEntry(id: id, timestamp: timestamp, kind: kind))
+    }
+}
+
+private extension WebSocketTimelineFrame.Kind {
+    init(opcode: Int) {
+        switch opcode {
+        case 0:
+            self = .continuation
+        case 1:
+            self = .text
+        case 2:
+            self = .binary
+        case 8:
+            self = .close
+        case 9:
+            self = .ping
+        case 10:
+            self = .pong
+        default:
+            self = .unknown(opcode)
+        }
+    }
+
+    var opcode: Int {
+        switch self {
+        case .continuation:
+            0
+        case .text:
+            1
+        case .binary:
+            2
+        case .close:
+            8
+        case .ping:
+            9
+        case .pong:
+            10
+        case let .unknown(opcode):
+            opcode
+        }
     }
 }
 
@@ -1055,7 +1269,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
 
     /// A Boolean value indicating whether the response body can be fetched now.
     public var canFetchResponseBody: Bool {
-        guard state == .finished else {
+        guard state == .finished, hasResponseBody else {
             return false
         }
         return responseBody.needsFetch
@@ -1161,12 +1375,10 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     /// Concurrent callers join one protocol command. Cancelling a caller ends
     /// only that caller's wait and does not cancel the shared response fetch.
     public func fetchResponseBody(isolation: isolated (any Actor) = #isolation) async {
-        let body = responseBody
-        if case .available = body.phase {
-            guard state == .finished else {
-                return
-            }
+        guard state == .finished, hasResponseBody else {
+            return
         }
+        let body = responseBody
 
         let lease: NetworkBody.ResponseFetchLease
         switch body.acquireResponseFetch() {
@@ -1220,6 +1432,26 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         timestamp: Double,
         chronologySequence: UInt64
     ) {
+        resetLifecycle(
+            request: request,
+            initiator: initiator,
+            navigationVisit: navigationVisit,
+            resourceType: resourceType,
+            timestamp: timestamp,
+            chronologySequence: chronologySequence,
+            requestHeaderSource: .requestWillBeSent
+        )
+    }
+
+    private func resetLifecycle(
+        request: Network.Request,
+        initiator: Network.Initiator?,
+        navigationVisit: NetworkNavigationVisit?,
+        resourceType: Network.ResourceType?,
+        timestamp: Double?,
+        chronologySequence: UInt64,
+        requestHeaderSource: NetworkRequestHeaderSource
+    ) {
         precondition(lifecycleRevision < UInt64.max, "Network request lifecycle revision overflowed.")
         lifecycleRevision += 1
         currentRequest = request
@@ -1233,7 +1465,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         requestBody = NetworkBody.makeRequestBody(for: request)
         updateRequestHeaders(
             request.headers,
-            source: .requestWillBeSent,
+            source: requestHeaderSource,
             resetsPrecedence: true
         )
         status = nil
@@ -1409,7 +1641,23 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         state = .finished
     }
 
-    func applyWebSocketCreated(url: String) {
+    func applyWebSocketCreated(url: String, chronologySequence: UInt64) {
+        guard isActive else {
+            resetLifecycle(
+                request: Network.Request(
+                    id: currentRequest.id,
+                    url: url,
+                    method: "GET"
+                ),
+                initiator: nil,
+                navigationVisit: nil,
+                resourceType: .webSocket,
+                timestamp: nil,
+                chronologySequence: chronologySequence,
+                requestHeaderSource: .unavailable
+            )
+            return
+        }
         self.url = url
         currentRequest = requestWithURL(url)
         resourceType = .webSocket
@@ -1417,13 +1665,17 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         _ = ensureWebSocketState()
     }
 
+    @discardableResult
     func applyWebSocketHandshakeRequest(
         _ request: Network.Request,
         timestamp: Double?,
         chronologySequence: UInt64
-    ) {
-        recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
+    ) -> Bool {
         let request = requestPreservingCurrentURLIfNeeded(request)
+        guard ensureWebSocketState().applyHandshakeRequest(request) else {
+            return false
+        }
+        recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
         currentRequest = request
         url = request.url
         method = request.method
@@ -1445,29 +1697,44 @@ public final class NetworkRequest: WebInspectorFetchableModel {
             requestSentTimestamp = timestamp
         }
         state = .pending
-        ensureWebSocketState().applyHandshakeRequest(request)
+        return true
     }
 
+    @discardableResult
     func applyWebSocketHandshakeResponse(
         _ response: Network.Response,
         timestamp: Double?,
         chronologySequence: UInt64
-    ) {
+    ) -> Bool {
+        guard ensureWebSocketState().applyHandshakeResponse(
+            response,
+            timestamp: timestamp,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        ) else {
+            return false
+        }
         recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
         applyResponse(response, resourceType: .webSocket, timestamp: timestamp)
-        ensureWebSocketState().applyHandshakeResponse(response)
+        return true
     }
 
     func appendWebSocketFrame(
         _ frame: Network.WebSocketFrame,
-        direction: WebSocketState.FrameDirection,
+        direction: WebSocketTimelineFrame.Direction,
         timestamp: Double,
         chronologySequence: UInt64
     ) {
         recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
         decodedDataLength += max(0, frame.payloadLength)
         lastDataReceivedTimestamp = timestamp
-        ensureWebSocketState().appendFrame(frame, direction: direction, timestamp: timestamp)
+        ensureWebSocketState().appendFrame(
+            frame,
+            direction: direction,
+            timestamp: timestamp,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
     }
 
     func appendWebSocketError(
@@ -1477,14 +1744,27 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     ) {
         recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
         lastDataReceivedTimestamp = timestamp
-        ensureWebSocketState().appendError(message, timestamp: timestamp)
+        ensureWebSocketState().appendError(
+            message,
+            timestamp: timestamp,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        )
     }
 
-    func closeWebSocket(timestamp: Double, chronologySequence: UInt64) {
+    @discardableResult
+    func closeWebSocket(timestamp: Double, chronologySequence: UInt64) -> Bool {
+        guard ensureWebSocketState().close(
+            timestamp: timestamp,
+            lifecycleRevision: lifecycleRevision,
+            chronologySequence: chronologySequence
+        ) else {
+            return false
+        }
         recordWebSocketLogicalStartIfNeeded(timestamp, chronologySequence: chronologySequence)
-        ensureWebSocketState().markClosed()
         finishedOrFailedTimestamp = timestamp
         state = .finished
+        return true
     }
 
     private func recordWebSocketLogicalStartIfNeeded(

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -417,8 +417,11 @@ public final class WebSocketState {
         lifecycleRevision: UInt64,
         chronologySequence: UInt64
     ) {
+        let frameKind = WebSocketTimelineFrame.Kind(opcode: frame.opcode)
         var entries: [WebSocketTimelineEntry] = []
-        if readyState == .connecting {
+        // WebCore can synthesize a close frame when a handshake fails, so only
+        // a non-close frame is definitive evidence that the connection opened.
+        if readyState == .connecting, frameKind != .close {
             readyState = .open
             let switchingProtocolsResponse = timelineEntries.last { entry in
                 guard case let .handshakeResponse(response) = entry.kind,
@@ -439,7 +442,7 @@ public final class WebSocketState {
             timestamp: timestamp,
             kind: .frame(WebSocketTimelineFrame(
                 direction: direction,
-                kind: WebSocketTimelineFrame.Kind(opcode: frame.opcode),
+                kind: frameKind,
                 payload: frame.opcode == 1
                     ? .text(frame.payloadData)
                     : .base64Encoded(frame.payloadData),

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -376,40 +376,9 @@ public final class WebSocketState {
     public private(set) var handshakeResponse: NetworkResponseSnapshot?
 
     /// Frames and errors observed for the WebSocket.
-    public var frames: [Frame] {
-        timelineEntries.compactMap { entry in
-            switch entry.kind {
-            case .handshakeResponse, .connectionEstablished, .connectionClosed:
-                return nil
-            case let .frame(frame):
-                guard let timestamp = entry.timestamp else {
-                    preconditionFailure("A WebSocket frame timeline entry must have a timestamp.")
-                }
-                let payloadData: String
-                switch frame.payload {
-                case let .text(text), let .base64Encoded(text):
-                    payloadData = text
-                }
-                return Frame(
-                    direction: frame.direction == .sent ? .sent : .received,
-                    opcode: frame.kind.opcode,
-                    mask: frame.isMasked,
-                    payloadData: payloadData,
-                    payloadLength: frame.payloadLength,
-                    timestamp: timestamp
-                )
-            case let .error(message):
-                guard let timestamp = entry.timestamp else {
-                    preconditionFailure("A WebSocket error timeline entry must have a timestamp.")
-                }
-                return Frame(
-                    direction: .error(message),
-                    errorMessage: message,
-                    timestamp: timestamp
-                )
-            }
-        }
-    }
+    ///
+    /// This compatibility projection preserves arrival order while omitting lifecycle entries.
+    public private(set) var frames: [Frame]
 
     package private(set) var timelineEntries: [WebSocketTimelineEntry]
 
@@ -417,6 +386,7 @@ public final class WebSocketState {
         self.readyState = readyState
         handshakeRequest = nil
         handshakeResponse = nil
+        frames = []
         timelineEntries = []
     }
 
@@ -581,6 +551,9 @@ public final class WebSocketState {
         guard let firstEntry = entries.first else {
             return
         }
+        let compatibilityFrames = entries.compactMap { entry in
+            Self.compatibilityFrame(for: entry)
+        }
         let lifecycleRevision = firstEntry.id.lifecycleRevision
         let existingRevisionMatches = timelineEntries.last.map {
             $0.id.lifecycleRevision == lifecycleRevision
@@ -605,7 +578,47 @@ public final class WebSocketState {
             timelineEntries.count <= Int.max - entries.count,
             "WebSocket timeline entry count overflowed."
         )
+        precondition(
+            frames.count <= Int.max - compatibilityFrames.count,
+            "WebSocket frame count overflowed."
+        )
         timelineEntries.append(contentsOf: entries)
+        if compatibilityFrames.isEmpty == false {
+            frames.append(contentsOf: compatibilityFrames)
+        }
+    }
+
+    private static func compatibilityFrame(for entry: WebSocketTimelineEntry) -> Frame? {
+        switch entry.kind {
+        case .handshakeResponse, .connectionEstablished, .connectionClosed:
+            return nil
+        case let .frame(frame):
+            guard let timestamp = entry.timestamp else {
+                preconditionFailure("A WebSocket frame timeline entry must have a timestamp.")
+            }
+            let payloadData: String
+            switch frame.payload {
+            case let .text(text), let .base64Encoded(text):
+                payloadData = text
+            }
+            return Frame(
+                direction: frame.direction == .sent ? .sent : .received,
+                opcode: frame.kind.opcode,
+                mask: frame.isMasked,
+                payloadData: payloadData,
+                payloadLength: frame.payloadLength,
+                timestamp: timestamp
+            )
+        case let .error(message):
+            guard let timestamp = entry.timestamp else {
+                preconditionFailure("A WebSocket error timeline entry must have a timestamp.")
+            }
+            return Frame(
+                direction: .error(message),
+                errorMessage: message,
+                timestamp: timestamp
+            )
+        }
     }
 }
 

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -1054,6 +1054,10 @@ public final class WebInspectorContext {
         eventPumpAppliedSequenceForTestingStorage
     }
 
+    package var networkRequestIndexSequenceForTesting: UInt64 {
+        networkRequestIndexSequence
+    }
+
     package var orderedEventSubscriptionStateForTesting: (generation: UInt64, sequence: UInt64) {
         (orderedEventSubscriptionGeneration, lastOrderedEventSequence)
     }
@@ -6280,21 +6284,25 @@ extension WebInspectorContext {
             guard let networkRequest = networkRequest(for: id, method: "webSocketWillSendHandshakeRequest") else {
                 return
             }
-            networkRequest.applyWebSocketHandshakeRequest(
+            guard networkRequest.applyWebSocketHandshakeRequest(
                 request,
                 timestamp: timestamp,
                 chronologySequence: chronologySequence
-            )
+            ) else {
+                return
+            }
             await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .handshakeResponse(id, response, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketHandshakeResponseReceived") else {
                 return
             }
-            networkRequest.applyWebSocketHandshakeResponse(
+            guard networkRequest.applyWebSocketHandshakeResponse(
                 response,
                 timestamp: timestamp,
                 chronologySequence: chronologySequence
-            )
+            ) else {
+                return
+            }
             await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case let .frameSent(id, frame, timestamp):
             guard let networkRequest = networkRequest(for: id, method: "webSocketFrameSent") else {
@@ -6332,10 +6340,12 @@ extension WebInspectorContext {
             guard let networkRequest = networkRequest(for: id, method: "webSocketClosed") else {
                 return
             }
-            networkRequest.closeWebSocket(
+            guard networkRequest.closeWebSocket(
                 timestamp: timestamp,
                 chronologySequence: chronologySequence
-            )
+            ) else {
+                return
+            }
             await notifyNetworkRequestMutated(networkRequest, isolation: isolation)
         case .other:
             break
@@ -6370,7 +6380,7 @@ extension WebInspectorContext {
             appendNetworkRequestID(id)
             inserted = true
         }
-        request.applyWebSocketCreated(url: url)
+        request.applyWebSocketCreated(url: url, chronologySequence: chronologySequence)
         if inserted {
             await notifyNetworkRequestInserted(request, isolation: isolation)
         } else {

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -5931,6 +5931,244 @@
         }
       }
     },
+    "network.websocket.connection.closed" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WebSocket Connection Closed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WebSocket接続を終了"
+          }
+        }
+      }
+    },
+    "network.websocket.connection.established" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WebSocket Connection Established"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WebSocket接続を確立"
+          }
+        }
+      }
+    },
+    "network.websocket.direction.received" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Received"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受信"
+          }
+        }
+      }
+    },
+    "network.websocket.direction.sent" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "送信"
+          }
+        }
+      }
+    },
+    "network.websocket.error" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.binary" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Binary Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バイナリフレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.close" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Close Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続終了フレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.continuation" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continuation Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "継続フレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.ping" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ping Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pingフレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.pong" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pong Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pongフレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Text Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストフレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.frame.unknown" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Frame"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明なフレーム"
+          }
+        }
+      }
+    },
+    "network.websocket.opcode" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Opcode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オペコード"
+          }
+        }
+      }
+    },
+    "network.websocket.time.not_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time not reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時刻は未報告"
+          }
+        }
+      }
+    },
     "redo" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -6135,6 +6135,40 @@
         }
       }
     },
+    "network.websocket.handshake.rejected" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WebSocket Handshake Rejected"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WebSocketハンドシェイクを拒否"
+          }
+        }
+      }
+    },
+    "network.websocket.handshake.response" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WebSocket Handshake Response"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WebSocketハンドシェイク応答"
+          }
+        }
+      }
+    },
     "network.websocket.opcode" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -6148,6 +6182,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "オペコード"
+          }
+        }
+      }
+    },
+    "network.websocket.status.not_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status not reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータスは未報告"
           }
         }
       }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -84,6 +84,7 @@ package final class NetworkDetailViewController: UIViewController {
     private var isBodyRenderingActive = false
     private lazy var bodyViewController = makeBodyViewController(scrollEdgeController)
     private lazy var cookiesViewController = NetworkCookiesViewController()
+    private let webSocketPreviewViewController: NetworkWebSocketPreviewViewController
     private lazy var modeControlController: NetworkDetailModeControlController = {
         let controller = NetworkDetailModeControlController(initialMode: mode)
         controller.selectionHandler = { [weak self] mode in
@@ -124,6 +125,7 @@ package final class NetworkDetailViewController: UIViewController {
 #if DEBUG
     private var modelObservationDelivery: PortableObservationTracking.Token?
     private var selectedRequestRenderObservationDelivery: PortableObservationTracking.Token?
+    private var selectedRequestRenderCountStorageForTesting = 0
 #endif
     private lazy var headersTextView: NetworkHeadersTextView = {
         let view = NetworkHeadersTextView()
@@ -137,12 +139,16 @@ package final class NetworkDetailViewController: UIViewController {
     package init(
         model: NetworkPanelModel,
         initialMode: NetworkDetailViewController.Mode = .headers,
+        webSocketFrameScheduler: any NetworkFrameScheduling = NetworkDisplayLinkFrameScheduler(),
         makeBodyViewController: @escaping NetworkBodyViewControllerFactory = { scrollEdgeSink in
             UnavailableNetworkBodyPreviewViewController(scrollEdgeSink: scrollEdgeSink)
         }
     ) {
         self.model = model
         self.makeBodyViewController = makeBodyViewController
+        webSocketPreviewViewController = NetworkWebSocketPreviewViewController(
+            frameScheduler: webSocketFrameScheduler
+        )
         mode = initialMode
         super.init(nibName: nil, bundle: nil)
     }
@@ -160,13 +166,13 @@ package final class NetworkDetailViewController: UIViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
+        installContentViews()
         applyBackgroundFromTraits()
         if #available(iOS 26.0, *) {
             webInspectorRegisterForBackgroundTraitChanges { viewController in
                 viewController.applyBackgroundFromTraits()
             }
         }
-        installContentViews()
         installModeTitleView()
         scrollEdgeController.install(previewRoleControlContainerView: previewRoleControlController.containerView)
     }
@@ -256,6 +262,7 @@ package final class NetworkDetailViewController: UIViewController {
         selectedRequestRenderObservation = nil
         unbindResponseBodyFetchObservation()
         setBodyRenderingActive(false)
+        webSocketPreviewViewController.suspendKeepingSnapshot()
 #if DEBUG
         modelObservationDelivery = nil
         selectedRequestRenderObservationDelivery = nil
@@ -284,23 +291,30 @@ package final class NetworkDetailViewController: UIViewController {
         bodyViewController.view.backgroundColor = backgroundColor
         headersTextView.backgroundColor = backgroundColor
         cookiesViewController.view.backgroundColor = backgroundColor
+        webSocketPreviewViewController.view.backgroundColor = backgroundColor
+        webSocketPreviewViewController.collectionView.backgroundColor = backgroundColor
     }
 
     private func installContentViews() {
         addChild(bodyViewController)
         addChild(cookiesViewController)
+        addChild(webSocketPreviewViewController)
         view.addSubview(bodyViewController.view)
         view.addSubview(previewRoleControlController.containerView)
         view.addSubview(headersTextView)
         view.addSubview(cookiesViewController.view)
+        view.addSubview(webSocketPreviewViewController.view)
         bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
         bodyViewController.view.isHidden = true
         bodyViewController.view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
         cookiesViewController.view.translatesAutoresizingMaskIntoConstraints = false
         cookiesViewController.view.isHidden = true
+        webSocketPreviewViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        webSocketPreviewViewController.view.isHidden = true
         previewRoleControlController.containerView.translatesAutoresizingMaskIntoConstraints = false
         bodyViewController.didMove(toParent: self)
         cookiesViewController.didMove(toParent: self)
+        webSocketPreviewViewController.didMove(toParent: self)
 
         let bodyTopToPreviewContainerConstraint = bodyViewController.view.topAnchor.constraint(
             equalTo: view.topAnchor
@@ -333,6 +347,14 @@ package final class NetworkDetailViewController: UIViewController {
             cookiesViewController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             cookiesViewController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             cookiesViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webSocketPreviewViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            webSocketPreviewViewController.view.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor
+            ),
+            webSocketPreviewViewController.view.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor
+            ),
+            webSocketPreviewViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
 
@@ -453,6 +475,9 @@ package final class NetworkDetailViewController: UIViewController {
                   requestInstancesMatch(observedRequests, requests) else {
                 return
             }
+#if DEBUG
+            selectedRequestRenderCountStorageForTesting += 1
+#endif
             renderSelection(selection, requests: observedRequests)
         }
         selectedRequestRenderObservation = token
@@ -470,6 +495,12 @@ package final class NetworkDetailViewController: UIViewController {
         }
         switch mode {
         case .preview:
+            let activeRequest = activeRequest(for: selection, requests: requests)
+            let activeWebSocket = activeRequest.webSocket
+            if activeWebSocket != nil {
+                renderWebSocketPreviewSurface(request: activeRequest)
+                return
+            }
             let candidate: PreviewCandidate
             switch selection {
             case .entry:
@@ -497,21 +528,26 @@ package final class NetworkDetailViewController: UIViewController {
                 renderHeadersSurface(request: request)
             }
         case .cookies:
-            let request: NetworkRequest
-            switch selection {
-            case .entry:
-                guard let representativeRequest = requests.first else {
-                    preconditionFailure("A selected Network entry must contain at least one request.")
-                }
-                request = representativeRequest
-            case .request:
-                guard requests.count == 1,
-                      let selectedRequest = requests.first else {
-                    preconditionFailure("An explicit Network request selection must render exactly one request.")
-                }
-                request = selectedRequest
+            renderCookiesSurface(request: activeRequest(for: selection, requests: requests))
+        }
+    }
+
+    private func activeRequest(
+        for selection: NetworkPanelSelection,
+        requests: [NetworkRequest]
+    ) -> NetworkRequest {
+        switch selection {
+        case .entry:
+            guard let representativeRequest = requests.first else {
+                preconditionFailure("A selected Network entry must contain at least one request.")
             }
-            renderCookiesSurface(request: request)
+            return representativeRequest
+        case .request:
+            guard requests.count == 1,
+                  let selectedRequest = requests.first else {
+                preconditionFailure("An explicit Network request selection must render exactly one request.")
+            }
+            return selectedRequest
         }
     }
 
@@ -522,6 +558,13 @@ package final class NetworkDetailViewController: UIViewController {
         showPreview()
         renderPreview(candidate: candidate)
         updateBodyRenderingActiveForCurrentSurface()
+    }
+
+    private func renderWebSocketPreviewSurface(request: NetworkRequest) {
+        observedRequest = request
+        title = request.displayName
+        webSocketPreviewViewController.bind(to: request)
+        showWebSocketPreview()
     }
 
     private func renderHeadersSurface(entryRequests requests: [NetworkRequest]) {
@@ -660,6 +703,8 @@ package final class NetworkDetailViewController: UIViewController {
         headersTextView.clear()
         cookiesViewController.view.isHidden = true
         cookiesViewController.clear()
+        webSocketPreviewViewController.view.isHidden = true
+        webSocketPreviewViewController.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
         scrollEdgeController.contentScrollView = nil
 
@@ -674,12 +719,16 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showPreview() {
+        webSocketPreviewViewController.suspendKeepingSnapshot()
+        webSocketPreviewViewController.view.isHidden = true
         headersTextView.isHidden = true
         cookiesViewController.view.isHidden = true
         bodyViewController.view.isHidden = false
     }
 
     private func showHeaders() {
+        webSocketPreviewViewController.suspendKeepingSnapshot()
+        webSocketPreviewViewController.view.isHidden = true
         setBodyRenderingActive(false)
         bodyViewController.view.isHidden = true
         previewRoleControlController.containerView.isHidden = true
@@ -692,6 +741,8 @@ package final class NetworkDetailViewController: UIViewController {
     }
 
     private func showCookies() {
+        webSocketPreviewViewController.suspendKeepingSnapshot()
+        webSocketPreviewViewController.view.isHidden = true
         setBodyRenderingActive(false)
         bodyViewController.view.isHidden = true
         previewRoleControlController.containerView.isHidden = true
@@ -701,6 +752,20 @@ package final class NetworkDetailViewController: UIViewController {
         headersTextView.isHidden = true
         cookiesViewController.view.isHidden = false
         scrollEdgeController.contentScrollView = cookiesViewController.collectionView
+    }
+
+    private func showWebSocketPreview() {
+        setBodyRenderingActive(false)
+        bodyViewController.view.isHidden = true
+        bodyViewController.setSurface(.none)
+        unbindResponseBodyFetchObservation()
+        previewRoleControlController.containerView.isHidden = true
+        renderPreviewRoleControl(roles: [], selectedRole: nil)
+        headersTextView.isHidden = true
+        cookiesViewController.view.isHidden = true
+        webSocketPreviewViewController.view.isHidden = false
+        scrollEdgeController.contentScrollView = webSocketPreviewViewController.collectionView
+        webSocketPreviewViewController.resumeRendering()
     }
 
     private func renderPreview(candidate: PreviewCandidate) {
@@ -889,6 +954,9 @@ package final class NetworkDetailViewController: UIViewController {
         var latestStandard: PreviewCandidate?
         var latestUnavailableMedia: PreviewCandidate?
         for request in requests.reversed() {
+            guard request.webSocket == nil else {
+                continue
+            }
             guard let candidate = previewCandidate(for: request) else {
                 continue
             }
@@ -1098,6 +1166,10 @@ extension NetworkDetailViewController {
         cookiesViewController
     }
 
+    var webSocketPreviewViewControllerForTesting: NetworkWebSocketPreviewViewController {
+        webSocketPreviewViewController
+    }
+
     var bodyViewControllerForTesting: NetworkBodyPreviewViewController {
         bodyViewController
     }
@@ -1128,6 +1200,10 @@ extension NetworkDetailViewController {
 
     var selectedRequestRenderObservationDeliveryForTesting: PortableObservationTracking.Token? {
         selectedRequestRenderObservationDelivery
+    }
+
+    var selectedRequestRenderCountForTesting: Int {
+        selectedRequestRenderCountStorageForTesting
     }
 
     var responseBodyFetchObservationDeliveryForTesting: PortableObservationTracking.Token? {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -407,6 +407,8 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
                 accessibilityLabel: title,
                 accessibilityValue: time
             )
+        case let .handshakeResponse(response):
+            return handshakeResponseRowContent(response, time: time)
         case .error(let message):
             let error = localized("network.websocket.error", defaultValue: "Error")
             let subtitle = [error, time].joined(separator: " · ")
@@ -459,6 +461,67 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             accessibilityLabel: title,
             accessibilityValue: subtitle
         )
+    }
+
+    private func handshakeResponseRowContent(
+        _ response: WebSocketTimelineHandshakeResponse,
+        time: String
+    ) -> RowContent {
+        let title: String
+        let symbolName: String
+        let style: RowContent.Style
+        switch response.disposition {
+        case .switchingProtocols, .unreported:
+            title = localized(
+                "network.websocket.handshake.response",
+                defaultValue: "WebSocket Handshake Response"
+            )
+            symbolName = "arrow.left.arrow.right"
+            style = .lifecycle
+        case .rejected:
+            title = localized(
+                "network.websocket.handshake.rejected",
+                defaultValue: "WebSocket Handshake Rejected"
+            )
+            symbolName = "exclamationmark.shield"
+            style = .error
+        }
+        let subtitle = [
+            handshakeStatusText(statusCode: response.statusCode, statusText: response.statusText),
+            time,
+        ].joined(separator: " · ")
+        return RowContent(
+            title: title,
+            subtitle: subtitle,
+            symbolName: symbolName,
+            style: style,
+            accessibilityLabel: title,
+            accessibilityValue: subtitle
+        )
+    }
+
+    private func handshakeStatusText(
+        statusCode: Int?,
+        statusText: String?
+    ) -> String {
+        let statusText = statusText?.isEmpty == false ? statusText : nil
+        switch (statusCode, statusText) {
+        case let (.some(statusCode), .some(statusText)):
+            return "\(statusCode) \(statusText)"
+        case let (.some(statusCode), .none):
+            return String(statusCode)
+        case let (.none, .some(statusText)):
+            let notReported = localized(
+                "network.websocket.status.not_reported",
+                defaultValue: "Status not reported"
+            )
+            return "\(notReported) · \(statusText)"
+        case (.none, .none):
+            return localized(
+                "network.websocket.status.not_reported",
+                defaultValue: "Status not reported"
+            )
+        }
     }
 
     private func directionText(_ direction: WebSocketTimelineFrame.Direction) -> String {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -62,6 +62,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     private var latestSnapshotApplyGeneration: UInt64 = 0
     private var userScrollRevision: UInt64 = 0
     private var isUserScrolling = false
+    private var isPerformingProgrammaticTailScroll = false
     private var textPayloadCopyHandler: @MainActor (String) -> Void
     private lazy var dataSource = makeDataSource()
     private lazy var byteCountFormatter: ByteCountFormatter = {
@@ -208,14 +209,13 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     }
 
     override package func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard isUserScrolling
-                || scrollView.isTracking
-                || scrollView.isDragging
-                || scrollView.isDecelerating else {
+        guard isPerformingProgrammaticTailScroll == false else {
             return
         }
-        isUserScrolling = true
         advanceUserScrollRevision()
+        if scrollView.isTracking || scrollView.isDragging || scrollView.isDecelerating {
+            isUserScrolling = true
+        }
     }
 
     override package func scrollViewDidEndDragging(
@@ -228,6 +228,17 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     }
 
     override package func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        isUserScrolling = false
+    }
+
+    override package func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        isUserScrolling = true
+        advanceUserScrollRevision()
+        return true
+    }
+
+    override package func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
+        advanceUserScrollRevision()
         isUserScrolling = false
     }
 
@@ -468,6 +479,9 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             return
         }
         let indexPath = IndexPath(item: renderedEntryIDs.count - 1, section: 0)
+        precondition(isPerformingProgrammaticTailScroll == false)
+        isPerformingProgrammaticTailScroll = true
+        defer { isPerformingProgrammaticTailScroll = false }
         collectionView.scrollToItem(at: indexPath, at: .bottom, animated: false)
 #if DEBUG
         tailScrollCountStorageForTesting += 1

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -1,0 +1,638 @@
+#if canImport(UIKit)
+import Foundation
+import ObservationBridge
+import WebInspectorDataKit
+import WebInspectorUIBase
+import UIKit
+
+@MainActor
+package final class NetworkWebSocketPreviewViewController: UICollectionViewController {
+    package struct RequestEpoch: Hashable, Sendable {
+        private let requestID: NetworkRequest.ID
+        private let requestInstance: ObjectIdentifier
+        private let lifecycleRevision: UInt64
+        private let webSocketInstance: ObjectIdentifier
+
+        package init(request: NetworkRequest, webSocket: WebSocketState) {
+            requestID = request.id
+            requestInstance = ObjectIdentifier(request)
+            lifecycleRevision = request.lifecycleRevision
+            webSocketInstance = ObjectIdentifier(webSocket)
+        }
+    }
+
+    package enum SectionID: Hashable, Sendable {
+        case timeline
+    }
+
+    package enum ItemID: Hashable, Sendable {
+        case timeline(epoch: RequestEpoch, entryID: WebSocketTimelineEntry.ID)
+    }
+
+    package struct RowContent: Equatable, Sendable {
+        package enum Style: Equatable, Sendable {
+            case lifecycle
+            case sent
+            case received
+            case error
+        }
+
+        package let title: String
+        package let subtitle: String
+        package let symbolName: String
+        package let style: Style
+        package let accessibilityLabel: String
+        package let accessibilityValue: String
+    }
+
+    private let frameScheduler: any NetworkFrameScheduling
+    private var timelineObservation: PortableObservationTracking.Token?
+    private var observationStartTask: Task<Void, Never>?
+    private weak var request: NetworkRequest?
+    private weak var webSocket: WebSocketState?
+    private var requestEpoch: RequestEpoch?
+    private var renderedEntryIDs: [WebSocketTimelineEntry.ID] = []
+    private var rowContents: [ItemID: RowContent] = [:]
+    private var isRenderingActive = false
+    private var wasFollowingTailWhenSuspended: Bool?
+    private lazy var dataSource = makeDataSource()
+    private lazy var byteCountFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useBytes
+        formatter.countStyle = .memory
+        formatter.isAdaptive = false
+        return formatter
+    }()
+#if DEBUG
+    private var snapshotApplyCountStorageForTesting = 0
+    private var tailScrollCountStorageForTesting = 0
+    private var nextSnapshotApplyCompletionForTesting: (@MainActor () -> Void)?
+    private var deinitHandlerForTesting: (@MainActor () -> Void)?
+#endif
+
+    package convenience init() {
+        self.init(frameScheduler: NetworkDisplayLinkFrameScheduler())
+    }
+
+    package init(frameScheduler: any NetworkFrameScheduling) {
+        self.frameScheduler = frameScheduler
+        super.init(collectionViewLayout: Self.makeLayout())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    isolated deinit {
+        timelineObservation?.cancel()
+        observationStartTask?.cancel()
+        frameScheduler.invalidate()
+#if DEBUG
+        deinitHandlerForTesting?()
+#endif
+    }
+
+    override package func viewDidLoad() {
+        super.viewDidLoad()
+        _ = dataSource
+        collectionView.allowsSelection = false
+        collectionView.alwaysBounceVertical = true
+        collectionView.keyboardDismissMode = .onDrag
+        collectionView.accessibilityIdentifier = "WebInspector.Network.WebSocketPreview"
+        applyBackgroundFromTraits()
+        if #available(iOS 26.0, *) {
+            webInspectorRegisterForBackgroundTraitChanges { viewController in
+                viewController.applyBackgroundFromTraits()
+            }
+        }
+        applyEmptySnapshot()
+    }
+
+    package func bind(to request: NetworkRequest) {
+        loadViewIfNeeded()
+        guard let webSocket = request.webSocket else {
+            preconditionFailure("A WebSocket preview can only bind a request with WebSocket state.")
+        }
+        let nextEpoch = RequestEpoch(request: request, webSocket: webSocket)
+        guard requestEpoch != nextEpoch
+                || self.request !== request
+                || self.webSocket !== webSocket else {
+            if isRenderingActive, timelineObservation?.isActive != true {
+                scheduleTimelineObservationStart()
+            }
+            return
+        }
+
+        timelineObservation?.cancel()
+        timelineObservation = nil
+        cancelTimelineObservationStart()
+        frameScheduler.cancel()
+        self.request = request
+        self.webSocket = webSocket
+        requestEpoch = nextEpoch
+        renderedEntryIDs = []
+        rowContents = [:]
+        wasFollowingTailWhenSuspended = nil
+        applyEmptySnapshot()
+        if isRenderingActive {
+            scheduleTimelineObservationStart()
+        }
+    }
+
+    package func resumeRendering() {
+        guard request != nil, webSocket != nil, requestEpoch != nil else {
+            return
+        }
+        isRenderingActive = true
+        scheduleTimelineObservationStart()
+    }
+
+    package func suspendKeepingSnapshot() {
+        if isRenderingActive {
+            wasFollowingTailWhenSuspended = isFollowingTail
+        }
+        isRenderingActive = false
+        timelineObservation?.cancel()
+        timelineObservation = nil
+        cancelTimelineObservationStart()
+        frameScheduler.cancel()
+    }
+
+    package func clear() {
+        isRenderingActive = false
+        timelineObservation?.cancel()
+        timelineObservation = nil
+        cancelTimelineObservationStart()
+        frameScheduler.cancel()
+        request = nil
+        webSocket = nil
+        requestEpoch = nil
+        renderedEntryIDs = []
+        rowContents = [:]
+        wasFollowingTailWhenSuspended = nil
+        loadViewIfNeeded()
+        applyEmptySnapshot()
+    }
+
+    private static func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout.list(using: listLayoutConfiguration)
+    }
+
+    private static var listLayoutConfiguration: UICollectionLayoutListConfiguration {
+        var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        configuration.showsSeparators = true
+        return configuration
+    }
+
+    private func applyBackgroundFromTraits() {
+        let backgroundColor = webInspectorBackgroundPolicy.backgroundColor
+        view.backgroundColor = backgroundColor
+        collectionView.backgroundColor = backgroundColor
+    }
+
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionID, ItemID> {
+        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+            [weak self] cell, _, itemID in
+            guard let self, let content = rowContents[itemID] else {
+                Self.clear(cell)
+                return
+            }
+            configure(cell, with: content)
+        }
+        return UICollectionViewDiffableDataSource<SectionID, ItemID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, itemID in
+            collectionView.dequeueConfiguredReusableCell(
+                using: registration,
+                for: indexPath,
+                item: itemID
+            )
+        }
+    }
+
+    private func scheduleTimelineObservationStart() {
+        guard isRenderingActive,
+              request != nil,
+              webSocket != nil,
+              requestEpoch != nil,
+              timelineObservation?.isActive != true,
+              observationStartTask == nil else {
+            return
+        }
+        let expectedEpoch = requestEpoch
+        // Keep this next-turn boundary. Nested Observation tracking merges the
+        // child's access list into the parent, which would make every frame
+        // bypass this controller's display-frame scheduler.
+        observationStartTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard Task.isCancelled == false,
+                  let self,
+                  isRenderingActive,
+                  requestEpoch == expectedEpoch else {
+                return
+            }
+            observationStartTask = nil
+            startObservingTimeline()
+        }
+    }
+
+    private func cancelTimelineObservationStart() {
+        observationStartTask?.cancel()
+        observationStartTask = nil
+    }
+
+    private func startObservingTimeline() {
+        guard isRenderingActive,
+              let webSocket,
+              let requestEpoch else {
+            return
+        }
+        timelineObservation?.cancel()
+        let token = withPortableContinuousObservation { [weak self, weak webSocket] event in
+            guard let self,
+                  let webSocket,
+                  isRenderingActive,
+                  self.webSocket === webSocket,
+                  self.requestEpoch == requestEpoch else {
+                return
+            }
+            let entries = webSocket.timelineEntries
+            if event.kind == .initial {
+                let followsTail = wasFollowingTailWhenSuspended ?? isFollowingTail
+                wasFollowingTailWhenSuspended = nil
+                appendTimeline(entries, epoch: requestEpoch, followsTail: followsTail)
+                return
+            }
+            scheduleTimelineRendering(for: requestEpoch)
+        }
+        timelineObservation = token
+    }
+
+    private func scheduleTimelineRendering(for epoch: RequestEpoch) {
+        frameScheduler.schedule { [weak self] in
+            guard let self,
+                  isRenderingActive,
+                  requestEpoch == epoch,
+                  let webSocket else {
+                return
+            }
+            appendTimeline(
+                webSocket.timelineEntries,
+                epoch: epoch,
+                followsTail: isFollowingTail
+            )
+        }
+    }
+
+    private func appendTimeline(
+        _ entries: [WebSocketTimelineEntry],
+        epoch: RequestEpoch,
+        followsTail: Bool
+    ) {
+        guard requestEpoch == epoch else {
+            return
+        }
+        let renderedCount = renderedEntryIDs.count
+        precondition(
+            entries.count >= renderedCount,
+            "A WebSocket timeline cannot shrink or replace its prefix within one request epoch."
+        )
+        if renderedCount > 0 {
+            precondition(
+                entries[renderedCount - 1].id == renderedEntryIDs[renderedCount - 1],
+                "A WebSocket timeline cannot shrink or replace its prefix within one request epoch."
+            )
+        }
+        guard entries.count > renderedCount else {
+            return
+        }
+        let suffix = entries.dropFirst(renderedCount)
+        let itemIDs = suffix.map { ItemID.timeline(epoch: epoch, entryID: $0.id) }
+        for (itemID, entry) in zip(itemIDs, suffix) {
+            rowContents[itemID] = rowContent(for: entry)
+        }
+        renderedEntryIDs.append(contentsOf: suffix.map(\.id))
+        var snapshot = dataSource.snapshot()
+        if snapshot.sectionIdentifiers.isEmpty {
+            snapshot.appendSections([.timeline])
+        }
+        snapshot.appendItems(itemIDs, toSection: .timeline)
+        apply(snapshot, epoch: epoch, followsTail: followsTail)
+    }
+
+    private func applyEmptySnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<SectionID, ItemID>()
+        snapshot.appendSections([.timeline])
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+
+    private func apply(
+        _ snapshot: NSDiffableDataSourceSnapshot<SectionID, ItemID>,
+        epoch: RequestEpoch,
+        followsTail: Bool
+    ) {
+        dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+            guard let self else {
+                return
+            }
+#if DEBUG
+            snapshotApplyCountStorageForTesting += 1
+            let testCompletion = nextSnapshotApplyCompletionForTesting
+            nextSnapshotApplyCompletionForTesting = nil
+            defer { testCompletion?() }
+#endif
+            snapshotApplyDidFinish(epoch: epoch, followsTail: followsTail)
+        }
+    }
+
+    private func snapshotApplyDidFinish(epoch: RequestEpoch, followsTail: Bool) {
+        guard requestEpoch == epoch else {
+            return
+        }
+        if followsTail {
+            scrollToTail(epoch: epoch)
+        }
+    }
+
+    private var isFollowingTail: Bool {
+        guard renderedEntryIDs.isEmpty == false else {
+            return true
+        }
+        collectionView.layoutIfNeeded()
+        let visibleBottom = collectionView.contentOffset.y
+            + collectionView.bounds.height
+            - collectionView.adjustedContentInset.bottom
+        return visibleBottom >= collectionView.contentSize.height - 1
+    }
+
+    private func scrollToTail(epoch: RequestEpoch) {
+        guard requestEpoch == epoch,
+              renderedEntryIDs.isEmpty == false else {
+            return
+        }
+        let indexPath = IndexPath(item: renderedEntryIDs.count - 1, section: 0)
+        collectionView.scrollToItem(at: indexPath, at: .bottom, animated: false)
+#if DEBUG
+        tailScrollCountStorageForTesting += 1
+#endif
+    }
+
+    private func rowContent(for entry: WebSocketTimelineEntry) -> RowContent {
+        let time = relativeTimeText(for: entry.timestamp)
+        switch entry.kind {
+        case .connectionEstablished:
+            let title = localized(
+                "network.websocket.connection.established",
+                defaultValue: "WebSocket Connection Established"
+            )
+            return RowContent(
+                title: title,
+                subtitle: time,
+                symbolName: "network",
+                style: .lifecycle,
+                accessibilityLabel: title,
+                accessibilityValue: time
+            )
+        case .connectionClosed:
+            let title = localized(
+                "network.websocket.connection.closed",
+                defaultValue: "WebSocket Connection Closed"
+            )
+            return RowContent(
+                title: title,
+                subtitle: time,
+                symbolName: "xmark.circle",
+                style: .lifecycle,
+                accessibilityLabel: title,
+                accessibilityValue: time
+            )
+        case .error(let message):
+            let error = localized("network.websocket.error", defaultValue: "Error")
+            let subtitle = [error, time].joined(separator: " · ")
+            return RowContent(
+                title: message,
+                subtitle: subtitle,
+                symbolName: "exclamationmark.triangle",
+                style: .error,
+                accessibilityLabel: message,
+                accessibilityValue: subtitle
+            )
+        case .frame(let frame):
+            return frameRowContent(frame, time: time)
+        }
+    }
+
+    private func frameRowContent(
+        _ frame: WebSocketTimelineFrame,
+        time: String
+    ) -> RowContent {
+        let direction = directionText(frame.direction)
+        let frameKind = frameKindText(frame.kind)
+        let style: RowContent.Style
+        let symbolName: String
+        switch frame.direction {
+        case .sent:
+            style = .sent
+            symbolName = "arrow.up"
+        case .received:
+            style = .received
+            symbolName = "arrow.down"
+        }
+
+        let title: String
+        switch frame.kind {
+        case .text:
+            guard case let .text(payload) = frame.payload else {
+                preconditionFailure("A text WebSocket frame must carry a text payload.")
+            }
+            title = payload
+        case .continuation, .binary, .close, .ping, .pong, .unknown:
+            title = [frameKind, byteCountText(frame.payloadLength)].joined(separator: " · ")
+        }
+        let subtitle = [direction, frameKind, time].joined(separator: " · ")
+        return RowContent(
+            title: title,
+            subtitle: subtitle,
+            symbolName: symbolName,
+            style: style,
+            accessibilityLabel: title,
+            accessibilityValue: subtitle
+        )
+    }
+
+    private func directionText(_ direction: WebSocketTimelineFrame.Direction) -> String {
+        switch direction {
+        case .sent:
+            localized("network.websocket.direction.sent", defaultValue: "Sent")
+        case .received:
+            localized("network.websocket.direction.received", defaultValue: "Received")
+        }
+    }
+
+    private func frameKindText(_ kind: WebSocketTimelineFrame.Kind) -> String {
+        switch kind {
+        case .continuation:
+            return localized("network.websocket.frame.continuation", defaultValue: "Continuation Frame")
+        case .text:
+            return localized("network.websocket.frame.text", defaultValue: "Text Frame")
+        case .binary:
+            return localized("network.websocket.frame.binary", defaultValue: "Binary Frame")
+        case .close:
+            return localized("network.websocket.frame.close", defaultValue: "Connection Close Frame")
+        case .ping:
+            return localized("network.websocket.frame.ping", defaultValue: "Ping Frame")
+        case .pong:
+            return localized("network.websocket.frame.pong", defaultValue: "Pong Frame")
+        case .unknown(let opcode):
+            let unknown = localized("network.websocket.frame.unknown", defaultValue: "Unknown Frame")
+            let opcodeLabel = localized("network.websocket.opcode", defaultValue: "Opcode")
+            return "\(unknown) (\(opcodeLabel) \(opcode))"
+        }
+    }
+
+    private func byteCountText(_ payloadLength: Int) -> String {
+        byteCountFormatter.string(fromByteCount: Int64(payloadLength))
+    }
+
+    private func relativeTimeText(for timestamp: Double?) -> String {
+        guard let timestamp,
+              let startTimestamp = request?.logicalStartTimestamp else {
+            return localized("network.websocket.time.not_reported", defaultValue: "Time not reported")
+        }
+        let interval = timestamp - startTimestamp
+        let sign = interval < 0 ? "−" : "+"
+        let magnitude = abs(interval)
+        if magnitude < 1 {
+            return "\(sign)\((magnitude * 1_000).formatted(.number.precision(.fractionLength(0)))) ms"
+        }
+        return "\(sign)\(magnitude.formatted(.number.precision(.fractionLength(2)))) s"
+    }
+
+    private func configure(_ cell: UICollectionViewListCell, with content: RowContent) {
+        var configuration = UIListContentConfiguration.subtitleCell()
+        configuration.text = content.title
+        configuration.secondaryText = content.subtitle
+        configuration.image = UIImage(systemName: content.symbolName)
+        configuration.textProperties.numberOfLines = 0
+        configuration.secondaryTextProperties.numberOfLines = 0
+        configuration.imageProperties.tintColor = tintColor(for: content.style)
+        cell.contentConfiguration = configuration
+        cell.accessories = []
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = .staticText
+        cell.accessibilityLabel = content.accessibilityLabel
+        cell.accessibilityValue = content.accessibilityValue
+    }
+
+    private func tintColor(for style: RowContent.Style) -> UIColor {
+        switch style {
+        case .lifecycle:
+            .secondaryLabel
+        case .sent:
+            .systemOrange
+        case .received:
+            .systemBlue
+        case .error:
+            .systemRed
+        }
+    }
+
+    private static func clear(_ cell: UICollectionViewListCell) {
+        cell.contentConfiguration = nil
+        cell.accessories = []
+        cell.accessibilityLabel = nil
+        cell.accessibilityValue = nil
+    }
+
+    private func localized(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        String(localized: key, defaultValue: defaultValue, bundle: WebInspectorUILocalization.bundle)
+    }
+}
+
+#if DEBUG
+extension NetworkWebSocketPreviewViewController {
+    package static var listLayoutConfigurationForTesting: UICollectionLayoutListConfiguration {
+        listLayoutConfiguration
+    }
+
+    package var timelineObservationDeliveryForTesting: PortableObservationTracking.Token? {
+        timelineObservation
+    }
+
+    package var snapshotForTesting: NSDiffableDataSourceSnapshot<SectionID, ItemID> {
+        dataSource.snapshot()
+    }
+
+    package var renderedEntryIDsForTesting: [WebSocketTimelineEntry.ID] {
+        renderedEntryIDs
+    }
+
+    package var requestEpochForTesting: RequestEpoch? {
+        requestEpoch
+    }
+
+    package func rowContentForTesting(_ itemID: ItemID) -> RowContent? {
+        rowContents[itemID]
+    }
+
+    package var boundRequestForTesting: NetworkRequest? {
+        request
+    }
+
+    package var boundWebSocketForTesting: WebSocketState? {
+        webSocket
+    }
+
+    package var isRenderingActiveForTesting: Bool {
+        isRenderingActive
+    }
+
+    package var snapshotApplyCountForTesting: Int {
+        snapshotApplyCountStorageForTesting
+    }
+
+    package var tailScrollCountForTesting: Int {
+        tailScrollCountStorageForTesting
+    }
+
+    package var isFollowingTailForTesting: Bool {
+        isFollowingTail
+    }
+
+    package var hasPendingObservationStartForTesting: Bool {
+        observationStartTask != nil
+    }
+
+    package var observationStartTaskForTesting: Task<Void, Never>? {
+        observationStartTask
+    }
+
+    package func waitForTimelineObservationStartForTesting() async {
+        let task = observationStartTask
+        await task?.value
+    }
+
+    package func setNextSnapshotApplyCompletionForTesting(
+        _ completion: @escaping @MainActor () -> Void
+    ) {
+        precondition(nextSnapshotApplyCompletionForTesting == nil)
+        nextSnapshotApplyCompletionForTesting = completion
+    }
+
+    package func invokeSnapshotApplyCompletionForTesting(
+        epoch: RequestEpoch,
+        followsTail: Bool
+    ) {
+        snapshotApplyDidFinish(epoch: epoch, followsTail: followsTail)
+    }
+
+    package func setDeinitHandlerForTesting(_ handler: @escaping @MainActor () -> Void) {
+        deinitHandlerForTesting = handler
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 
 @MainActor
 package final class NetworkWebSocketPreviewViewController: UICollectionViewController {
-    private static let maximumRenderedTextPayloadCharacters = 2_048
+    private static let maximumRenderedTextPayloadUTF8Bytes = 4_096
     private static let maximumTitleLineCount = 8
     private static let textPayloadTruncationMarker = "…"
 
@@ -59,6 +59,9 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     private var rowContents: [ItemID: RowContent] = [:]
     private var isRenderingActive = false
     private var wasFollowingTailWhenSuspended: Bool?
+    private var latestSnapshotApplyGeneration: UInt64 = 0
+    private var userScrollRevision: UInt64 = 0
+    private var isUserScrolling = false
     private var textPayloadCopyHandler: @MainActor (String) -> Void
     private lazy var dataSource = makeDataSource()
     private lazy var byteCountFormatter: ByteCountFormatter = {
@@ -159,8 +162,10 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     package func suspendKeepingSnapshot() {
         if isRenderingActive {
             wasFollowingTailWhenSuspended = isFollowingTail
+            _ = advanceSnapshotApplyGeneration()
         }
         isRenderingActive = false
+        isUserScrolling = false
         timelineObservation?.cancel()
         timelineObservation = nil
         cancelTimelineObservationStart()
@@ -179,6 +184,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         renderedEntryIDs = []
         rowContents = [:]
         wasFollowingTailWhenSuspended = nil
+        isUserScrolling = false
         loadViewIfNeeded()
         applyEmptySnapshot()
     }
@@ -194,6 +200,40 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             return nil
         }
         return contextMenuConfiguration(for: itemID)
+    }
+
+    override package func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isUserScrolling = true
+        advanceUserScrollRevision()
+    }
+
+    override package func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard isUserScrolling
+                || scrollView.isTracking
+                || scrollView.isDragging
+                || scrollView.isDecelerating else {
+            return
+        }
+        isUserScrolling = true
+        advanceUserScrollRevision()
+    }
+
+    override package func scrollViewDidEndDragging(
+        _ scrollView: UIScrollView,
+        willDecelerate decelerate: Bool
+    ) {
+        if decelerate == false {
+            isUserScrolling = false
+        }
+    }
+
+    override package func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        isUserScrolling = false
+    }
+
+    private func advanceUserScrollRevision() {
+        precondition(userScrollRevision < UInt64.max, "WebSocket preview user-scroll revision overflowed.")
+        userScrollRevision += 1
     }
 
     private static func makeLayout() -> UICollectionViewLayout {
@@ -353,6 +393,8 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         epoch: RequestEpoch,
         followsTail: Bool
     ) {
+        let applyGeneration = advanceSnapshotApplyGeneration()
+        let userScrollRevision = self.userScrollRevision
         dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
             guard let self else {
                 return
@@ -363,12 +405,39 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             nextSnapshotApplyCompletionForTesting = nil
             defer { testCompletion?() }
 #endif
-            snapshotApplyDidFinish(epoch: epoch, followsTail: followsTail)
+            snapshotApplyDidFinish(
+                epoch: epoch,
+                followsTail: followsTail,
+                applyGeneration: applyGeneration,
+                userScrollRevision: userScrollRevision
+            )
         }
     }
 
-    private func snapshotApplyDidFinish(epoch: RequestEpoch, followsTail: Bool) {
-        guard requestEpoch == epoch else {
+    @discardableResult
+    private func advanceSnapshotApplyGeneration() -> UInt64 {
+        precondition(
+            latestSnapshotApplyGeneration < UInt64.max,
+            "WebSocket preview snapshot apply generation overflowed."
+        )
+        latestSnapshotApplyGeneration += 1
+        return latestSnapshotApplyGeneration
+    }
+
+    private func snapshotApplyDidFinish(
+        epoch: RequestEpoch,
+        followsTail: Bool,
+        applyGeneration: UInt64,
+        userScrollRevision: UInt64
+    ) {
+        guard isRenderingActive,
+              requestEpoch == epoch,
+              latestSnapshotApplyGeneration == applyGeneration,
+              self.userScrollRevision == userScrollRevision,
+              isUserScrolling == false,
+              collectionView.isTracking == false,
+              collectionView.isDragging == false,
+              collectionView.isDecelerating == false else {
             return
         }
         if followsTail {
@@ -377,6 +446,12 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     }
 
     private var isFollowingTail: Bool {
+        guard isUserScrolling == false,
+              collectionView.isTracking == false,
+              collectionView.isDragging == false,
+              collectionView.isDecelerating == false else {
+            return false
+        }
         guard renderedEntryIDs.isEmpty == false else {
             return true
         }
@@ -601,14 +676,31 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     }
 
     private static func textPayloadTruncationIndex(in payload: String) -> String.Index? {
-        guard let index = payload.index(
-            payload.startIndex,
-            offsetBy: maximumRenderedTextPayloadCharacters,
-            limitedBy: payload.endIndex
-        ), index != payload.endIndex else {
-            return nil
+        let scalars = payload.unicodeScalars
+        var index = scalars.startIndex
+        var encodedByteCount = 0
+        while index != scalars.endIndex {
+            let scalarByteCount = utf8ByteCount(of: scalars[index])
+            guard scalarByteCount <= maximumRenderedTextPayloadUTF8Bytes - encodedByteCount else {
+                return index
+            }
+            encodedByteCount += scalarByteCount
+            index = scalars.index(after: index)
         }
-        return index
+        return nil
+    }
+
+    private static func utf8ByteCount(of scalar: Unicode.Scalar) -> Int {
+        switch scalar.value {
+        case 0..<0x80:
+            return 1
+        case 0..<0x800:
+            return 2
+        case 0..<0x1_0000:
+            return 3
+        default:
+            return 4
+        }
     }
 
     private func configure(
@@ -687,9 +779,6 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         guard case let .text(payload) = frame.payload else {
             preconditionFailure("A text WebSocket frame must carry a text payload.")
         }
-        guard Self.textPayloadTruncationIndex(in: payload) != nil else {
-            return nil
-        }
         return payload
     }
 
@@ -728,12 +817,16 @@ extension NetworkWebSocketPreviewViewController {
         listLayoutConfiguration
     }
 
-    package static var maximumRenderedTextPayloadCharactersForTesting: Int {
-        maximumRenderedTextPayloadCharacters
+    package static var maximumRenderedTextPayloadUTF8BytesForTesting: Int {
+        maximumRenderedTextPayloadUTF8Bytes
     }
 
     package static var maximumTitleLineCountForTesting: Int {
         maximumTitleLineCount
+    }
+
+    package static func renderedTextPayloadForTesting(_ payload: String) -> String {
+        renderedTextPayload(payload)
     }
 
     package var timelineObservationDeliveryForTesting: PortableObservationTracking.Token? {
@@ -788,6 +881,18 @@ extension NetworkWebSocketPreviewViewController {
         tailScrollCountStorageForTesting
     }
 
+    package var snapshotApplyGenerationForTesting: UInt64 {
+        latestSnapshotApplyGeneration
+    }
+
+    package var userScrollRevisionForTesting: UInt64 {
+        userScrollRevision
+    }
+
+    package var isUserScrollingForTesting: Bool {
+        isUserScrolling
+    }
+
     package var isFollowingTailForTesting: Bool {
         isFollowingTail
     }
@@ -814,9 +919,16 @@ extension NetworkWebSocketPreviewViewController {
 
     package func invokeSnapshotApplyCompletionForTesting(
         epoch: RequestEpoch,
-        followsTail: Bool
+        followsTail: Bool,
+        applyGeneration: UInt64,
+        userScrollRevision: UInt64
     ) {
-        snapshotApplyDidFinish(epoch: epoch, followsTail: followsTail)
+        snapshotApplyDidFinish(
+            epoch: epoch,
+            followsTail: followsTail,
+            applyGeneration: applyGeneration,
+            userScrollRevision: userScrollRevision
+        )
     }
 
     package func setDeinitHandlerForTesting(_ handler: @escaping @MainActor () -> Void) {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -7,6 +7,10 @@ import UIKit
 
 @MainActor
 package final class NetworkWebSocketPreviewViewController: UICollectionViewController {
+    private static let maximumRenderedTextPayloadCharacters = 2_048
+    private static let maximumTitleLineCount = 8
+    private static let textPayloadTruncationMarker = "…"
+
     package struct RequestEpoch: Hashable, Sendable {
         private let requestID: NetworkRequest.ID
         private let requestInstance: ObjectIdentifier
@@ -55,6 +59,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
     private var rowContents: [ItemID: RowContent] = [:]
     private var isRenderingActive = false
     private var wasFollowingTailWhenSuspended: Bool?
+    private var textPayloadCopyHandler: @MainActor (String) -> Void
     private lazy var dataSource = makeDataSource()
     private lazy var byteCountFormatter: ByteCountFormatter = {
         let formatter = ByteCountFormatter()
@@ -76,6 +81,9 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
 
     package init(frameScheduler: any NetworkFrameScheduling) {
         self.frameScheduler = frameScheduler
+        textPayloadCopyHandler = { payload in
+            UIPasteboard.general.string = payload
+        }
         super.init(collectionViewLayout: Self.makeLayout())
     }
 
@@ -175,6 +183,19 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         applyEmptySnapshot()
     }
 
+    override package func collectionView(
+        _ collectionView: UICollectionView,
+        contextMenuConfigurationForItemsAt indexPaths: [IndexPath],
+        point: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard indexPaths.count == 1,
+              let indexPath = indexPaths.first,
+              let itemID = dataSource.itemIdentifier(for: indexPath) else {
+            return nil
+        }
+        return contextMenuConfiguration(for: itemID)
+    }
+
     private static func makeLayout() -> UICollectionViewLayout {
         UICollectionViewCompositionalLayout.list(using: listLayoutConfiguration)
     }
@@ -198,7 +219,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
                 Self.clear(cell)
                 return
             }
-            configure(cell, with: content)
+            configure(cell, with: content, itemID: itemID)
         }
         return UICollectionViewDiffableDataSource<SectionID, ItemID>(
             collectionView: collectionView
@@ -448,7 +469,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             guard case let .text(payload) = frame.payload else {
                 preconditionFailure("A text WebSocket frame must carry a text payload.")
             }
-            title = payload
+            title = Self.renderedTextPayload(payload)
         case .continuation, .binary, .close, .ping, .pong, .unknown:
             title = [frameKind, byteCountText(frame.payloadLength)].joined(separator: " · ")
         }
@@ -572,12 +593,34 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         return "\(sign)\(magnitude.formatted(.number.precision(.fractionLength(2)))) s"
     }
 
-    private func configure(_ cell: UICollectionViewListCell, with content: RowContent) {
+    private static func renderedTextPayload(_ payload: String) -> String {
+        guard let truncationIndex = textPayloadTruncationIndex(in: payload) else {
+            return payload
+        }
+        return String(payload[..<truncationIndex]) + textPayloadTruncationMarker
+    }
+
+    private static func textPayloadTruncationIndex(in payload: String) -> String.Index? {
+        guard let index = payload.index(
+            payload.startIndex,
+            offsetBy: maximumRenderedTextPayloadCharacters,
+            limitedBy: payload.endIndex
+        ), index != payload.endIndex else {
+            return nil
+        }
+        return index
+    }
+
+    private func configure(
+        _ cell: UICollectionViewListCell,
+        with content: RowContent,
+        itemID: ItemID
+    ) {
         var configuration = UIListContentConfiguration.subtitleCell()
         configuration.text = content.title
         configuration.secondaryText = content.subtitle
         configuration.image = UIImage(systemName: content.symbolName)
-        configuration.textProperties.numberOfLines = 0
+        configuration.textProperties.numberOfLines = Self.maximumTitleLineCount
         configuration.secondaryTextProperties.numberOfLines = 0
         configuration.imageProperties.tintColor = tintColor(for: content.style)
         cell.contentConfiguration = configuration
@@ -586,6 +629,68 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         cell.accessibilityTraits = .staticText
         cell.accessibilityLabel = content.accessibilityLabel
         cell.accessibilityValue = content.accessibilityValue
+        if copyableTextPayload(for: itemID) != nil {
+            cell.accessibilityCustomActions = [UIAccessibilityCustomAction(
+                name: copyActionTitle,
+                image: UIImage(systemName: "doc.on.doc")
+            ) { [weak self] _ in
+                self?.copyTextPayload(for: itemID) ?? false
+            }]
+        } else {
+            cell.accessibilityCustomActions = nil
+        }
+    }
+
+    private func contextMenuConfiguration(for itemID: ItemID) -> UIContextMenuConfiguration? {
+        guard copyableTextPayload(for: itemID) != nil else {
+            return nil
+        }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self, copyableTextPayload(for: itemID) != nil else {
+                return nil
+            }
+            return UIMenu(children: [copyTextPayloadAction(for: itemID)])
+        }
+    }
+
+    private func copyTextPayloadAction(for itemID: ItemID) -> UIAction {
+        UIAction(
+            title: copyActionTitle,
+            image: UIImage(systemName: "doc.on.doc")
+        ) { [weak self] _ in
+            _ = self?.copyTextPayload(for: itemID)
+        }
+    }
+
+    private var copyActionTitle: String {
+        localized("Copy", defaultValue: "Copy")
+    }
+
+    private func copyTextPayload(for itemID: ItemID) -> Bool {
+        guard isRenderingActive,
+              viewIfLoaded?.window != nil,
+              let payload = copyableTextPayload(for: itemID) else {
+            return false
+        }
+        textPayloadCopyHandler(payload)
+        return true
+    }
+
+    private func copyableTextPayload(for itemID: ItemID) -> String? {
+        guard case let .timeline(epoch, entryID) = itemID,
+              requestEpoch == epoch,
+              let entry = webSocket?.timelineEntry(for: entryID),
+              case let .frame(frame) = entry.kind,
+              frame.kind == .text else {
+            return nil
+        }
+        guard case let .text(payload) = frame.payload else {
+            preconditionFailure("A text WebSocket frame must carry a text payload.")
+        }
+        guard Self.textPayloadTruncationIndex(in: payload) != nil else {
+            return nil
+        }
+        return payload
     }
 
     private func tintColor(for style: RowContent.Style) -> UIColor {
@@ -606,6 +711,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         cell.accessories = []
         cell.accessibilityLabel = nil
         cell.accessibilityValue = nil
+        cell.accessibilityCustomActions = nil
     }
 
     private func localized(
@@ -620,6 +726,14 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
 extension NetworkWebSocketPreviewViewController {
     package static var listLayoutConfigurationForTesting: UICollectionLayoutListConfiguration {
         listLayoutConfiguration
+    }
+
+    package static var maximumRenderedTextPayloadCharactersForTesting: Int {
+        maximumRenderedTextPayloadCharacters
+    }
+
+    package static var maximumTitleLineCountForTesting: Int {
+        maximumTitleLineCount
     }
 
     package var timelineObservationDeliveryForTesting: PortableObservationTracking.Token? {
@@ -640,6 +754,18 @@ extension NetworkWebSocketPreviewViewController {
 
     package func rowContentForTesting(_ itemID: ItemID) -> RowContent? {
         rowContents[itemID]
+    }
+
+    package func contextMenuConfigurationForTesting(
+        _ itemID: ItemID
+    ) -> UIContextMenuConfiguration? {
+        contextMenuConfiguration(for: itemID)
+    }
+
+    package func setTextPayloadCopyHandlerForTesting(
+        _ handler: @escaping @MainActor (String) -> Void
+    ) {
+        textPayloadCopyHandler = handler
     }
 
     package var boundRequestForTesting: NetworkRequest? {

--- a/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
@@ -240,7 +240,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private var snapshotCoordinator = SnapshotCoordinator()
     private var needsListProjectionCapture = false
-    private let listFrameScheduler: any NetworkListFrameScheduling
+    private let listFrameScheduler: any NetworkFrameScheduling
     private let listSnapshotBuildCoordinator: ListSnapshotBuildCoordinator
     private let snapshotApplyCompletionScheduler: any NetworkListSnapshotApplyCompletionScheduling
     private var isApplyingSearchPresentation = false
@@ -283,7 +283,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     package convenience init(model: NetworkPanelModel) {
         self.init(
             model: model,
-            listFrameScheduler: NetworkListDisplayLinkFrameScheduler(),
+            listFrameScheduler: NetworkDisplayLinkFrameScheduler(),
             listSnapshotBuilderFactory: NetworkListSnapshotBuilderFactory(),
             snapshotApplyCompletionScheduler: NetworkListImmediateSnapshotApplyCompletionScheduler()
         )
@@ -291,7 +291,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     package convenience init(
         model: NetworkPanelModel,
-        listFrameScheduler: any NetworkListFrameScheduling,
+        listFrameScheduler: any NetworkFrameScheduling,
         listSnapshotBuilderFactory: any NetworkListSnapshotBuilderMaking,
         snapshotApplyCompletionScheduler: any NetworkListSnapshotApplyCompletionScheduling =
             NetworkListImmediateSnapshotApplyCompletionScheduler()
@@ -306,7 +306,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private init(
         model: NetworkPanelModel,
-        frameScheduler: any NetworkListFrameScheduling,
+        frameScheduler: any NetworkFrameScheduling,
         snapshotBuilderFactory: any NetworkListSnapshotBuilderMaking,
         snapshotApplyCompletionScheduler: any NetworkListSnapshotApplyCompletionScheduling
     ) {

--- a/Sources/WebInspectorUINetwork/NetworkFrameScheduler.swift
+++ b/Sources/WebInspectorUINetwork/NetworkFrameScheduler.swift
@@ -2,19 +2,19 @@
 import UIKit
 
 @MainActor
-package protocol NetworkListFrameScheduling: AnyObject {
+package protocol NetworkFrameScheduling: AnyObject {
     func schedule(_ action: @escaping @MainActor () -> Void)
     func cancel()
     func invalidate()
 }
 
 @MainActor
-package final class NetworkListDisplayLinkFrameScheduler: NetworkListFrameScheduling {
+package final class NetworkDisplayLinkFrameScheduler: NetworkFrameScheduling {
     @MainActor
     private final class Target: NSObject {
-        weak var scheduler: NetworkListDisplayLinkFrameScheduler?
+        weak var scheduler: NetworkDisplayLinkFrameScheduler?
 
-        init(scheduler: NetworkListDisplayLinkFrameScheduler) {
+        init(scheduler: NetworkDisplayLinkFrameScheduler) {
             self.scheduler = scheduler
         }
 

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -10801,9 +10801,15 @@ func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) t
         chronologySequence: 9
     )
 
-    #expect(webSocket.timelineEntries.count == 2)
-    #expect(webSocket.timelineEntries[0].kind == .connectionEstablished)
-    #expect(webSocket.timelineEntries[0].id.ordinalWithinEvent == 0)
+    if opcode == 8 {
+        #expect(webSocket.timelineEntries.count == 1)
+        #expect(webSocket.readyState == .connecting)
+    } else {
+        #expect(webSocket.timelineEntries.count == 2)
+        #expect(webSocket.timelineEntries[0].kind == .connectionEstablished)
+        #expect(webSocket.timelineEntries[0].id.ordinalWithinEvent == 0)
+        #expect(webSocket.readyState == .open)
+    }
     let entry = try #require(webSocket.timelineEntries.last)
     #expect(entry.id.ordinalWithinEvent == 1)
     guard case let .frame(frame) = entry.kind else {
@@ -10828,6 +10834,57 @@ func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) t
     #expect(frame.payload == (opcode == 1 ? .text("text") : .base64Encoded("AQID")))
     #expect(frame.payloadLength == 3)
     #expect(frame.isMasked)
+}
+
+@Test
+func webSocketCloseFrameAloneDoesNotConfirmEstablishedConnection() throws {
+    let webSocket = WebSocketState()
+    #expect(webSocket.applyHandshakeResponse(
+        Network.Response(status: 101, statusText: "Switching Protocols"),
+        timestamp: 1,
+        lifecycleRevision: 6,
+        chronologySequence: 10
+    ))
+
+    webSocket.appendFrame(
+        Network.WebSocketFrame(
+            opcode: 8,
+            mask: false,
+            payloadData: "A+g=",
+            payloadLength: 2
+        ),
+        direction: .received,
+        timestamp: 2,
+        lifecycleRevision: 6,
+        chronologySequence: 11
+    )
+
+    #expect(webSocket.readyState == .connecting)
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 101,
+            statusText: "Switching Protocols"
+        )),
+        .frame(WebSocketTimelineFrame(
+            direction: .received,
+            kind: .close,
+            payload: .base64Encoded("A+g="),
+            payloadLength: 2,
+            isMasked: false
+        )),
+    ])
+    #expect(webSocket.timelineEntries[1].id == .init(
+        lifecycleRevision: 6,
+        chronologySequence: 11,
+        ordinalWithinEvent: 1
+    ))
+    #expect(webSocket.timelineEntries.contains { entry in
+        if case .connectionEstablished = entry.kind {
+            return true
+        }
+        return false
+    } == false)
+    #expect(webSocket.frames.map(\.opcode) == [8])
 }
 
 @MainActor

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -11036,7 +11036,10 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
     ]
     #expect(webSocket.timelineEntries == expected)
     #expect(expected.map(\.id) == expected.map(\.id).sorted())
+    #expect(webSocket.timelineEntry(for: expected[0].id) == expected[0])
     #expect(webSocket.timelineEntry(for: expected[4].id) == expected[4])
+    #expect(webSocket.timelineEntry(for: expected[7].id) == expected[7])
+    #expect(webSocket.timelineEntry(for: .init(lifecycleRevision: 0, chronologySequence: 1)) == nil)
     #expect(webSocket.timelineEntry(for: .init(lifecycleRevision: 0, chronologySequence: 99)) == nil)
     #expect(webSocket.readyState == .closed)
     #expect(request.finishedOrFailedTimestamp == 1)
@@ -11395,6 +11398,44 @@ func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) t
 }
 
 @Test
+func webSocketTimelineEntryLookupCoversLargeOrderedHistory() throws {
+    let webSocket = WebSocketState()
+    for index in 0..<4_096 {
+        webSocket.appendFrame(
+            Network.WebSocketFrame(
+                opcode: 2,
+                mask: false,
+                payloadData: "AA==",
+                payloadLength: 1
+            ),
+            direction: .received,
+            timestamp: Double(index),
+            lifecycleRevision: 12,
+            chronologySequence: UInt64(index + 1)
+        )
+    }
+
+    let entries = webSocket.timelineEntries
+    #expect(entries.count == 4_097)
+    for index in [0, entries.count / 2, entries.count - 1] {
+        #expect(webSocket.timelineEntry(for: entries[index].id) == entries[index])
+    }
+    #expect(webSocket.timelineEntry(for: .init(
+        lifecycleRevision: 12,
+        chronologySequence: 2_048,
+        ordinalWithinEvent: 0
+    )) == nil)
+    #expect(webSocket.timelineEntry(for: .init(
+        lifecycleRevision: 12,
+        chronologySequence: 5_000
+    )) == nil)
+    #expect(webSocket.timelineEntry(for: .init(
+        lifecycleRevision: 13,
+        chronologySequence: 1
+    )) == nil)
+}
+
+@Test
 func webSocketCloseFrameAloneDoesNotConfirmEstablishedConnection() throws {
     let webSocket = WebSocketState()
     #expect(webSocket.applyHandshakeResponse(
@@ -11580,6 +11621,77 @@ func terminalWebSocketCreatedRestartsSameRequestThroughCommonLifecycleReset() as
     #expect(request.decodedDataLength == 0)
     #expect(request.encodedDataLength == 0)
     #expect(request.hasResponse == false)
+}
+
+@MainActor
+@Test(arguments: [false, true])
+func webSocketCreatedRestartsLifecycleClosedByErrorWithoutClosedEvent(
+    hasHandshakeResponse: Bool
+) async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-error-restarted-\(hasHandshakeResponse)")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/first")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    if hasHandshakeResponse {
+        await runtime.backend.emit(
+            .webSocket(.handshakeResponse(
+                id: requestID,
+                response: Network.Response(status: 101, statusText: "Switching Protocols"),
+                timestamp: 0.5
+            )),
+            target: target
+        )
+        try await waitUntil { request.state == .responded }
+    }
+    let stateBeforeError = request.state
+    await runtime.backend.emit(
+        .webSocket(.error(id: requestID, message: "upgrade failed", timestamp: 1)),
+        target: target
+    )
+    try await waitUntil { request.webSocket?.readyState == .closed }
+    let previousState = try #require(request.webSocket)
+    #expect(stateBeforeError == (hasHandshakeResponse ? .responded : .pending))
+    #expect(request.state == stateBeforeError)
+    #expect(previousState.frames.map(\.direction) == [.error("upgrade failed")])
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/restarted")),
+        target: target
+    )
+    try await waitUntil {
+        request.lifecycleRevision == 1 && request.webSocket?.readyState == .connecting
+    }
+
+    #expect(results.items.first === request)
+    #expect(request.webSocket !== previousState)
+    #expect(request.webSocket?.timelineEntries.isEmpty == true)
+    #expect(request.webSocket?.frames.isEmpty == true)
+    #expect(request.url == "wss://example.com/restarted")
+    #expect(request.state == .pending)
+
+    await runtime.backend.emit(
+        .webSocket(.handshakeRequest(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "wss://example.com/restarted",
+                method: "GET",
+                headers: ["Upgrade": "websocket"]
+            ),
+            timestamp: 2
+        )),
+        target: target
+    )
+    try await waitUntil {
+        request.webSocket?.handshakeRequest?.headers["Upgrade"] == "websocket"
+    }
 }
 
 @MainActor

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -10143,10 +10143,13 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
         )),
         target: target
     )
-    try await waitUntil { request.webSocket?.readyState == .open }
+    try await waitUntil {
+        request.webSocket?.handshakeResponse?.status == 101 && request.state == .responded
+    }
 
     let currentWebSocket = try #require(request.webSocket)
     #expect(currentWebSocket === webSocket)
+    #expect(currentWebSocket.readyState == .connecting)
     #expect(request.url == "wss://example.com/socket?created")
     #expect(request.method == "GET")
     #expect(request.requestHeaders["Upgrade"] == "websocket")
@@ -10212,7 +10215,7 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
         target: target
     )
     try await waitUntil {
-        request.webSocket?.readyState == .open && request.state == .responded
+        request.webSocket?.handshakeResponse?.status == 101 && request.state == .responded
     }
     #expect(request.webSocket?.handshakeResponse?.status == 101)
     #expect(request.status == 101)
@@ -10221,6 +10224,7 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
     #expect(request.responseReceivedTimestamp == 2)
     #expect(request.hasResponse)
     #expect(request.hasResponseBody == false)
+    #expect(request.webSocket?.readyState == .connecting)
 
     await runtime.backend.emit(
         .webSocket(.frameSent(
@@ -10252,6 +10256,30 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
     #expect(webSocket.frames[1].payloadData == "world")
     #expect(webSocket.frames[2].errorMessage == "boom")
     #expect(webSocket.frames.map(\.timestamp) == [3, 4, 5])
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 101,
+            statusText: "Switching Protocols"
+        )),
+        .connectionEstablished,
+        .frame(WebSocketTimelineFrame(
+            direction: .sent,
+            kind: .text,
+            payload: .text("hello"),
+            payloadLength: 5,
+            isMasked: true
+        )),
+        .frame(WebSocketTimelineFrame(
+            direction: .received,
+            kind: .text,
+            payload: .text("world"),
+            payloadLength: 5,
+            isMasked: false
+        )),
+        .error("boom"),
+    ])
+    #expect(webSocket.timelineEntries[1].timestamp == 2)
+    #expect(webSocket.readyState == .closed)
     #expect(request.decodedDataLength == 10)
     #expect(request.lastDataReceivedTimestamp == 5)
 
@@ -10357,16 +10385,32 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
         target: target
     )
 
-    try await waitUntil { request.webSocket?.timelineEntries.count == 7 }
+    try await waitUntil { request.webSocket?.timelineEntries.count == 8 }
     let webSocket = try #require(request.webSocket)
     let expected = [
         WebSocketTimelineEntry(
             id: .init(lifecycleRevision: 0, chronologySequence: 2),
             timestamp: nil,
+            kind: .handshakeResponse(WebSocketTimelineHandshakeResponse(
+                statusCode: 101,
+                statusText: nil
+            ))
+        ),
+        WebSocketTimelineEntry(
+            id: .init(
+                lifecycleRevision: 0,
+                chronologySequence: 3,
+                ordinalWithinEvent: 0
+            ),
+            timestamp: 7,
             kind: .connectionEstablished
         ),
         WebSocketTimelineEntry(
-            id: .init(lifecycleRevision: 0, chronologySequence: 3),
+            id: .init(
+                lifecycleRevision: 0,
+                chronologySequence: 3,
+                ordinalWithinEvent: 1
+            ),
             timestamp: 7,
             kind: .frame(WebSocketTimelineFrame(
                 direction: .sent,
@@ -10377,7 +10421,11 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
             ))
         ),
         WebSocketTimelineEntry(
-            id: .init(lifecycleRevision: 0, chronologySequence: 4),
+            id: .init(
+                lifecycleRevision: 0,
+                chronologySequence: 4,
+                ordinalWithinEvent: 1
+            ),
             timestamp: 7,
             kind: .frame(WebSocketTimelineFrame(
                 direction: .received,
@@ -10398,7 +10446,11 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
             kind: .connectionClosed
         ),
         WebSocketTimelineEntry(
-            id: .init(lifecycleRevision: 0, chronologySequence: 7),
+            id: .init(
+                lifecycleRevision: 0,
+                chronologySequence: 7,
+                ordinalWithinEvent: 1
+            ),
             timestamp: 0.5,
             kind: .frame(WebSocketTimelineFrame(
                 direction: .received,
@@ -10409,7 +10461,11 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
             ))
         ),
         WebSocketTimelineEntry(
-            id: .init(lifecycleRevision: 0, chronologySequence: 8),
+            id: .init(
+                lifecycleRevision: 0,
+                chronologySequence: 8,
+                ordinalWithinEvent: 1
+            ),
             timestamp: 9,
             kind: .frame(WebSocketTimelineFrame(
                 direction: .sent,
@@ -10421,7 +10477,8 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
         ),
     ]
     #expect(webSocket.timelineEntries == expected)
-    #expect(webSocket.timelineEntry(for: expected[3].id) == expected[3])
+    #expect(expected.map(\.id) == expected.map(\.id).sorted())
+    #expect(webSocket.timelineEntry(for: expected[4].id) == expected[4])
     #expect(webSocket.timelineEntry(for: .init(lifecycleRevision: 0, chronologySequence: 99)) == nil)
     #expect(webSocket.readyState == .closed)
     #expect(request.finishedOrFailedTimestamp == 1)
@@ -10491,9 +10548,194 @@ func webSocketFirstCloseAndHandshakeAreTerminalAndDuplicateEventsDoNotNotify() a
     #expect(webSocket.handshakeResponse?.statusText == "First")
     #expect(webSocket.handshakeRequest == nil)
     #expect(webSocket.timelineEntries.count == 2)
-    #expect(webSocket.timelineEntries.map(\.kind) == [.connectionEstablished, .connectionClosed])
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 101,
+            statusText: "First"
+        )),
+        .connectionClosed,
+    ])
+    guard case let .handshakeResponse(handshakeResponse) = webSocket.timelineEntries[0].kind else {
+        Issue.record("Expected switching-protocols handshake response evidence.")
+        return
+    }
+    #expect(handshakeResponse.disposition == .switchingProtocols(
+        statusText: "First"
+    ))
     #expect(request.finishedOrFailedTimestamp == 3)
     #expect(request.responseReceivedTimestamp == 2)
+}
+
+@MainActor
+@Test
+func webSocketRejectedHandshakePreservesResponseWithoutOpeningAndOrdersTerminalEvidence() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-rejected-handshake")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/rejected")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(
+                url: "wss://example.com/rejected",
+                status: 403,
+                statusText: "Forbidden",
+                headers: ["content-type": "text/plain"]
+            ),
+            timestamp: 2
+        )),
+        target: target
+    )
+    try await waitUntil { request.webSocket?.timelineEntries.count == 1 }
+
+    let webSocket = try #require(request.webSocket)
+    #expect(webSocket.readyState == .connecting)
+    #expect(webSocket.handshakeResponse?.status == 403)
+    #expect(webSocket.handshakeResponse?.statusText == "Forbidden")
+    #expect(request.status == 403)
+    #expect(request.statusText == "Forbidden")
+    #expect(request.state == .responded)
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 403,
+            statusText: "Forbidden"
+        ))
+    ])
+    guard case let .handshakeResponse(handshakeResponse) = webSocket.timelineEntries[0].kind else {
+        Issue.record("Expected rejected handshake response evidence.")
+        return
+    }
+    #expect(handshakeResponse.disposition == .rejected(
+        statusCode: 403,
+        statusText: "Forbidden"
+    ))
+    #expect(webSocket.frames.isEmpty)
+
+    let indexSequence = context.networkRequestIndexSequenceForTesting
+    let eventSequence = context.eventPumpAppliedSequenceForTesting
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 101, statusText: "Late Success"),
+            timestamp: 2.5
+        )),
+        target: target
+    )
+    #expect(await context.waitForEventPumpAppliedSequenceForTesting(after: eventSequence))
+    #expect(context.networkRequestIndexSequenceForTesting == indexSequence)
+    #expect(webSocket.handshakeResponse?.status == 403)
+    #expect(webSocket.timelineEntries.count == 1)
+
+    await runtime.backend.emit(
+        .webSocket(.error(id: requestID, message: "upgrade failed", timestamp: 3)),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 4)),
+        target: target
+    )
+    try await waitUntil { webSocket.timelineEntries.count == 3 }
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 403,
+            statusText: "Forbidden"
+        )),
+        .error("upgrade failed"),
+        .connectionClosed,
+    ])
+    #expect(webSocket.readyState == .closed)
+    #expect(request.finishedOrFailedTimestamp == 4)
+    #expect(webSocket.frames.map(\.direction) == [.error("upgrade failed")])
+}
+
+@Test
+func webSocketHandshakeWithoutStatusIsUnreportedWithoutInventingMetadata() throws {
+    let webSocket = WebSocketState()
+
+    #expect(webSocket.applyHandshakeResponse(
+        Network.Response(status: nil, statusText: nil),
+        timestamp: nil,
+        lifecycleRevision: 7,
+        chronologySequence: 9
+    ))
+    #expect(webSocket.readyState == .connecting)
+    #expect(webSocket.handshakeResponse?.status == nil)
+    #expect(webSocket.handshakeResponse?.statusText == nil)
+    #expect(webSocket.timelineEntries == [WebSocketTimelineEntry(
+        id: .init(lifecycleRevision: 7, chronologySequence: 9),
+        timestamp: nil,
+        kind: .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: nil,
+            statusText: nil
+        ))
+    )])
+    guard case let .handshakeResponse(handshakeResponse) = webSocket.timelineEntries[0].kind else {
+        Issue.record("Expected unreported handshake response evidence.")
+        return
+    }
+    #expect(handshakeResponse.disposition == .unreported(statusText: nil))
+    #expect(webSocket.frames.isEmpty)
+}
+
+@Test
+func webSocketSwitchingProtocolsResponseFollowedByErrorNeverClaimsEstablished() throws {
+    let webSocket = WebSocketState()
+
+    #expect(webSocket.applyHandshakeResponse(
+        Network.Response(status: 101, statusText: "Switching Protocols"),
+        timestamp: 1,
+        lifecycleRevision: 2,
+        chronologySequence: 5
+    ))
+    #expect(webSocket.readyState == .connecting)
+    webSocket.appendError(
+        "Invalid Sec-WebSocket-Accept",
+        timestamp: 2,
+        lifecycleRevision: 2,
+        chronologySequence: 6
+    )
+    #expect(webSocket.readyState == .closed)
+    #expect(webSocket.close(
+        timestamp: 3,
+        lifecycleRevision: 2,
+        chronologySequence: 7
+    ))
+    #expect(webSocket.close(
+        timestamp: 4,
+        lifecycleRevision: 2,
+        chronologySequence: 8
+    ) == false)
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 101,
+            statusText: "Switching Protocols"
+        )),
+        .error("Invalid Sec-WebSocket-Accept"),
+        .connectionClosed,
+    ])
+    guard case let .handshakeResponse(handshakeResponse) = webSocket.timelineEntries[0].kind else {
+        Issue.record("Expected switching-protocols handshake response evidence.")
+        return
+    }
+    #expect(handshakeResponse.disposition == .switchingProtocols(
+        statusText: "Switching Protocols"
+    ))
+    #expect(webSocket.timelineEntries.contains { entry in
+        if case .connectionEstablished = entry.kind {
+            return true
+        }
+        return false
+    } == false)
+    #expect(webSocket.frames.map(\.direction) == [
+        .error("Invalid Sec-WebSocket-Accept")
+    ])
 }
 
 @MainActor
@@ -10526,7 +10768,7 @@ func activeDuplicateWebSocketCreatedPreservesStateIdentityAndTimeline() async th
         )),
         target: target
     )
-    try await waitUntil { request.webSocket?.timelineEntries.count == 2 }
+    try await waitUntil { request.webSocket?.timelineEntries.count == 3 }
     let originalState = try #require(request.webSocket)
     let originalTimeline = originalState.timelineEntries
 
@@ -10559,7 +10801,11 @@ func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) t
         chronologySequence: 9
     )
 
-    let entry = try #require(webSocket.timelineEntries.first)
+    #expect(webSocket.timelineEntries.count == 2)
+    #expect(webSocket.timelineEntries[0].kind == .connectionEstablished)
+    #expect(webSocket.timelineEntries[0].id.ordinalWithinEvent == 0)
+    let entry = try #require(webSocket.timelineEntries.last)
+    #expect(entry.id.ordinalWithinEvent == 1)
     guard case let .frame(frame) = entry.kind else {
         Issue.record("Expected a WebSocket frame timeline entry.")
         return
@@ -10573,7 +10819,11 @@ func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) t
     case 10: .pong
     default: .unknown(opcode)
     }
-    #expect(entry.id == .init(lifecycleRevision: 4, chronologySequence: 9))
+    #expect(entry.id == .init(
+        lifecycleRevision: 4,
+        chronologySequence: 9,
+        ordinalWithinEvent: 1
+    ))
     #expect(frame.kind == expectedKind)
     #expect(frame.payload == (opcode == 1 ? .text("text") : .base64Encoded("AQID")))
     #expect(frame.payloadLength == 3)

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import Testing
 @testable import WebInspectorDataKit
 import WebInspectorProxyKit
@@ -10266,6 +10267,539 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
 
 @MainActor
 @Test
+func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-timeline")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/timeline")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+
+    await runtime.backend.emit(
+        .webSocket(.handshakeRequest(
+            id: requestID,
+            request: Network.Request(id: requestID, url: "", method: "GET"),
+            timestamp: nil
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 101),
+            timestamp: nil
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameSent(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "hello",
+                payloadLength: 5
+            ),
+            timestamp: 7
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 2,
+                mask: true,
+                payloadData: "AQID",
+                payloadLength: 3
+            ),
+            timestamp: 7
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.error(id: requestID, message: "boom", timestamp: 2)),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 1)),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 8,
+                mask: false,
+                payloadData: "A+g=",
+                payloadLength: 2
+            ),
+            timestamp: 0.5
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameSent(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 42,
+                mask: true,
+                payloadData: "CQ==",
+                payloadLength: 1
+            ),
+            timestamp: 9
+        )),
+        target: target
+    )
+
+    try await waitUntil { request.webSocket?.timelineEntries.count == 7 }
+    let webSocket = try #require(request.webSocket)
+    let expected = [
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 2),
+            timestamp: nil,
+            kind: .connectionEstablished
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 3),
+            timestamp: 7,
+            kind: .frame(WebSocketTimelineFrame(
+                direction: .sent,
+                kind: .text,
+                payload: .text("hello"),
+                payloadLength: 5,
+                isMasked: false
+            ))
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 4),
+            timestamp: 7,
+            kind: .frame(WebSocketTimelineFrame(
+                direction: .received,
+                kind: .binary,
+                payload: .base64Encoded("AQID"),
+                payloadLength: 3,
+                isMasked: true
+            ))
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 5),
+            timestamp: 2,
+            kind: .error("boom")
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 6),
+            timestamp: 1,
+            kind: .connectionClosed
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 7),
+            timestamp: 0.5,
+            kind: .frame(WebSocketTimelineFrame(
+                direction: .received,
+                kind: .close,
+                payload: .base64Encoded("A+g="),
+                payloadLength: 2,
+                isMasked: false
+            ))
+        ),
+        WebSocketTimelineEntry(
+            id: .init(lifecycleRevision: 0, chronologySequence: 8),
+            timestamp: 9,
+            kind: .frame(WebSocketTimelineFrame(
+                direction: .sent,
+                kind: .unknown(42),
+                payload: .base64Encoded("CQ=="),
+                payloadLength: 1,
+                isMasked: true
+            ))
+        ),
+    ]
+    #expect(webSocket.timelineEntries == expected)
+    #expect(webSocket.timelineEntry(for: expected[3].id) == expected[3])
+    #expect(webSocket.timelineEntry(for: .init(lifecycleRevision: 0, chronologySequence: 99)) == nil)
+    #expect(webSocket.readyState == .closed)
+    #expect(request.finishedOrFailedTimestamp == 1)
+    #expect(webSocket.frames.map(\.opcode) == [1, 2, nil, 8, 42])
+}
+
+@MainActor
+@Test
+func webSocketFirstCloseAndHandshakeAreTerminalAndDuplicateEventsDoNotNotify() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-terminal")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/terminal")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 101, statusText: "First"),
+            timestamp: 2
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 3)),
+        target: target
+    )
+    try await waitUntil { request.webSocket?.readyState == .closed }
+
+    let indexSequence = context.networkRequestIndexSequenceForTesting
+    let eventSequence = context.eventPumpAppliedSequenceForTesting
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 99)),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.handshakeRequest(
+            id: requestID,
+            request: Network.Request(id: requestID, url: "", method: "POST"),
+            timestamp: 100
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 299, statusText: "Late"),
+            timestamp: 101
+        )),
+        target: target
+    )
+    let processed = await context.waitForEventPumpAppliedSequenceForTesting(
+        after: eventSequence,
+        count: 3
+    )
+    #expect(processed)
+
+    let webSocket = try #require(request.webSocket)
+    #expect(context.networkRequestIndexSequenceForTesting == indexSequence)
+    #expect(webSocket.readyState == .closed)
+    #expect(webSocket.handshakeResponse?.status == 101)
+    #expect(webSocket.handshakeResponse?.statusText == "First")
+    #expect(webSocket.handshakeRequest == nil)
+    #expect(webSocket.timelineEntries.count == 2)
+    #expect(webSocket.timelineEntries.map(\.kind) == [.connectionEstablished, .connectionClosed])
+    #expect(request.finishedOrFailedTimestamp == 3)
+    #expect(request.responseReceivedTimestamp == 2)
+}
+
+@MainActor
+@Test
+func activeDuplicateWebSocketCreatedPreservesStateIdentityAndTimeline() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-active-created")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/initial")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 101),
+            timestamp: 1
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(opcode: 9, mask: false, payloadData: "", payloadLength: 0),
+            timestamp: 2
+        )),
+        target: target
+    )
+    try await waitUntil { request.webSocket?.timelineEntries.count == 2 }
+    let originalState = try #require(request.webSocket)
+    let originalTimeline = originalState.timelineEntries
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/enriched")),
+        target: target
+    )
+    try await waitUntil { request.url == "wss://example.com/enriched" }
+
+    #expect(request.webSocket === originalState)
+    #expect(request.webSocket?.readyState == .open)
+    #expect(request.webSocket?.timelineEntries == originalTimeline)
+    #expect(request.lifecycleRevision == 0)
+    #expect(request.state == .responded)
+}
+
+@Test(arguments: [0, 1, 2, 8, 9, 10, 42])
+func webSocketTimelineMapsEveryOpcodeWithoutTreatingNonTextAsText(opcode: Int) throws {
+    let webSocket = WebSocketState()
+    webSocket.appendFrame(
+        Network.WebSocketFrame(
+            opcode: opcode,
+            mask: true,
+            payloadData: opcode == 1 ? "text" : "AQID",
+            payloadLength: 3
+        ),
+        direction: .sent,
+        timestamp: 1,
+        lifecycleRevision: 4,
+        chronologySequence: 9
+    )
+
+    let entry = try #require(webSocket.timelineEntries.first)
+    guard case let .frame(frame) = entry.kind else {
+        Issue.record("Expected a WebSocket frame timeline entry.")
+        return
+    }
+    let expectedKind: WebSocketTimelineFrame.Kind = switch opcode {
+    case 0: .continuation
+    case 1: .text
+    case 2: .binary
+    case 8: .close
+    case 9: .ping
+    case 10: .pong
+    default: .unknown(opcode)
+    }
+    #expect(entry.id == .init(lifecycleRevision: 4, chronologySequence: 9))
+    #expect(frame.kind == expectedKind)
+    #expect(frame.payload == (opcode == 1 ? .text("text") : .base64Encoded("AQID")))
+    #expect(frame.payloadLength == 3)
+    #expect(frame.isMasked)
+}
+
+@MainActor
+@Test
+func terminalWebSocketCreatedRestartsSameRequestThroughCommonLifecycleReset() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-restarted")
+
+    await runtime.backend.emit(
+        .requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "wss://example.com/start",
+                method: "POST",
+                headers: ["X-Initial": "1"],
+                postData: "old body"
+            ),
+            resourceType: .webSocket,
+            redirectResponse: nil,
+            timestamp: 1
+        ),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    let responseBody = request.responseBody
+    await runtime.backend.emit(
+        .requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "wss://example.com/redirected",
+                method: "POST",
+                headers: ["X-Redirected": "1"],
+                postData: "redirect body"
+            ),
+            resourceType: .webSocket,
+            redirectResponse: Network.Response(status: 302),
+            timestamp: 2
+        ),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.handshakeRequest(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "",
+                method: "GET",
+                headers: ["Upgrade": "websocket"],
+                postData: "handshake body"
+            ),
+            timestamp: 3
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(
+                status: 101,
+                headers: ["Upgrade": "websocket"],
+                requestHeaders: ["Upgrade": "websocket"]
+            ),
+            timestamp: 4
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.frameSent(
+            id: requestID,
+            frame: Network.WebSocketFrame(opcode: 1, mask: true, payloadData: "old", payloadLength: 3),
+            timestamp: 5
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .loadingFinished(
+            id: requestID,
+            timestamp: 6,
+            sourceMapURL: "old.map",
+            metrics: Network.Metrics(encodedDataLength: 8, decodedBodyLength: 13)
+                .reporting(requestHeaders: ["X-Metrics": "1"])
+        ),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 7)),
+        target: target
+    )
+    try await waitUntil { request.webSocket?.readyState == .closed }
+    let previousState = try #require(request.webSocket)
+    #expect(request.redirects.count == 1)
+    #expect(request.metrics != nil)
+    #expect(request.requestBody != nil)
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/restarted")),
+        target: target
+    )
+    try await waitUntil {
+        request.lifecycleRevision == 1 && request.webSocket?.readyState == .connecting
+    }
+
+    #expect(results.items.first === request)
+    #expect(request.webSocket !== previousState)
+    #expect(request.webSocket?.timelineEntries.isEmpty == true)
+    #expect(request.url == "wss://example.com/restarted")
+    #expect(request.method == "GET")
+    #expect(request.resourceType == .webSocket)
+    #expect(request.state == .pending)
+    #expect(request.logicalStartTimestamp == nil)
+    #expect(request.chronologySequence == 7)
+    #expect(request.requestSentTimestamp == nil)
+    #expect(request.responseReceivedTimestamp == nil)
+    #expect(request.lastDataReceivedTimestamp == nil)
+    #expect(request.finishedOrFailedTimestamp == nil)
+    #expect(request.status == nil)
+    #expect(request.statusText == nil)
+    #expect(request.responseURL == nil)
+    #expect(request.mimeType == nil)
+    #expect(request.responseSource == nil)
+    #expect(request.sourceMapURL == nil)
+    #expect(request.requestHeaders.isEmpty)
+    #expect(request.requestHeaderSource == .unavailable)
+    #expect(request.responseHeaders.isEmpty)
+    #expect(request.requestBody == nil)
+    #expect(request.responseBody === responseBody)
+    #expect(request.responseBody.phase == .available)
+    #expect(request.metrics == nil)
+    #expect(request.redirects.isEmpty)
+    #expect(request.decodedDataLength == 0)
+    #expect(request.encodedDataLength == 0)
+    #expect(request.hasResponse == false)
+}
+
+@MainActor
+@Test
+func legacyWebSocketFramesProjectionPublishesTimelineChangesThroughObservation() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let requestID = Network.Request.ID("websocket-legacy-observation")
+    let request = NetworkRequest(
+        request: Network.Request(id: requestID, url: "wss://example.com/legacy", method: "GET"),
+        initiator: nil,
+        resourceType: .webSocket,
+        timestamp: nil,
+        modelContext: context
+    )
+    let webSocket = try #require(request.webSocket)
+    let observation = SynchronousObservationProbe()
+    withObservationTracking {
+        _ = webSocket.frames
+    } onChange: {
+        observation.markChanged()
+    }
+
+    request.appendWebSocketFrame(
+        Network.WebSocketFrame(opcode: 1, mask: true, payloadData: "legacy", payloadLength: 6),
+        direction: .received,
+        timestamp: 4,
+        chronologySequence: 1
+    )
+    try await waitUntil { observation.hasChanged }
+
+    #expect(webSocket.frames == [
+        WebSocketState.Frame(
+            direction: .received,
+            opcode: 1,
+            mask: true,
+            payloadData: "legacy",
+            payloadLength: 6,
+            timestamp: 4
+        )
+    ])
+}
+
+@MainActor
+@Test
+func closedWebSocketCannotFetchResponseBodyOrSendProtocolCommand() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let (target, context) = try await startContext(runtime: runtime)
+    let requestID = Network.Request.ID("websocket-no-response-body")
+
+    await runtime.backend.emit(
+        .webSocket(.created(id: requestID, url: "wss://example.com/no-body")),
+        target: target
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    try await waitUntil { results.items.count == 1 }
+    let request = try #require(results.items.first)
+    await runtime.backend.emit(
+        .webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(status: 101),
+            timestamp: 1
+        )),
+        target: target
+    )
+    await runtime.backend.emit(
+        .webSocket(.closed(id: requestID, timestamp: 2)),
+        target: target
+    )
+    try await waitUntil { request.state == .finished }
+
+    #expect(request.hasResponse)
+    #expect(request.hasResponseBody == false)
+    #expect(request.canFetchResponseBody == false)
+    let commandsBeforeFetch = await runtime.backend.recordedCommands()
+    await request.fetchResponseBody()
+    let commandsAfterFetch = await runtime.backend.recordedCommands()
+    #expect(commandsAfterFetch == commandsBeforeFetch)
+    #expect(commandsAfterFetch.filter {
+        $0 == RecordedCommand(domain: "Network", method: "getResponseBody")
+    }.isEmpty)
+    #expect(request.responseBody.phase == .available)
+}
+
+@MainActor
+@Test
 func webSocketEventForUnknownRequestIsSkipped() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
@@ -13413,6 +13947,23 @@ private final class CancellationProbe: @unchecked Sendable {
             lock.unlock()
         }
         return isCancelled
+    }
+}
+
+private final class SynchronousObservationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var changed = false
+
+    var hasChanged: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return changed
+    }
+
+    func markChanged() {
+        lock.lock()
+        defer { lock.unlock() }
+        changed = true
     }
 }
 

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -11622,6 +11622,97 @@ func legacyWebSocketFramesProjectionPublishesTimelineChangesThroughObservation()
     ])
 }
 
+@Test
+func legacyWebSocketFramesProjectionObservesOnlyIncomingFrameAndErrorEntries() throws {
+    let webSocket = WebSocketState()
+    let firstFrame = WebSocketState.Frame(
+        direction: .received,
+        opcode: 1,
+        mask: false,
+        payloadData: "hello",
+        payloadLength: 5,
+        timestamp: 2
+    )
+    let error = WebSocketState.Frame(
+        direction: .error("boom"),
+        errorMessage: "boom",
+        timestamp: 3
+    )
+
+    let firstFrameObservation = SynchronousObservationProbe()
+    withObservationTracking {
+        _ = webSocket.frames
+    } onChange: {
+        firstFrameObservation.markChanged()
+    }
+    #expect(webSocket.applyHandshakeResponse(
+        Network.Response(status: 101, statusText: "Switching Protocols"),
+        timestamp: 1,
+        lifecycleRevision: 4,
+        chronologySequence: 1
+    ))
+    #expect(firstFrameObservation.hasChanged == false)
+    #expect(webSocket.frames.isEmpty)
+
+    webSocket.appendFrame(
+        Network.WebSocketFrame(
+            opcode: 1,
+            mask: false,
+            payloadData: "hello",
+            payloadLength: 5
+        ),
+        direction: .received,
+        timestamp: 2,
+        lifecycleRevision: 4,
+        chronologySequence: 2
+    )
+    #expect(firstFrameObservation.hasChanged)
+    #expect(webSocket.timelineEntries.map(\.kind) == [
+        .handshakeResponse(WebSocketTimelineHandshakeResponse(
+            statusCode: 101,
+            statusText: "Switching Protocols"
+        )),
+        .connectionEstablished,
+        .frame(WebSocketTimelineFrame(
+            direction: .received,
+            kind: .text,
+            payload: .text("hello"),
+            payloadLength: 5,
+            isMasked: false
+        )),
+    ])
+    #expect(webSocket.frames == [firstFrame])
+
+    let errorObservation = SynchronousObservationProbe()
+    withObservationTracking {
+        _ = webSocket.frames
+    } onChange: {
+        errorObservation.markChanged()
+    }
+    webSocket.appendError(
+        "boom",
+        timestamp: 3,
+        lifecycleRevision: 4,
+        chronologySequence: 3
+    )
+    #expect(errorObservation.hasChanged)
+    #expect(webSocket.frames == [firstFrame, error])
+
+    let closeObservation = SynchronousObservationProbe()
+    withObservationTracking {
+        _ = webSocket.frames
+    } onChange: {
+        closeObservation.markChanged()
+    }
+    #expect(webSocket.close(
+        timestamp: 4,
+        lifecycleRevision: 4,
+        chronologySequence: 4
+    ))
+    #expect(closeObservation.hasChanged == false)
+    #expect(webSocket.frames == [firstFrame, error])
+}
+
 @MainActor
 @Test
 func closedWebSocketCannotFetchResponseBodyOrSendProtocolCommand() async throws {

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -2967,6 +2967,82 @@ func transportBackendDecodesWebSocketHandshakeEventsForTargetRoute() async throw
 }
 
 @Test
+func transportBackendPreservesEveryWebSocketOpcodeDirectionMaskAndPayloadMetadata() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(
+        backend: backend,
+        protocolProfile: .latest,
+        responseTimeout: .milliseconds(750)
+    )
+    await installPageTarget(in: transport)
+    let target = pageTarget(proxy: WebInspectorProxy(backend: LiveWebInspectorProxyBackend(transport: transport)))
+    let cases: [(method: String, opcode: Int, mask: Bool, payload: String, length: Int)] = [
+        ("Network.webSocketFrameSent", 0, false, "AA==", 1),
+        ("Network.webSocketFrameSent", 1, true, "sent text", 9),
+        ("Network.webSocketFrameReceived", 1, false, "received text", 13),
+        ("Network.webSocketFrameReceived", 2, true, "AQID", 3),
+        ("Network.webSocketFrameSent", 8, false, "A+g=", 2),
+        ("Network.webSocketFrameReceived", 9, false, "", 0),
+        ("Network.webSocketFrameSent", 10, true, "BA==", 1),
+        ("Network.webSocketFrameReceived", 42, true, "BQY=", 2),
+    ]
+
+    let eventsTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        var events: [Network.WebSocketEvent] = []
+        while events.count < cases.count, let event = await iterator.next() {
+            guard case let .webSocket(webSocketEvent) = event else {
+                continue
+            }
+            events.append(webSocketEvent)
+        }
+        return events
+    }
+
+    await waitForEventSubscription(target, domain: .network)
+    for (index, testCase) in cases.enumerated() {
+        await receiveTargetEvent(
+            transport,
+            targetID: ProtocolTarget.ID("page-main"),
+            method: testCase.method,
+            params: """
+            {"requestId":"ws-opcodes","timestamp":\(Double(index) + 0.5),"response":{"opcode":\(testCase.opcode),"mask":\(testCase.mask),"payloadData":"\(testCase.payload)","payloadLength":\(testCase.length)}}
+            """
+        )
+    }
+
+    let events = try await value(of: eventsTask)
+    #expect(events.count == cases.count)
+    for (index, pair) in zip(cases.indices, zip(cases, events)) {
+        let (testCase, event) = pair
+        let id: Network.Request.ID
+        let frame: Network.WebSocketFrame
+        let timestamp: Double
+        switch event {
+        case let .frameSent(eventID, eventFrame, eventTimestamp):
+            #expect(testCase.method == "Network.webSocketFrameSent")
+            id = eventID
+            frame = eventFrame
+            timestamp = eventTimestamp
+        case let .frameReceived(eventID, eventFrame, eventTimestamp):
+            #expect(testCase.method == "Network.webSocketFrameReceived")
+            id = eventID
+            frame = eventFrame
+            timestamp = eventTimestamp
+        default:
+            Issue.record("Expected a WebSocket frame event.")
+            continue
+        }
+        #expect(id == Network.Request.ID("ws-opcodes"))
+        #expect(frame.opcode == testCase.opcode)
+        #expect(frame.mask == testCase.mask)
+        #expect(frame.payloadData == testCase.payload)
+        #expect(frame.payloadLength == testCase.length)
+        #expect(timestamp == Double(index) + 0.5)
+    }
+}
+
+@Test
 func transportBackendFiltersEventsByRoute() async throws {
     let backend = FakeTransportBackend()
     let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(750))

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -3199,7 +3199,7 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(context: context)
         let selectedRequest = try #require(context.registeredRequest(for: selectedRequestID))
         model.selectRequest(selectedRequest)
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let listViewController = NetworkListViewController(
             model: model,
@@ -3291,7 +3291,7 @@ struct NetworkDetailViewControllerTests {
         )
         let model = NetworkPanelModel(context: context)
         let request = try #require(context.registeredRequest(for: requestID))
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let listViewController = NetworkListViewController(
             model: model,
@@ -3627,7 +3627,7 @@ struct NetworkDetailViewControllerTests {
         )
         let model = NetworkPanelModel(context: context)
         _ = try #require(context.registeredRequest(for: initialRequestID))
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let applyCompletionScheduler = ManualNetworkListSnapshotApplyCompletionScheduler()
         let listViewController = NetworkListViewController(
@@ -3727,7 +3727,7 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(context: context)
         let selectedRequest = try #require(context.registeredRequest(for: selectedRequestID))
         model.selectRequest(selectedRequest)
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let listViewController = NetworkListViewController(
             model: model,
@@ -3961,7 +3961,7 @@ struct NetworkDetailViewControllerTests {
         )
         let model = NetworkPanelModel(context: context)
         let firstRequest = try #require(context.registeredRequest(for: firstRequestID))
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let listViewController = NetworkListViewController(
             model: model,
@@ -4153,7 +4153,7 @@ struct NetworkDetailViewControllerTests {
             responseMimeType: "video/mp4"
         ))
         let model = NetworkPanelModel(context: context)
-        let frameScheduler = ManualNetworkListFrameScheduler()
+        let frameScheduler = ManualNetworkFrameScheduler()
         let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
         let applyCompletionScheduler = ManualNetworkListSnapshotApplyCompletionScheduler()
         let listViewController = NetworkListViewController(
@@ -6046,7 +6046,7 @@ private final class RecordingNetworkBodyPreviewViewController: UIViewController,
 }
 
 @MainActor
-private final class ManualNetworkListFrameScheduler: NetworkListFrameScheduling {
+private final class ManualNetworkFrameScheduler: NetworkFrameScheduling {
     private var pendingAction: (@MainActor () -> Void)?
     private(set) var scheduledFrameCount = 0
 

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -956,6 +956,11 @@ struct NetworkDetailViewControllerTests {
             defaultValue: "Text Frame",
             bundle: WebInspectorUILocalization.bundle
         )
+        let copy = String(
+            localized: "Copy",
+            defaultValue: "Copy",
+            bundle: WebInspectorUILocalization.bundle
+        )
         let handshakeResponse = String(
             localized: "network.websocket.handshake.response",
             defaultValue: "WebSocket Handshake Response",
@@ -974,9 +979,11 @@ struct NetworkDetailViewControllerTests {
         #expect(contents[2].subtitle.contains("+5 ms"))
         #expect(contents[2].accessibilityLabel == "hello\nworld")
         #expect(contents[2].accessibilityValue == contents[2].subtitle)
+        #expect(viewController.contextMenuConfigurationForTesting(itemIDs[2]) != nil)
         #expect(contents[3].style == .received)
         #expect(contents[3].symbolName == "arrow.down")
         #expect(contents[3].title.contains(13.formatted()))
+        #expect(viewController.contextMenuConfigurationForTesting(itemIDs[3]) == nil)
         #expect(contents[8].title.contains("15"))
         #expect(contents[9].style == .error)
         #expect(contents[9].title == "decode failed")
@@ -1009,6 +1016,7 @@ struct NetworkDetailViewControllerTests {
         )
         #expect(configuration.textProperties.adjustsFontForContentSizeCategory)
         #expect(configuration.secondaryTextProperties.numberOfLines == 0)
+        #expect(textCell.accessibilityCustomActions?.map(\.name) == [copy])
         viewController.collectionView.semanticContentAttribute = .forceRightToLeft
         #expect(viewController.collectionView.effectiveUserInterfaceLayoutDirection == .rightToLeft)
     }
@@ -1021,11 +1029,17 @@ struct NetworkDetailViewControllerTests {
             requestID: "ws-large-text",
             url: "wss://example.com/large-text"
         )
-        let limit = NetworkWebSocketPreviewViewController
-            .maximumRenderedTextPayloadCharactersForTesting
-        let payload = String(repeating: "a", count: limit - 1)
-            + "👩🏽‍💻"
-            + String(repeating: "z", count: 1_000_000)
+        let byteLimit = NetworkWebSocketPreviewViewController
+            .maximumRenderedTextPayloadUTF8BytesForTesting
+        let scalarBoundaryPayload = String(repeating: "a", count: byteLimit - 1)
+            + "💡"
+            + "scalar-boundary-tail"
+        let scalarBoundarySummary = NetworkWebSocketPreviewViewController
+            .renderedTextPayloadForTesting(scalarBoundaryPayload)
+        #expect(scalarBoundarySummary == String(repeating: "a", count: byteLimit - 1) + "…")
+        #expect(scalarBoundarySummary.contains("�") == false)
+        let payload = "a"
+            + String(repeating: "\u{0301}", count: 1_000_000)
             + "full-payload-tail"
         await context.apply(.webSocket(.frameReceived(
             id: request.proxyID,
@@ -1042,8 +1056,8 @@ struct NetworkDetailViewControllerTests {
             frame: Network.WebSocketFrame(
                 opcode: 2,
                 mask: false,
-                payloadData: String(repeating: "QQ==", count: limit),
-                payloadLength: limit * 3
+                payloadData: String(repeating: "QQ==", count: byteLimit),
+                payloadLength: byteLimit * 3
             ),
             timestamp: 13
         )))
@@ -1068,8 +1082,9 @@ struct NetworkDetailViewControllerTests {
         let textItemID = try #require(itemIDs.dropLast().last)
         let binaryItemID = try #require(itemIDs.last)
         let content = try #require(viewController.rowContentForTesting(textItemID))
-        #expect(content.title.count == limit + 1)
-        #expect(content.title.hasSuffix("👩🏽‍💻…"))
+        #expect(content.title.utf8.count <= byteLimit + "…".utf8.count)
+        #expect(Array(content.title.unicodeScalars.prefix(2).map(\.value)) == [0x61, 0x301])
+        #expect(content.title.hasSuffix("…"))
         #expect(content.title.contains("full-payload-tail") == false)
         #expect(content.accessibilityLabel == content.title)
         #expect(content.accessibilityValue.contains("full-payload-tail") == false)
@@ -1371,6 +1386,9 @@ struct NetworkDetailViewControllerTests {
         await resumeWebSocketPreview(viewController)
         #expect(viewController.tailScrollCountForTesting == 1)
         #expect(viewController.isFollowingTailForTesting)
+        let epoch = try #require(viewController.requestEpochForTesting)
+        let priorApplyGeneration = viewController.snapshotApplyGenerationForTesting
+        let priorUserScrollRevision = viewController.userScrollRevisionForTesting
 
         viewController.collectionView.setContentOffset(
             CGPoint(x: 0, y: -viewController.collectionView.adjustedContentInset.top),
@@ -1393,6 +1411,13 @@ struct NetworkDetailViewControllerTests {
         await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
         #expect(viewController.tailScrollCountForTesting == scrollCountBeforeUnpinnedAppend)
         #expect(abs(viewController.collectionView.contentOffset.y - offsetBeforeUnpinnedAppend) < 0.5)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: priorApplyGeneration,
+            userScrollRevision: priorUserScrollRevision
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeUnpinnedAppend)
 
         let lastIndexPath = IndexPath(
             item: viewController.snapshotForTesting.itemIdentifiers.count - 1,
@@ -1419,6 +1444,68 @@ struct NetworkDetailViewControllerTests {
         await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
         #expect(viewController.tailScrollCountForTesting == scrollCountBeforePinnedAppend + 1)
         #expect(viewController.isFollowingTailForTesting)
+        #expect(viewController.userScrollRevisionForTesting == priorUserScrollRevision)
+
+        let completedApplyGeneration = viewController.snapshotApplyGenerationForTesting
+        let userScrollRevisionBeforeDrag = viewController.userScrollRevisionForTesting
+        let scrollCountBeforeDrag = viewController.tailScrollCountForTesting
+        viewController.scrollViewWillBeginDragging(viewController.collectionView)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionBeforeDrag
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+
+        let userScrollRevisionAtDragStart = viewController.userScrollRevisionForTesting
+        #expect(viewController.isUserScrollingForTesting)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionAtDragStart
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+        viewController.scrollViewDidScroll(viewController.collectionView)
+        #expect(viewController.userScrollRevisionForTesting > userScrollRevisionAtDragStart)
+        viewController.scrollViewDidEndDragging(
+            viewController.collectionView,
+            willDecelerate: false
+        )
+        #expect(viewController.isUserScrollingForTesting == false)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionAtDragStart
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+
+        viewController.scrollViewWillBeginDragging(viewController.collectionView)
+        let userScrollRevisionBeforeDeceleration = viewController.userScrollRevisionForTesting
+        viewController.scrollViewDidEndDragging(
+            viewController.collectionView,
+            willDecelerate: true
+        )
+        #expect(viewController.isUserScrollingForTesting)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionBeforeDeceleration
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+        viewController.scrollViewDidScroll(viewController.collectionView)
+        viewController.scrollViewDidEndDecelerating(viewController.collectionView)
+        #expect(viewController.isUserScrollingForTesting == false)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionBeforeDeceleration
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
     }
 
     @Test
@@ -1608,6 +1695,13 @@ struct NetworkDetailViewControllerTests {
         )
         let snapshotBeforeHide = viewController.webSocketPreviewViewControllerForTesting
             .snapshotForTesting.itemIdentifiers
+        let requestEpochBeforeHide = try #require(
+            viewController.webSocketPreviewViewControllerForTesting.requestEpochForTesting
+        )
+        let applyGenerationBeforeHide = viewController.webSocketPreviewViewControllerForTesting
+            .snapshotApplyGenerationForTesting
+        let userScrollRevisionBeforeHide = viewController.webSocketPreviewViewControllerForTesting
+            .userScrollRevisionForTesting
 
         viewController.beginAppearanceTransition(false, animated: false)
         viewController.endAppearanceTransition()
@@ -1643,10 +1737,27 @@ struct NetworkDetailViewControllerTests {
             viewController.webSocketPreviewViewControllerForTesting
                 .timelineObservationDeliveryForTesting?.isActive == true
         )
+        let tailScrollCountAfterResume = viewController.webSocketPreviewViewControllerForTesting
+            .tailScrollCountForTesting
+        viewController.webSocketPreviewViewControllerForTesting
+            .invokeSnapshotApplyCompletionForTesting(
+                epoch: requestEpochBeforeHide,
+                followsTail: true,
+                applyGeneration: applyGenerationBeforeHide,
+                userScrollRevision: userScrollRevisionBeforeHide
+            )
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .tailScrollCountForTesting == tailScrollCountAfterResume
+        )
 
         let firstRequestEpoch = try #require(
             viewController.webSocketPreviewViewControllerForTesting.requestEpochForTesting
         )
+        let firstApplyGeneration = viewController.webSocketPreviewViewControllerForTesting
+            .snapshotApplyGenerationForTesting
+        let firstUserScrollRevision = viewController.webSocketPreviewViewControllerForTesting
+            .userScrollRevisionForTesting
         model.selectRequest(second)
         #expect(await waitUntilWebSocketPreviewBound(to: second, in: viewController))
         #expect(
@@ -1658,7 +1769,9 @@ struct NetworkDetailViewControllerTests {
         viewController.webSocketPreviewViewControllerForTesting
             .invokeSnapshotApplyCompletionForTesting(
                 epoch: firstRequestEpoch,
-                followsTail: true
+                followsTail: true,
+                applyGeneration: firstApplyGeneration,
+                userScrollRevision: firstUserScrollRevision
             )
         #expect(
             viewController.webSocketPreviewViewControllerForTesting

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1003,11 +1003,120 @@ struct NetworkDetailViewControllerTests {
         let configuration = try #require(
             textCell.contentConfiguration as? UIListContentConfiguration
         )
-        #expect(configuration.textProperties.numberOfLines == 0)
+        #expect(
+            configuration.textProperties.numberOfLines
+                == NetworkWebSocketPreviewViewController.maximumTitleLineCountForTesting
+        )
         #expect(configuration.textProperties.adjustsFontForContentSizeCategory)
         #expect(configuration.secondaryTextProperties.numberOfLines == 0)
         viewController.collectionView.semanticContentAttribute = .forceRightToLeft
         #expect(viewController.collectionView.effectiveUserInterfaceLayoutDirection == .rightToLeft)
+    }
+
+    @Test
+    func webSocketPreviewBoundsLargeTextPayloadAndResolvesFullCopyOnDemand() async throws {
+        let context = makeContext()
+        let request = try await applyWebSocket(
+            to: context,
+            requestID: "ws-large-text",
+            url: "wss://example.com/large-text"
+        )
+        let limit = NetworkWebSocketPreviewViewController
+            .maximumRenderedTextPayloadCharactersForTesting
+        let payload = String(repeating: "a", count: limit - 1)
+            + "👩🏽‍💻"
+            + String(repeating: "z", count: 1_000_000)
+            + "full-payload-tail"
+        await context.apply(.webSocket(.frameReceived(
+            id: request.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: payload,
+                payloadLength: payload.utf8.count
+            ),
+            timestamp: 12
+        )))
+        await context.apply(.webSocket(.frameReceived(
+            id: request.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 2,
+                mask: false,
+                payloadData: String(repeating: "QQ==", count: limit),
+                payloadLength: limit * 3
+            ),
+            timestamp: 13
+        )))
+
+        let replacement = try await applyWebSocket(
+            to: context,
+            requestID: "ws-large-text-replacement",
+            url: "wss://example.com/large-text-replacement"
+        )
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = NetworkWebSocketPreviewViewController(frameScheduler: frameScheduler)
+        var copiedPayload: String?
+        viewController.setTextPayloadCopyHandlerForTesting { payload in
+            copiedPayload = payload
+        }
+        let window = showInWindow(viewController, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        viewController.bind(to: request)
+        await resumeWebSocketPreview(viewController)
+
+        let itemIDs = viewController.snapshotForTesting.itemIdentifiers
+        let textItemID = try #require(itemIDs.dropLast().last)
+        let binaryItemID = try #require(itemIDs.last)
+        let content = try #require(viewController.rowContentForTesting(textItemID))
+        #expect(content.title.count == limit + 1)
+        #expect(content.title.hasSuffix("👩🏽‍💻…"))
+        #expect(content.title.contains("full-payload-tail") == false)
+        #expect(content.accessibilityLabel == content.title)
+        #expect(content.accessibilityValue.contains("full-payload-tail") == false)
+        #expect(viewController.contextMenuConfigurationForTesting(textItemID) != nil)
+        #expect(viewController.contextMenuConfigurationForTesting(binaryItemID) == nil)
+
+        viewController.collectionView.layoutIfNeeded()
+        let textIndex = try #require(itemIDs.firstIndex(of: textItemID))
+        let textCell = try #require(
+            viewController.collectionView.cellForItem(at: IndexPath(item: textIndex, section: 0))
+                as? UICollectionViewListCell
+        )
+        let textConfiguration = try #require(
+            textCell.contentConfiguration as? UIListContentConfiguration
+        )
+        #expect(
+            textConfiguration.textProperties.numberOfLines
+                == NetworkWebSocketPreviewViewController.maximumTitleLineCountForTesting
+        )
+        #expect(textConfiguration.text == content.title)
+        #expect(textCell.accessibilityLabel == content.title)
+        #expect(textCell.accessibilityValue?.contains("full-payload-tail") == false)
+        let copyAction = try #require(textCell.accessibilityCustomActions?.first)
+        #expect(copyAction.name == String(
+            localized: "Copy",
+            defaultValue: "Copy",
+            bundle: WebInspectorUILocalization.bundle
+        ))
+        #expect(copyAction.actionHandler?(copyAction) == true)
+        #expect(copiedPayload == payload)
+
+        let binaryIndex = try #require(itemIDs.firstIndex(of: binaryItemID))
+        let binaryCell = try #require(
+            viewController.collectionView.cellForItem(at: IndexPath(item: binaryIndex, section: 0))
+                as? UICollectionViewListCell
+        )
+        #expect(binaryCell.accessibilityCustomActions?.isEmpty ?? true)
+
+        copiedPayload = nil
+        viewController.suspendKeepingSnapshot()
+        #expect(copyAction.actionHandler?(copyAction) == false)
+        #expect(copiedPayload == nil)
+
+        viewController.bind(to: replacement)
+        await resumeWebSocketPreview(viewController)
+        #expect(copyAction.actionHandler?(copyAction) == false)
+        #expect(copiedPayload == nil)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -67,6 +67,11 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.headersTextViewForTesting.isHidden)
         #expect(viewController.cookiesViewControllerForTesting.view.isHidden)
         #expect(viewController.cookiesViewControllerForTesting.snapshotForTesting.itemIdentifiers.isEmpty)
+        #expect(viewController.webSocketPreviewViewControllerForTesting.view.isHidden)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.isEmpty
+        )
         #expect(viewController.contentUnavailableConfiguration != nil)
         let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
         #expect(configuration?.text?.isEmpty == false)
@@ -90,6 +95,10 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.view.backgroundColor == .clear)
         #expect(viewController.headersTextViewForTesting.backgroundColor == .clear)
         #expect(viewController.cookiesViewControllerForTesting.collectionView.backgroundColor == .clear)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting.collectionView.backgroundColor
+                == .clear
+        )
         #expect(viewController.syntaxBodyViewControllerForTesting.view.backgroundColor == .clear)
     }
 
@@ -213,10 +222,12 @@ struct NetworkDetailViewControllerTests {
         let trailingInset = viewController.view.safeAreaLayoutGuide.layoutFrame.maxX
         let bounds = viewController.view.bounds
         let cookiesView: UIView = viewController.cookiesViewControllerForTesting.view
+        let webSocketView: UIView = viewController.webSocketPreviewViewControllerForTesting.view
         for contentView in [
             viewController.headersTextViewForTesting,
             viewController.previewViewForTesting,
             cookiesView,
+            webSocketView,
         ] {
             #expect(contentView.frame.minX == leadingInset)
             #expect(contentView.frame.maxX == trailingInset)
@@ -225,6 +236,7 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.headersTextViewForTesting.frame.minY == bounds.minY)
         #expect(viewController.previewViewForTesting.frame.minY == bounds.minY)
         #expect(cookiesView.frame.minY == bounds.minY)
+        #expect(webSocketView.frame.minY == bounds.minY)
         #expect(viewController.previewRoleControlContainerViewForTesting.frame.minY == topInset)
     }
 
@@ -260,6 +272,7 @@ struct NetworkDetailViewControllerTests {
             return viewController.currentModeForTesting == .headers
                 && viewController.previewViewForTesting.isHidden
                 && viewController.headersTextViewForTesting.isHidden == false
+                && viewController.webSocketPreviewViewControllerForTesting.view.isHidden
                 && viewController.headersTextViewForTesting.usesTextKit2ForTesting
                 && viewController.headersTextViewForTesting.isSelectableForTesting
                 && text.contains("accept: application/json")
@@ -280,6 +293,7 @@ struct NetworkDetailViewControllerTests {
                 && viewController.previewViewForTesting.isHidden
                 && viewController.headersTextViewForTesting.isHidden
                 && viewController.cookiesViewControllerForTesting.view.isHidden == false
+                && viewController.webSocketPreviewViewControllerForTesting.view.isHidden
                 && items.contains(where: isRequestCookieItem)
                 && items.contains(where: isResponseCookieItem)
         }
@@ -296,6 +310,7 @@ struct NetworkDetailViewControllerTests {
                 && viewController.previewViewForTesting.isHidden == false
                 && viewController.headersTextViewForTesting.isHidden
                 && viewController.cookiesViewControllerForTesting.view.isHidden
+                && viewController.webSocketPreviewViewControllerForTesting.view.isHidden
                 && viewController.isPreviewRoleControlHiddenForTesting == false
         }
         #expect(didRenderPreview)
@@ -816,6 +831,737 @@ struct NetworkDetailViewControllerTests {
             requestCookieName(in: viewController) == "current"
                 && requestCookieValue(in: viewController) == "5"
         })
+    }
+
+    @Test
+    func webSocketPreviewRendersAllTimelineRowsWithoutDisclosingBase64Payloads() async throws {
+        let context = makeContext()
+        let request = try await applyWebSocket(
+            to: context,
+            requestID: "ws-all-rows",
+            url: "wss://example.com/all-rows",
+            requestTimestamp: 10,
+            responseTimestamp: nil
+        )
+        let requestID = request.proxyID
+        let frames: [Network.WebSocketEvent] = [
+            (.frameSent(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 1,
+                    mask: true,
+                    payloadData: "hello\nworld",
+                    payloadLength: 11
+                ),
+                timestamp: 10.005
+            )),
+            (.frameReceived(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 2,
+                    mask: false,
+                    payloadData: "QklOQVJZX1NFQ1JFVA==",
+                    payloadLength: 13
+                ),
+                timestamp: 11.25
+            )),
+            (.frameSent(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 0,
+                    mask: true,
+                    payloadData: "Q09OVElOVUFUSU9OX1NFQ1JFVA==",
+                    payloadLength: 18
+                ),
+                timestamp: 12
+            )),
+            (.frameReceived(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 8,
+                    mask: false,
+                    payloadData: "Q0xPU0VfU0VDUkVU",
+                    payloadLength: 12
+                ),
+                timestamp: 13
+            )),
+            (.frameSent(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 9,
+                    mask: true,
+                    payloadData: "UElOR19TRUNSRVQ=",
+                    payloadLength: 11
+                ),
+                timestamp: 14
+            )),
+            (.frameReceived(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 10,
+                    mask: false,
+                    payloadData: "UE9OR19TRUNSRVQ=",
+                    payloadLength: 11
+                ),
+                timestamp: 15
+            )),
+            (.frameReceived(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 15,
+                    mask: false,
+                    payloadData: "VU5LTk9XTl9TRUNSRVQ=",
+                    payloadLength: 14
+                ),
+                timestamp: 16
+            )),
+        ]
+        for event in frames {
+            await context.apply(.webSocket(event))
+        }
+        await context.apply(.webSocket(.error(
+            id: requestID,
+            message: "decode failed",
+            timestamp: 17
+        )))
+        await context.apply(.webSocket(.closed(id: requestID, timestamp: 18)))
+
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = NetworkWebSocketPreviewViewController(frameScheduler: frameScheduler)
+        let window = showInWindow(viewController, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        viewController.bind(to: request)
+        await resumeWebSocketPreview(viewController)
+
+        #expect(NetworkWebSocketPreviewViewController.listLayoutConfigurationForTesting.appearance == .plain)
+        #expect(viewController.collectionView.allowsSelection == false)
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.timeline])
+        let itemIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(itemIDs.count == 10)
+        let contents = try itemIDs.map { itemID in
+            try #require(viewController.rowContentForTesting(itemID))
+        }
+        let notReported = String(
+            localized: "network.websocket.time.not_reported",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let sent = String(
+            localized: "network.websocket.direction.sent",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let textFrame = String(
+            localized: "network.websocket.frame.text",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(contents[0].style == .lifecycle)
+        #expect(contents[0].subtitle == notReported)
+        #expect(contents[1].title == "hello\nworld")
+        #expect(contents[1].style == .sent)
+        #expect(contents[1].symbolName == "arrow.up")
+        #expect(contents[1].subtitle.contains(sent))
+        #expect(contents[1].subtitle.contains(textFrame))
+        #expect(contents[1].subtitle.contains("+5 ms"))
+        #expect(contents[1].accessibilityLabel == "hello\nworld")
+        #expect(contents[1].accessibilityValue == contents[1].subtitle)
+        #expect(contents[2].style == .received)
+        #expect(contents[2].symbolName == "arrow.down")
+        #expect(contents[2].title.contains(13.formatted()))
+        #expect(contents[7].title.contains("15"))
+        #expect(contents[8].style == .error)
+        #expect(contents[8].title == "decode failed")
+        #expect(contents[9].style == .lifecycle)
+        let copiedText = contents.flatMap {
+            [$0.title, $0.subtitle, $0.accessibilityLabel, $0.accessibilityValue]
+        }.joined(separator: "\n")
+        for secret in [
+            "QklOQVJZX1NFQ1JFVA==",
+            "Q09OVElOVUFUSU9OX1NFQ1JFVA==",
+            "Q0xPU0VfU0VDUkVU",
+            "UElOR19TRUNSRVQ=",
+            "UE9OR19TRUNSRVQ=",
+            "VU5LTk9XTl9TRUNSRVQ=",
+        ] {
+            #expect(copiedText.contains(secret) == false)
+        }
+
+        viewController.collectionView.layoutIfNeeded()
+        let textCell = try #require(
+            viewController.collectionView.cellForItem(at: IndexPath(item: 1, section: 0))
+                as? UICollectionViewListCell
+        )
+        let configuration = try #require(
+            textCell.contentConfiguration as? UIListContentConfiguration
+        )
+        #expect(configuration.textProperties.numberOfLines == 0)
+        #expect(configuration.textProperties.adjustsFontForContentSizeCategory)
+        #expect(configuration.secondaryTextProperties.numberOfLines == 0)
+        viewController.collectionView.semanticContentAttribute = .forceRightToLeft
+        #expect(viewController.collectionView.effectiveUserInterfaceLayoutDirection == .rightToLeft)
+    }
+
+    @Test
+    func webSocketPreviewCoalescesLiveSuffixAndRetainsExistingRows() async throws {
+        let context = makeContext()
+        let request = try await applyWebSocket(
+            to: context,
+            requestID: "ws-live-suffix",
+            url: "wss://example.com/live-suffix"
+        )
+        let requestID = request.proxyID
+        await context.apply(.webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "initial",
+                payloadLength: 7
+            ),
+            timestamp: 12
+        )))
+
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = NetworkWebSocketPreviewViewController(frameScheduler: frameScheduler)
+        let window = showInWindow(viewController, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        viewController.bind(to: request)
+        await resumeWebSocketPreview(viewController)
+        let initialIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(initialIDs.count == 2)
+        let initialCell = try #require(
+            viewController.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
+        )
+        let initialCellIdentity = ObjectIdentifier(initialCell)
+        let scheduledFrameBaseline = frameScheduler.scheduledFrameCount
+
+        for (index, timestamp) in [13.0, 12.5, 14.0].enumerated() {
+            await context.apply(.webSocket(.frameSent(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 1,
+                    mask: true,
+                    payloadData: "live-\(index)",
+                    payloadLength: 6
+                ),
+                timestamp: timestamp
+            )))
+        }
+
+        #expect(frameScheduler.scheduledFrameCount == scheduledFrameBaseline + 1)
+        #expect(frameScheduler.hasScheduledFrame)
+        #expect(viewController.snapshotForTesting.itemIdentifiers == initialIDs)
+        await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
+
+        let renderedIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(renderedIDs.count == 5)
+        #expect(Array(renderedIDs.prefix(initialIDs.count)) == initialIDs)
+        #expect(
+            viewController.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
+                .map(ObjectIdentifier.init) == initialCellIdentity
+        )
+        let renderedSequences = viewController.renderedEntryIDsForTesting.map(\.chronologySequence)
+        #expect(zip(renderedSequences, renderedSequences.dropFirst()).allSatisfy { pair in
+            pair.0 < pair.1
+        })
+    }
+
+    @Test
+    func webSocketPreviewFollowsTailOnlyWhilePinned() async throws {
+        let context = makeContext()
+        let request = try await applyWebSocket(
+            to: context,
+            requestID: "ws-tail",
+            url: "wss://example.com/tail"
+        )
+        let requestID = request.proxyID
+        for index in 0..<30 {
+            await context.apply(.webSocket(.frameReceived(
+                id: requestID,
+                frame: Network.WebSocketFrame(
+                    opcode: 1,
+                    mask: false,
+                    payloadData: "row-\(index)",
+                    payloadLength: 6
+                ),
+                timestamp: 12 + Double(index)
+            )))
+        }
+
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = NetworkWebSocketPreviewViewController(frameScheduler: frameScheduler)
+        let window = showInWindow(viewController, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        viewController.bind(to: request)
+        await resumeWebSocketPreview(viewController)
+        #expect(viewController.tailScrollCountForTesting == 1)
+        #expect(viewController.isFollowingTailForTesting)
+
+        viewController.collectionView.setContentOffset(
+            CGPoint(x: 0, y: -viewController.collectionView.adjustedContentInset.top),
+            animated: false
+        )
+        viewController.collectionView.layoutIfNeeded()
+        #expect(viewController.isFollowingTailForTesting == false)
+        let offsetBeforeUnpinnedAppend = viewController.collectionView.contentOffset.y
+        let scrollCountBeforeUnpinnedAppend = viewController.tailScrollCountForTesting
+        await context.apply(.webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "while-unpinned",
+                payloadLength: 14
+            ),
+            timestamp: 50
+        )))
+        await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeUnpinnedAppend)
+        #expect(abs(viewController.collectionView.contentOffset.y - offsetBeforeUnpinnedAppend) < 0.5)
+
+        let lastIndexPath = IndexPath(
+            item: viewController.snapshotForTesting.itemIdentifiers.count - 1,
+            section: 0
+        )
+        viewController.collectionView.scrollToItem(
+            at: lastIndexPath,
+            at: .bottom,
+            animated: false
+        )
+        viewController.collectionView.layoutIfNeeded()
+        #expect(viewController.isFollowingTailForTesting)
+        let scrollCountBeforePinnedAppend = viewController.tailScrollCountForTesting
+        await context.apply(.webSocket(.frameReceived(
+            id: requestID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "while-pinned",
+                payloadLength: 12
+            ),
+            timestamp: 51
+        )))
+        await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforePinnedAppend + 1)
+        #expect(viewController.isFollowingTailForTesting)
+    }
+
+    @Test
+    func webSocketPreviewRoutesOnlyTheActiveGroupedRequestAndReturnsToBodyPreview() async throws {
+        let context = makeContext()
+        let frameID = FrameID("ws-group-frame")
+        installNavigationVisit(in: context, frameID: frameID)
+
+        let webSocketFirstNodeID = DOM.Node.ID("ws-first-node")
+        let webSocketFirst = try await applyGroupedWebSocket(
+            to: context,
+            requestID: "ws-group-first",
+            url: "wss://example.com/first",
+            frameID: frameID,
+            initiatorNodeID: webSocketFirstNodeID,
+            timestamp: 1
+        )
+        await context.apply(.webSocket(.closed(id: webSocketFirst.proxyID, timestamp: 3)))
+        let ordinarySecond = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "ws-group-ordinary-second",
+            url: "https://example.com/second.json",
+            frameID: frameID,
+            initiatorNodeID: webSocketFirstNodeID,
+            responseHeaders: ["content-type": "application/json"],
+            responseMIMEType: "application/json",
+            resourceType: .xhr,
+            timestamp: 4
+        ))
+        applyResponseBody(
+            to: context,
+            request: ordinarySecond,
+            body: #"{"request":"ordinary-second"}"#
+        )
+
+        let ordinaryFirstNodeID = DOM.Node.ID("ordinary-first-node")
+        let ordinaryFirst = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "ws-group-ordinary-first",
+            url: "https://example.com/ordinary-first.json",
+            frameID: frameID,
+            initiatorNodeID: ordinaryFirstNodeID,
+            responseHeaders: ["content-type": "application/json"],
+            responseMIMEType: "application/json",
+            resourceType: .xhr,
+            timestamp: 10
+        ))
+        applyResponseBody(
+            to: context,
+            request: ordinaryFirst,
+            body: #"{"request":"ordinary-first"}"#
+        )
+        let webSocketSecond = try await applyGroupedWebSocket(
+            to: context,
+            requestID: "ws-group-second",
+            url: "wss://example.com/second",
+            frameID: frameID,
+            initiatorNodeID: ordinaryFirstNodeID,
+            timestamp: 14
+        )
+
+        let model = NetworkPanelModel(context: context)
+        try selectEntry(containing: webSocketFirst, in: model)
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .preview,
+            webSocketFrameScheduler: frameScheduler
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilWebSocketPreviewBound(to: webSocketFirst, in: viewController))
+        #expect(viewController.webSocketPreviewViewControllerForTesting.view.isHidden == false)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 2
+        )
+        #expect(viewController.previewViewForTesting.isHidden)
+        #expect(viewController.isPreviewRoleControlHiddenForTesting)
+        #expect(webSocketFirst.canFetchResponseBody == false)
+        #expect(viewController.responseBodyFetchObservationDeliveryForTesting == nil)
+        #expect(
+            viewController.contentScrollView(for: .top)
+                === viewController.webSocketPreviewViewControllerForTesting.collectionView
+        )
+        #expect(viewController.requestPickerItemForTesting != nil)
+
+        let parentRenderBaseline = viewController.selectedRequestRenderCountForTesting
+        let scheduledFrameBaseline = frameScheduler.scheduledFrameCount
+        let webSocketSnapshotBeforeFrame = viewController.webSocketPreviewViewControllerForTesting
+            .snapshotForTesting.itemIdentifiers
+        let childObservation = try #require(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting
+        )
+        let didScheduleChildFrame = await childObservation.values {
+            frameScheduler.hasScheduledFrame
+        }
+        defer { didScheduleChildFrame.cancel() }
+        let rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await context.apply(.webSocket(.frameReceived(
+            id: webSocketFirst.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "child-only-update",
+                payloadLength: 17
+            ),
+            timestamp: 3
+        )))
+        #expect(await didScheduleChildFrame.waitUntilValue(true))
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
+        #expect(viewController.selectedRequestRenderCountForTesting == parentRenderBaseline)
+        #expect(frameScheduler.scheduledFrameCount == scheduledFrameBaseline + 1)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers == webSocketSnapshotBeforeFrame
+        )
+        await fireWebSocketRenderingFrame(
+            frameScheduler,
+            in: viewController.webSocketPreviewViewControllerForTesting
+        )
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 3
+        )
+
+        model.selectRequest(ordinarySecond)
+        #expect(await waitUntilPreparedTextPreviewRendered(in: viewController) {
+            viewController.webSocketPreviewViewControllerForTesting.view.isHidden
+                && viewController.previewViewForTesting.isHidden == false
+                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text
+                    .contains("ordinary-second")
+        })
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting == nil
+        )
+
+        try selectEntry(containing: ordinaryFirst, in: model)
+        #expect(await waitUntilPreparedTextPreviewRendered(in: viewController) {
+            viewController.webSocketPreviewViewControllerForTesting.view.isHidden
+                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text
+                    .contains("ordinary-first")
+        })
+
+        model.selectRequest(webSocketSecond)
+        #expect(await waitUntilWebSocketPreviewBound(to: webSocketSecond, in: viewController))
+        #expect(viewController.webSocketPreviewViewControllerForTesting.view.isHidden == false)
+        #expect(viewController.previewViewForTesting.isHidden)
+        #expect(viewController.responseBodyFetchObservationDeliveryForTesting == nil)
+    }
+
+    @Test
+    func webSocketPreviewSuspendsCatchesUpAndRebindsRequestEpochs() async throws {
+        let context = makeContext()
+        let first = try await applyWebSocket(
+            to: context,
+            requestID: "ws-rebind-first",
+            url: "wss://example.com/rebind-first"
+        )
+        let second = try await applyWebSocket(
+            to: context,
+            requestID: "ws-rebind-second",
+            url: "wss://example.com/rebind-second"
+        )
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(first)
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .preview,
+            webSocketFrameScheduler: frameScheduler
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilWebSocketPreviewBound(to: first, in: viewController))
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 1
+        )
+        let firstTimelineObservation = try #require(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting
+        )
+        let snapshotBeforeHide = viewController.webSocketPreviewViewControllerForTesting
+            .snapshotForTesting.itemIdentifiers
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        #expect(firstTimelineObservation.isActive == false)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting == nil
+        )
+        await context.apply(.webSocket(.frameReceived(
+            id: first.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "hidden",
+                payloadLength: 6
+            ),
+            timestamp: 12
+        )))
+        #expect(frameScheduler.hasScheduledFrame == false)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers == snapshotBeforeHide
+        )
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+        #expect(await waitUntilWebSocketPreviewBound(to: first, in: viewController))
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 2
+        })
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting?.isActive == true
+        )
+
+        let firstRequestEpoch = try #require(
+            viewController.webSocketPreviewViewControllerForTesting.requestEpochForTesting
+        )
+        model.selectRequest(second)
+        #expect(await waitUntilWebSocketPreviewBound(to: second, in: viewController))
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 1
+        )
+        let tailScrollCountAfterRebind = viewController.webSocketPreviewViewControllerForTesting
+            .tailScrollCountForTesting
+        viewController.webSocketPreviewViewControllerForTesting
+            .invokeSnapshotApplyCompletionForTesting(
+                epoch: firstRequestEpoch,
+                followsTail: true
+            )
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .tailScrollCountForTesting == tailScrollCountAfterRebind
+        )
+        let secondSnapshot = viewController.webSocketPreviewViewControllerForTesting
+            .snapshotForTesting.itemIdentifiers
+        await context.apply(.webSocket(.frameReceived(
+            id: first.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "stale-first",
+                payloadLength: 11
+            ),
+            timestamp: 13
+        )))
+        #expect(frameScheduler.hasScheduledFrame == false)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers == secondSnapshot
+        )
+
+        let priorWebSocket = try #require(second.webSocket)
+        let priorLifecycleRevision = second.lifecycleRevision
+        let priorTimelineObservation = try #require(
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting
+        )
+        let restartTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await context.apply(.webSocket(.closed(id: second.proxyID, timestamp: 14)))
+        #expect(await model.waitForRawTransactionDeliveryForTesting(
+            after: restartTransactionBaseline
+        ))
+        let createdTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await context.apply(.webSocket(.created(
+            id: second.proxyID,
+            url: "wss://example.com/rebind-second-restarted"
+        )))
+        #expect(await model.waitForRawTransactionDeliveryForTesting(
+            after: createdTransactionBaseline
+        ))
+        let restartedWebSocket = try #require(second.webSocket)
+        #expect(restartedWebSocket !== priorWebSocket)
+        #expect(await waitUntilWebSocketPreviewBound(
+            to: second,
+            webSocket: restartedWebSocket,
+            in: viewController
+        ))
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.isEmpty
+        )
+        #expect(priorTimelineObservation.isActive == false)
+        #expect(frameScheduler.hasScheduledFrame == false)
+
+        priorWebSocket.appendError(
+            "stale-old-state",
+            timestamp: 15,
+            lifecycleRevision: priorLifecycleRevision,
+            chronologySequence: 1_000
+        )
+        #expect(frameScheduler.hasScheduledFrame == false)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.isEmpty
+        )
+
+        let transactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await context.apply(.webSocket(.handshakeResponse(
+            id: second.proxyID,
+            response: Network.Response(
+                url: second.url,
+                status: 101,
+                statusText: "Switching Protocols"
+            ),
+            timestamp: 16
+        )))
+        #expect(frameScheduler.hasScheduledFrame)
+        await fireWebSocketRenderingFrame(
+            frameScheduler,
+            in: viewController.webSocketPreviewViewControllerForTesting
+        )
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 1
+        )
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: transactionBaseline))
+
+        let replacedWebSocket = try #require(second.webSocket)
+        let replacement = NetworkRequest(
+            request: Network.Request(
+                id: second.proxyID,
+                url: "wss://example.com/rebind-second-instance",
+                method: "GET"
+            ),
+            initiator: nil,
+            resourceType: .webSocket,
+            timestamp: 20,
+            chronologySequence: 2_000,
+            requestHeaderSource: .unavailable,
+            modelContext: context
+        )
+        _ = replacement.applyWebSocketHandshakeResponse(
+            Network.Response(
+                url: replacement.url,
+                status: 101,
+                statusText: "Switching Protocols"
+            ),
+            timestamp: 21,
+            chronologySequence: 2_001
+        )
+        model.upsertRequestForTesting(replacement)
+        #expect(await waitUntilWebSocketPreviewBound(to: replacement, in: viewController))
+        #expect(model.selectedRequest === replacement)
+        #expect(
+            viewController.webSocketPreviewViewControllerForTesting
+                .snapshotForTesting.itemIdentifiers.count == 1
+        )
+        replacedWebSocket.appendError(
+            "stale-replaced-instance",
+            timestamp: 22,
+            lifecycleRevision: second.lifecycleRevision,
+            chronologySequence: 2_002
+        )
+        #expect(frameScheduler.hasScheduledFrame == false)
+    }
+
+    @Test
+    func webSocketPreviewClearAndDeinitReleaseRenderingLifecycle() async throws {
+        let context = makeContext()
+        let request = try await applyWebSocket(
+            to: context,
+            requestID: "ws-clear",
+            url: "wss://example.com/clear"
+        )
+        let frameScheduler = ManualNetworkFrameScheduler()
+        var viewController: NetworkWebSocketPreviewViewController? =
+            NetworkWebSocketPreviewViewController(frameScheduler: frameScheduler)
+        viewController?.bind(to: request)
+        await resumeWebSocketPreview(try #require(viewController))
+        let observation = try #require(viewController?.timelineObservationDeliveryForTesting)
+
+        await context.apply(.webSocket(.frameReceived(
+            id: request.proxyID,
+            frame: Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "pending",
+                payloadLength: 7
+            ),
+            timestamp: 12
+        )))
+        #expect(frameScheduler.hasScheduledFrame)
+        viewController?.clear()
+        #expect(observation.isActive == false)
+        #expect(frameScheduler.hasScheduledFrame == false)
+        #expect(viewController?.boundRequestForTesting == nil)
+        #expect(viewController?.boundWebSocketForTesting == nil)
+        #expect(viewController?.snapshotForTesting.itemIdentifiers.isEmpty == true)
+
+        viewController?.bind(to: request)
+        viewController?.resumeRendering()
+        let deferredObservationStart = try #require(
+            viewController?.observationStartTaskForTesting
+        )
+        #expect(viewController?.hasPendingObservationStartForTesting == true)
+        viewController?.clear()
+        await deferredObservationStart.value
+        #expect(viewController?.timelineObservationDeliveryForTesting == nil)
+        #expect(viewController?.snapshotForTesting.itemIdentifiers.isEmpty == true)
+        #expect(frameScheduler.hasScheduledFrame == false)
+
+        var didDeinitialize = false
+        viewController?.setDeinitHandlerForTesting {
+            didDeinitialize = true
+        }
+        viewController = nil
+        #expect(didDeinitialize)
+        #expect(frameScheduler.invalidationCount == 1)
     }
 
     @Test
@@ -5555,6 +6301,78 @@ struct NetworkDetailViewControllerTests {
         return context.registeredRequest(forProxyID: requestID)
     }
 
+    private func applyWebSocket(
+        to context: WebInspectorContext,
+        requestID rawRequestID: String,
+        url: String,
+        requestTimestamp: Double? = 10,
+        responseTimestamp: Double? = 11
+    ) async throws -> NetworkRequest {
+        let requestID = Network.Request.ID(rawRequestID)
+        await context.apply(.webSocket(.created(id: requestID, url: url)))
+        await context.apply(.webSocket(.handshakeRequest(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: url,
+                method: "GET",
+                headers: ["Upgrade": "websocket"]
+            ),
+            timestamp: requestTimestamp
+        )))
+        await context.apply(.webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(
+                url: url,
+                status: 101,
+                statusText: "Switching Protocols",
+                headers: ["Upgrade": "websocket"]
+            ),
+            timestamp: responseTimestamp
+        )))
+        return try #require(context.registeredRequest(forProxyID: requestID))
+    }
+
+    private func applyGroupedWebSocket(
+        to context: WebInspectorContext,
+        requestID rawRequestID: String,
+        url: String,
+        frameID: FrameID,
+        initiatorNodeID: DOM.Node.ID,
+        timestamp: Double
+    ) async throws -> NetworkRequest {
+        let requestID = Network.Request.ID(rawRequestID)
+        await context.apply(.requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: url,
+                method: "GET",
+                headers: ["Upgrade": "websocket"],
+                origin: Network.Request.Origin(
+                    frameID: frameID,
+                    loaderID: "loader",
+                    targetID: "page"
+                )
+            ),
+            initiator: Network.Initiator(kind: "script", nodeID: initiatorNodeID),
+            resourceType: .webSocket,
+            redirectResponse: nil,
+            timestamp: timestamp
+        ))
+        await context.apply(.webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(
+                url: url,
+                status: 101,
+                statusText: "Switching Protocols",
+                headers: ["Upgrade": "websocket"]
+            ),
+            timestamp: timestamp + 1
+        )))
+        return try #require(context.registeredRequest(forProxyID: requestID))
+    }
+
     private func applyResponseReceived(
         to context: WebInspectorContext,
         requestID rawRequestID: String,
@@ -5638,6 +6456,54 @@ struct NetworkDetailViewControllerTests {
             }
         }
         viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func resumeWebSocketPreview(
+        _ viewController: NetworkWebSocketPreviewViewController
+    ) async {
+        await withCheckedContinuation { continuation in
+            viewController.setNextSnapshotApplyCompletionForTesting {
+                continuation.resume()
+            }
+            viewController.resumeRendering()
+        }
+        viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func fireWebSocketRenderingFrame(
+        _ frameScheduler: ManualNetworkFrameScheduler,
+        in viewController: NetworkWebSocketPreviewViewController
+    ) async {
+        await withCheckedContinuation { continuation in
+            viewController.setNextSnapshotApplyCompletionForTesting {
+                continuation.resume()
+            }
+            frameScheduler.fireScheduledFrame()
+        }
+        viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func waitUntilWebSocketPreviewBound(
+        to request: NetworkRequest,
+        webSocket expectedWebSocket: WebSocketState? = nil,
+        in viewController: NetworkDetailViewController
+    ) async -> Bool {
+        let webSocketPreview = viewController.webSocketPreviewViewControllerForTesting
+        guard await waitUntilRendered(in: viewController, {
+            guard webSocketPreview.boundRequestForTesting === request else {
+                return false
+            }
+            guard let expectedWebSocket else {
+                return true
+            }
+            return webSocketPreview.boundWebSocketForTesting === expectedWebSocket
+        }) else {
+            return false
+        }
+        await webSocketPreview.waitForTimelineObservationStartForTesting()
+        webSocketPreview.collectionView.layoutIfNeeded()
+        return webSocketPreview.boundRequestForTesting === request
+            && webSocketPreview.timelineObservationDeliveryForTesting?.isActive == true
     }
 
     private func requestCookieName(in viewController: NetworkDetailViewController) -> String? {
@@ -5864,6 +6730,8 @@ struct NetworkDetailViewControllerTests {
             viewController.modelObservationDeliveryForTesting,
             viewController.selectedRequestRenderObservationDeliveryForTesting,
             viewController.responseBodyFetchObservationDeliveryForTesting,
+            viewController.webSocketPreviewViewControllerForTesting
+                .timelineObservationDeliveryForTesting,
         ].compactMap { $0 }
         if let syntaxBodyViewController = viewController.bodyViewControllerForTesting as? NetworkBodyViewController {
             deliveries.append(contentsOf: [
@@ -5928,11 +6796,13 @@ struct NetworkDetailViewControllerTests {
 private func makeNetworkDetailViewController(
     model: NetworkPanelModel,
     initialMode: NetworkDetailViewController.Mode = .headers,
+    webSocketFrameScheduler: any NetworkFrameScheduling = NetworkDisplayLinkFrameScheduler(),
     makeBodyViewController: @escaping NetworkBodyViewControllerFactory = NetworkBodyPreviewFactory.make(scrollEdgeSink:)
 ) -> NetworkDetailViewController {
     NetworkDetailViewController(
         model: model,
         initialMode: initialMode,
+        webSocketFrameScheduler: webSocketFrameScheduler,
         makeBodyViewController: makeBodyViewController
     )
 }
@@ -6049,6 +6919,7 @@ private final class RecordingNetworkBodyPreviewViewController: UIViewController,
 private final class ManualNetworkFrameScheduler: NetworkFrameScheduling {
     private var pendingAction: (@MainActor () -> Void)?
     private(set) var scheduledFrameCount = 0
+    private(set) var invalidationCount = 0
 
     var hasScheduledFrame: Bool {
         pendingAction != nil
@@ -6067,12 +6938,13 @@ private final class ManualNetworkFrameScheduler: NetworkFrameScheduling {
     }
 
     func invalidate() {
+        invalidationCount += 1
         cancel()
     }
 
     func fireScheduledFrame() {
         guard let action = pendingAction else {
-            preconditionFailure("Expected a scheduled Network list projection frame.")
+            preconditionFailure("Expected a scheduled Network rendering frame.")
         }
         pendingAction = nil
         action()

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -1431,6 +1431,7 @@ struct NetworkDetailViewControllerTests {
         viewController.collectionView.layoutIfNeeded()
         #expect(viewController.isFollowingTailForTesting)
         let scrollCountBeforePinnedAppend = viewController.tailScrollCountForTesting
+        let userScrollRevisionBeforePinnedAppend = viewController.userScrollRevisionForTesting
         await context.apply(.webSocket(.frameReceived(
             id: requestID,
             frame: Network.WebSocketFrame(
@@ -1444,7 +1445,7 @@ struct NetworkDetailViewControllerTests {
         await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
         #expect(viewController.tailScrollCountForTesting == scrollCountBeforePinnedAppend + 1)
         #expect(viewController.isFollowingTailForTesting)
-        #expect(viewController.userScrollRevisionForTesting == priorUserScrollRevision)
+        #expect(viewController.userScrollRevisionForTesting == userScrollRevisionBeforePinnedAppend)
 
         let completedApplyGeneration = viewController.snapshotApplyGenerationForTesting
         let userScrollRevisionBeforeDrag = viewController.userScrollRevisionForTesting
@@ -1504,6 +1505,44 @@ struct NetworkDetailViewControllerTests {
             followsTail: true,
             applyGeneration: completedApplyGeneration,
             userScrollRevision: userScrollRevisionBeforeDeceleration
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+
+        #expect(viewController.scrollViewShouldScrollToTop(viewController.collectionView))
+        let userScrollRevisionAtScrollToTopStart = viewController.userScrollRevisionForTesting
+        #expect(viewController.isUserScrollingForTesting)
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionAtScrollToTopStart
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+        viewController.scrollViewDidScrollToTop(viewController.collectionView)
+        #expect(viewController.isUserScrollingForTesting == false)
+        #expect(
+            viewController.userScrollRevisionForTesting
+                > userScrollRevisionAtScrollToTopStart
+        )
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionAtScrollToTopStart
+        )
+        #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
+
+        let userScrollRevisionBeforeNonDragScroll = viewController.userScrollRevisionForTesting
+        viewController.scrollViewDidScroll(viewController.collectionView)
+        #expect(
+            viewController.userScrollRevisionForTesting
+                > userScrollRevisionBeforeNonDragScroll
+        )
+        viewController.invokeSnapshotApplyCompletionForTesting(
+            epoch: epoch,
+            followsTail: true,
+            applyGeneration: completedApplyGeneration,
+            userScrollRevision: userScrollRevisionBeforeNonDragScroll
         )
         #expect(viewController.tailScrollCountForTesting == scrollCountBeforeDrag)
     }

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -943,18 +943,22 @@ struct NetworkDetailViewControllerTests {
         }
         let notReported = String(
             localized: "network.websocket.time.not_reported",
+            defaultValue: "Time not reported",
             bundle: WebInspectorUILocalization.bundle
         )
         let sent = String(
             localized: "network.websocket.direction.sent",
+            defaultValue: "Sent",
             bundle: WebInspectorUILocalization.bundle
         )
         let textFrame = String(
             localized: "network.websocket.frame.text",
+            defaultValue: "Text Frame",
             bundle: WebInspectorUILocalization.bundle
         )
         let handshakeResponse = String(
             localized: "network.websocket.handshake.response",
+            defaultValue: "WebSocket Handshake Response",
             bundle: WebInspectorUILocalization.bundle
         )
         #expect(contents[0].title == handshakeResponse)
@@ -1043,10 +1047,12 @@ struct NetworkDetailViewControllerTests {
         }
         let rejectionTitle = String(
             localized: "network.websocket.handshake.rejected",
+            defaultValue: "WebSocket Handshake Rejected",
             bundle: WebInspectorUILocalization.bundle
         )
         let establishedTitle = String(
             localized: "network.websocket.connection.established",
+            defaultValue: "WebSocket Connection Established",
             bundle: WebInspectorUILocalization.bundle
         )
         #expect(contents[0].title == rejectionTitle)
@@ -1063,14 +1069,17 @@ struct NetworkDetailViewControllerTests {
     func webSocketPreviewKeepsQuietAndUnreportedHandshakeResponsesNeutral() async throws {
         let handshakeTitle = String(
             localized: "network.websocket.handshake.response",
+            defaultValue: "WebSocket Handshake Response",
             bundle: WebInspectorUILocalization.bundle
         )
         let establishedTitle = String(
             localized: "network.websocket.connection.established",
+            defaultValue: "WebSocket Connection Established",
             bundle: WebInspectorUILocalization.bundle
         )
         let statusNotReported = String(
             localized: "network.websocket.status.not_reported",
+            defaultValue: "Status not reported",
             bundle: WebInspectorUILocalization.bundle
         )
         for (suffix, status, statusText) in [

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -937,7 +937,7 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.collectionView.allowsSelection == false)
         #expect(viewController.snapshotForTesting.sectionIdentifiers == [.timeline])
         let itemIDs = viewController.snapshotForTesting.itemIdentifiers
-        #expect(itemIDs.count == 10)
+        #expect(itemIDs.count == 11)
         let contents = try itemIDs.map { itemID in
             try #require(viewController.rowContentForTesting(itemID))
         }
@@ -953,23 +953,30 @@ struct NetworkDetailViewControllerTests {
             localized: "network.websocket.frame.text",
             bundle: WebInspectorUILocalization.bundle
         )
+        let handshakeResponse = String(
+            localized: "network.websocket.handshake.response",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(contents[0].title == handshakeResponse)
         #expect(contents[0].style == .lifecycle)
-        #expect(contents[0].subtitle == notReported)
-        #expect(contents[1].title == "hello\nworld")
-        #expect(contents[1].style == .sent)
-        #expect(contents[1].symbolName == "arrow.up")
-        #expect(contents[1].subtitle.contains(sent))
-        #expect(contents[1].subtitle.contains(textFrame))
-        #expect(contents[1].subtitle.contains("+5 ms"))
-        #expect(contents[1].accessibilityLabel == "hello\nworld")
-        #expect(contents[1].accessibilityValue == contents[1].subtitle)
-        #expect(contents[2].style == .received)
-        #expect(contents[2].symbolName == "arrow.down")
-        #expect(contents[2].title.contains(13.formatted()))
-        #expect(contents[7].title.contains("15"))
-        #expect(contents[8].style == .error)
-        #expect(contents[8].title == "decode failed")
-        #expect(contents[9].style == .lifecycle)
+        #expect(contents[0].subtitle.contains("101 Switching Protocols"))
+        #expect(contents[0].subtitle.contains(notReported))
+        #expect(contents[1].style == .lifecycle)
+        #expect(contents[2].title == "hello\nworld")
+        #expect(contents[2].style == .sent)
+        #expect(contents[2].symbolName == "arrow.up")
+        #expect(contents[2].subtitle.contains(sent))
+        #expect(contents[2].subtitle.contains(textFrame))
+        #expect(contents[2].subtitle.contains("+5 ms"))
+        #expect(contents[2].accessibilityLabel == "hello\nworld")
+        #expect(contents[2].accessibilityValue == contents[2].subtitle)
+        #expect(contents[3].style == .received)
+        #expect(contents[3].symbolName == "arrow.down")
+        #expect(contents[3].title.contains(13.formatted()))
+        #expect(contents[8].title.contains("15"))
+        #expect(contents[9].style == .error)
+        #expect(contents[9].title == "decode failed")
+        #expect(contents[10].style == .lifecycle)
         let copiedText = contents.flatMap {
             [$0.title, $0.subtitle, $0.accessibilityLabel, $0.accessibilityValue]
         }.joined(separator: "\n")
@@ -986,7 +993,7 @@ struct NetworkDetailViewControllerTests {
 
         viewController.collectionView.layoutIfNeeded()
         let textCell = try #require(
-            viewController.collectionView.cellForItem(at: IndexPath(item: 1, section: 0))
+            viewController.collectionView.cellForItem(at: IndexPath(item: 2, section: 0))
                 as? UICollectionViewListCell
         )
         let configuration = try #require(
@@ -997,6 +1004,158 @@ struct NetworkDetailViewControllerTests {
         #expect(configuration.secondaryTextProperties.numberOfLines == 0)
         viewController.collectionView.semanticContentAttribute = .forceRightToLeft
         #expect(viewController.collectionView.effectiveUserInterfaceLayoutDirection == .rightToLeft)
+    }
+
+    @Test
+    func webSocketPreviewRendersRejectedHandshakeWithoutEstablishedRow() async throws {
+        let context = makeContext()
+        let requestID = Network.Request.ID("ws-rejected-preview")
+        await context.apply(.webSocket(.created(
+            id: requestID,
+            url: "wss://example.com/rejected-preview"
+        )))
+        await context.apply(.webSocket(.handshakeResponse(
+            id: requestID,
+            response: Network.Response(
+                url: "wss://example.com/rejected-preview",
+                status: 403,
+                statusText: "Forbidden"
+            ),
+            timestamp: 2
+        )))
+        await context.apply(.webSocket(.error(
+            id: requestID,
+            message: "upgrade failed",
+            timestamp: 3
+        )))
+        await context.apply(.webSocket(.closed(id: requestID, timestamp: 4)))
+        let request = try #require(context.registeredRequest(forProxyID: requestID))
+        let viewController = NetworkWebSocketPreviewViewController(
+            frameScheduler: ManualNetworkFrameScheduler()
+        )
+        viewController.bind(to: request)
+        await resumeWebSocketPreview(viewController)
+
+        let itemIDs = viewController.snapshotForTesting.itemIdentifiers
+        #expect(itemIDs.count == 3)
+        let contents = try itemIDs.map { itemID in
+            try #require(viewController.rowContentForTesting(itemID))
+        }
+        let rejectionTitle = String(
+            localized: "network.websocket.handshake.rejected",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let establishedTitle = String(
+            localized: "network.websocket.connection.established",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(contents[0].title == rejectionTitle)
+        #expect(contents[0].subtitle.contains("403 Forbidden"))
+        #expect(contents[0].style == .error)
+        #expect(contents[0].symbolName == "exclamationmark.shield")
+        #expect(contents[0].accessibilityLabel == rejectionTitle)
+        #expect(contents[0].accessibilityValue.contains("403 Forbidden"))
+        #expect(contents[1].title == "upgrade failed")
+        #expect(contents.contains { $0.title == establishedTitle } == false)
+    }
+
+    @Test
+    func webSocketPreviewKeepsQuietAndUnreportedHandshakeResponsesNeutral() async throws {
+        let handshakeTitle = String(
+            localized: "network.websocket.handshake.response",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let establishedTitle = String(
+            localized: "network.websocket.connection.established",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let statusNotReported = String(
+            localized: "network.websocket.status.not_reported",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        for (suffix, status, statusText) in [
+            ("switching", Optional(101), Optional("Switching Protocols")),
+            ("unreported", Optional<Int>.none, Optional("Opaque Response")),
+        ] {
+            let context = makeContext()
+            let requestID = Network.Request.ID("ws-neutral-\(suffix)")
+            await context.apply(.webSocket(.created(
+                id: requestID,
+                url: "wss://example.com/neutral-\(suffix)"
+            )))
+            await context.apply(.webSocket(.handshakeResponse(
+                id: requestID,
+                response: Network.Response(status: status, statusText: statusText),
+                timestamp: 2
+            )))
+            let request = try #require(context.registeredRequest(forProxyID: requestID))
+            let viewController = NetworkWebSocketPreviewViewController(
+                frameScheduler: ManualNetworkFrameScheduler()
+            )
+            viewController.bind(to: request)
+            await resumeWebSocketPreview(viewController)
+
+            let itemIDs = viewController.snapshotForTesting.itemIdentifiers
+            #expect(itemIDs.count == 1)
+            let content = try #require(viewController.rowContentForTesting(itemIDs[0]))
+            #expect(content.title == handshakeTitle)
+            #expect(content.style == .lifecycle)
+            #expect(content.accessibilityLabel == handshakeTitle)
+            #expect(content.title != establishedTitle)
+            #expect(request.webSocket?.readyState == .connecting)
+            if let status {
+                #expect(content.subtitle.contains(String(status)))
+                #expect(content.subtitle.contains(statusText ?? ""))
+            } else {
+                #expect(content.subtitle.contains(statusNotReported))
+                #expect(content.subtitle.contains(statusText ?? ""))
+            }
+        }
+    }
+
+    @Test
+    func webSocketFirstFramePublishesEstablishedAndFrameInOneObservationDelivery() async throws {
+        let webSocket = WebSocketState()
+        let observation = withPortableContinuousObservation { _ in
+            _ = webSocket.timelineEntries
+            _ = webSocket.frames
+        }
+        defer { observation.cancel() }
+        let values = await observation.values {
+            [webSocket.timelineEntries.count, webSocket.frames.count]
+        }
+        defer { values.cancel() }
+        let deliveryBaseline = values.snapshot().count
+
+        webSocket.appendFrame(
+            Network.WebSocketFrame(
+                opcode: 1,
+                mask: false,
+                payloadData: "first",
+                payloadLength: 5
+            ),
+            direction: .received,
+            timestamp: 4,
+            lifecycleRevision: 3,
+            chronologySequence: 8
+        )
+
+        #expect(await values.waitUntilValue([2, 1]))
+        #expect(values.snapshot().count == deliveryBaseline + 1)
+        #expect(values.snapshot().contains([1, 0]) == false)
+        #expect(webSocket.readyState == .open)
+        #expect(webSocket.timelineEntries.map(\.id) == [
+            .init(
+                lifecycleRevision: 3,
+                chronologySequence: 8,
+                ordinalWithinEvent: 0
+            ),
+            .init(
+                lifecycleRevision: 3,
+                chronologySequence: 8,
+                ordinalWithinEvent: 1
+            ),
+        ])
     }
 
     @Test
@@ -1026,7 +1185,7 @@ struct NetworkDetailViewControllerTests {
         viewController.bind(to: request)
         await resumeWebSocketPreview(viewController)
         let initialIDs = viewController.snapshotForTesting.itemIdentifiers
-        #expect(initialIDs.count == 2)
+        #expect(initialIDs.count == 3)
         let initialCell = try #require(
             viewController.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
         )
@@ -1052,14 +1211,14 @@ struct NetworkDetailViewControllerTests {
         await fireWebSocketRenderingFrame(frameScheduler, in: viewController)
 
         let renderedIDs = viewController.snapshotForTesting.itemIdentifiers
-        #expect(renderedIDs.count == 5)
+        #expect(renderedIDs.count == 6)
         #expect(Array(renderedIDs.prefix(initialIDs.count)) == initialIDs)
         #expect(
             viewController.collectionView.cellForItem(at: IndexPath(item: 0, section: 0))
                 .map(ObjectIdentifier.init) == initialCellIdentity
         )
-        let renderedSequences = viewController.renderedEntryIDsForTesting.map(\.chronologySequence)
-        #expect(zip(renderedSequences, renderedSequences.dropFirst()).allSatisfy { pair in
+        let renderedEntryIDs = viewController.renderedEntryIDsForTesting
+        #expect(zip(renderedEntryIDs, renderedEntryIDs.dropFirst()).allSatisfy { pair in
             pair.0 < pair.1
         })
     }
@@ -1360,7 +1519,7 @@ struct NetworkDetailViewControllerTests {
         #expect(await waitUntilWebSocketPreviewBound(to: first, in: viewController))
         #expect(await waitUntilRendered(in: viewController) {
             viewController.webSocketPreviewViewControllerForTesting
-                .snapshotForTesting.itemIdentifiers.count == 2
+                .snapshotForTesting.itemIdentifiers.count == 3
         })
         #expect(
             viewController.webSocketPreviewViewControllerForTesting


### PR DESCRIPTION
## Purpose

Add a specialized live WebSocket surface to Network Preview so handshake evidence, lifecycle events, frames, and protocol errors can be inspected without requesting a response body.

Closes #239

## Changes

- Model an append-only WebSocket timeline with lifecycle-scoped stable identities, exact opcode mapping, sent/received direction, errors, and close evidence.
- Preserve handshake responses factually: non-101 responses render as rejected, while 101 and missing-status responses are not guessed to mean an established connection.
- Confirm connection establishment only from the first non-close frame; invalid-101 responses and synthetic close frames cannot produce a false Established row.
- Preserve the public `WebSocketState.frames` API as an incrementally maintained compatibility projection and resolve ordered timeline IDs with binary search.
- Reset completed and error-closed WebSocket lifecycles when a request ID is reused, while preserving active connecting/open duplicate events.
- Prevent WebSocket requests from invoking `Network.getResponseBody`.
- Render existing and live entries in a native diffable list with display-frame coalescing, atomic suffix updates, observation teardown/rebinding, and tail-follow authority that respects drag, deceleration, status-bar, and other non-tail scrolling.
- Render text payload summaries within a 4 KB UTF-8 budget and eight lines, with native context-menu and accessibility Copy actions that resolve the current full payload on demand.
- Keep non-text base64 payloads out of visible and accessibility content; display frame kind and byte length instead.
- Add localized and accessible handshake, lifecycle, direction, frame-kind, error, rejection, and relative-time presentation.
- Generalize the existing Network frame scheduler for reuse by both the request list and WebSocket preview.

## Testing

- WebInspectorDataKit and WebInspectorProxyKit suites plus Network detail and parent UI suites: 636 test functions / 682 concrete runs, 0 failures on iPhone 17 with iOS 26.5.
- Focused WebSocket coverage includes incremental compatibility projection and Observation behavior, a 4,097-entry ordered lookup history, pending/responded error-only lifecycle reuse, atomic first-frame delivery, rejection and close semantics, a one-million-combining-mark text payload, UTF-8 scalar boundaries, full-payload Copy, stale actions, binary-payload exclusion, user/system scroll invalidation, suspend/rebind, and teardown.
- Consumer contract tests: 11/11 passed.
- Generic iOS build and build-for-testing passed.
- DataKit symbol-boundary validation passed.
- Localization catalog compilation passed with 46 outputs.
- DocC validation passed for all four targets with no DocC warnings.
- `git diff --check` passed.
- Branch-wide `codex-review` against current `main` completed with no remaining P0-P2 findings.

## Screenshots

Not included; no live WebSocket inspection capture was produced.
