### PR TITLE
Expand Network Headers request context

### DIFF
--- a/Sources/WebInspectorDataKit/NetworkCookies.swift
+++ b/Sources/WebInspectorDataKit/NetworkCookies.swift
@@ -134,7 +134,7 @@ private struct NetworkResponseCookieProjection: Hashable, Sendable {
         var diagnostics: [NetworkCookieParseDiagnostic] = []
 
         for attribute in attributes {
-            guard NetworkCookieParser.isHTTPToken(attribute.name) else {
+            guard NetworkHTTPGrammar.isHTTPToken(attribute.name) else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
                     kind: .invalidAttribute,
                     rawFragment: attribute.raw
@@ -142,7 +142,7 @@ private struct NetworkResponseCookieProjection: Hashable, Sendable {
                 continue
             }
 
-            switch NetworkCookieParser.lowercaseASCII(attribute.name) {
+            switch NetworkHTTPGrammar.lowercaseASCII(attribute.name) {
             case "domain":
                 guard let value = attribute.value, value.isEmpty == false else {
                     diagnostics.append(NetworkCookieParseDiagnostic(
@@ -227,7 +227,7 @@ private struct NetworkResponseCookieProjection: Hashable, Sendable {
                     ))
                     continue
                 }
-                switch NetworkCookieParser.lowercaseASCII(value) {
+                switch NetworkHTTPGrammar.lowercaseASCII(value) {
                 case "none":
                     sameSite = .none
                 case "lax":
@@ -316,7 +316,7 @@ package enum NetworkCookieParser {
         }
 
         let rawHeaderValue = rawHeaderValues[0]
-        guard trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
+        guard NetworkHTTPGrammar.trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
             return NetworkRequestCookieParseReport(
                 cookies: [],
                 rawHeaderValues: rawHeaderValues,
@@ -332,7 +332,7 @@ package enum NetworkCookieParser {
 
         for (ordinal, fragment) in fragments.enumerated() {
             let rawFragment = String(fragment)
-            let trimmedFragment = trimOptionalWhitespace(rawFragment)
+            let trimmedFragment = NetworkHTTPGrammar.trimOptionalWhitespace(rawFragment)
             guard containsNonOWSControlCharacter(rawFragment) == false else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
                     kind: .prohibitedControlCharacter,
@@ -348,9 +348,9 @@ package enum NetworkCookieParser {
                 continue
             }
 
-            let name = trimOptionalWhitespace(String(trimmedFragment[..<equalsIndex]))
+            let name = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedFragment[..<equalsIndex]))
             let valueStart = trimmedFragment.index(after: equalsIndex)
-            let value = trimOptionalWhitespace(String(trimmedFragment[valueStart...]))
+            let value = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedFragment[valueStart...]))
             guard containsControlCharacter(name) == false,
                   containsControlCharacter(value) == false else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
@@ -359,7 +359,7 @@ package enum NetworkCookieParser {
                 ))
                 continue
             }
-            guard isHTTPToken(name) else {
+            guard NetworkHTTPGrammar.isHTTPToken(name) else {
                 diagnostics.append(NetworkCookieParseDiagnostic(
                     kind: .invalidCookieFragment,
                     rawFragment: rawFragment
@@ -402,7 +402,7 @@ package enum NetworkCookieParser {
         }
 
         let rawHeaderValue = rawHeaderValues[0]
-        guard trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
+        guard NetworkHTTPGrammar.trimOptionalWhitespace(rawHeaderValue).isEmpty == false else {
             return NetworkResponseCookieParseReport(
                 cookies: [],
                 rawHeaderValues: rawHeaderValues,
@@ -437,7 +437,7 @@ package enum NetworkCookieParser {
 
         let fragments = rawHeaderValue.split(separator: ";", omittingEmptySubsequences: false)
         let rawCookiePair = String(fragments[0])
-        let trimmedCookiePair = trimOptionalWhitespace(rawCookiePair)
+        let trimmedCookiePair = NetworkHTTPGrammar.trimOptionalWhitespace(rawCookiePair)
         guard let equalsIndex = trimmedCookiePair.firstIndex(of: "=") else {
             return unparsedResponseReport(
                 rawHeaderValues: rawHeaderValues,
@@ -447,9 +447,9 @@ package enum NetworkCookieParser {
                 )
             )
         }
-        let name = trimOptionalWhitespace(String(trimmedCookiePair[..<equalsIndex]))
+        let name = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedCookiePair[..<equalsIndex]))
         let valueStart = trimmedCookiePair.index(after: equalsIndex)
-        let value = trimOptionalWhitespace(String(trimmedCookiePair[valueStart...]))
+        let value = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedCookiePair[valueStart...]))
         guard containsControlCharacter(name) == false,
               containsControlCharacter(value) == false else {
             return unparsedResponseReport(
@@ -460,7 +460,7 @@ package enum NetworkCookieParser {
                 )
             )
         }
-        guard isHTTPToken(name) else {
+        guard NetworkHTTPGrammar.isHTTPToken(name) else {
             return unparsedResponseReport(
                 rawHeaderValues: rawHeaderValues,
                 diagnostic: NetworkCookieParseDiagnostic(
@@ -474,13 +474,13 @@ package enum NetworkCookieParser {
         attributes.reserveCapacity(max(fragments.count - 1, 0))
         for (ordinal, fragment) in fragments.dropFirst().enumerated() {
             let rawAttribute = String(fragment)
-            let trimmedAttribute = trimOptionalWhitespace(rawAttribute)
+            let trimmedAttribute = NetworkHTTPGrammar.trimOptionalWhitespace(rawAttribute)
             let attributeName: String
             let attributeValue: String?
             if let equalsIndex = trimmedAttribute.firstIndex(of: "=") {
-                attributeName = trimOptionalWhitespace(String(trimmedAttribute[..<equalsIndex]))
+                attributeName = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedAttribute[..<equalsIndex]))
                 let valueStart = trimmedAttribute.index(after: equalsIndex)
-                attributeValue = trimOptionalWhitespace(String(trimmedAttribute[valueStart...]))
+                attributeValue = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmedAttribute[valueStart...]))
             } else {
                 attributeName = trimmedAttribute
                 attributeValue = nil
@@ -535,7 +535,7 @@ fileprivate extension NetworkCookieParser {
         in headers: [String: String]
     ) -> [HeaderField]? {
         let fields = headers.compactMap { name, value -> HeaderField? in
-            guard asciiCaseInsensitiveEqual(name, targetName) else {
+            guard NetworkHTTPGrammar.asciiCaseInsensitiveEqual(name, targetName) else {
                 return nil
             }
             return HeaderField(name: name, value: value)
@@ -546,49 +546,6 @@ fileprivate extension NetworkCookieParser {
             return lhs.value < rhs.value
         }
         return fields.isEmpty ? nil : fields
-    }
-
-    static func asciiCaseInsensitiveEqual(_ lhs: String, _ rhs: String) -> Bool {
-        let lhsBytes = lhs.utf8
-        let rhsBytes = rhs.utf8
-        guard lhsBytes.count == rhsBytes.count else {
-            return false
-        }
-        return zip(lhsBytes, rhsBytes).allSatisfy { lhsByte, rhsByte in
-            lowercaseASCII(lhsByte) == lowercaseASCII(rhsByte)
-        }
-    }
-
-    static func lowercaseASCII(_ value: String) -> String {
-        String(decoding: value.utf8.map(lowercaseASCII), as: UTF8.self)
-    }
-
-    static func lowercaseASCII(_ byte: UInt8) -> UInt8 {
-        guard (65...90).contains(byte) else {
-            return byte
-        }
-        return byte + 32
-    }
-
-    static func trimOptionalWhitespace(_ value: String) -> String {
-        let bytes = value.utf8
-        var lowerBound = bytes.startIndex
-        var upperBound = bytes.endIndex
-        while lowerBound < upperBound, isOptionalWhitespace(bytes[lowerBound]) {
-            lowerBound = bytes.index(after: lowerBound)
-        }
-        while lowerBound < upperBound {
-            let preceding = bytes.index(before: upperBound)
-            guard isOptionalWhitespace(bytes[preceding]) else {
-                break
-            }
-            upperBound = preceding
-        }
-        return String(decoding: bytes[lowerBound..<upperBound], as: UTF8.self)
-    }
-
-    static func isOptionalWhitespace(_ byte: UInt8) -> Bool {
-        byte == 0x20 || byte == 0x09
     }
 
     static func parseStatus(
@@ -636,7 +593,7 @@ fileprivate extension NetworkCookieParser {
         guard let value else {
             return false
         }
-        if lowercaseASCII(name) == "expires" {
+        if NetworkHTTPGrammar.lowercaseASCII(name) == "expires" {
             return containsNonOWSControlCharacter(value)
         }
         return containsControlCharacter(value)
@@ -646,17 +603,17 @@ fileprivate extension NetworkCookieParser {
         let bytes = Array(value.utf8)
         for commaIndex in bytes.indices where bytes[commaIndex] == 0x2C {
             var index = commaIndex + 1
-            while index < bytes.count, isOptionalWhitespace(bytes[index]) {
+            while index < bytes.count, NetworkHTTPGrammar.isOptionalWhitespace(bytes[index]) {
                 index += 1
             }
             let tokenStart = index
-            while index < bytes.count, isHTTPTokenCharacter(bytes[index]) {
+            while index < bytes.count, NetworkHTTPGrammar.isHTTPTokenCharacter(bytes[index]) {
                 index += 1
             }
             guard index > tokenStart else {
                 continue
             }
-            while index < bytes.count, isOptionalWhitespace(bytes[index]) {
+            while index < bytes.count, NetworkHTTPGrammar.isOptionalWhitespace(bytes[index]) {
                 index += 1
             }
             if index < bytes.count, bytes[index] == 0x3D {
@@ -664,23 +621,6 @@ fileprivate extension NetworkCookieParser {
             }
         }
         return false
-    }
-
-    static func isHTTPTokenCharacter(_ byte: UInt8) -> Bool {
-        switch byte {
-        case 48...57, 65...90, 97...122:
-            return true
-        case 0x21, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2A, 0x2B, 0x2D, 0x2E,
-             0x5E, 0x5F, 0x60, 0x7C, 0x7E:
-            return true
-        default:
-            return false
-        }
-    }
-
-    static func isHTTPToken(_ value: String) -> Bool {
-        let bytes = value.utf8
-        return bytes.isEmpty == false && bytes.allSatisfy(isHTTPTokenCharacter)
     }
 
     static func parseMaxAge(_ value: String) -> Int64? {
@@ -871,7 +811,10 @@ fileprivate extension NetworkCookieParser {
         guard token.count >= 3 else {
             return nil
         }
-        let prefix = String(decoding: token.prefix(3).map(lowercaseASCII), as: UTF8.self)
+        let prefix = String(
+            decoding: token.prefix(3).map(NetworkHTTPGrammar.lowercaseASCII),
+            as: UTF8.self
+        )
         switch prefix {
         case "jan": return 1
         case "feb": return 2

--- a/Sources/WebInspectorDataKit/NetworkHTTPGrammar.swift
+++ b/Sources/WebInspectorDataKit/NetworkHTTPGrammar.swift
@@ -1,0 +1,58 @@
+enum NetworkHTTPGrammar {
+    static func asciiCaseInsensitiveEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = lhs.utf8
+        let rhsBytes = rhs.utf8
+        guard lhsBytes.count == rhsBytes.count else {
+            return false
+        }
+        return zip(lhsBytes, rhsBytes).allSatisfy { lhsByte, rhsByte in
+            lowercaseASCII(lhsByte) == lowercaseASCII(rhsByte)
+        }
+    }
+
+    static func lowercaseASCII(_ value: String) -> String {
+        String(decoding: value.utf8.map(lowercaseASCII), as: UTF8.self)
+    }
+
+    static func lowercaseASCII(_ byte: UInt8) -> UInt8 {
+        (65...90).contains(byte) ? byte + 32 : byte
+    }
+
+    static func trimOptionalWhitespace(_ value: String) -> String {
+        let bytes = value.utf8
+        var lowerBound = bytes.startIndex
+        var upperBound = bytes.endIndex
+        while lowerBound < upperBound, isOptionalWhitespace(bytes[lowerBound]) {
+            lowerBound = bytes.index(after: lowerBound)
+        }
+        while lowerBound < upperBound {
+            let preceding = bytes.index(before: upperBound)
+            guard isOptionalWhitespace(bytes[preceding]) else {
+                break
+            }
+            upperBound = preceding
+        }
+        return String(decoding: bytes[lowerBound..<upperBound], as: UTF8.self)
+    }
+
+    static func isOptionalWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09
+    }
+
+    static func isHTTPToken(_ value: String) -> Bool {
+        let bytes = value.utf8
+        return bytes.isEmpty == false && bytes.allSatisfy(isHTTPTokenCharacter)
+    }
+
+    static func isHTTPTokenCharacter(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 48...57, 65...90, 97...122:
+            return true
+        case 0x21, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2A, 0x2B, 0x2D, 0x2E,
+            0x5E, 0x5F, 0x60, 0x7C, 0x7E:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -1045,10 +1045,19 @@ public final class NetworkBody {
         url: String,
         role: Role
     ) -> (kind: Kind, syntaxKind: SyntaxKind) {
-        let contentType = NetworkContentTypeParser.effectiveNormalizedMediaType(
+        let contentTypeResolution = NetworkContentTypeParser.normalizedMediaTypeResolution(
             protocolMIMEType: mimeType,
             headers: headers
-        ) ?? ""
+        )
+        let contentType: String
+        switch contentTypeResolution {
+        case .absent:
+            contentType = ""
+        case .invalid:
+            return (.binary, .plainText)
+        case .value(let value):
+            contentType = value
+        }
 
         if role == .request && contentType == "application/x-www-form-urlencoded" {
             return (.form, .plainText)

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -974,10 +974,10 @@ public final class NetworkBody {
         url: String,
         role: Role
     ) -> (kind: Kind, syntaxKind: SyntaxKind) {
-        let contentType = (mimeType ?? headerValue(named: "content-type", in: headers) ?? "")
-            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-            .first
-            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() } ?? ""
+        let contentType = NetworkContentTypeParser.effectiveNormalizedMediaType(
+            protocolMIMEType: mimeType,
+            headers: headers
+        ) ?? ""
 
         if role == .request && contentType == "application/x-www-form-urlencoded" {
             return (.form, .plainText)
@@ -1001,10 +1001,6 @@ public final class NetworkBody {
             return (.text, syntaxKind(forPathExtensionIn: url))
         }
         return (.binary, .plainText)
-    }
-
-    private static func headerValue(named name: String, in headers: [String: String]) -> String? {
-        headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
     }
 
     private static func syntaxKind(forPathExtensionIn url: String) -> SyntaxKind {
@@ -1081,37 +1077,20 @@ public final class NetworkBody {
     }
 
     private func formattedURLEncodedFormText(from text: String?) -> String? {
-        guard let text, text.isEmpty == false, text.contains("=") else {
+        guard let text else {
             return nil
         }
-
-        var lines: [String] = []
-        for pair in text.split(separator: "&", omittingEmptySubsequences: false) {
-            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-            guard parts.isEmpty == false else {
-                continue
-            }
-            guard let name = decodeFormComponent(String(parts[0])) else {
-                return nil
-            }
-            let value: String
-            if parts.count > 1 {
-                guard let decodedValue = decodeFormComponent(String(parts[1])) else {
-                    return nil
-                }
-                value = decodedValue
-            } else {
-                value = ""
-            }
-            lines.append("\(name)=\(value)")
+        let report = NetworkParameterParser.parseForm(text)
+        guard report.parameters.isEmpty == false else {
+            return text
         }
-        return lines.isEmpty ? nil : lines.joined(separator: "\n")
-    }
-
-    private func decodeFormComponent(_ component: String) -> String? {
-        component
-            .replacingOccurrences(of: "+", with: " ")
-            .removingPercentEncoding
+        return report.parameters.map { parameter in
+            let name = parameter.name.displayValue
+            guard parameter.hadEqualsSign else {
+                return name
+            }
+            return "\(name)=\(parameter.value.displayValue)"
+        }.joined(separator: "\n")
     }
 }
 
@@ -2070,36 +2049,21 @@ public final class NetworkRequest: WebInspectorFetchableModel {
     }
 
     package static func effectiveMIMEType(mimeType: String?, headers: [String: String]) -> String? {
-        if let mimeType, mimeType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            return mimeType
-        }
-        guard let contentType = headers.first(where: { key, _ in
-            key.caseInsensitiveCompare("content-type") == .orderedSame
-        })?.value else {
-            return nil
-        }
-        return contentType
+        NetworkContentTypeParser.effectiveMediaType(
+            protocolMIMEType: mimeType,
+            headers: headers
+        )
     }
 
     private static func normalizedMIMEType(_ mimeType: String?) -> String {
-        mimeType?
-            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-            .first?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() ?? ""
+        guard let mimeType else {
+            return ""
+        }
+        return NetworkContentTypeParser.parse(mimeType).normalizedMediaType ?? ""
     }
 
     private static func isMultipartMixedReplace(_ mimeType: String?) -> Bool {
-        guard let mimeType else {
-            return false
-        }
-        return mimeType.utf8.elementsEqual(
-            "multipart/x-mixed-replace".utf8,
-            by: { lhs, rhs in
-                let folded = lhs >= 65 && lhs <= 90 ? lhs + 32 : lhs
-                return folded == rhs
-            }
-        )
+        normalizedMIMEType(mimeType) == "multipart/x-mixed-replace"
     }
 
     private static func isPreviewableImage(mimeType: String, pathExtension: String) -> Bool {

--- a/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
@@ -1,0 +1,704 @@
+import Foundation
+import WebInspectorProxyKit
+
+package enum NetworkParameterParseStatus: Hashable, Sendable {
+    case complete
+    case partial
+    case unparsed
+}
+
+package struct NetworkParameterParseDiagnostic: Hashable, Sendable {
+    package enum Field: Hashable, Sendable {
+        case name
+        case value
+    }
+
+    package let ordinal: Int
+    package let field: Field
+    package let rawValue: String
+    package let reason: NetworkParameter.Component.MalformedReason
+
+    package init(
+        ordinal: Int,
+        field: Field,
+        rawValue: String,
+        reason: NetworkParameter.Component.MalformedReason
+    ) {
+        self.ordinal = ordinal
+        self.field = field
+        self.rawValue = rawValue
+        self.reason = reason
+    }
+}
+
+package struct NetworkParameterParseReport: Hashable, Sendable {
+    package let rawValue: String
+    package let parameters: [NetworkParameter]
+
+    package var diagnostics: [NetworkParameterParseDiagnostic] {
+        parameters.flatMap { parameter in
+            var diagnostics: [NetworkParameterParseDiagnostic] = []
+            if case let .malformed(rawValue, reason) = parameter.name {
+                diagnostics.append(
+                    NetworkParameterParseDiagnostic(
+                        ordinal: parameter.ordinal,
+                        field: .name,
+                        rawValue: rawValue,
+                        reason: reason
+                    ))
+            }
+            if case let .malformed(rawValue, reason) = parameter.value {
+                diagnostics.append(
+                    NetworkParameterParseDiagnostic(
+                        ordinal: parameter.ordinal,
+                        field: .value,
+                        rawValue: rawValue,
+                        reason: reason
+                    ))
+            }
+            return diagnostics
+        }
+    }
+
+    package var status: NetworkParameterParseStatus {
+        let malformedComponentCount = parameters.reduce(into: 0) { count, parameter in
+            count += parameter.name.isMalformed ? 1 : 0
+            count += parameter.value.isMalformed ? 1 : 0
+        }
+        guard malformedComponentCount > 0 else {
+            return .complete
+        }
+        return malformedComponentCount == parameters.count * 2 ? .unparsed : .partial
+    }
+
+    package init(rawValue: String, parameters: [NetworkParameter]) {
+        self.rawValue = rawValue
+        self.parameters = parameters
+    }
+}
+
+package struct NetworkParameter: Identifiable, Hashable, Sendable {
+    package enum Component: Hashable, Sendable {
+        package enum MalformedReason: Hashable, Sendable {
+            case malformedPercentEscape
+            case invalidUTF8
+        }
+
+        case decoded(rawValue: String, value: String)
+        case malformed(rawValue: String, reason: MalformedReason)
+
+        package var rawValue: String {
+            switch self {
+            case let .decoded(rawValue, _), let .malformed(rawValue, _):
+                rawValue
+            }
+        }
+
+        package var decodedValue: String? {
+            guard case let .decoded(_, value) = self else {
+                return nil
+            }
+            return value
+        }
+
+        package var displayValue: String {
+            decodedValue ?? rawValue
+        }
+
+        fileprivate var isMalformed: Bool {
+            guard case .malformed = self else {
+                return false
+            }
+            return true
+        }
+    }
+
+    package var id: Int { ordinal }
+    package let ordinal: Int
+    package let rawFragment: String
+    package let hadEqualsSign: Bool
+    package let name: Component
+    package let value: Component
+
+    package init(
+        ordinal: Int,
+        rawFragment: String,
+        hadEqualsSign: Bool,
+        name: Component,
+        value: Component
+    ) {
+        self.ordinal = ordinal
+        self.rawFragment = rawFragment
+        self.hadEqualsSign = hadEqualsSign
+        self.name = name
+        self.value = value
+    }
+}
+
+package enum NetworkParameterParser {
+    package static func parseQuery(in rawURL: String) -> NetworkParameterParseReport? {
+        // URLComponents may reject or normalize the malformed escapes this report must preserve.
+        let querySearchEnd = rawURL.firstIndex(of: "#") ?? rawURL.endIndex
+        guard let questionMark = rawURL[..<querySearchEnd].firstIndex(of: "?") else {
+            return nil
+        }
+        let queryStart = rawURL.index(after: questionMark)
+        return parse(String(rawURL[queryStart..<querySearchEnd]))
+    }
+
+    package static func parseForm(_ rawValue: String) -> NetworkParameterParseReport {
+        parse(rawValue)
+    }
+
+    private static func parse(_ rawValue: String) -> NetworkParameterParseReport {
+        guard rawValue.isEmpty == false else {
+            return NetworkParameterParseReport(rawValue: rawValue, parameters: [])
+        }
+
+        let fragments = rawValue.split(separator: "&", omittingEmptySubsequences: false)
+        let parameters = fragments.enumerated().map { ordinal, fragment in
+            let rawFragment = String(fragment)
+            let parts = rawFragment.split(
+                separator: "=",
+                maxSplits: 1,
+                omittingEmptySubsequences: false
+            )
+            let hadEqualsSign = parts.count == 2
+            let rawName = parts.first.map(String.init) ?? ""
+            let rawValue = hadEqualsSign ? String(parts[1]) : ""
+            return NetworkParameter(
+                ordinal: ordinal,
+                rawFragment: rawFragment,
+                hadEqualsSign: hadEqualsSign,
+                name: decode(rawName),
+                value: decode(rawValue)
+            )
+        }
+        return NetworkParameterParseReport(rawValue: rawValue, parameters: parameters)
+    }
+
+    private static func decode(_ rawValue: String) -> NetworkParameter.Component {
+        let source = Array(rawValue.utf8)
+        var decoded: [UInt8] = []
+        decoded.reserveCapacity(source.count)
+        var index = 0
+        while index < source.count {
+            switch source[index] {
+            case 0x2B:
+                decoded.append(0x20)
+                index += 1
+            case 0x25:
+                guard index + 2 < source.count,
+                    let high = hexadecimalValue(source[index + 1]),
+                    let low = hexadecimalValue(source[index + 2])
+                else {
+                    return .malformed(rawValue: rawValue, reason: .malformedPercentEscape)
+                }
+                decoded.append((high << 4) | low)
+                index += 3
+            default:
+                decoded.append(source[index])
+                index += 1
+            }
+        }
+        guard let value = String(bytes: decoded, encoding: .utf8) else {
+            return .malformed(rawValue: rawValue, reason: .invalidUTF8)
+        }
+        return .decoded(rawValue: rawValue, value: value)
+    }
+
+    private static func hexadecimalValue(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 48...57:
+            byte - 48
+        case 65...70:
+            byte - 55
+        case 97...102:
+            byte - 87
+        default:
+            nil
+        }
+    }
+}
+
+package enum NetworkContentTypeHeader: Hashable, Sendable {
+    case absent
+    case value(NetworkContentType)
+    case ambiguous(rawValues: [String])
+
+    package var contentType: NetworkContentType? {
+        guard case let .value(contentType) = self else {
+            return nil
+        }
+        return contentType
+    }
+}
+
+package struct NetworkContentType: Hashable, Sendable {
+    package struct Parameter: Identifiable, Hashable, Sendable {
+        package enum Issue: Hashable, Sendable {
+            case missingEqualsSign
+            case invalidName
+            case invalidValue
+            case malformedQuotedValue
+        }
+
+        package var id: Int { ordinal }
+        package let ordinal: Int
+        package let rawFragment: String
+        package let rawName: String?
+        package let normalizedName: String?
+        package let rawValue: String?
+        package let value: String?
+        package let issue: Issue?
+
+        package init(
+            ordinal: Int,
+            rawFragment: String,
+            rawName: String?,
+            normalizedName: String?,
+            rawValue: String?,
+            value: String?,
+            issue: Issue?
+        ) {
+            self.ordinal = ordinal
+            self.rawFragment = rawFragment
+            self.rawName = rawName
+            self.normalizedName = normalizedName
+            self.rawValue = rawValue
+            self.value = value
+            self.issue = issue
+        }
+    }
+
+    package let rawValue: String
+    package let mediaType: String
+    package let normalizedMediaType: String?
+    package let parameters: [Parameter]
+
+    package var boundary: [String] {
+        parameterValues(named: "boundary")
+    }
+
+    package var charset: [String] {
+        parameterValues(named: "charset")
+    }
+
+    package init(
+        rawValue: String,
+        mediaType: String,
+        normalizedMediaType: String?,
+        parameters: [Parameter]
+    ) {
+        self.rawValue = rawValue
+        self.mediaType = mediaType
+        self.normalizedMediaType = normalizedMediaType
+        self.parameters = parameters
+    }
+
+    private func parameterValues(named name: String) -> [String] {
+        parameters.compactMap { parameter in
+            guard parameter.normalizedName == name, parameter.issue == nil else {
+                return nil
+            }
+            return parameter.value
+        }
+    }
+}
+
+package enum NetworkContentTypeParser {
+    private enum ParameterValueParseResult {
+        case value(String)
+        case issue(NetworkContentType.Parameter.Issue)
+    }
+
+    package static func parseHeader(in headers: [String: String]) -> NetworkContentTypeHeader {
+        // Case-variant dictionary keys are distinct protocol fields; choosing one would invent precedence.
+        let fields = headers.compactMap { name, value -> (name: String, value: String)? in
+            guard NetworkHTTPGrammar.asciiCaseInsensitiveEqual(name, "Content-Type") else {
+                return nil
+            }
+            return (name, value)
+        }.sorted { lhs, rhs in
+            if lhs.name != rhs.name {
+                return lhs.name < rhs.name
+            }
+            return lhs.value < rhs.value
+        }
+        switch fields.count {
+        case 0:
+            return .absent
+        case 1:
+            return .value(parse(fields[0].value))
+        default:
+            return .ambiguous(rawValues: fields.map(\.value))
+        }
+    }
+
+    package static func parse(_ rawValue: String) -> NetworkContentType {
+        let fragments = quoteAwareFragments(in: rawValue)
+        let rawMediaType = fragments.first ?? ""
+        let mediaType = NetworkHTTPGrammar.trimOptionalWhitespace(rawMediaType)
+        let normalizedMediaType = normalizedMediaType(mediaType)
+        let parameters = fragments.dropFirst().enumerated().map { ordinal, fragment in
+            parseParameter(rawFragment: fragment, ordinal: ordinal)
+        }
+        return NetworkContentType(
+            rawValue: rawValue,
+            mediaType: mediaType,
+            normalizedMediaType: normalizedMediaType,
+            parameters: parameters
+        )
+    }
+
+    package static func effectiveMediaType(
+        protocolMIMEType: String?,
+        headers: [String: String]
+    ) -> String? {
+        if let protocolMIMEType {
+            let trimmed = NetworkHTTPGrammar.trimOptionalWhitespace(protocolMIMEType)
+            if trimmed.isEmpty == false {
+                return trimmed
+            }
+        }
+        guard case let .value(contentType) = parseHeader(in: headers),
+            contentType.mediaType.isEmpty == false
+        else {
+            return nil
+        }
+        return contentType.mediaType
+    }
+
+    package static func effectiveNormalizedMediaType(
+        protocolMIMEType: String?,
+        headers: [String: String]
+    ) -> String? {
+        if let protocolMIMEType {
+            let trimmed = NetworkHTTPGrammar.trimOptionalWhitespace(protocolMIMEType)
+            if trimmed.isEmpty == false {
+                return parse(trimmed).normalizedMediaType
+            }
+        }
+        return parseHeader(in: headers).contentType?.normalizedMediaType
+    }
+
+    private static func normalizedMediaType(_ mediaType: String) -> String? {
+        let components = mediaType.split(
+            separator: "/",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        guard components.count == 2,
+            NetworkHTTPGrammar.isHTTPToken(String(components[0])),
+            NetworkHTTPGrammar.isHTTPToken(String(components[1]))
+        else {
+            return nil
+        }
+        return NetworkHTTPGrammar.lowercaseASCII(mediaType)
+    }
+
+    private static func parseParameter(rawFragment: String, ordinal: Int) -> NetworkContentType.Parameter {
+        let trimmed = NetworkHTTPGrammar.trimOptionalWhitespace(rawFragment)
+        guard let equalsIndex = firstUnquotedEquals(in: trimmed) else {
+            return NetworkContentType.Parameter(
+                ordinal: ordinal,
+                rawFragment: rawFragment,
+                rawName: trimmed.isEmpty ? nil : trimmed,
+                normalizedName: nil,
+                rawValue: nil,
+                value: nil,
+                issue: .missingEqualsSign
+            )
+        }
+
+        let rawName = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmed[..<equalsIndex]))
+        let valueStart = trimmed.index(after: equalsIndex)
+        let rawValue = NetworkHTTPGrammar.trimOptionalWhitespace(String(trimmed[valueStart...]))
+        guard NetworkHTTPGrammar.isHTTPToken(rawName) else {
+            return NetworkContentType.Parameter(
+                ordinal: ordinal,
+                rawFragment: rawFragment,
+                rawName: rawName,
+                normalizedName: nil,
+                rawValue: rawValue,
+                value: nil,
+                issue: .invalidName
+            )
+        }
+
+        let normalizedName = NetworkHTTPGrammar.lowercaseASCII(rawName)
+        switch parseParameterValue(rawValue) {
+        case let .value(value):
+            return NetworkContentType.Parameter(
+                ordinal: ordinal,
+                rawFragment: rawFragment,
+                rawName: rawName,
+                normalizedName: normalizedName,
+                rawValue: rawValue,
+                value: value,
+                issue: nil
+            )
+        case let .issue(issue):
+            return NetworkContentType.Parameter(
+                ordinal: ordinal,
+                rawFragment: rawFragment,
+                rawName: rawName,
+                normalizedName: normalizedName,
+                rawValue: rawValue,
+                value: nil,
+                issue: issue
+            )
+        }
+    }
+
+    private static func parseParameterValue(
+        _ rawValue: String
+    ) -> ParameterValueParseResult {
+        guard rawValue.first == "\"" else {
+            return NetworkHTTPGrammar.isHTTPToken(rawValue)
+                ? .value(rawValue)
+                : .issue(.invalidValue)
+        }
+
+        let bytes = Array(rawValue.utf8)
+        var valueBytes: [UInt8] = []
+        valueBytes.reserveCapacity(max(bytes.count - 2, 0))
+        var index = 1
+        var didClose = false
+        while index < bytes.count {
+            switch bytes[index] {
+            case 0x22:
+                didClose = true
+                index += 1
+            case 0x5C:
+                guard index + 1 < bytes.count else {
+                    return .issue(.malformedQuotedValue)
+                }
+                let escapedByte = bytes[index + 1]
+                guard isAllowedQuotedValueByte(escapedByte) else {
+                    return .issue(.malformedQuotedValue)
+                }
+                valueBytes.append(escapedByte)
+                index += 2
+                continue
+            default:
+                let byte = bytes[index]
+                guard isAllowedQuotedValueByte(byte) else {
+                    return .issue(.malformedQuotedValue)
+                }
+                valueBytes.append(byte)
+                index += 1
+                continue
+            }
+            break
+        }
+        guard didClose, index == bytes.count,
+            let value = String(bytes: valueBytes, encoding: .utf8)
+        else {
+            return .issue(.malformedQuotedValue)
+        }
+        return .value(value)
+    }
+
+    private static func isAllowedQuotedValueByte(_ byte: UInt8) -> Bool {
+        byte == 0x09 || (byte >= 0x20 && byte != 0x7F)
+    }
+
+    private static func quoteAwareFragments(in rawValue: String) -> [String] {
+        let bytes = Array(rawValue.utf8)
+        var fragments: [String] = []
+        var fragmentStart = 0
+        var insideQuotes = false
+        var escaped = false
+        for index in bytes.indices {
+            let byte = bytes[index]
+            if escaped {
+                escaped = false
+                continue
+            }
+            if insideQuotes, byte == 0x5C {
+                escaped = true
+                continue
+            }
+            if byte == 0x22 {
+                insideQuotes.toggle()
+                continue
+            }
+            if byte == 0x3B, insideQuotes == false {
+                fragments.append(String(decoding: bytes[fragmentStart..<index], as: UTF8.self))
+                fragmentStart = index + 1
+            }
+        }
+        fragments.append(String(decoding: bytes[fragmentStart...], as: UTF8.self))
+        return fragments
+    }
+
+    private static func firstUnquotedEquals(in value: String) -> String.Index? {
+        var insideQuotes = false
+        var escaped = false
+        for index in value.indices {
+            let character = value[index]
+            if escaped {
+                escaped = false
+                continue
+            }
+            if insideQuotes, character == "\\" {
+                escaped = true
+                continue
+            }
+            if character == "\"" {
+                insideQuotes.toggle()
+                continue
+            }
+            if character == "=", insideQuotes == false {
+                return index
+            }
+        }
+        return nil
+    }
+}
+
+package struct NetworkRequestHeadersContext: Hashable, Sendable {
+    package enum Outcome: Hashable, Sendable {
+        case canceled(reason: String)
+        case failed(reason: String)
+    }
+
+    package struct Initiator: Hashable, Sendable {
+        package let kind: String
+        package let url: String?
+        package let line: Int?
+        package let nodeID: DOM.Node.ID?
+
+        package init(kind: String, url: String?, line: Int?, nodeID: DOM.Node.ID?) {
+            self.kind = kind
+            self.url = url
+            self.line = line
+            self.nodeID = nodeID
+        }
+    }
+
+    package enum RequestData: Hashable, Sendable {
+        case form(
+            contentType: NetworkContentTypeHeader,
+            parameters: NetworkParameterParseReport
+        )
+        case body(contentType: NetworkContentTypeHeader)
+    }
+
+    package let outcome: Outcome?
+    package let resourceType: String?
+    package let effectiveMIMEType: String?
+    package let initiator: Initiator?
+    package let queryParameters: NetworkParameterParseReport?
+    package let requestData: RequestData?
+
+    fileprivate init(request: NetworkRequest) {
+        switch request.state {
+        case let .failed(errorText, canceled: true):
+            outcome = .canceled(reason: errorText)
+        case let .failed(errorText, canceled: false):
+            outcome = .failed(reason: errorText)
+        case .pending, .responded, .finished:
+            outcome = nil
+        }
+        resourceType = request.resourceType?.rawValue
+        effectiveMIMEType = NetworkContentTypeParser.effectiveMediaType(
+            protocolMIMEType: request.mimeType,
+            headers: request.responseHeaders
+        )
+        initiator = request.initiator.map {
+            Initiator(kind: $0.kind, url: $0.url, line: $0.line, nodeID: $0.nodeID)
+        }
+        queryParameters = NetworkParameterParser.parseQuery(in: request.url)
+
+        requestData = Self.makeRequestData(
+            requestBody: request.requestBody,
+            requestHeaders: request.requestHeaders
+        )
+    }
+
+    static func makeRequestData(
+        requestBody: NetworkBody?,
+        requestHeaders: [String: String]
+    ) -> RequestData? {
+        guard let requestBody, let rawBody = requestBody.full else {
+            return nil
+        }
+        let contentType = NetworkContentTypeParser.parseHeader(in: requestHeaders)
+        if requestBody.kind == .form,
+            requestBody.isBase64Encoded == false
+        {
+            return .form(
+                contentType: contentType,
+                parameters: NetworkParameterParser.parseForm(rawBody)
+            )
+        }
+        return .body(contentType: contentType)
+    }
+}
+
+extension NetworkRequest {
+    package var headersContext: NetworkRequestHeadersContext {
+        NetworkRequestHeadersContext(request: self)
+    }
+}
+
+private enum NetworkHTTPGrammar {
+    static func asciiCaseInsensitiveEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = lhs.utf8
+        let rhsBytes = rhs.utf8
+        guard lhsBytes.count == rhsBytes.count else {
+            return false
+        }
+        return zip(lhsBytes, rhsBytes).allSatisfy { lhsByte, rhsByte in
+            lowercaseASCII(lhsByte) == lowercaseASCII(rhsByte)
+        }
+    }
+
+    static func lowercaseASCII(_ value: String) -> String {
+        String(decoding: value.utf8.map(lowercaseASCII), as: UTF8.self)
+    }
+
+    static func lowercaseASCII(_ byte: UInt8) -> UInt8 {
+        (65...90).contains(byte) ? byte + 32 : byte
+    }
+
+    static func trimOptionalWhitespace(_ value: String) -> String {
+        let bytes = value.utf8
+        var lowerBound = bytes.startIndex
+        var upperBound = bytes.endIndex
+        while lowerBound < upperBound, isOptionalWhitespace(bytes[lowerBound]) {
+            lowerBound = bytes.index(after: lowerBound)
+        }
+        while lowerBound < upperBound {
+            let preceding = bytes.index(before: upperBound)
+            guard isOptionalWhitespace(bytes[preceding]) else {
+                break
+            }
+            upperBound = preceding
+        }
+        return String(decoding: bytes[lowerBound..<upperBound], as: UTF8.self)
+    }
+
+    static func isHTTPToken(_ value: String) -> Bool {
+        let bytes = value.utf8
+        return bytes.isEmpty == false && bytes.allSatisfy(isHTTPTokenCharacter)
+    }
+
+    private static func isOptionalWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09
+    }
+
+    private static func isHTTPTokenCharacter(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 48...57, 65...90, 97...122:
+            return true
+        case 0x21, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2A, 0x2B, 0x2D, 0x2E,
+            0x5E, 0x5F, 0x60, 0x7C, 0x7E:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
@@ -626,7 +626,8 @@ package struct NetworkRequestHeadersContext: Hashable, Sendable {
             return nil
         }
         let contentType = NetworkContentTypeParser.parseHeader(in: requestHeaders)
-        if requestBody.kind == .form,
+        if contentType.contentType?.normalizedMediaType
+            == "application/x-www-form-urlencoded",
             requestBody.isBase64Encoded == false
         {
             return .form(

--- a/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
@@ -307,6 +307,12 @@ package struct NetworkContentType: Hashable, Sendable {
 }
 
 package enum NetworkContentTypeParser {
+    enum NormalizedMediaTypeResolution: Equatable, Sendable {
+        case absent
+        case invalid
+        case value(String)
+    }
+
     private enum ParameterValueParseResult {
         case value(String)
         case issue(NetworkContentType.Parameter.Issue)
@@ -367,17 +373,28 @@ package enum NetworkContentTypeParser {
         return reportedMediaType(in: contentType)
     }
 
-    package static func effectiveNormalizedMediaType(
+    static func normalizedMediaTypeResolution(
         protocolMIMEType: String?,
         headers: [String: String]
-    ) -> String? {
+    ) -> NormalizedMediaTypeResolution {
         if let protocolMIMEType {
             let trimmed = NetworkHTTPGrammar.trimOptionalWhitespace(protocolMIMEType)
             if trimmed.isEmpty == false {
-                return parse(trimmed).normalizedMediaType
+                return parse(trimmed).normalizedMediaType.map(NormalizedMediaTypeResolution.value)
+                    ?? .invalid
             }
         }
-        return parseHeader(in: headers).contentType?.normalizedMediaType
+        switch parseHeader(in: headers) {
+        case .absent:
+            return .absent
+        case .ambiguous:
+            return .invalid
+        case .value(let contentType):
+            if let normalizedMediaType = contentType.normalizedMediaType {
+                return .value(normalizedMediaType)
+            }
+            return contentType.mediaType.isEmpty ? .absent : .invalid
+        }
     }
 
     private static func normalizedMediaType(_ mediaType: String) -> String? {

--- a/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestHeadersContext.swift
@@ -358,15 +358,13 @@ package enum NetworkContentTypeParser {
         if let protocolMIMEType {
             let trimmed = NetworkHTTPGrammar.trimOptionalWhitespace(protocolMIMEType)
             if trimmed.isEmpty == false {
-                return trimmed
+                return reportedMediaType(in: parse(trimmed))
             }
         }
-        guard case let .value(contentType) = parseHeader(in: headers),
-            contentType.mediaType.isEmpty == false
-        else {
+        guard case let .value(contentType) = parseHeader(in: headers) else {
             return nil
         }
-        return contentType.mediaType
+        return reportedMediaType(in: contentType)
     }
 
     package static func effectiveNormalizedMediaType(
@@ -395,6 +393,13 @@ package enum NetworkContentTypeParser {
             return nil
         }
         return NetworkHTTPGrammar.lowercaseASCII(mediaType)
+    }
+
+    private static func reportedMediaType(in contentType: NetworkContentType) -> String? {
+        guard contentType.mediaType.isEmpty == false else {
+            return nil
+        }
+        return contentType.mediaType
     }
 
     private static func parseParameter(rawFragment: String, ordinal: Int) -> NetworkContentType.Parameter {
@@ -568,13 +573,13 @@ package struct NetworkRequestHeadersContext: Hashable, Sendable {
         package let kind: String
         package let url: String?
         package let line: Int?
-        package let nodeID: DOM.Node.ID?
+        package let nodeIDRawValue: String?
 
-        package init(kind: String, url: String?, line: Int?, nodeID: DOM.Node.ID?) {
+        package init(kind: String, url: String?, line: Int?, nodeIDRawValue: String?) {
             self.kind = kind
             self.url = url
             self.line = line
-            self.nodeID = nodeID
+            self.nodeIDRawValue = nodeIDRawValue
         }
     }
 
@@ -608,7 +613,12 @@ package struct NetworkRequestHeadersContext: Hashable, Sendable {
             headers: request.responseHeaders
         )
         initiator = request.initiator.map {
-            Initiator(kind: $0.kind, url: $0.url, line: $0.line, nodeID: $0.nodeID)
+            Initiator(
+                kind: $0.kind,
+                url: $0.url,
+                line: $0.line,
+                nodeIDRawValue: $0.nodeID?.unscopedRawValue
+            )
         }
         queryParameters = NetworkParameterParser.parseQuery(in: request.url)
 
@@ -642,64 +652,5 @@ package struct NetworkRequestHeadersContext: Hashable, Sendable {
 extension NetworkRequest {
     package var headersContext: NetworkRequestHeadersContext {
         NetworkRequestHeadersContext(request: self)
-    }
-}
-
-private enum NetworkHTTPGrammar {
-    static func asciiCaseInsensitiveEqual(_ lhs: String, _ rhs: String) -> Bool {
-        let lhsBytes = lhs.utf8
-        let rhsBytes = rhs.utf8
-        guard lhsBytes.count == rhsBytes.count else {
-            return false
-        }
-        return zip(lhsBytes, rhsBytes).allSatisfy { lhsByte, rhsByte in
-            lowercaseASCII(lhsByte) == lowercaseASCII(rhsByte)
-        }
-    }
-
-    static func lowercaseASCII(_ value: String) -> String {
-        String(decoding: value.utf8.map(lowercaseASCII), as: UTF8.self)
-    }
-
-    static func lowercaseASCII(_ byte: UInt8) -> UInt8 {
-        (65...90).contains(byte) ? byte + 32 : byte
-    }
-
-    static func trimOptionalWhitespace(_ value: String) -> String {
-        let bytes = value.utf8
-        var lowerBound = bytes.startIndex
-        var upperBound = bytes.endIndex
-        while lowerBound < upperBound, isOptionalWhitespace(bytes[lowerBound]) {
-            lowerBound = bytes.index(after: lowerBound)
-        }
-        while lowerBound < upperBound {
-            let preceding = bytes.index(before: upperBound)
-            guard isOptionalWhitespace(bytes[preceding]) else {
-                break
-            }
-            upperBound = preceding
-        }
-        return String(decoding: bytes[lowerBound..<upperBound], as: UTF8.self)
-    }
-
-    static func isHTTPToken(_ value: String) -> Bool {
-        let bytes = value.utf8
-        return bytes.isEmpty == false && bytes.allSatisfy(isHTTPTokenCharacter)
-    }
-
-    private static func isOptionalWhitespace(_ byte: UInt8) -> Bool {
-        byte == 0x20 || byte == 0x09
-    }
-
-    private static func isHTTPTokenCharacter(_ byte: UInt8) -> Bool {
-        switch byte {
-        case 48...57, 65...90, 97...122:
-            return true
-        case 0x21, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2A, 0x2B, 0x2D, 0x2E,
-            0x5E, 0x5F, 0x60, 0x7C, 0x7E:
-            return true
-        default:
-            return false
-        }
     }
 }

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -4910,6 +4910,70 @@
         }
       }
     },
+    "network.headers.parameters.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No parameters"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パラメータがありません"
+          }
+        }
+      }
+    },
+    "network.headers.parameters.error.percent_escape" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Malformed percent escape"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不正なパーセントエスケープ"
+          }
+        }
+      }
+    },
+    "network.headers.parameters.error.utf8" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid UTF-8"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効なUTF-8"
+          }
+        }
+      }
+    },
+    "network.headers.parameters.unparsed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unparsed Parameter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解析できないパラメータ"
+          }
+        }
+      }
+    },
     "network.headers.request.empty" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4927,6 +4991,118 @@
         }
       }
     },
+    "network.headers.request_data.boundary" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boundary"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "境界"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.content_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Content Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンテンツタイプ"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.content_type_ambiguous" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambiguous Content Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "曖昧なコンテンツタイプ"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.content_type_parameter_unparsed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unparsed Content-Type Parameter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解析できないContent-Typeパラメータ"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.encoding" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encoding"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字エンコーディング"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.media_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メディアタイプ"
+          }
+        }
+      }
+    },
+    "network.headers.request_data.view_preview" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Request Preview"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストのプレビューを表示"
+          }
+        }
+      }
+    },
     "network.headers.response.empty" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4940,6 +5116,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "レスポンスヘッダーなし"
+          }
+        }
+      }
+    },
+    "network.headers.section.query" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Query String Parameters"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クエリ文字列パラメータ"
+          }
+        }
+      }
+    },
+    "network.headers.section.request_data" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Data"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストデータ"
           }
         }
       }
@@ -5046,6 +5254,150 @@
         }
       }
     },
+    "network.headers.summary.failure_reason" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failure Reason"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗理由"
+          }
+        }
+      }
+    },
+    "network.headers.summary.initiator_kind" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Initiator Kind"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始元の種類"
+          }
+        }
+      }
+    },
+    "network.headers.summary.initiator_line" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Initiator Line"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始元の行"
+          }
+        }
+      }
+    },
+    "network.headers.summary.initiator_node" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Initiator Node"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始元ノード"
+          }
+        }
+      }
+    },
+    "network.headers.summary.initiator_url" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Initiator URL"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始元URL"
+          }
+        }
+      }
+    },
+    "network.headers.summary.mime_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MIME Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MIMEタイプ"
+          }
+        }
+      }
+    },
+    "network.headers.summary.outcome" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outcome"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
+        }
+      }
+    },
+    "network.headers.summary.outcome.canceled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canceled"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        }
+      }
+    },
+    "network.headers.summary.outcome.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗"
+          }
+        }
+      }
+    },
     "network.headers.summary.redirects" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -5059,6 +5411,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "リダイレクト"
+          }
+        }
+      }
+    },
+    "network.headers.summary.resource_type" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resource Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リソースタイプ"
           }
         }
       }
@@ -5110,6 +5478,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL"
+          }
+        }
+      }
+    },
+    "network.headers.value.not_reported" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未報告"
           }
         }
       }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -131,6 +131,9 @@ package final class NetworkDetailViewController: UIViewController {
         let view = NetworkHeadersTextView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isHidden = true
+        view.requestPreviewAction = { [weak self] in
+            self?.activateRequestPreviewFromHeaders()
+        }
         return view
     }()
     fileprivate var mode: NetworkDetailViewController.Mode = .headers
@@ -574,14 +577,17 @@ package final class NetworkDetailViewController: UIViewController {
         observedRequest = representativeRequest
         title = representativeRequest.displayName
         showHeaders()
-        headersTextView.render(requests: requests)
+        headersTextView.render(
+            requests: requests,
+            activeRequest: representativeRequest
+        )
     }
 
     private func renderHeadersSurface(request: NetworkRequest) {
         observedRequest = request
         title = request.displayName
         showHeaders()
-        headersTextView.render(request: request)
+        headersTextView.render(request: request, activeRequest: request)
     }
 
     private func renderCookiesSurface(request: NetworkRequest) {
@@ -620,6 +626,59 @@ package final class NetworkDetailViewController: UIViewController {
             return
         }
         rebindSelectedRequestRendering()
+    }
+
+    private func activateRequestPreviewFromHeaders() {
+        guard mode == .headers,
+              isRenderingActive,
+              let selection = model.selection,
+              let entry = model.selectedEntry,
+              let selectedRequest = model.selectedRequest else {
+            return
+        }
+        let currentRequests: [NetworkRequest] = switch selection {
+        case .entry:
+            entry.requests
+        case .request:
+            [selectedRequest]
+        }
+        let activeRequest = activeRequest(for: selection, requests: currentRequests)
+        guard activeRequest.webSocket == nil,
+              let requestData = activeRequest.headersContext.requestData,
+              case .body = requestData else {
+            return
+        }
+
+        previewRole = .request
+        let explicitRequest = promoteHeadersActiveRequestToExplicitSelection(
+            activeRequest,
+            expectedEntryID: entry.id
+        )
+
+        mode = .preview
+        bindSelection(
+            model.selection,
+            entry: model.selectedEntry,
+            selectedRequest: explicitRequest,
+            force: true
+        )
+    }
+
+    private func promoteHeadersActiveRequestToExplicitSelection(
+        _ request: NetworkRequest,
+        expectedEntryID: NetworkListEntry.ID
+    ) -> NetworkRequest {
+        model.selectRequest(request)
+        guard case let .request(entryID, requestID) = model.selection,
+              entryID == expectedEntryID,
+              requestID == request.id,
+              let selectedRequest = model.selectedRequest,
+              selectedRequest === request else {
+            preconditionFailure(
+                "A current Network headers request must become the exact explicit selection."
+            )
+        }
+        return selectedRequest
     }
 
     private func renderModeControl(selectedRequest request: NetworkRequest? = nil) {
@@ -933,16 +992,10 @@ package final class NetworkDetailViewController: UIViewController {
         from explicitMimeType: String?,
         headers: [String: String]
     ) -> String? {
-        let rawMimeType = explicitMimeType ?? headerValue(named: "content-type", in: headers)
-        let mimeType = rawMimeType?
-            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
-            .first
-            .map(String.init)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let mimeType, mimeType.isEmpty == false else {
-            return nil
-        }
-        return mimeType
+        NetworkContentTypeParser.effectiveMediaType(
+            protocolMIMEType: explicitMimeType,
+            headers: headers
+        )
     }
 
     private func headerValue(named name: String, in headers: [String: String]) -> String? {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
@@ -291,7 +291,7 @@ struct NetworkHeadersTextDocumentBuilder {
                         style: .summary
                     ))
             }
-            if let nodeID = initiator.nodeID {
+            if let nodeIDRawValue = initiator.nodeIDRawValue {
                 rows.append(
                     Row(
                         key: String(
@@ -299,7 +299,7 @@ struct NetworkHeadersTextDocumentBuilder {
                             defaultValue: "Initiator Node",
                             bundle: WebInspectorUILocalization.bundle
                         ),
-                        value: nodeID.rawValue,
+                        value: nodeIDRawValue,
                         style: .summary
                     ))
             }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
@@ -280,6 +280,8 @@ struct NetworkHeadersTextDocumentBuilder {
                     ))
             }
             if let line = initiator.line {
+                // Do not add one: WebKit reports this Network initiator coordinate one-based.
+                // Its frontend subtracts one only when creating a zero-based editor location.
                 rows.append(
                     Row(
                         key: String(

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
@@ -1,0 +1,1053 @@
+#if canImport(UIKit)
+import WebInspectorUIBase
+import WebInspectorDataKit
+import UIKit
+
+enum NetworkHeadersTextSectionRuleKind: Hashable {
+    case system
+    case header
+
+    var color: UIColor {
+        switch self {
+        case .system:
+            NetworkHeadersWebKitStyle.networkSystemColor
+        case .header:
+            NetworkHeadersWebKitStyle.networkHeaderColor
+        }
+    }
+}
+
+enum NetworkHeadersTextRowStyle: Hashable {
+    case summary
+    case header
+    case pseudoHeader
+    case message
+    case warning
+    case action
+}
+
+struct NetworkHeadersTextSectionRule: Equatable {
+    var range: NSRange
+    var kind: NetworkHeadersTextSectionRuleKind
+}
+
+enum NetworkHeadersTextAttributeStyle: Equatable {
+    case sectionTitle
+    case requestHeading
+    case rowKey(NetworkHeadersTextRowStyle)
+    case rowValue(NetworkHeadersTextRowStyle)
+}
+
+struct NetworkHeadersTextAttributeRun: Equatable {
+    var range: NSRange
+    var style: NetworkHeadersTextAttributeStyle
+}
+
+struct NetworkHeadersTextTag: Equatable {
+    var identifier: String
+    var range: NSRange
+}
+
+struct NetworkHeadersTextDocumentSignature: Equatable {
+    var visibleText: String
+    var attributeRuns: [NetworkHeadersTextAttributeRun]
+    var sectionRules: [NetworkHeadersTextSectionRule]
+    var tag: NetworkHeadersTextTag?
+}
+
+struct NetworkHeadersTextDocument {
+    var attributedString: NSAttributedString
+    var sectionRules: [NetworkHeadersTextSectionRule]
+    var signature: NetworkHeadersTextDocumentSignature
+}
+
+@MainActor
+struct NetworkHeadersTextDocumentBuilder {
+    private struct Row {
+        var key: String
+        var value: String?
+        var style: NetworkHeadersTextRowStyle
+        var alwaysShowsValueSeparator = false
+        var tagIdentifier: String?
+    }
+
+    private struct Section {
+        var title: String
+        var rows: [Row]
+        var ruleKind: NetworkHeadersTextSectionRuleKind
+    }
+
+    var requests: [NetworkRequest]
+    var activeRequest: NetworkRequest
+    var traitCollection: UITraitCollection
+
+    func makeDocument() -> NetworkHeadersTextDocument {
+        let text = NSMutableAttributedString()
+        var rules: [NetworkHeadersTextSectionRule] = []
+        var attributeRuns: [NetworkHeadersTextAttributeRun] = []
+        var tag: NetworkHeadersTextTag?
+        for (index, request) in requests.enumerated() {
+            if requests.count > 1 {
+                appendRequestHeading(
+                    request: request,
+                    index: index,
+                    to: text,
+                    attributeRuns: &attributeRuns
+                )
+            }
+            for section in sections(for: request) where section.rows.isEmpty == false {
+                append(
+                    section: section,
+                    to: text,
+                    rules: &rules,
+                    attributeRuns: &attributeRuns,
+                    tag: &tag
+                )
+            }
+        }
+        let signature = NetworkHeadersTextDocumentSignature(
+            visibleText: text.string,
+            attributeRuns: attributeRuns,
+            sectionRules: rules,
+            tag: tag
+        )
+        return NetworkHeadersTextDocument(
+            attributedString: text,
+            sectionRules: rules,
+            signature: signature
+        )
+    }
+
+    private func sections(for request: NetworkRequest) -> [Section] {
+        let context = request.headersContext
+        var sections = [summarySection(for: request, context: context)]
+        for (index, redirect) in request.redirects.enumerated() {
+            sections.append(redirectRequestSection(redirect.request, index: index))
+            sections.append(redirectResponseSection(redirect.response, index: index))
+        }
+        sections.append(requestSection(for: request))
+        if let responseSection = responseSection(for: request) {
+            sections.append(responseSection)
+        }
+        if let queryParameters = context.queryParameters {
+            sections.append(
+                parameterSection(
+                    title: String(
+                        localized: "network.headers.section.query",
+                        defaultValue: "Query String Parameters",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    report: queryParameters
+                ))
+        }
+        if let requestData = context.requestData {
+            sections.append(
+                requestDataSection(
+                    requestData,
+                    exposesPreviewAction: request === activeRequest && request.webSocket == nil
+                ))
+        }
+        return sections
+    }
+
+    private func summarySection(
+        for request: NetworkRequest,
+        context: NetworkRequestHeadersContext
+    ) -> Section {
+        var rows: [Row] = [
+            Row(
+                key: String(
+                    localized: "network.headers.summary.url", defaultValue: "URL",
+                    bundle: WebInspectorUILocalization.bundle), value: request.url, style: .summary),
+            Row(
+                key: String(
+                    localized: "network.headers.summary.status", defaultValue: "Status",
+                    bundle: WebInspectorUILocalization.bundle), value: statusText(for: request), style: .summary),
+            Row(
+                key: String(
+                    localized: "network.headers.summary.source", defaultValue: "Source",
+                    bundle: WebInspectorUILocalization.bundle), value: sourceText(for: request), style: .summary),
+        ]
+        if request.redirects.isEmpty == false {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.redirects", defaultValue: "Redirects",
+                        bundle: WebInspectorUILocalization.bundle),
+                    value: String(request.redirects.count),
+                    style: .summary
+                ))
+        }
+        if let remoteAddress = request.metrics?.remoteAddress, remoteAddress.isEmpty == false {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.address", defaultValue: "Address",
+                        bundle: WebInspectorUILocalization.bundle),
+                    value: remoteAddress,
+                    style: .summary
+                )
+            )
+        }
+        if let outcome = context.outcome {
+            let outcomeText: String
+            let reason: String
+            switch outcome {
+            case .canceled(let rawReason):
+                outcomeText = String(
+                    localized: "network.headers.summary.outcome.canceled",
+                    defaultValue: "Canceled",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+                reason = rawReason
+            case .failed(let rawReason):
+                outcomeText = String(
+                    localized: "network.headers.summary.outcome.failed",
+                    defaultValue: "Failed",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+                reason = rawReason
+            }
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.outcome",
+                        defaultValue: "Outcome",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: outcomeText,
+                    style: .warning
+                ))
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.failure_reason",
+                        defaultValue: "Failure Reason",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: reason,
+                    style: .warning,
+                    alwaysShowsValueSeparator: true
+                ))
+        }
+        if let resourceType = context.resourceType {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.resource_type",
+                        defaultValue: "Resource Type",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: resourceType,
+                    style: .summary
+                ))
+        }
+        if let effectiveMIMEType = context.effectiveMIMEType {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.mime_type",
+                        defaultValue: "MIME Type",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: effectiveMIMEType,
+                    style: .summary
+                ))
+        }
+        if let initiator = context.initiator {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.summary.initiator_kind",
+                        defaultValue: "Initiator Kind",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: initiator.kind,
+                    style: .summary,
+                    alwaysShowsValueSeparator: true
+                ))
+            if let url = initiator.url {
+                rows.append(
+                    Row(
+                        key: String(
+                            localized: "network.headers.summary.initiator_url",
+                            defaultValue: "Initiator URL",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: url,
+                        style: .summary,
+                        alwaysShowsValueSeparator: true
+                    ))
+            }
+            if let line = initiator.line {
+                rows.append(
+                    Row(
+                        key: String(
+                            localized: "network.headers.summary.initiator_line",
+                            defaultValue: "Initiator Line",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: String(line),
+                        style: .summary
+                    ))
+            }
+            if let nodeID = initiator.nodeID {
+                rows.append(
+                    Row(
+                        key: String(
+                            localized: "network.headers.summary.initiator_node",
+                            defaultValue: "Initiator Node",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: nodeID.rawValue,
+                        style: .summary
+                    ))
+            }
+        }
+        return Section(
+            title: String(localized: "network.detail.section.overview", bundle: WebInspectorUILocalization.bundle),
+            rows: rows,
+            ruleKind: .system
+        )
+    }
+
+    private func parameterSection(
+        title: String,
+        report: NetworkParameterParseReport
+    ) -> Section {
+        var rows = parameterRows(report)
+        if rows.isEmpty {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.parameters.empty",
+                        defaultValue: "No parameters",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: nil,
+                    style: .message
+                ))
+        }
+        return Section(title: title, rows: rows, ruleKind: .system)
+    }
+
+    private func requestDataSection(
+        _ requestData: NetworkRequestHeadersContext.RequestData,
+        exposesPreviewAction: Bool
+    ) -> Section {
+        let title = String(
+            localized: "network.headers.section.request_data",
+            defaultValue: "Request Data",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        var rows: [Row]
+        switch requestData {
+        case let .form(contentType, parameters):
+            rows = contentTypeRows(contentType)
+            let parametersSection = parameterSection(title: title, report: parameters)
+            rows.append(contentsOf: parametersSection.rows)
+        case .body(let contentType):
+            rows = contentTypeRows(contentType)
+            if exposesPreviewAction {
+                rows.append(
+                    Row(
+                        key: String(
+                            localized: "network.headers.request_data.view_preview",
+                            defaultValue: "View Request Preview",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: nil,
+                        style: .action,
+                        tagIdentifier: NetworkHeadersTextView.requestPreviewTagIdentifier
+                    ))
+            }
+        }
+        return Section(title: title, rows: rows, ruleKind: .system)
+    }
+
+    private func parameterRows(_ report: NetworkParameterParseReport) -> [Row] {
+        report.parameters.map { parameter in
+            guard case let .decoded(_, name) = parameter.name,
+                case let .decoded(_, value) = parameter.value
+            else {
+                return Row(
+                    key: String(
+                        localized: "network.headers.parameters.unparsed",
+                        defaultValue: "Unparsed Parameter",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: "\(parameter.rawFragment) — \(malformedReasonText(for: parameter))",
+                    style: .warning,
+                    alwaysShowsValueSeparator: true
+                )
+            }
+            return Row(
+                key: name,
+                value: value,
+                style: .summary,
+                alwaysShowsValueSeparator: true
+            )
+        }
+    }
+
+    private func malformedReasonText(for parameter: NetworkParameter) -> String {
+        var reasons: [NetworkParameter.Component.MalformedReason] = []
+        if case let .malformed(_, reason) = parameter.name {
+            reasons.append(reason)
+        }
+        if case let .malformed(_, reason) = parameter.value,
+            reasons.contains(reason) == false
+        {
+            reasons.append(reason)
+        }
+        return reasons.map(malformedReasonText).joined(separator: ", ")
+    }
+
+    private func malformedReasonText(
+        _ reason: NetworkParameter.Component.MalformedReason
+    ) -> String {
+        switch reason {
+        case .malformedPercentEscape:
+            String(
+                localized: "network.headers.parameters.error.percent_escape",
+                defaultValue: "Malformed percent escape",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        case .invalidUTF8:
+            String(
+                localized: "network.headers.parameters.error.utf8",
+                defaultValue: "Invalid UTF-8",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        }
+    }
+
+    private func contentTypeRows(_ header: NetworkContentTypeHeader) -> [Row] {
+        let contentTypeLabel = String(
+            localized: "network.headers.request_data.content_type",
+            defaultValue: "Content Type",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        switch header {
+        case .absent:
+            return [
+                Row(
+                    key: contentTypeLabel,
+                    value: String(
+                        localized: "network.headers.value.not_reported",
+                        defaultValue: "Not reported",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    style: .message
+                )
+            ]
+        case .ambiguous(let rawValues):
+            return rawValues.map { rawValue in
+                Row(
+                    key: String(
+                        localized: "network.headers.request_data.content_type_ambiguous",
+                        defaultValue: "Ambiguous Content Type",
+                        bundle: WebInspectorUILocalization.bundle
+                    ),
+                    value: rawValue,
+                    style: .warning,
+                    alwaysShowsValueSeparator: true
+                )
+            }
+        case .value(let contentType):
+            var rows = [
+                Row(
+                    key: contentTypeLabel,
+                    value: contentType.rawValue,
+                    style: contentType.normalizedMediaType == nil ? .warning : .summary,
+                    alwaysShowsValueSeparator: true
+                )
+            ]
+            if contentType.mediaType.isEmpty == false {
+                rows.append(
+                    Row(
+                        key: String(
+                            localized: "network.headers.request_data.media_type",
+                            defaultValue: "Media Type",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: contentType.mediaType,
+                        style: contentType.normalizedMediaType == nil ? .warning : .summary
+                    ))
+            }
+            rows.append(
+                contentsOf: contentType.boundary.map { boundary in
+                    Row(
+                        key: String(
+                            localized: "network.headers.request_data.boundary",
+                            defaultValue: "Boundary",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: boundary,
+                        style: .summary,
+                        alwaysShowsValueSeparator: true
+                    )
+                })
+            rows.append(
+                contentsOf: contentType.charset.map { charset in
+                    Row(
+                        key: String(
+                            localized: "network.headers.request_data.encoding",
+                            defaultValue: "Encoding",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: charset,
+                        style: .summary,
+                        alwaysShowsValueSeparator: true
+                    )
+                })
+            rows.append(
+                contentsOf: contentType.parameters.compactMap { parameter in
+                    guard parameter.issue != nil else {
+                        return nil
+                    }
+                    return Row(
+                        key: String(
+                            localized: "network.headers.request_data.content_type_parameter_unparsed",
+                            defaultValue: "Unparsed Content-Type Parameter",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        value: parameter.rawFragment,
+                        style: .warning,
+                        alwaysShowsValueSeparator: true
+                    )
+                })
+            return rows
+        }
+    }
+
+    private func requestSection(for request: NetworkRequest) -> Section {
+        let headers = request.requestHeaders
+        var rows: [Row] = requestProtocolRows(
+            url: request.url,
+            method: request.method,
+            protocolName: request.metrics?.networkProtocol
+        )
+        rows.append(contentsOf: headerRows(headers))
+        if rows.isEmpty {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.request.empty", defaultValue: "No request headers",
+                        bundle: WebInspectorUILocalization.bundle),
+                    value: nil,
+                    style: .message
+                )
+            )
+        }
+        return Section(
+            title: String(localized: "network.section.request", bundle: WebInspectorUILocalization.bundle),
+            rows: rows,
+            ruleKind: .header
+        )
+    }
+
+    private func responseSection(for request: NetworkRequest) -> Section? {
+        guard request.hasResponse else {
+            return nil
+        }
+        let headers = request.responseHeaders
+        var rows: [Row] = responseProtocolRows(
+            status: request.status,
+            statusText: request.statusText,
+            protocolName: request.metrics?.networkProtocol
+        )
+        rows.append(contentsOf: headerRows(headers))
+        if rows.isEmpty {
+            rows.append(
+                Row(
+                    key: String(
+                        localized: "network.headers.response.empty", defaultValue: "No response headers",
+                        bundle: WebInspectorUILocalization.bundle),
+                    value: nil,
+                    style: .message
+                )
+            )
+        }
+        return Section(
+            title: String(localized: "network.section.response", bundle: WebInspectorUILocalization.bundle),
+            rows: rows,
+            ruleKind: .header
+        )
+    }
+
+    private func redirectRequestSection(
+        _ request: NetworkRequestSnapshot,
+        index: Int
+    ) -> Section {
+        var rows = requestProtocolRows(url: request.url, method: request.method, protocolName: nil)
+        rows.append(contentsOf: headerRows(request.headers))
+        return Section(
+            title: String(
+                localized: "network.section.redirect_request",
+                defaultValue: "Redirect Request",
+                bundle: WebInspectorUILocalization.bundle
+            ) + " \(index + 1)",
+            rows: rows,
+            ruleKind: .header
+        )
+    }
+
+    private func redirectResponseSection(
+        _ response: NetworkResponseSnapshot,
+        index: Int
+    ) -> Section {
+        var rows = responseProtocolRows(
+            status: response.status,
+            statusText: response.statusText,
+            protocolName: nil
+        )
+        rows.append(contentsOf: headerRows(response.headers))
+        return Section(
+            title: String(
+                localized: "network.section.redirect_response",
+                defaultValue: "Redirect Response",
+                bundle: WebInspectorUILocalization.bundle
+            ) + " \(index + 1)",
+            rows: rows,
+            ruleKind: .header
+        )
+    }
+
+    private func requestProtocolRows(
+        url: String,
+        method: String,
+        protocolName rawProtocolName: String?
+    ) -> [Row] {
+        let protocolName = rawProtocolName ?? ""
+        let components = URLComponents(string: url)
+        if protocolName == "h2" {
+            return [
+                Row(key: ":method", value: method, style: .pseudoHeader),
+                Row(key: ":scheme", value: components?.scheme, style: .pseudoHeader),
+                Row(key: ":authority", value: authority(from: components), style: .pseudoHeader),
+                Row(key: ":path", value: path(from: components), style: .pseudoHeader),
+            ].compactMap { row in
+                guard row.value?.isEmpty == false else {
+                    return nil
+                }
+                return row
+            }
+        }
+        let path = path(from: components) ?? "/"
+        let suffix = protocolName.hasPrefix("http/1") ? " \(protocolName.uppercased())" : ""
+        return [
+            Row(key: "\(method) \(path)\(suffix)", value: nil, style: .pseudoHeader)
+        ]
+    }
+
+    private func responseProtocolRows(
+        status: Int?,
+        statusText: String?,
+        protocolName rawProtocolName: String?
+    ) -> [Row] {
+        guard let status else {
+            return []
+        }
+        let protocolName = rawProtocolName ?? ""
+        if protocolName == "h2" {
+            return [Row(key: ":status", value: "\(status)", style: .pseudoHeader)]
+        }
+        if protocolName.hasPrefix("http/1") {
+            let resolvedStatusText = statusText ?? ""
+            let suffix = resolvedStatusText.isEmpty ? "" : " \(resolvedStatusText)"
+            return [Row(key: "\(protocolName.uppercased()) \(status)\(suffix)", value: nil, style: .pseudoHeader)]
+        }
+        let resolvedStatusText = statusText ?? ""
+        let suffix = resolvedStatusText.isEmpty ? "" : " \(resolvedStatusText)"
+        return [Row(key: "\(status)\(suffix)", value: nil, style: .pseudoHeader)]
+    }
+
+    private func headerRows(_ headers: [String: String]) -> [Row] {
+        headers
+            .map { Row(key: $0.key, value: $0.value, style: .header) }
+            .sorted {
+                let nameComparison = $0.key.localizedCaseInsensitiveCompare($1.key)
+                if nameComparison == .orderedSame {
+                    return ($0.value ?? "") < ($1.value ?? "")
+                }
+                return nameComparison == .orderedAscending
+            }
+    }
+
+    private func statusText(for request: NetworkRequest) -> String {
+        guard request.hasResponse else {
+            return "-"
+        }
+        let statusText = request.statusText ?? ""
+        let suffix = statusText.isEmpty ? "" : " \(statusText)"
+        return request.status.map { "\($0)\(suffix)" } ?? (statusText.isEmpty ? "-" : statusText)
+    }
+
+    private func sourceText(for request: NetworkRequest) -> String {
+        guard let source = request.responseSource else {
+            return "-"
+        }
+        switch source {
+        case "network":
+            return String(
+                localized: "network.headers.source.network", defaultValue: "Network",
+                bundle: WebInspectorUILocalization.bundle)
+        case "memory-cache":
+            return String(
+                localized: "network.headers.source.memory_cache", defaultValue: "Memory Cache",
+                bundle: WebInspectorUILocalization.bundle)
+        case "disk-cache":
+            return String(
+                localized: "network.headers.source.disk_cache", defaultValue: "Disk Cache",
+                bundle: WebInspectorUILocalization.bundle)
+        case "service-worker":
+            return String(
+                localized: "network.headers.source.service_worker", defaultValue: "Service Worker",
+                bundle: WebInspectorUILocalization.bundle)
+        case "inspector-override":
+            return String(
+                localized: "network.headers.source.local_override", defaultValue: "Local Override",
+                bundle: WebInspectorUILocalization.bundle)
+        default:
+            return source
+        }
+    }
+
+    private func authority(from components: URLComponents?) -> String? {
+        guard let host = components?.host, host.isEmpty == false else {
+            return nil
+        }
+        guard let port = components?.port else {
+            return host
+        }
+        return "\(host):\(port)"
+    }
+
+    private func path(from components: URLComponents?) -> String? {
+        guard let components else {
+            return nil
+        }
+        var path = components.percentEncodedPath.isEmpty ? "/" : components.percentEncodedPath
+        if let query = components.percentEncodedQuery, query.isEmpty == false {
+            path += "?\(query)"
+        }
+        return path
+    }
+
+    private func appendRequestHeading(
+        request: NetworkRequest,
+        index: Int,
+        to text: NSMutableAttributedString,
+        attributeRuns: inout [NetworkHeadersTextAttributeRun]
+    ) {
+        if text.length > 0 {
+            append(
+                "\n",
+                attributes: rowAttributes(style: .message).value,
+                style: .rowValue(.message),
+                to: text,
+                attributeRuns: &attributeRuns
+            )
+        }
+        append(
+            "\(index + 1). \(request.displayName)\n",
+            attributes: requestHeadingAttributes(),
+            style: .requestHeading,
+            to: text,
+            attributeRuns: &attributeRuns
+        )
+    }
+
+    private func append(
+        section: Section,
+        to text: NSMutableAttributedString,
+        rules: inout [NetworkHeadersTextSectionRule],
+        attributeRuns: inout [NetworkHeadersTextAttributeRun],
+        tag: inout NetworkHeadersTextTag?
+    ) {
+        if text.length > 0 {
+            append(
+                "\n",
+                attributes: rowAttributes(style: .message).value,
+                style: .rowValue(.message),
+                to: text,
+                attributeRuns: &attributeRuns
+            )
+        }
+
+        append(
+            section.title + "\n",
+            attributes: sectionTitleAttributes(),
+            style: .sectionTitle,
+            to: text,
+            attributeRuns: &attributeRuns
+        )
+        let ruleStart = text.length
+        for row in section.rows {
+            append(
+                row: row,
+                to: text,
+                attributeRuns: &attributeRuns,
+                tag: &tag
+            )
+        }
+        let ruleLength = text.length - ruleStart
+        if ruleLength > 0 {
+            rules.append(
+                NetworkHeadersTextSectionRule(
+                    range: NSRange(location: ruleStart, length: ruleLength),
+                    kind: section.ruleKind
+                ))
+        }
+    }
+
+    private func append(
+        row: Row,
+        to text: NSMutableAttributedString,
+        attributeRuns: inout [NetworkHeadersTextAttributeRun],
+        tag: inout NetworkHeadersTextTag?
+    ) {
+        let attributes = rowAttributes(style: row.style)
+        let keyRange = append(
+            row.key,
+            attributes: attributes.key,
+            style: .rowKey(row.style),
+            to: text,
+            attributeRuns: &attributeRuns
+        )
+        if let tagIdentifier = row.tagIdentifier {
+            precondition(tag == nil, "Network headers may expose only one active request preview action.")
+            text.addAttributes(
+                [
+                    .textItemTag: tagIdentifier,
+                    .foregroundColor: UIColor.link,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                ], range: keyRange)
+            tag = NetworkHeadersTextTag(identifier: tagIdentifier, range: keyRange)
+        }
+        if let value = row.value, value.isEmpty == false || row.alwaysShowsValueSeparator {
+            append(
+                ": ",
+                attributes: attributes.key,
+                style: .rowKey(row.style),
+                to: text,
+                attributeRuns: &attributeRuns
+            )
+            append(
+                value,
+                attributes: attributes.value,
+                style: .rowValue(row.style),
+                to: text,
+                attributeRuns: &attributeRuns
+            )
+        } else if row.value == nil, row.alwaysShowsValueSeparator {
+            append(
+                ": ",
+                attributes: attributes.key,
+                style: .rowKey(row.style),
+                to: text,
+                attributeRuns: &attributeRuns
+            )
+        }
+        append(
+            "\n",
+            attributes: attributes.value,
+            style: .rowValue(row.style),
+            to: text,
+            attributeRuns: &attributeRuns
+        )
+    }
+
+    @discardableResult
+    private func append(
+        _ string: String,
+        attributes: [NSAttributedString.Key: Any],
+        style: NetworkHeadersTextAttributeStyle,
+        to text: NSMutableAttributedString,
+        attributeRuns: inout [NetworkHeadersTextAttributeRun]
+    ) -> NSRange {
+        let range = NSRange(location: text.length, length: string.utf16.count)
+        text.append(NSAttributedString(string: string, attributes: attributes))
+        if range.length > 0 {
+            attributeRuns.append(NetworkHeadersTextAttributeRun(range: range, style: style))
+        }
+        return range
+    }
+
+    private func sectionTitleAttributes() -> [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.sectionTitleBottomSpacing
+        return [
+            .font: NetworkHeadersWebKitStyle.sectionTitleFont(compatibleWith: traitCollection),
+            .foregroundColor: NetworkHeadersWebKitStyle.textColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+    }
+
+    private func requestHeadingAttributes() -> [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.sectionTitleBottomSpacing
+        return [
+            .font: UIFont.preferredFont(
+                forTextStyle: .headline,
+                compatibleWith: traitCollection
+            ),
+            .foregroundColor: NetworkHeadersWebKitStyle.textColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+    }
+
+    private func rowAttributes(
+        style: NetworkHeadersTextRowStyle
+    ) -> (key: [NSAttributedString.Key: Any], value: [NSAttributedString.Key: Any]) {
+        let font = NetworkHeadersWebKitStyle.bodyFont(compatibleWith: traitCollection)
+        let keyFont = NetworkHeadersWebKitStyle.keyFont(compatibleWith: traitCollection)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.firstLineHeadIndent = NetworkHeadersWebKitStyle.rowFirstLineHeadIndent
+        paragraphStyle.headIndent = NetworkHeadersWebKitStyle.rowWrappedLineHeadIndent
+        paragraphStyle.paragraphSpacingBefore = NetworkHeadersWebKitStyle.rowVerticalPadding
+        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.rowVerticalPadding
+
+        let keyColor: UIColor
+        switch style {
+        case .summary:
+            keyColor = NetworkHeadersWebKitStyle.networkSystemColor
+        case .header:
+            keyColor = NetworkHeadersWebKitStyle.networkHeaderColor
+        case .pseudoHeader:
+            keyColor = NetworkHeadersWebKitStyle.networkPseudoHeaderColor
+        case .message:
+            keyColor = NetworkHeadersWebKitStyle.consoleSecondaryTextColor
+        case .warning:
+            keyColor = .systemOrange
+        case .action:
+            keyColor = .link
+        }
+
+        let keyAttributes: [NSAttributedString.Key: Any] = [
+            .font: keyFont,
+            .foregroundColor: keyColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+        let valueColor: UIColor =
+            switch style {
+            case .message:
+                NetworkHeadersWebKitStyle.consoleSecondaryTextColor
+            case .warning:
+                .systemOrange
+            case .action:
+                .link
+            default:
+                NetworkHeadersWebKitStyle.textColor
+            }
+        let valueAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: valueColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+        return (keyAttributes, valueAttributes)
+    }
+}
+
+enum NetworkHeadersWebKitStyle {
+    static let textInsets = UIEdgeInsets(top: 16, left: 18, bottom: 16, right: 18)
+    static let ruleWidth: CGFloat = 2
+    static let ruleGap = detailsTextPadding
+    static let sectionTitleBottomSpacing: CGFloat = 10
+    static let rowVerticalPadding: CGFloat = 2
+    private static let detailsMarginStart: CGFloat = 12
+    private static let detailsTextPadding: CGFloat = 12
+    private static let detailsValueIndent: CGFloat = 12
+    static let rowFirstLineHeadIndent = detailsMarginStart + detailsTextPadding
+    static let rowWrappedLineHeadIndent = rowFirstLineHeadIndent + detailsValueIndent
+
+    static func bodyFont(compatibleWith traitCollection: UITraitCollection) -> UIFont {
+        UIFont.preferredFont(forTextStyle: .callout, compatibleWith: traitCollection)
+    }
+
+    static func keyFont(compatibleWith traitCollection: UITraitCollection) -> UIFont {
+        bodyFont(compatibleWith: traitCollection).withWeight(.medium)
+    }
+
+    static func sectionTitleFont(compatibleWith traitCollection: UITraitCollection) -> UIFont {
+        UIFont.preferredFont(forTextStyle: .headline, compatibleWith: traitCollection)
+    }
+
+    static var textColor: UIColor {
+        dynamic(light: .black, dark: hsl(0, 0, 88))
+    }
+
+    static var consoleSecondaryTextColor: UIColor {
+        dynamic(
+            light: hsl(0, 0, 0, alpha: 0.33),
+            dark: hsl(0, 0, 100, alpha: 0.45)
+        )
+    }
+
+    static var networkSystemColor: UIColor {
+        dynamic(light: hsl(79, 32, 50), dark: hsl(79, 95, 50))
+    }
+
+    static var networkHeaderColor: UIColor {
+        hsl(204, 52, 55)
+    }
+
+    static var networkPseudoHeaderColor: UIColor {
+        dynamic(light: hsl(312, 35, 51), dark: hsl(312, 55, 61))
+    }
+
+    private static func dynamic(light: UIColor, dark: UIColor) -> UIColor {
+        UIColor { traitCollection in
+            traitCollection.userInterfaceStyle == .dark ? dark : light
+        }
+    }
+
+    private static func hsl(
+        _ hue: CGFloat,
+        _ saturation: CGFloat,
+        _ lightness: CGFloat,
+        alpha: CGFloat = 1
+    ) -> UIColor {
+        let hue = hue / 360
+        let saturation = saturation / 100
+        let lightness = lightness / 100
+        let chroma = (1 - abs(2 * lightness - 1)) * saturation
+        let huePrime = hue * 6
+        let secondary = chroma * (1 - abs(huePrime.truncatingRemainder(dividingBy: 2) - 1))
+        let match = lightness - chroma / 2
+
+        let components: (red: CGFloat, green: CGFloat, blue: CGFloat)
+        switch huePrime {
+        case 0..<1:
+            components = (chroma, secondary, 0)
+        case 1..<2:
+            components = (secondary, chroma, 0)
+        case 2..<3:
+            components = (0, chroma, secondary)
+        case 3..<4:
+            components = (0, secondary, chroma)
+        case 4..<5:
+            components = (secondary, 0, chroma)
+        default:
+            components = (chroma, 0, secondary)
+        }
+
+        return UIColor(
+            red: components.red + match,
+            green: components.green + match,
+            blue: components.blue + match,
+            alpha: alpha
+        )
+    }
+}
+
+private extension UIFont {
+    func withWeight(_ weight: UIFont.Weight) -> UIFont {
+        UIFont.systemFont(ofSize: pointSize, weight: weight)
+    }
+}
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
@@ -7,9 +7,10 @@ import UIKit
 final class NetworkHeadersTextView: UIView {
     private struct SectionRule {
         var range: NSRange
-        var color: UIColor
+        var kind: NetworkHeadersTextSectionRuleKind
     }
 
+    static let requestPreviewTagIdentifier = "WebInspector.Network.Headers.RequestPreview"
     private static let textInsets = NetworkHeadersWebKitStyle.textInsets
     private static let ruleWidth = NetworkHeadersWebKitStyle.ruleWidth
     private static let ruleGap = NetworkHeadersWebKitStyle.ruleGap
@@ -37,8 +38,10 @@ final class NetworkHeadersTextView: UIView {
         return view
     }()
     private var sectionRules: [SectionRule] = []
-    private var renderedText = ""
+    private var renderedSignature: NetworkHeadersTextDocumentSignature?
     private var renderedRequests: [NetworkRequest] = []
+    private weak var renderedActiveRequest: NetworkRequest?
+    var requestPreviewAction: (@MainActor () -> Void)?
 #if DEBUG
     private var attributedTextAssignmentCount = 0
 #endif
@@ -58,30 +61,42 @@ final class NetworkHeadersTextView: UIView {
         updateSectionRuleRuns()
     }
 
-    func render(request: NetworkRequest) {
-        render(requests: [request])
+    func render(request: NetworkRequest, activeRequest: NetworkRequest) {
+        render(requests: [request], activeRequest: activeRequest)
     }
 
-    func render(requests: [NetworkRequest]) {
-        render(requests: requests, forceDocumentAssignment: false)
+    func render(requests: [NetworkRequest], activeRequest: NetworkRequest) {
+        render(
+            requests: requests,
+            activeRequest: activeRequest,
+            forceDocumentAssignment: false
+        )
     }
 
     private func render(
         requests: [NetworkRequest],
+        activeRequest: NetworkRequest,
         forceDocumentAssignment: Bool
     ) {
         precondition(requests.isEmpty == false, "Network headers require at least one request.")
+        precondition(requests.contains { $0 === activeRequest })
         renderedRequests = requests
-        let document = NetworkHeadersTextDocumentBuilder(requests: requests).makeDocument()
-        let documentText = document.attributedString.string
-        if forceDocumentAssignment == false, renderedText == documentText {
+        renderedActiveRequest = activeRequest
+        let document = NetworkHeadersTextDocumentBuilder(
+            requests: requests,
+            activeRequest: activeRequest,
+            traitCollection: traitCollection
+        ).makeDocument()
+        if forceDocumentAssignment == false, renderedSignature == document.signature {
             updateSectionRuleRuns()
             return
         }
 
-        renderedText = documentText
-        sectionRules = document.sectionRules.map { SectionRule(range: $0.range, color: $0.color) }
+        renderedSignature = document.signature
+        sectionRules = document.sectionRules.map { SectionRule(range: $0.range, kind: $0.kind) }
+        let selectedRange = textView.selectedRange
         textView.attributedText = document.attributedString
+        textView.selectedRange = clamped(selectedRange, toUTF16Length: document.attributedString.length)
 #if DEBUG
         attributedTextAssignmentCount += 1
 #endif
@@ -90,7 +105,8 @@ final class NetworkHeadersTextView: UIView {
 
     func clear() {
         renderedRequests = []
-        renderedText = ""
+        renderedActiveRequest = nil
+        renderedSignature = nil
         sectionRules = []
         textView.attributedText = NSAttributedString()
         updateSectionRuleRuns()
@@ -128,7 +144,14 @@ final class NetworkHeadersTextView: UIView {
         guard renderedRequests.isEmpty == false else {
             return
         }
-        render(requests: renderedRequests, forceDocumentAssignment: true)
+        guard let renderedActiveRequest else {
+            preconditionFailure("Rendered Network headers must retain an active request.")
+        }
+        render(
+            requests: renderedRequests,
+            activeRequest: renderedActiveRequest,
+            forceDocumentAssignment: true
+        )
     }
 
     private func updateSectionRuleRuns() {
@@ -139,9 +162,15 @@ final class NetworkHeadersTextView: UIView {
             }
             return NetworkHeadersRuleOverlayView.RuleRun(
                 rect: rect,
-                color: rule.color.resolvedColor(with: traitCollection).cgColor
+                color: rule.kind.color.resolvedColor(with: traitCollection).cgColor
             )
         }
+    }
+
+    private func clamped(_ range: NSRange, toUTF16Length length: Int) -> NSRange {
+        let location = min(max(0, range.location), length)
+        let selectionLength = min(max(0, range.length), length - location)
+        return NSRange(location: location, length: selectionLength)
     }
 
     private func sectionRuleRect(for range: NSRange) -> CGRect? {
@@ -152,8 +181,21 @@ final class NetworkHeadersTextView: UIView {
         let unionRect = rects.dropFirst().reduce(firstRect) { partialResult, rect in
             partialResult.union(rect)
         }
+        let ruleX: CGFloat
+        if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+            ruleX = textView.textContainerInset.left
+                + unionRect.maxX
+                + Self.ruleGap
+                - Self.ruleWidth
+                - textView.contentOffset.x
+        } else {
+            ruleX = textView.textContainerInset.left
+                + unionRect.minX
+                - Self.ruleGap
+                - textView.contentOffset.x
+        }
         return CGRect(
-            x: textView.textContainerInset.left + unionRect.minX - Self.ruleGap - textView.contentOffset.x,
+            x: ruleX,
             y: textView.textContainerInset.top + unionRect.minY - textView.contentOffset.y,
             width: Self.ruleWidth,
             height: unionRect.height
@@ -200,6 +242,24 @@ final class NetworkHeadersTextView: UIView {
 }
 
 extension NetworkHeadersTextView: UITextViewDelegate {
+    func textView(
+        _ textView: UITextView,
+        primaryActionFor textItem: UITextItem,
+        defaultAction: UIAction
+    ) -> UIAction? {
+        guard case .tag(Self.requestPreviewTagIdentifier) = textItem.content else {
+            return defaultAction
+        }
+        let title = String(
+            localized: "network.headers.request_data.view_preview",
+            defaultValue: "View Request Preview",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        return UIAction(title: title) { [weak self] _ in
+            self?.requestPreviewAction?()
+        }
+    }
+
     nonisolated func scrollViewDidScroll(_ scrollView: UIScrollView) {
         MainActor.assumeIsolated {
             updateSectionRuleRuns()
@@ -244,506 +304,10 @@ private final class NetworkHeadersRuleOverlayView: UIView {
     }
 }
 
-private struct NetworkHeadersTextSectionRule {
-    var range: NSRange
-    var color: UIColor
-}
-
-private struct NetworkHeadersTextDocument {
-    var attributedString: NSAttributedString
-    var sectionRules: [NetworkHeadersTextSectionRule]
-}
-
-@MainActor
-private struct NetworkHeadersTextDocumentBuilder {
-    private enum RowStyle {
-        case summary
-        case header
-        case pseudoHeader
-        case message
-    }
-
-    private struct Row {
-        var key: String
-        var value: String?
-        var style: RowStyle
-    }
-
-    private struct Section {
-        var title: String
-        var rows: [Row]
-        var ruleColor: UIColor
-    }
-
-    var requests: [NetworkRequest]
-
-    func makeDocument() -> NetworkHeadersTextDocument {
-        let text = NSMutableAttributedString()
-        var rules: [NetworkHeadersTextSectionRule] = []
-        for (index, request) in requests.enumerated() {
-            if requests.count > 1 {
-                appendRequestHeading(request: request, index: index, to: text)
-            }
-            for section in sections(for: request) where section.rows.isEmpty == false {
-                append(section: section, to: text, rules: &rules)
-            }
-        }
-        return NetworkHeadersTextDocument(attributedString: text, sectionRules: rules)
-    }
-
-    private func sections(for request: NetworkRequest) -> [Section] {
-        var sections = [summarySection(for: request)]
-        for (index, redirect) in request.redirects.enumerated() {
-            sections.append(redirectRequestSection(redirect.request, index: index))
-            sections.append(redirectResponseSection(redirect.response, index: index))
-        }
-        sections.append(requestSection(for: request))
-        if let responseSection = responseSection(for: request) {
-            sections.append(responseSection)
-        }
-        return sections
-    }
-
-    private func summarySection(for request: NetworkRequest) -> Section {
-        var rows: [Row] = [
-            Row(key: String(localized: "network.headers.summary.url", defaultValue: "URL", bundle: WebInspectorUILocalization.bundle), value: request.url, style: .summary),
-            Row(key: String(localized: "network.headers.summary.status", defaultValue: "Status", bundle: WebInspectorUILocalization.bundle), value: statusText(for: request), style: .summary),
-            Row(key: String(localized: "network.headers.summary.source", defaultValue: "Source", bundle: WebInspectorUILocalization.bundle), value: sourceText(for: request), style: .summary),
-        ]
-        if request.redirects.isEmpty == false {
-            rows.append(Row(
-                key: String(localized: "network.headers.summary.redirects", defaultValue: "Redirects", bundle: WebInspectorUILocalization.bundle),
-                value: String(request.redirects.count),
-                style: .summary
-            ))
-        }
-        if let remoteAddress = request.metrics?.remoteAddress, remoteAddress.isEmpty == false {
-            rows.append(
-                Row(
-                    key: String(localized: "network.headers.summary.address", defaultValue: "Address", bundle: WebInspectorUILocalization.bundle),
-                    value: remoteAddress,
-                    style: .summary
-                )
-            )
-        }
-        return Section(
-            title: String(localized: "network.detail.section.overview", bundle: WebInspectorUILocalization.bundle),
-            rows: rows,
-            ruleColor: NetworkHeadersWebKitStyle.networkSystemColor
-        )
-    }
-
-    private func requestSection(for request: NetworkRequest) -> Section {
-        let headers = request.requestHeaders
-        var rows: [Row] = requestProtocolRows(
-            url: request.url,
-            method: request.method,
-            protocolName: request.metrics?.networkProtocol
-        )
-        rows.append(contentsOf: headerRows(headers))
-        if rows.isEmpty {
-            rows.append(
-                Row(
-                    key: String(localized: "network.headers.request.empty", defaultValue: "No request headers", bundle: WebInspectorUILocalization.bundle),
-                    value: nil,
-                    style: .message
-                )
-            )
-        }
-        return Section(
-            title: String(localized: "network.section.request", bundle: WebInspectorUILocalization.bundle),
-            rows: rows,
-            ruleColor: NetworkHeadersWebKitStyle.networkHeaderColor
-        )
-    }
-
-    private func responseSection(for request: NetworkRequest) -> Section? {
-        guard request.hasResponse else {
-            return nil
-        }
-        let headers = request.responseHeaders
-        var rows: [Row] = responseProtocolRows(
-            status: request.status,
-            statusText: request.statusText,
-            protocolName: request.metrics?.networkProtocol
-        )
-        rows.append(contentsOf: headerRows(headers))
-        if rows.isEmpty {
-            rows.append(
-                Row(
-                    key: String(localized: "network.headers.response.empty", defaultValue: "No response headers", bundle: WebInspectorUILocalization.bundle),
-                    value: nil,
-                    style: .message
-                )
-            )
-        }
-        return Section(
-            title: String(localized: "network.section.response", bundle: WebInspectorUILocalization.bundle),
-            rows: rows,
-            ruleColor: NetworkHeadersWebKitStyle.networkHeaderColor
-        )
-    }
-
-    private func redirectRequestSection(
-        _ request: NetworkRequestSnapshot,
-        index: Int
-    ) -> Section {
-        var rows = requestProtocolRows(url: request.url, method: request.method, protocolName: nil)
-        rows.append(contentsOf: headerRows(request.headers))
-        return Section(
-            title: String(
-                localized: "network.section.redirect_request",
-                defaultValue: "Redirect Request",
-                bundle: WebInspectorUILocalization.bundle
-            ) + " \(index + 1)",
-            rows: rows,
-            ruleColor: NetworkHeadersWebKitStyle.networkHeaderColor
-        )
-    }
-
-    private func redirectResponseSection(
-        _ response: NetworkResponseSnapshot,
-        index: Int
-    ) -> Section {
-        var rows = responseProtocolRows(
-            status: response.status,
-            statusText: response.statusText,
-            protocolName: nil
-        )
-        rows.append(contentsOf: headerRows(response.headers))
-        return Section(
-            title: String(
-                localized: "network.section.redirect_response",
-                defaultValue: "Redirect Response",
-                bundle: WebInspectorUILocalization.bundle
-            ) + " \(index + 1)",
-            rows: rows,
-            ruleColor: NetworkHeadersWebKitStyle.networkHeaderColor
-        )
-    }
-
-    private func requestProtocolRows(
-        url: String,
-        method: String,
-        protocolName rawProtocolName: String?
-    ) -> [Row] {
-        let protocolName = rawProtocolName ?? ""
-        let components = URLComponents(string: url)
-        if protocolName == "h2" {
-            return [
-                Row(key: ":method", value: method, style: .pseudoHeader),
-                Row(key: ":scheme", value: components?.scheme, style: .pseudoHeader),
-                Row(key: ":authority", value: authority(from: components), style: .pseudoHeader),
-                Row(key: ":path", value: path(from: components), style: .pseudoHeader),
-            ].compactMap { row in
-                guard row.value?.isEmpty == false else {
-                    return nil
-                }
-                return row
-            }
-        }
-        let path = path(from: components) ?? "/"
-        let suffix = protocolName.hasPrefix("http/1") ? " \(protocolName.uppercased())" : ""
-        return [
-            Row(key: "\(method) \(path)\(suffix)", value: nil, style: .pseudoHeader),
-        ]
-    }
-
-    private func responseProtocolRows(
-        status: Int?,
-        statusText: String?,
-        protocolName rawProtocolName: String?
-    ) -> [Row] {
-        guard let status else {
-            return []
-        }
-        let protocolName = rawProtocolName ?? ""
-        if protocolName == "h2" {
-            return [Row(key: ":status", value: "\(status)", style: .pseudoHeader)]
-        }
-        if protocolName.hasPrefix("http/1") {
-            let resolvedStatusText = statusText ?? ""
-            let suffix = resolvedStatusText.isEmpty ? "" : " \(resolvedStatusText)"
-            return [Row(key: "\(protocolName.uppercased()) \(status)\(suffix)", value: nil, style: .pseudoHeader)]
-        }
-        let resolvedStatusText = statusText ?? ""
-        let suffix = resolvedStatusText.isEmpty ? "" : " \(resolvedStatusText)"
-        return [Row(key: "\(status)\(suffix)", value: nil, style: .pseudoHeader)]
-    }
-
-    private func headerRows(_ headers: [String: String]) -> [Row] {
-        headers
-            .map { Row(key: $0.key, value: $0.value, style: .header) }
-            .sorted {
-                let nameComparison = $0.key.localizedCaseInsensitiveCompare($1.key)
-                if nameComparison == .orderedSame {
-                    return ($0.value ?? "") < ($1.value ?? "")
-                }
-                return nameComparison == .orderedAscending
-            }
-    }
-
-    private func statusText(for request: NetworkRequest) -> String {
-        guard request.hasResponse else {
-            return "-"
-        }
-        let statusText = request.statusText ?? ""
-        let suffix = statusText.isEmpty ? "" : " \(statusText)"
-        return request.status.map { "\($0)\(suffix)" } ?? (statusText.isEmpty ? "-" : statusText)
-    }
-
-    private func sourceText(for request: NetworkRequest) -> String {
-        guard let source = request.responseSource else {
-            return "-"
-        }
-        switch source {
-        case "network":
-            return String(localized: "network.headers.source.network", defaultValue: "Network", bundle: WebInspectorUILocalization.bundle)
-        case "memory-cache":
-            return String(localized: "network.headers.source.memory_cache", defaultValue: "Memory Cache", bundle: WebInspectorUILocalization.bundle)
-        case "disk-cache":
-            return String(localized: "network.headers.source.disk_cache", defaultValue: "Disk Cache", bundle: WebInspectorUILocalization.bundle)
-        case "service-worker":
-            return String(localized: "network.headers.source.service_worker", defaultValue: "Service Worker", bundle: WebInspectorUILocalization.bundle)
-        case "inspector-override":
-            return String(localized: "network.headers.source.local_override", defaultValue: "Local Override", bundle: WebInspectorUILocalization.bundle)
-        default:
-            return source
-        }
-    }
-
-    private func authority(from components: URLComponents?) -> String? {
-        guard let host = components?.host, host.isEmpty == false else {
-            return nil
-        }
-        guard let port = components?.port else {
-            return host
-        }
-        return "\(host):\(port)"
-    }
-
-    private func path(from components: URLComponents?) -> String? {
-        guard let components else {
-            return nil
-        }
-        var path = components.percentEncodedPath.isEmpty ? "/" : components.percentEncodedPath
-        if let query = components.percentEncodedQuery, query.isEmpty == false {
-            path += "?\(query)"
-        }
-        return path
-    }
-
-    private func appendRequestHeading(
-        request: NetworkRequest,
-        index: Int,
-        to text: NSMutableAttributedString
-    ) {
-        if text.length > 0 {
-            text.append(NSAttributedString(
-                string: "\n",
-                attributes: rowAttributes(style: .message).value
-            ))
-        }
-        text.append(NSAttributedString(
-            string: "\(index + 1). \(request.displayName)\n",
-            attributes: requestHeadingAttributes()
-        ))
-    }
-
-    private func append(
-        section: Section,
-        to text: NSMutableAttributedString,
-        rules: inout [NetworkHeadersTextSectionRule]
-    ) {
-        if text.length > 0 {
-            text.append(NSAttributedString(string: "\n", attributes: rowAttributes(style: .message).value))
-        }
-
-        text.append(NSAttributedString(string: section.title + "\n", attributes: sectionTitleAttributes()))
-        let ruleStart = text.length
-        for row in section.rows {
-            append(row: row, to: text)
-        }
-        let ruleLength = text.length - ruleStart
-        if ruleLength > 0 {
-            rules.append(NetworkHeadersTextSectionRule(range: NSRange(location: ruleStart, length: ruleLength), color: section.ruleColor))
-        }
-    }
-
-    private func append(row: Row, to text: NSMutableAttributedString) {
-        let attributes = rowAttributes(style: row.style)
-        text.append(NSAttributedString(string: row.key, attributes: attributes.key))
-        if let value = row.value, value.isEmpty == false {
-            text.append(NSAttributedString(string: ": ", attributes: attributes.key))
-            text.append(NSAttributedString(string: value, attributes: attributes.value))
-        }
-        text.append(NSAttributedString(string: "\n", attributes: attributes.value))
-    }
-
-    private func sectionTitleAttributes() -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.sectionTitleBottomSpacing
-        return [
-            .font: NetworkHeadersWebKitStyle.sectionTitleFont,
-            .foregroundColor: NetworkHeadersWebKitStyle.textColor,
-            .paragraphStyle: paragraphStyle,
-        ]
-    }
-
-    private func requestHeadingAttributes() -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.sectionTitleBottomSpacing
-        return [
-            .font: UIFont.preferredFont(forTextStyle: .headline),
-            .foregroundColor: NetworkHeadersWebKitStyle.textColor,
-            .paragraphStyle: paragraphStyle,
-        ]
-    }
-
-    private func rowAttributes(
-        style: RowStyle
-    ) -> (key: [NSAttributedString.Key: Any], value: [NSAttributedString.Key: Any]) {
-        let font = NetworkHeadersWebKitStyle.bodyFont
-        let keyFont = NetworkHeadersWebKitStyle.keyFont
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.firstLineHeadIndent = NetworkHeadersWebKitStyle.rowFirstLineHeadIndent
-        paragraphStyle.headIndent = NetworkHeadersWebKitStyle.rowWrappedLineHeadIndent
-        paragraphStyle.paragraphSpacingBefore = NetworkHeadersWebKitStyle.rowVerticalPadding
-        paragraphStyle.paragraphSpacing = NetworkHeadersWebKitStyle.rowVerticalPadding
-
-        let keyColor: UIColor
-        switch style {
-        case .summary:
-            keyColor = NetworkHeadersWebKitStyle.networkSystemColor
-        case .header:
-            keyColor = NetworkHeadersWebKitStyle.networkHeaderColor
-        case .pseudoHeader:
-            keyColor = NetworkHeadersWebKitStyle.networkPseudoHeaderColor
-        case .message:
-            keyColor = NetworkHeadersWebKitStyle.consoleSecondaryTextColor
-        }
-
-        let keyAttributes: [NSAttributedString.Key: Any] = [
-            .font: keyFont,
-            .foregroundColor: keyColor,
-            .paragraphStyle: paragraphStyle,
-        ]
-        let valueAttributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: style == .message
-                ? NetworkHeadersWebKitStyle.consoleSecondaryTextColor
-                : NetworkHeadersWebKitStyle.textColor,
-            .paragraphStyle: paragraphStyle,
-        ]
-        return (keyAttributes, valueAttributes)
-    }
-}
-
-private enum NetworkHeadersWebKitStyle {
-    static let textInsets = UIEdgeInsets(top: 16, left: 18, bottom: 16, right: 18)
-    static let ruleWidth: CGFloat = 2
-    static let ruleGap = detailsTextPadding
-    static let sectionTitleBottomSpacing: CGFloat = 10
-    static let rowVerticalPadding: CGFloat = 2
-    private static let detailsMarginStart: CGFloat = 12
-    private static let detailsTextPadding: CGFloat = 12
-    private static let detailsValueIndent: CGFloat = 12
-    static let rowFirstLineHeadIndent = detailsMarginStart + detailsTextPadding
-    static let rowWrappedLineHeadIndent = rowFirstLineHeadIndent + detailsValueIndent
-
-    static var bodyFont: UIFont {
-        UIFont.preferredFont(forTextStyle: .callout)
-    }
-
-    static var keyFont: UIFont {
-        UIFont.preferredFont(forTextStyle: .callout).withWeight(.medium)
-    }
-
-    static var sectionTitleFont: UIFont {
-        UIFont.preferredFont(forTextStyle: .headline)
-    }
-
-    static var textColor: UIColor {
-        dynamic(light: .black, dark: hsl(0, 0, 88))
-    }
-
-    static var consoleSecondaryTextColor: UIColor {
-        dynamic(
-            light: hsl(0, 0, 0, alpha: 0.33),
-            dark: hsl(0, 0, 100, alpha: 0.45)
-        )
-    }
-
-    static var networkSystemColor: UIColor {
-        dynamic(light: hsl(79, 32, 50), dark: hsl(79, 95, 50))
-    }
-
-    static var networkHeaderColor: UIColor {
-        hsl(204, 52, 55)
-    }
-
-    static var networkPseudoHeaderColor: UIColor {
-        dynamic(light: hsl(312, 35, 51), dark: hsl(312, 55, 61))
-    }
-
-    private static func dynamic(light: UIColor, dark: UIColor) -> UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? dark : light
-        }
-    }
-
-    private static func hsl(
-        _ hue: CGFloat,
-        _ saturation: CGFloat,
-        _ lightness: CGFloat,
-        alpha: CGFloat = 1
-    ) -> UIColor {
-        let hue = hue / 360
-        let saturation = saturation / 100
-        let lightness = lightness / 100
-        let chroma = (1 - abs(2 * lightness - 1)) * saturation
-        let huePrime = hue * 6
-        let secondary = chroma * (1 - abs(huePrime.truncatingRemainder(dividingBy: 2) - 1))
-        let match = lightness - chroma / 2
-
-        let components: (red: CGFloat, green: CGFloat, blue: CGFloat)
-        switch huePrime {
-        case 0..<1:
-            components = (chroma, secondary, 0)
-        case 1..<2:
-            components = (secondary, chroma, 0)
-        case 2..<3:
-            components = (0, chroma, secondary)
-        case 3..<4:
-            components = (0, secondary, chroma)
-        case 4..<5:
-            components = (secondary, 0, chroma)
-        default:
-            components = (chroma, 0, secondary)
-        }
-
-        return UIColor(
-            red: components.red + match,
-            green: components.green + match,
-            blue: components.blue + match,
-            alpha: alpha
-        )
-    }
-}
-
-private extension UIFont {
-    func withWeight(_ weight: UIFont.Weight) -> UIFont {
-        UIFont.systemFont(ofSize: pointSize, weight: weight)
-    }
-}
-
 #if DEBUG
 extension NetworkHeadersTextView {
     var renderedTextForTesting: String {
-        renderedText
+        textView.attributedText.string
     }
 
     var usesTextKit2ForTesting: Bool {
@@ -765,6 +329,37 @@ extension NetworkHeadersTextView {
 
     var attributedTextAssignmentCountForTesting: Int {
         attributedTextAssignmentCount
+    }
+
+    var requestPreviewTagRangesForTesting: [NSRange] {
+        let attributedText = AttributedString(textView.attributedText)
+        return attributedText.runs.compactMap { run in
+            guard run.uiKit.textItemTag == Self.requestPreviewTagIdentifier else {
+                return nil
+            }
+            let prefix = String(attributedText.characters[..<run.range.lowerBound])
+            let value = String(attributedText.characters[run.range])
+            return NSRange(location: prefix.utf16.count, length: value.utf16.count)
+        }
+    }
+
+    var sectionRuleRectsForTesting: [CGRect] {
+        ruleOverlayView.ruleRuns.map(\.rect)
+    }
+
+    var effectiveLayoutDirectionForTesting: UIUserInterfaceLayoutDirection {
+        effectiveUserInterfaceLayoutDirection
+    }
+
+    var requestPreviewFontPointSizeForTesting: CGFloat? {
+        let attributedText = AttributedString(textView.attributedText)
+        return attributedText.runs.first(where: {
+            $0.uiKit.textItemTag == Self.requestPreviewTagIdentifier
+        })?.uiKit.font?.pointSize
+    }
+
+    func activateRequestPreviewForTesting() {
+        requestPreviewAction?()
     }
 }
 #endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
@@ -92,11 +92,19 @@ final class NetworkHeadersTextView: UIView {
             return
         }
 
+        let previousSignature = renderedSignature
+        let selectedRange = textView.selectedRange
         renderedSignature = document.signature
         sectionRules = document.sectionRules.map { SectionRule(range: $0.range, kind: $0.kind) }
-        let selectedRange = textView.selectedRange
         textView.attributedText = document.attributedString
-        textView.selectedRange = clamped(selectedRange, toUTF16Length: document.attributedString.length)
+        if previousSignature?.visibleText == document.signature.visibleText {
+            textView.selectedRange = clamped(
+                selectedRange,
+                toUTF16Length: document.attributedString.length
+            )
+        } else {
+            textView.selectedRange = NSRange(location: 0, length: 0)
+        }
 #if DEBUG
         attributedTextAssignmentCount += 1
 #endif

--- a/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
@@ -507,6 +507,40 @@ struct NetworkRequestHeadersContextTests {
         }
         #expect(capturedEmptyParameters.parameters.isEmpty)
 
+        let misleadingFormHint = NetworkBody(
+            role: .request,
+            kind: .form,
+            full: "raw=body",
+            phase: .loaded
+        )
+        #expect(
+            NetworkRequestHeadersContext.makeRequestData(
+                requestBody: misleadingFormHint,
+                requestHeaders: ["Content-Type": "application/json"]
+            )
+                == .body(
+                    contentType: .value(NetworkContentTypeParser.parse("application/json"))
+                )
+        )
+
+        let staleTextHint = NetworkBody(
+            role: .request,
+            kind: .text,
+            full: "fresh=form",
+            phase: .loaded
+        )
+        guard
+            case let .form(_, staleHintParameters) = NetworkRequestHeadersContext.makeRequestData(
+                requestBody: staleTextHint,
+                requestHeaders: ["Content-Type": "application/x-www-form-urlencoded"]
+            )
+        else {
+            Issue.record("Expected Content-Type to own URL-encoded form classification.")
+            return
+        }
+        #expect(staleHintParameters.parameters.first?.name.decodedValue == "fresh")
+        #expect(staleHintParameters.parameters.first?.value.decodedValue == "form")
+
         let multipart = NetworkRequest(
             request: Network.Request(
                 id: Network.Request.ID("multipart-post-data"),

--- a/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
@@ -203,7 +203,7 @@ struct NetworkRequestHeadersContextTests {
     @Test
     func headersContextDistinguishesCancellationFailureAndProjectsResourceAndInitiator() throws {
         let context = WebInspectorContext.preview(isolation: MainActor.shared)
-        let nodeID = DOM.Node.ID("42")
+        let nodeID = DOM.Node.ID("42", scopedToTargetRawValue: "page-target")
         let canceled = NetworkRequest(
             request: Network.Request(
                 id: Network.Request.ID("canceled-context"),
@@ -231,8 +231,11 @@ struct NetworkRequestHeadersContextTests {
                     kind: "script",
                     url: "https://example.test/app.js",
                     line: 17,
-                    nodeID: nodeID
+                    nodeIDRawValue: "42"
                 ))
+        #expect(canceled.headersContext.initiator?.nodeIDRawValue == "42")
+        #expect(canceled.headersContext.initiator?.nodeIDRawValue?.contains("page-target") == false)
+        #expect(canceled.headersContext.initiator?.nodeIDRawValue?.contains("\u{1E}") == false)
 
         let failed = NetworkRequest(
             request: Network.Request(
@@ -299,6 +302,25 @@ struct NetworkRequestHeadersContextTests {
             timestamp: 4
         )
         #expect(request.headersContext.effectiveMIMEType == nil)
+
+        #expect(
+            NetworkContentTypeParser.effectiveMediaType(
+                protocolMIMEType: " Text/CSS ; charset=utf-8 ",
+                headers: [:]
+            ) == "Text/CSS"
+        )
+        #expect(
+            NetworkContentTypeParser.effectiveMediaType(
+                protocolMIMEType: nil,
+                headers: ["Content-Type": " Text/CSS ; charset=utf-8 "]
+            ) == "Text/CSS"
+        )
+        #expect(
+            NetworkContentTypeParser.effectiveMediaType(
+                protocolMIMEType: " invalid mime ; charset=utf-8 ",
+                headers: ["Content-Type": "text/plain"]
+            ) == "invalid mime"
+        )
     }
 
     @MainActor

--- a/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
@@ -199,6 +199,73 @@ struct NetworkRequestHeadersContextTests {
         #expect(repeatedValue == .ambiguous(rawValues: ["same", "same"]))
     }
 
+    @Test
+    func normalizedMediaTypeResolutionDistinguishesAbsentInvalidAndAmbiguousInput() {
+        #expect(
+            NetworkContentTypeParser.normalizedMediaTypeResolution(
+                protocolMIMEType: nil,
+                headers: [:]
+            ) == .absent
+        )
+        #expect(
+            NetworkContentTypeParser.normalizedMediaTypeResolution(
+                protocolMIMEType: "not a media type",
+                headers: ["Content-Type": "text/plain"]
+            ) == .invalid
+        )
+        #expect(
+            NetworkContentTypeParser.normalizedMediaTypeResolution(
+                protocolMIMEType: nil,
+                headers: ["Content-Type": "not a media type"]
+            ) == .invalid
+        )
+        #expect(
+            NetworkContentTypeParser.normalizedMediaTypeResolution(
+                protocolMIMEType: nil,
+                headers: [
+                    "Content-Type": "text/plain",
+                    "content-type": "application/octet-stream",
+                ]
+            ) == .invalid
+        )
+        #expect(
+            NetworkContentTypeParser.normalizedMediaTypeResolution(
+                protocolMIMEType: " \t ",
+                headers: ["Content-Type": " Text/Plain; charset=utf-8"]
+            ) == .value("text/plain")
+        )
+    }
+
+    @Test
+    func bodyHintsTreatOnlyAbsentContentTypeAsURLInferredText() {
+        let absent = NetworkBody.bodyHints(
+            mimeType: nil,
+            headers: [:],
+            url: "https://example.test/data.json",
+            role: .response
+        )
+        #expect(absent.kind == .text)
+        #expect(absent.syntaxKind == .json)
+
+        for (mimeType, headers) in [
+            ("not a media type", [:]),
+            (nil, ["Content-Type": "not a media type"]),
+            (nil, [
+                "Content-Type": "text/plain",
+                "content-type": "application/octet-stream",
+            ]),
+        ] as [(String?, [String: String])] {
+            let invalid = NetworkBody.bodyHints(
+                mimeType: mimeType,
+                headers: headers,
+                url: "https://example.test/data.json",
+                role: .response
+            )
+            #expect(invalid.kind == .binary)
+            #expect(invalid.syntaxKind == .plainText)
+        }
+    }
+
     @MainActor
     @Test
     func headersContextDistinguishesCancellationFailureAndProjectsResourceAndInitiator() throws {

--- a/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkRequestHeadersContextTests.swift
@@ -1,0 +1,583 @@
+import Foundation
+import Testing
+@testable import WebInspectorDataKit
+import WebInspectorProxyKit
+
+@Suite
+struct NetworkRequestHeadersContextTests {
+
+    @Test
+    func queryParametersPreserveRepeatsEmptyValuesBareNamesAndEmptyFragments() throws {
+        let report = try #require(
+            NetworkParameterParser.parseQuery(
+                in: "https://example.test/path?repeat=1&empty=&bare&=value&&repeat=2&#ignored"
+            ))
+
+        #expect(report.rawValue == "repeat=1&empty=&bare&=value&&repeat=2&")
+        #expect(report.parameters.map(\.ordinal) == Array(0...6))
+        #expect(
+            report.parameters.map(\.rawFragment) == [
+                "repeat=1", "empty=", "bare", "=value", "", "repeat=2", "",
+            ])
+        #expect(report.parameters.map(\.hadEqualsSign) == [true, true, false, true, false, true, false])
+        #expect(
+            report.parameters.map { $0.name.decodedValue } == [
+                "repeat", "empty", "bare", "", "", "repeat", "",
+            ])
+        #expect(
+            report.parameters.map { $0.value.decodedValue } == [
+                "1", "", "", "value", "", "2", "",
+            ])
+        #expect(report.status == .complete)
+        #expect(report.diagnostics.isEmpty)
+    }
+
+    @Test
+    func parameterDecoderHandlesPlusReservedBytesAndLiteralAndEncodedUTF8() throws {
+        let report = try #require(
+            NetworkParameterParser.parseQuery(
+                in: "?space=a+b&plus=%2B&reserved=%26%3D&literal=東京&encoded=%E6%9D%B1%E4%BA%AC"
+            ))
+
+        #expect(
+            report.parameters.map { $0.value.decodedValue } == [
+                "a b", "+", "&=", "東京", "東京",
+            ])
+        #expect(report.status == .complete)
+    }
+
+    @Test
+    func malformedParameterComponentsRemainLocalAndKeepValidSiblings() throws {
+        let report = try #require(
+            NetworkParameterParser.parseQuery(
+                in: "?badPercent=%&badHex=%G0&invalid=%FF&incomplete=%E3%81&%FF=value&good=%E6%9D%B1&next=ok"
+            ))
+
+        #expect(report.parameters.count == 7)
+        #expect(report.parameters[0].name.decodedValue == "badPercent")
+        #expect(
+            report.parameters[0].value
+                == .malformed(
+                    rawValue: "%",
+                    reason: .malformedPercentEscape
+                ))
+        #expect(
+            report.parameters[1].value
+                == .malformed(
+                    rawValue: "%G0",
+                    reason: .malformedPercentEscape
+                ))
+        #expect(report.parameters[2].value == .malformed(rawValue: "%FF", reason: .invalidUTF8))
+        #expect(report.parameters[3].value == .malformed(rawValue: "%E3%81", reason: .invalidUTF8))
+        #expect(report.parameters[4].name == .malformed(rawValue: "%FF", reason: .invalidUTF8))
+        #expect(report.parameters[4].value.decodedValue == "value")
+        #expect(report.parameters[5].value.decodedValue == "東")
+        #expect(report.parameters[6].value.decodedValue == "ok")
+        #expect(report.status == .partial)
+        #expect(report.diagnostics.map(\.ordinal) == [0, 1, 2, 3, 4])
+        #expect(report.diagnostics.map(\.field) == [.value, .value, .value, .value, .name])
+
+        let unparsed = NetworkParameterParser.parseForm("%=%")
+        #expect(unparsed.status == .unparsed)
+        #expect(unparsed.diagnostics.count == 2)
+    }
+
+    @Test
+    func queryExtractionUsesRawQuestionMarkBeforeFragmentWithoutURLNormalization() throws {
+        let malformedURLReport = try #require(
+            NetworkParameterParser.parseQuery(
+                in: "not a valid URL ?first=1#fragment?ignored=2"
+            ))
+        #expect(malformedURLReport.rawValue == "first=1")
+        #expect(malformedURLReport.parameters.first?.value.decodedValue == "1")
+
+        let empty = try #require(NetworkParameterParser.parseQuery(in: "https://example.test/path?"))
+        #expect(empty.rawValue == "")
+        #expect(empty.parameters.isEmpty)
+        #expect(empty.status == .complete)
+
+        #expect(NetworkParameterParser.parseQuery(in: "https://example.test/path") == nil)
+        #expect(NetworkParameterParser.parseQuery(in: "https://example.test/path#fragment?ignored=1") == nil)
+    }
+
+    @Test
+    func formAndQueryUseTheSameParameterParserContract() throws {
+        let rawValue = "repeat=1&repeat=2&bare&empty=&bad=%ZZ"
+        let query = try #require(NetworkParameterParser.parseQuery(in: "scheme:?\(rawValue)#fragment"))
+        let form = NetworkParameterParser.parseForm(rawValue)
+
+        #expect(form == query)
+    }
+
+    @Test
+    func contentTypeParserNormalizesTokensAndPreservesQuotedAndDuplicateParameters() throws {
+        let rawValue =
+            #"  Application/X-WWW-Form-Urlencoded ; CHARSET = "utf-8" ; boundary="a;b=c\"d\\e"; X-Foo=bar ; charset=second ; encoding=gzip  "#
+        let contentType = NetworkContentTypeParser.parse(rawValue)
+
+        #expect(contentType.rawValue == rawValue)
+        #expect(contentType.mediaType == "Application/X-WWW-Form-Urlencoded")
+        #expect(contentType.normalizedMediaType == "application/x-www-form-urlencoded")
+        #expect(contentType.parameters.count == 5)
+        #expect(contentType.parameters.map(\.ordinal) == Array(0...4))
+        #expect(
+            contentType.parameters.map(\.normalizedName) == [
+                "charset", "boundary", "x-foo", "charset", "encoding",
+            ])
+        #expect(
+            contentType.parameters.map(\.value) == [
+                "utf-8", #"a;b=c"d\e"#, "bar", "second", "gzip",
+            ])
+        #expect(contentType.boundary == [#"a;b=c"d\e"#])
+        #expect(contentType.charset == ["utf-8", "second"])
+        #expect(contentType.parameters[2].rawFragment.contains("X-Foo=bar"))
+        #expect(contentType.parameters.allSatisfy { $0.issue == nil })
+    }
+
+    @Test
+    func contentTypeParserRetainsMalformedParametersAndRejectsEscapedControls() {
+        let malformed = NetworkContentTypeParser.parse(
+            #"text/plain; missing; bad name=value; empty=; quote="unterminated; still=part"#
+        )
+
+        #expect(malformed.parameters.count == 4)
+        #expect(
+            malformed.parameters.map(\.issue) == [
+                .missingEqualsSign,
+                .invalidName,
+                .invalidValue,
+                .malformedQuotedValue,
+            ])
+        #expect(
+            malformed.parameters.map(\.rawFragment) == [
+                " missing", " bad name=value", " empty=", #" quote="unterminated; still=part"#,
+            ])
+
+        let escapedControl = NetworkContentTypeParser.parse(
+            "multipart/form-data; boundary=\"a\\\nb\""
+        )
+        #expect(escapedControl.parameters.first?.issue == .malformedQuotedValue)
+
+        let escapedQuoteAndSlash = NetworkContentTypeParser.parse(
+            #"multipart/form-data; boundary="a\"b\\c""#
+        )
+        #expect(escapedQuoteAndSlash.parameters.first?.value == #"a"b\c"#)
+        #expect(escapedQuoteAndSlash.parameters.first?.issue == nil)
+
+        let nonASCIITokens = NetworkContentTypeParser.parse("téxt/plain; naïve=value")
+        #expect(nonASCIITokens.mediaType == "téxt/plain")
+        #expect(nonASCIITokens.normalizedMediaType == nil)
+        #expect(nonASCIITokens.parameters.first?.issue == .invalidName)
+    }
+
+    @Test
+    func contentTypeHeaderDistinguishesAbsentUniqueAndAmbiguousCaseVariantsDeterministically() throws {
+        #expect(NetworkContentTypeParser.parseHeader(in: [:]) == .absent)
+
+        let unique = NetworkContentTypeParser.parseHeader(in: [
+            "cOnTeNt-TyPe": " Text/HTML ; Charset=UTF-8 "
+        ])
+        guard case let .value(contentType) = unique else {
+            Issue.record("Expected one Content-Type field.")
+            return
+        }
+        #expect(contentType.mediaType == "Text/HTML")
+        #expect(contentType.normalizedMediaType == "text/html")
+        #expect(contentType.charset == ["UTF-8"])
+
+        let ambiguous = NetworkContentTypeParser.parseHeader(in: [
+            "content-type": "lower",
+            "Content-Type": "mixed",
+            "CONTENT-TYPE": "upper",
+        ])
+        #expect(ambiguous == .ambiguous(rawValues: ["upper", "mixed", "lower"]))
+
+        let repeatedValue = NetworkContentTypeParser.parseHeader(in: [
+            "Content-Type": "same",
+            "content-type": "same",
+        ])
+        #expect(repeatedValue == .ambiguous(rawValues: ["same", "same"]))
+    }
+
+    @MainActor
+    @Test
+    func headersContextDistinguishesCancellationFailureAndProjectsResourceAndInitiator() throws {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let nodeID = DOM.Node.ID("42")
+        let canceled = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("canceled-context"),
+                url: "https://example.test/canceled",
+                method: "GET"
+            ),
+            initiator: Network.Initiator(
+                kind: "script",
+                url: "https://example.test/app.js",
+                line: 17,
+                column: 4,
+                nodeID: nodeID
+            ),
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        canceled.fail(errorText: "cancelled by client", canceled: true, timestamp: 2)
+
+        #expect(canceled.headersContext.outcome == .canceled(reason: "cancelled by client"))
+        #expect(canceled.headersContext.resourceType == Network.ResourceType.fetch.rawValue)
+        #expect(
+            canceled.headersContext.initiator
+                == NetworkRequestHeadersContext.Initiator(
+                    kind: "script",
+                    url: "https://example.test/app.js",
+                    line: 17,
+                    nodeID: nodeID
+                ))
+
+        let failed = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("failed-context"),
+                url: "https://example.test/failed",
+                method: "GET"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        failed.fail(errorText: "DNS lookup failed", canceled: false, timestamp: 2)
+        #expect(failed.headersContext.outcome == .failed(reason: "DNS lookup failed"))
+    }
+
+    @MainActor
+    @Test
+    func effectiveResponseMIMETypePrefersNonblankProtocolValueThenUniqueHeaderMediaType() {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let request = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("mime-context"),
+                url: "https://example.test/resource",
+                method: "GET"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+
+        request.applyResponse(
+            Network.Response(
+                status: 200,
+                mimeType: "  Application/JSON  ",
+                headers: ["Content-Type": "text/html; charset=utf-8"]
+            ),
+            resourceType: .fetch,
+            timestamp: 2
+        )
+        #expect(request.headersContext.effectiveMIMEType == "Application/JSON")
+
+        request.applyResponse(
+            Network.Response(
+                status: 200,
+                mimeType: "\t ",
+                headers: ["content-TYPE": " Text/HTML ; charset=utf-8"]
+            ),
+            resourceType: .fetch,
+            timestamp: 3
+        )
+        #expect(request.headersContext.effectiveMIMEType == "Text/HTML")
+
+        request.applyResponse(
+            Network.Response(
+                status: 200,
+                headers: [
+                    "Content-Type": "text/plain",
+                    "content-type": "application/json",
+                ]
+            ),
+            resourceType: .fetch,
+            timestamp: 4
+        )
+        #expect(request.headersContext.effectiveMIMEType == nil)
+    }
+
+    @MainActor
+    @Test
+    func redirectContextUsesFinalQueryAndBodyWhileKeepingInitialInitiator() throws {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let requestID = Network.Request.ID("redirect-context")
+        let request = NetworkRequest(
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.test/start?initial=1",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"],
+                postData: "initial=body"
+            ),
+            initiator: Network.Initiator(
+                kind: "script",
+                url: "https://example.test/start.js",
+                line: 9
+            ),
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+
+        request.applyRedirect(
+            to: Network.Request(
+                id: requestID,
+                url: "https://example.test/final?repeat=1&repeat=2",
+                method: "POST",
+                headers: ["content-type": "application/x-www-form-urlencoded; charset=utf-8"],
+                postData: "final=a+b&bare"
+            ),
+            redirectResponse: Network.Response(status: 302),
+            timestamp: 2,
+            resourceType: .fetch
+        )
+
+        let headersContext = request.headersContext
+        #expect(headersContext.queryParameters?.parameters.map { $0.value.decodedValue } == ["1", "2"])
+        #expect(headersContext.initiator?.url == "https://example.test/start.js")
+        #expect(headersContext.initiator?.line == 9)
+        guard case let .form(contentType, parameters) = headersContext.requestData else {
+            Issue.record("Expected final URL-encoded request data.")
+            return
+        }
+        #expect(contentType.contentType?.normalizedMediaType == "application/x-www-form-urlencoded")
+        #expect(parameters.rawValue == "final=a+b&bare")
+        #expect(parameters.parameters.map { $0.value.decodedValue } == ["a b", ""])
+        #expect(parameters.parameters.map(\.hadEqualsSign) == [true, false])
+    }
+
+    @MainActor
+    @Test
+    func lifecycleReuseRecomputesHeadersContextFromTheNewRequest() {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let requestID = Network.Request.ID("reused-context")
+        let request = NetworkRequest(
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.test/old?old=1",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"],
+                postData: "old=body"
+            ),
+            initiator: Network.Initiator(kind: "parser", line: 1),
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        request.fail(errorText: "old failure", canceled: false, timestamp: 2)
+
+        request.applyRequestWillBeSent(
+            request: Network.Request(
+                id: requestID,
+                url: "https://example.test/new?new=2",
+                method: "GET"
+            ),
+            initiator: Network.Initiator(kind: "other", line: 20),
+            navigationVisit: nil,
+            resourceType: .document,
+            timestamp: 3,
+            chronologySequence: 2
+        )
+
+        #expect(request.lifecycleRevision == 1)
+        #expect(request.headersContext.outcome == nil)
+        #expect(request.headersContext.resourceType == Network.ResourceType.document.rawValue)
+        #expect(request.headersContext.initiator?.kind == "other")
+        #expect(request.headersContext.initiator?.line == 20)
+        #expect(request.headersContext.queryParameters?.parameters.first?.name.decodedValue == "new")
+        #expect(request.headersContext.requestData == nil)
+    }
+
+    @MainActor
+    @Test
+    func metricsRequestHeadersRefineFormContextWithoutReplacingBodyIdentity() throws {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let request = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("metrics-form-context"),
+                url: "https://example.test/submit",
+                method: "POST",
+                postData: "name=Jane+Doe&bad=%ZZ&next=ok"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        let body = try #require(request.requestBody)
+        #expect(request.headersContext.requestData == .body(contentType: .absent))
+
+        request.finish(
+            timestamp: 2,
+            sourceMapURL: nil,
+            metrics: Network.Metrics().reporting(requestHeaders: [
+                "Content-Type": "application/x-www-form-urlencoded"
+            ])
+        )
+
+        #expect(request.requestBody === body)
+        #expect(body.kind == .form)
+        #expect(body.textRepresentation == "name=Jane Doe\nbad=%ZZ\nnext=ok")
+        guard case let .form(contentType, parameters) = request.headersContext.requestData else {
+            Issue.record("Expected refined URL-encoded request data.")
+            return
+        }
+        #expect(contentType.contentType?.normalizedMediaType == "application/x-www-form-urlencoded")
+        #expect(parameters.parameters[0].value.decodedValue == "Jane Doe")
+        #expect(
+            parameters.parameters[1].value
+                == .malformed(
+                    rawValue: "%ZZ",
+                    reason: .malformedPercentEscape
+                ))
+        #expect(parameters.parameters[2].value.decodedValue == "ok")
+    }
+
+    @MainActor
+    @Test
+    func requestDataDistinguishesUnavailableNilAndCapturedEmptyBodies() throws {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+
+        let noPostData = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("nil-post-data"),
+                url: "https://example.test/no-body",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"]
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        #expect(noPostData.requestBody == nil)
+        #expect(noPostData.headersContext.requestData == nil)
+
+        let emptyPostData = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("empty-post-data"),
+                url: "https://example.test/empty-body",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"],
+                postData: ""
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        guard case let .form(_, parameters) = emptyPostData.headersContext.requestData else {
+            Issue.record("Expected captured empty form data.")
+            return
+        }
+        #expect(parameters.rawValue == "")
+        #expect(parameters.parameters.isEmpty)
+
+        let unavailableBody = NetworkBody(
+            role: .request,
+            kind: .form,
+            full: nil,
+            phase: .available
+        )
+        #expect(
+            NetworkRequestHeadersContext.makeRequestData(
+                requestBody: unavailableBody,
+                requestHeaders: ["Content-Type": "application/x-www-form-urlencoded"]
+            ) == nil)
+
+        let capturedEmptyBody = NetworkBody(
+            role: .request,
+            kind: .form,
+            full: "",
+            phase: .loaded
+        )
+        guard
+            case let .form(_, capturedEmptyParameters) = NetworkRequestHeadersContext.makeRequestData(
+                requestBody: capturedEmptyBody,
+                requestHeaders: ["Content-Type": "application/x-www-form-urlencoded"]
+            )
+        else {
+            Issue.record("Expected standalone captured empty form data.")
+            return
+        }
+        #expect(capturedEmptyParameters.parameters.isEmpty)
+
+        let multipart = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("multipart-post-data"),
+                url: "https://example.test/multipart",
+                method: "POST",
+                headers: [
+                    "Content-Type": "multipart/form-data; boundary=first; boundary=second; charset=utf-8"
+                ],
+                postData: "captured payload"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+        guard case let .body(contentTypeHeader) = multipart.headersContext.requestData,
+            case let .value(contentType) = contentTypeHeader
+        else {
+            Issue.record("Expected non-URL-encoded request body metadata.")
+            return
+        }
+        #expect(contentType.normalizedMediaType == "multipart/form-data")
+        #expect(contentType.boundary == ["first", "second"])
+        #expect(contentType.charset == ["utf-8"])
+    }
+
+    @MainActor
+    @Test
+    func memoryCacheWithoutCapturedPostDataDoesNotSynthesizeRequestData() {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        let request = NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID("cached-context"),
+                url: "https://example.test/cached",
+                method: "GET"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: nil,
+            requestHeaderSource: .unavailable,
+            modelContext: context
+        )
+
+        request.applyMemoryCache(
+            response: Network.Response(
+                url: "https://example.test/cached",
+                status: 200,
+                mimeType: "text/plain",
+                requestHeaders: ["Content-Type": "application/x-www-form-urlencoded"]
+            ),
+            initiator: Network.Initiator(kind: "memory-cache"),
+            resourceType: .fetch,
+            timestamp: 1
+        )
+
+        #expect(request.responseSource == "memory-cache")
+        #expect(request.requestBody == nil)
+        #expect(request.headersContext.requestData == nil)
+    }
+
+    @Test
+    func formTextRepresentationUsesComponentLocalFallbackAndPreservesEqualsAndOrder() {
+        let body = NetworkBody(
+            role: .request,
+            kind: .form,
+            full: "good=ok&bad=%ZZ&next=a+b&bare&&tail=",
+            phase: .loaded
+        )
+
+        #expect(body.textRepresentation == "good=ok\nbad=%ZZ\nnext=a b\nbare\n\ntail=")
+        #expect(body.textRepresentationSyntaxKind == .plainText)
+    }
+
+}

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -3843,7 +3843,7 @@ struct NetworkDetailViewControllerTests {
                 initiator: Network.Initiator(
                     kind: "script",
                     url: "https://example.com/app.js",
-                    line: 17,
+                    line: 1,
                     nodeID: DOM.Node.ID("42", scopedToTargetRawValue: "page-target")
                 ),
                 resourceType: .xhr,
@@ -3984,7 +3984,7 @@ struct NetworkDetailViewControllerTests {
                     && text.contains("\(mimeTypeLabel): application/json")
                     && text.contains("\(initiatorKindLabel): script")
                     && text.contains("\(initiatorURLLabel): https://example.com/app.js")
-                    && text.contains("\(initiatorLineLabel): 17")
+                    && text.contains("\(initiatorLineLabel): 1")
                     && text.contains("\(initiatorNodeLabel): 42")
                     && text.contains("page-target") == false
                     && text.contains("\u{1E}") == false

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -3513,6 +3513,756 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func headersDocumentShowsOutcomeContextAndOrderedQueryAndFormParameters() async throws {
+        let context = makeContext()
+        let canceledID = Network.Request.ID("headers-context-canceled")
+        let requestHeaders = ["Content-Type": "application/x-www-form-urlencoded"]
+        let url = "https://example.com/submit?alpha=one&empty=&bad=%GG&alpha=two#ignored"
+        await context.apply(
+            .requestWillBeSent(
+                id: canceledID,
+                request: Network.Request(
+                    id: canceledID,
+                    url: url,
+                    method: "POST",
+                    headers: requestHeaders,
+                    postData: "field=one&empty=&bad=%GG&field=two"
+                ),
+                initiator: Network.Initiator(
+                    kind: "script",
+                    url: "https://example.com/app.js",
+                    line: 17,
+                    nodeID: DOM.Node.ID("42")
+                ),
+                resourceType: .xhr,
+                redirectResponse: nil,
+                timestamp: 1
+            ))
+        await context.apply(
+            .responseReceived(
+                id: canceledID,
+                response: Network.Response(
+                    url: url,
+                    status: 200,
+                    statusText: "OK",
+                    mimeType: "application/json",
+                    headers: ["content-type": "text/plain"],
+                    source: Network.Source(rawValue: "network"),
+                    requestHeaders: requestHeaders
+                ),
+                resourceType: .xhr,
+                timestamp: 2
+            ))
+        await context.apply(
+            .loadingFailed(
+                id: canceledID,
+                errorText: "The user canceled the upload",
+                canceled: true,
+                timestamp: 3
+            ))
+        let canceledRequest = try #require(context.registeredRequest(forProxyID: canceledID))
+
+        let failedID = Network.Request.ID("headers-context-failed")
+        await context.apply(
+            .requestWillBeSent(
+                id: failedID,
+                request: Network.Request(
+                    id: failedID,
+                    url: "https://example.com/failure",
+                    method: "GET"
+                ),
+                resourceType: .fetch,
+                redirectResponse: nil,
+                timestamp: 4
+            ))
+        await context.apply(
+            .loadingFailed(
+                id: failedID,
+                errorText: "The connection was reset",
+                canceled: false,
+                timestamp: 5
+            ))
+        let failedRequest = try #require(context.registeredRequest(forProxyID: failedID))
+
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(canceledRequest)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let overviewTitle = String(
+            localized: "network.detail.section.overview",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let requestTitle = String(
+            localized: "network.section.request",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let responseTitle = String(
+            localized: "network.section.response",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let queryTitle = String(
+            localized: "network.headers.section.query",
+            defaultValue: "Query String Parameters",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let requestDataTitle = String(
+            localized: "network.headers.section.request_data",
+            defaultValue: "Request Data",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let outcomeLabel = String(
+            localized: "network.headers.summary.outcome",
+            defaultValue: "Outcome",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let canceledValue = String(
+            localized: "network.headers.summary.outcome.canceled",
+            defaultValue: "Canceled",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let failedValue = String(
+            localized: "network.headers.summary.outcome.failed",
+            defaultValue: "Failed",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let failureReasonLabel = String(
+            localized: "network.headers.summary.failure_reason",
+            defaultValue: "Failure Reason",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let resourceTypeLabel = String(
+            localized: "network.headers.summary.resource_type",
+            defaultValue: "Resource Type",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let mimeTypeLabel = String(
+            localized: "network.headers.summary.mime_type",
+            defaultValue: "MIME Type",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let initiatorKindLabel = String(
+            localized: "network.headers.summary.initiator_kind",
+            defaultValue: "Initiator Kind",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let initiatorURLLabel = String(
+            localized: "network.headers.summary.initiator_url",
+            defaultValue: "Initiator URL",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let initiatorLineLabel = String(
+            localized: "network.headers.summary.initiator_line",
+            defaultValue: "Initiator Line",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let initiatorNodeLabel = String(
+            localized: "network.headers.summary.initiator_node",
+            defaultValue: "Initiator Node",
+            bundle: WebInspectorUILocalization.bundle
+        )
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                let text = viewController.headersTextViewForTesting.renderedTextForTesting
+                return text.contains("\(outcomeLabel): \(canceledValue)")
+                    && text.contains("\(failureReasonLabel): The user canceled the upload")
+                    && text.contains("\(resourceTypeLabel): XHR")
+                    && text.contains("\(mimeTypeLabel): application/json")
+                    && text.contains("\(initiatorKindLabel): script")
+                    && text.contains("\(initiatorURLLabel): https://example.com/app.js")
+                    && text.contains("\(initiatorLineLabel): 17")
+                    && text.contains("\(initiatorNodeLabel): 42")
+            })
+
+        let text = viewController.headersTextViewForTesting.renderedTextForTesting
+        let overviewRange = try #require(text.range(of: "\(overviewTitle)\n"))
+        let requestRange = try #require(
+            text.range(
+                of: "\(requestTitle)\n",
+                range: overviewRange.upperBound..<text.endIndex
+            ))
+        let responseRange = try #require(
+            text.range(
+                of: "\(responseTitle)\n",
+                range: requestRange.upperBound..<text.endIndex
+            ))
+        let queryRange = try #require(
+            text.range(
+                of: "\(queryTitle)\n",
+                range: responseRange.upperBound..<text.endIndex
+            ))
+        let requestDataRange = try #require(
+            text.range(
+                of: "\(requestDataTitle)\n",
+                range: queryRange.upperBound..<text.endIndex
+            ))
+        #expect(overviewRange.lowerBound < requestRange.lowerBound)
+        #expect(requestRange.lowerBound < responseRange.lowerBound)
+        #expect(responseRange.lowerBound < queryRange.lowerBound)
+        #expect(queryRange.lowerBound < requestDataRange.lowerBound)
+
+        let queryText = String(text[queryRange.upperBound..<requestDataRange.lowerBound])
+        let queryAlphaOne = try #require(queryText.range(of: "alpha: one"))
+        let queryEmpty = try #require(
+            queryText.range(
+                of: "empty: ",
+                range: queryAlphaOne.upperBound..<queryText.endIndex
+            ))
+        let queryMalformed = try #require(
+            queryText.range(
+                of: "bad=%GG",
+                range: queryEmpty.upperBound..<queryText.endIndex
+            ))
+        let queryAlphaTwo = try #require(
+            queryText.range(
+                of: "alpha: two",
+                range: queryMalformed.upperBound..<queryText.endIndex
+            ))
+        #expect(queryAlphaOne.lowerBound < queryEmpty.lowerBound)
+        #expect(queryEmpty.lowerBound < queryMalformed.lowerBound)
+        #expect(queryMalformed.lowerBound < queryAlphaTwo.lowerBound)
+        #expect(queryText.contains("ignored") == false)
+
+        let requestDataText = String(text[requestDataRange.upperBound...])
+        let formOne = try #require(requestDataText.range(of: "field: one"))
+        let formEmpty = try #require(
+            requestDataText.range(
+                of: "empty: ",
+                range: formOne.upperBound..<requestDataText.endIndex
+            ))
+        let formMalformed = try #require(
+            requestDataText.range(
+                of: "bad=%GG",
+                range: formEmpty.upperBound..<requestDataText.endIndex
+            ))
+        let formTwo = try #require(
+            requestDataText.range(
+                of: "field: two",
+                range: formMalformed.upperBound..<requestDataText.endIndex
+            ))
+        #expect(formOne.lowerBound < formEmpty.lowerBound)
+        #expect(formEmpty.lowerBound < formMalformed.lowerBound)
+        #expect(formMalformed.lowerBound < formTwo.lowerBound)
+        #expect(
+            requestDataText.contains(
+                String(
+                    localized: "network.headers.parameters.error.percent_escape",
+                    defaultValue: "Malformed percent escape",
+                    bundle: WebInspectorUILocalization.bundle
+                )))
+        #expect(viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.isEmpty)
+
+        model.selectRequest(failedRequest)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                let text = viewController.headersTextViewForTesting.renderedTextForTesting
+                return text.contains("\(outcomeLabel): \(failedValue)")
+                    && text.contains("\(failureReasonLabel): The connection was reset")
+                    && text.contains("\(outcomeLabel): \(canceledValue)") == false
+            })
+    }
+
+    @Test
+    func requestDataMetadataTagAndAtomicActionRenderTheExactRequestBody() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "request-preview-action",
+                url: "https://example.com/upload",
+                requestHeaders: [
+                    "Content-Type":
+                        "multipart/form-data; boundary=\"A;=B\"; charset=utf-8; boundary=second; broken"
+                ],
+                postData: "raw-body-secret",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json",
+                finishes: false
+            ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let bodyPreview = RecordingNetworkBodyPreviewViewController()
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            makeBodyViewController: { _ in bodyPreview }
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let mediaTypeLabel = String(
+            localized: "network.headers.request_data.media_type",
+            defaultValue: "Media Type",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let boundaryLabel = String(
+            localized: "network.headers.request_data.boundary",
+            defaultValue: "Boundary",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let encodingLabel = String(
+            localized: "network.headers.request_data.encoding",
+            defaultValue: "Encoding",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        let unparsedContentTypeParameterLabel = String(
+            localized: "network.headers.request_data.content_type_parameter_unparsed",
+            defaultValue: "Unparsed Content-Type Parameter",
+            bundle: WebInspectorUILocalization.bundle
+        )
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                let headers = viewController.headersTextViewForTesting
+                let text = headers.renderedTextForTesting
+                return text.contains("\(mediaTypeLabel): multipart/form-data")
+                    && text.contains("\(boundaryLabel): A;=B")
+                    && text.contains("\(boundaryLabel): second")
+                    && text.contains("\(encodingLabel): utf-8")
+                    && text.contains("\(unparsedContentTypeParameterLabel):  broken")
+                    && text.contains("raw-body-secret") == false
+                    && headers.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        let headers = viewController.headersTextViewForTesting
+        let tagRange = try #require(headers.requestPreviewTagRangesForTesting.first)
+        #expect(
+            (headers.renderedTextForTesting as NSString).substring(with: tagRange)
+                == String(
+                    localized: "network.headers.request_data.view_preview",
+                    defaultValue: "View Request Preview",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
+        let selectedRange = NSRange(location: 4, length: 8)
+        headers.selectedRangeForTesting = selectedRange
+        let initialFontSize = try #require(headers.requestPreviewFontPointSizeForTesting)
+        let initialAssignmentCount = headers.attributedTextAssignmentCountForTesting
+        viewController.traitOverrides.preferredContentSizeCategory = .accessibilityExtraExtraExtraLarge
+        viewController.updateTraitsIfNeeded()
+        headers.updateTraitsIfNeeded()
+        headers.layoutIfNeeded()
+        #expect(headers.attributedTextAssignmentCountForTesting > initialAssignmentCount)
+        #expect(try #require(headers.requestPreviewFontPointSizeForTesting) > initialFontSize)
+        #expect(headers.selectedRangeForTesting == selectedRange)
+
+        headers.semanticContentAttribute = .forceLeftToRight
+        headers.setNeedsLayout()
+        headers.layoutIfNeeded()
+        let leftToRightRuleX = try #require(headers.sectionRuleRectsForTesting.first).minX
+        headers.semanticContentAttribute = .forceRightToLeft
+        headers.setNeedsLayout()
+        headers.layoutIfNeeded()
+        let rightToLeftRuleX = try #require(headers.sectionRuleRectsForTesting.first).minX
+        #expect(headers.effectiveLayoutDirectionForTesting == .rightToLeft)
+        #expect(rightToLeftRuleX > leftToRightRuleX)
+
+        headers.activateRequestPreviewForTesting()
+
+        let requestBody = try #require(request.requestBody)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.currentModeForTesting == .preview
+                    && viewController.currentPreviewRoleForTesting == .request
+                    && model.selectedRequest === request
+                    && bodyPreview.currentBodyForTesting === requestBody
+                    && viewController.responseBodyFetchObservationDeliveryForTesting == nil
+            })
+        #expect(request.responseBody.phase == .available)
+    }
+
+    @Test
+    func groupedRequestPreviewActionPromotesRepresentativeInsteadOfRoutingToHLSSibling() async throws {
+        let context = makeContext()
+        let frameID = FrameID("headers-preview-group")
+        let nodeID = DOM.Node.ID("headers-preview-initiator")
+        installNavigationVisit(in: context, frameID: frameID)
+        let representative = try #require(
+            await applyGroupedRequest(
+                to: context,
+                requestID: "headers-preview-representative",
+                url: "https://example.com/submit.json",
+                frameID: frameID,
+                initiatorNodeID: nodeID,
+                requestHeaders: ["Content-Type": "application/json"],
+                postData: #"{"member":"representative"}"#,
+                responseHeaders: ["content-type": "application/json"],
+                responseMIMEType: "application/json",
+                resourceType: .fetch,
+                timestamp: 1
+            ))
+        let hlsSibling = try #require(
+            await applyGroupedRequest(
+                to: context,
+                requestID: "headers-preview-hls",
+                url: "https://media.example.com/master.m3u8",
+                frameID: frameID,
+                initiatorNodeID: nodeID,
+                requestHeaders: ["Content-Type": "application/json"],
+                postData: #"{"member":"hls"}"#,
+                responseHeaders: ["content-type": "application/vnd.apple.mpegurl"],
+                responseMIMEType: "application/vnd.apple.mpegurl",
+                resourceType: .media,
+                timestamp: 4
+            ))
+        let model = NetworkPanelModel(context: context)
+        try selectEntry(containing: hlsSibling, in: model)
+        let bodyPreview = RecordingNetworkBodyPreviewViewController()
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            makeBodyViewController: { _ in bodyPreview }
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                let headers = viewController.headersTextViewForTesting
+                return model.selectedRequest === representative
+                    && headers.renderedTextForTesting.contains("1. submit.json")
+                    && headers.renderedTextForTesting.contains("2. master.m3u8")
+                    && headers.requestPreviewTagRangesForTesting.count == 1
+            })
+        let groupedHeaders = viewController.headersTextViewForTesting
+        let groupedText = groupedHeaders.renderedTextForTesting as NSString
+        let representativeHeadingRange = groupedText.range(of: "1. submit.json")
+        let hlsHeadingRange = groupedText.range(of: "2. master.m3u8")
+        let groupedTagRange = try #require(groupedHeaders.requestPreviewTagRangesForTesting.first)
+        #expect(representativeHeadingRange.location != NSNotFound)
+        #expect(hlsHeadingRange.location != NSNotFound)
+        #expect(groupedTagRange.location > representativeHeadingRange.location)
+        #expect(NSMaxRange(groupedTagRange) < hlsHeadingRange.location)
+
+        let renderCountBeforeRepresentativeAction = viewController
+            .selectedRequestRenderCountForTesting
+        viewController.headersTextViewForTesting.activateRequestPreviewForTesting()
+        let representativeBody = try #require(representative.requestBody)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                guard case let .request(_, requestID) = model.selection else {
+                    return false
+                }
+                return requestID == representative.id
+                    && model.selectedRequest === representative
+                    && viewController.currentModeForTesting == .preview
+                    && viewController.currentPreviewRoleForTesting == .request
+                    && bodyPreview.currentBodyForTesting === representativeBody
+            })
+        #expect(
+            viewController.selectedRequestRenderCountForTesting
+                == renderCountBeforeRepresentativeAction + 1
+        )
+        #expect(representative.responseBody.phase == .available)
+        #expect(hlsSibling.responseBody.phase == .available)
+
+        viewController.setModeForTesting(.headers)
+        model.selectRequest(hlsSibling)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                model.selectedRequest === hlsSibling
+                    && viewController.currentModeForTesting == .headers
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("master.m3u8")
+                    && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        viewController.headersTextViewForTesting.activateRequestPreviewForTesting()
+        let hlsRequestBody = try #require(hlsSibling.requestBody)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                model.selectedRequest === hlsSibling
+                    && viewController.currentModeForTesting == .preview
+                    && viewController.currentPreviewRoleForTesting == .request
+                    && bodyPreview.currentBodyForTesting === hlsRequestBody
+                    && viewController.responseBodyFetchObservationDeliveryForTesting == nil
+            })
+        #expect(representative.responseBody.phase == .available)
+        #expect(hlsSibling.responseBody.phase == .available)
+    }
+
+    @Test
+    func webSocketRequestDataNeverExposesBodyPreviewAction() async throws {
+        let context = makeContext()
+        let requestID = Network.Request.ID("headers-websocket-body")
+        await context.apply(
+            .webSocket(
+                .created(
+                    id: requestID,
+                    url: "wss://example.com/socket"
+                )))
+        await context.apply(
+            .webSocket(
+                .handshakeRequest(
+                    id: requestID,
+                    request: Network.Request(
+                        id: requestID,
+                        url: "wss://example.com/socket",
+                        method: "GET",
+                        headers: [
+                            "Content-Type": "application/json",
+                            "Upgrade": "websocket",
+                        ],
+                        postData: #"{"websocket":"secret"}"#
+                    ),
+                    timestamp: 1
+                )))
+        let request = try #require(context.registeredRequest(forProxyID: requestID))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        let requestDataTitle = String(
+            localized: "network.headers.section.request_data",
+            defaultValue: "Request Data",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                let headers = viewController.headersTextViewForTesting
+                return headers.renderedTextForTesting.contains(requestDataTitle)
+                    && headers.renderedTextForTesting.contains(#"{"websocket":"secret"}"#) == false
+                    && headers.requestPreviewTagRangesForTesting.isEmpty
+            })
+
+        viewController.headersTextViewForTesting.activateRequestPreviewForTesting()
+        #expect(viewController.currentModeForTesting == .headers)
+        #expect(model.selectedRequest === request)
+    }
+
+    @Test
+    func hiddenHeadersCatchUpRequestDataClassificationAndSelectionClearRemovesAction() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "hidden-request-data",
+                url: "https://example.com/submit",
+                requestHeaders: ["Content-Type": "application/json"],
+                postData: "field=value",
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json",
+                finishes: false
+            ))
+        let body = try #require(request.requestBody)
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        let transactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await applyLoadingFinished(
+            to: context,
+            requestID: "hidden-request-data",
+            timestamp: 4,
+            requestHeaders: ["Content-Type": "application/x-www-form-urlencoded"]
+        )
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: transactionBaseline))
+        #expect(request.requestBody === body)
+        #expect(viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1)
+        viewController.headersTextViewForTesting.activateRequestPreviewForTesting()
+        #expect(viewController.currentModeForTesting == .headers)
+        #expect(model.selectedRequest === request)
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.isEmpty
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("field: value")
+            })
+        #expect(request.requestBody === body)
+
+        model.selectRequest(nil)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.contentUnavailableConfiguration != nil
+                    && viewController.headersTextViewForTesting.renderedTextForTesting.isEmpty
+                    && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.isEmpty
+            })
+    }
+
+    @Test
+    func headersRebindSameIDRequestDataActionAndIgnoreOldInstanceMutations() async throws {
+        let context = makeContext()
+        let original = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "headers-request-data-instance",
+                url: "https://example.com/original",
+                requestHeaders: ["Content-Type": "application/json"],
+                postData: #"{"instance":"original"}"#,
+                responseHeaders: ["content-type": "application/json"],
+                responseMimeType: "application/json",
+                finishes: false
+            ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(original)
+        let bodyPreview = RecordingNetworkBodyPreviewViewController()
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            makeBodyViewController: { _ in bodyPreview }
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        let proxyID = Network.Request.ID("headers-request-data-instance")
+        let replacement = NetworkRequest(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/replacement",
+                method: "POST",
+                headers: [
+                    "Content-Type": "application/json",
+                    "content-type": "text/plain",
+                ],
+                postData: #"{"instance":"replacement"}"#
+            ),
+            initiator: original.initiator,
+            navigationVisit: original.navigationVisit,
+            resourceType: original.resourceType,
+            timestamp: original.logicalStartTimestamp,
+            chronologySequence: original.chronologySequence,
+            modelContext: context
+        )
+        model.upsertRequestForTesting(replacement)
+        let ambiguousContentTypeLabel = String(
+            localized: "network.headers.request_data.content_type_ambiguous",
+            defaultValue: "Ambiguous Content Type",
+            bundle: WebInspectorUILocalization.bundle
+        )
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                model.selectedRequest === replacement
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("https://example.com/replacement")
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("\(ambiguousContentTypeLabel): application/json")
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("\(ambiguousContentTypeLabel): text/plain")
+                    && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        viewController.headersTextViewForTesting.activateRequestPreviewForTesting()
+        let replacementBody = try #require(replacement.requestBody)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.currentModeForTesting == .preview
+                    && model.selectedRequest === replacement
+                    && bodyPreview.currentBodyForTesting === replacementBody
+            })
+
+        viewController.setModeForTesting(.headers)
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.currentModeForTesting == .headers
+                    && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+            })
+
+        original.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/stale",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"],
+                postData: "stale=value"
+            ),
+            initiator: original.initiator,
+            navigationVisit: original.navigationVisit,
+            resourceType: original.resourceType,
+            timestamp: 5,
+            chronologySequence: 5
+        )
+        #expect(
+            viewController.headersTextViewForTesting.renderedTextForTesting
+                .contains("https://example.com/stale") == false)
+        #expect(viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1)
+
+        replacement.applyRequestWillBeSent(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.com/current",
+                method: "POST",
+                headers: ["Content-Type": "application/x-www-form-urlencoded"],
+                postData: "current=value"
+            ),
+            initiator: replacement.initiator,
+            navigationVisit: replacement.navigationVisit,
+            resourceType: replacement.resourceType,
+            timestamp: 6,
+            chronologySequence: 6
+        )
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.renderedTextForTesting
+                    .contains("https://example.com/current")
+                    && viewController.headersTextViewForTesting.renderedTextForTesting
+                        .contains("current: value")
+                    && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.isEmpty
+            })
+    }
+
+    @Test
+    func headersSemanticSignatureTracksKeyValueAttributeBoundaries() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "headers-semantic-signature",
+                url: "https://example.com/signature",
+                responseHeaders: ["a: b": ""],
+                responseMimeType: "text/plain",
+                finishes: false
+            ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.renderedTextForTesting.contains("a: b\n")
+            })
+        let renderedText = viewController.headersTextViewForTesting.renderedTextForTesting
+        let assignmentCount = viewController.headersTextViewForTesting
+            .attributedTextAssignmentCountForTesting
+
+        await applyResponseReceived(
+            to: context,
+            requestID: "headers-semantic-signature",
+            url: request.url,
+            responseHeaders: ["a": "b"],
+            responseMimeType: "text/plain",
+            timestamp: 4
+        )
+
+        #expect(
+            await waitUntilRendered(in: viewController) {
+                viewController.headersTextViewForTesting.attributedTextAssignmentCountForTesting
+                    == assignmentCount + 1
+            })
+        #expect(viewController.headersTextViewForTesting.renderedTextForTesting == renderedText)
+    }
+
+    @Test
     func hiddenDetailKeepsHeadersAndRebindsSameSelectedRequestOnReturn() async throws {
         let context = makeContext()
         let request = try #require(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -3513,6 +3513,48 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func headersModeClearsSelectionWhenResponseSectionAppears() async throws {
+        let context = makeContext()
+        let request = try #require(await applyRequestWithoutResponse(
+            to: context,
+            requestID: "headers-response-selection",
+            url: "https://example.com/pending"
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.renderedTextForTesting
+                .contains("GET /pending")
+        })
+        viewController.headersTextViewForTesting.selectedRangeForTesting = NSRange(
+            location: 2,
+            length: 4
+        )
+
+        await applyResponseReceived(
+            to: context,
+            requestID: "headers-response-selection",
+            url: request.url,
+            responseHeaders: ["x-response": "inserted"],
+            responseMimeType: "text/plain",
+            timestamp: 2
+        )
+
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.renderedTextForTesting
+                .contains("x-response: inserted")
+        })
+        #expect(
+            viewController.headersTextViewForTesting.selectedRangeForTesting
+                == NSRange(location: 0, length: 0)
+        )
+    }
+
+    @Test
     func headersDocumentShowsOutcomeContextAndOrderedQueryAndFormParameters() async throws {
         let context = makeContext()
         let canceledID = Network.Request.ID("headers-context-canceled")
@@ -3532,7 +3574,7 @@ struct NetworkDetailViewControllerTests {
                     kind: "script",
                     url: "https://example.com/app.js",
                     line: 17,
-                    nodeID: DOM.Node.ID("42")
+                    nodeID: DOM.Node.ID("42", scopedToTargetRawValue: "page-target")
                 ),
                 resourceType: .xhr,
                 redirectResponse: nil,
@@ -3674,6 +3716,8 @@ struct NetworkDetailViewControllerTests {
                     && text.contains("\(initiatorURLLabel): https://example.com/app.js")
                     && text.contains("\(initiatorLineLabel): 17")
                     && text.contains("\(initiatorNodeLabel): 42")
+                    && text.contains("page-target") == false
+                    && text.contains("\u{1E}") == false
             })
 
         let text = viewController.headersTextViewForTesting.renderedTextForTesting
@@ -4395,11 +4439,22 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didRenderFirst)
 
+        viewController.headersTextViewForTesting.selectedRangeForTesting = NSRange(
+            location: 2,
+            length: 4
+        )
         model.selectRequest(secondRequest)
         let didRenderSecond = await waitUntilRendered(in: viewController) {
             viewController.headersTextViewForTesting.renderedTextForTesting.contains("x-request: second")
         }
         #expect(didRenderSecond)
+        #expect(
+            viewController.headersTextViewForTesting.selectedRangeForTesting
+                == NSRange(location: 0, length: 0)
+        )
+
+        let currentSelection = NSRange(location: 3, length: 5)
+        viewController.headersTextViewForTesting.selectedRangeForTesting = currentSelection
 
         await applyResponseReceived(
             to: context,
@@ -4411,6 +4466,7 @@ struct NetworkDetailViewControllerTests {
         )
 
         #expect(viewController.headersTextViewForTesting.renderedTextForTesting.contains("x-old-request: stale") == false)
+        #expect(viewController.headersTextViewForTesting.selectedRangeForTesting == currentSelection)
 
         await applyResponseReceived(
             to: context,
@@ -4427,6 +4483,10 @@ struct NetworkDetailViewControllerTests {
                 && text.contains("x-old-request: stale") == false
         }
         #expect(didRenderCurrentUpdate)
+        #expect(
+            viewController.headersTextViewForTesting.selectedRangeForTesting
+                == NSRange(location: 0, length: 0)
+        )
     }
 
     @Test


### PR DESCRIPTION
## Stack

This PR is stacked on #245. Review the commits after `codex/issue-239-network-websocket-preview` and merge the lower stack layers first.

Closes #240.

## Purpose

Complete the Network Headers surface with request context that WebInspectorKit already captures or can derive, while preserving the aggregate and explicit-request selection contracts introduced by #235.

## Changes

- Distinguish canceled loads from failed loads and display their reported reason.
- Show resource type, effective MIME type, and initiator kind, URL, line, and node identifier.
- Parse query strings and URL-encoded form data without losing order, repeated keys, empty values, or malformed encoded fragments.
- Parse request `Content-Type` metadata, including quoted boundaries, charset values, ambiguity, and malformed parameters.
- Add a Request Preview action for captured non-form bodies without duplicating raw body content in Headers.
- Keep grouped Headers aggregate while routing the preview action through the active request as an explicit selection.
- Share HTTP token, optional-whitespace, and ASCII case-folding rules between Cookie and Content-Type parsing.
- Preserve header text selection when only presentation attributes change and clear it when the visible document changes.

## Testing

- Default `WebInspectorKit` test run on iPhone 17 / iOS 27: 804 test functions, 858 runs, 0 failures.
- DataKit and ProxyKit tests: 478/478 passed.
- Network Detail and parent-container tests: 171/171 passed.
- Focused Headers tests: 38/38 passed.
- Response-section regression test: 1/1 passed.
- Final targeted regression set: 4/4 passed.
- Fresh consumer contract tests: 8/8 passed.
- Public symbol boundary check passed.
- Generic iOS build passed.
- DocC generation passed for all four documented targets.
- String catalog compilation passed.
- `git diff --check` passed.
- Independent Data/API and UI reviews plus `codex-review` completed with no remaining P0-P2 findings.

## Screenshots

Not included; the new document content, ordering, adaptive typography, RTL layout, and Request Preview action are covered by UI rendering tests.