### PR TITLE
Add a Security summary pane to Network details

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -131,6 +131,7 @@ let package = Package(
             name: "WebInspectorUINetwork",
             dependencies: [
                 "WebInspectorDataKit",
+                "WebInspectorProxyKit",
                 "WebInspectorUIBase",
                 .product(name: "ObservationBridge", package: "ObservationBridge"),
                 .product(name: "UIHostingMenu", package: "UIHostingMenu", condition: .when(platforms: [.iOS]))

--- a/Sources/WebInspectorDataKit/NetworkSecuritySummary.swift
+++ b/Sources/WebInspectorDataKit/NetworkSecuritySummary.swift
@@ -1,0 +1,123 @@
+import WebInspectorProxyKit
+
+package enum NetworkSecuritySummary: Equatable, Sendable {
+    package enum PlaintextScheme: Equatable, Sendable {
+        case http
+        case ws
+    }
+
+    package enum EncryptedScheme: Equatable, Sendable {
+        case https
+        case wss
+    }
+
+    package enum Metadata: Equatable, Sendable {
+        case notReported
+        case reported(Network.Security)
+    }
+
+    package enum UnavailableReason: Equatable, Sendable {
+        case failedBeforeResponse(reason: String)
+        case canceledBeforeResponse(reason: String)
+        case completedWithoutResponse
+    }
+
+    case plaintextScheme(PlaintextScheme)
+    case pending(EncryptedScheme)
+    case encryptedScheme(EncryptedScheme, metadata: Metadata)
+    case unavailable(EncryptedScheme, reason: UnavailableReason)
+    case notApplicable(scheme: String?)
+}
+
+package extension NetworkRequest {
+    var securitySummary: NetworkSecuritySummary {
+        let scheme = Self.rawScheme(in: responseURL ?? url)
+
+        switch Self.classifySecurityScheme(scheme) {
+        case let .plaintext(plaintextScheme):
+            return .plaintextScheme(plaintextScheme)
+        case let .encrypted(encryptedScheme):
+            if let security {
+                return .encryptedScheme(encryptedScheme, metadata: .reported(security))
+            }
+            if hasResponse {
+                return .encryptedScheme(encryptedScheme, metadata: .notReported)
+            }
+            switch state {
+            case .pending, .responded:
+                return .pending(encryptedScheme)
+            case let .failed(errorText, canceled):
+                let reason: NetworkSecuritySummary.UnavailableReason =
+                    if canceled {
+                        .canceledBeforeResponse(reason: errorText)
+                    } else {
+                        .failedBeforeResponse(reason: errorText)
+                    }
+                return .unavailable(encryptedScheme, reason: reason)
+            case .finished:
+                return .unavailable(encryptedScheme, reason: .completedWithoutResponse)
+            }
+        case .other:
+            return .notApplicable(scheme: scheme)
+        }
+    }
+
+    private enum ClassifiedSecurityScheme {
+        case plaintext(NetworkSecuritySummary.PlaintextScheme)
+        case encrypted(NetworkSecuritySummary.EncryptedScheme)
+        case other
+    }
+
+    private static func classifySecurityScheme(_ scheme: String?) -> ClassifiedSecurityScheme {
+        switch scheme.map(asciiLowercased) {
+        case "http":
+            return .plaintext(.http)
+        case "ws":
+            return .plaintext(.ws)
+        case "https":
+            return .encrypted(.https)
+        case "wss":
+            return .encrypted(.wss)
+        default:
+            return .other
+        }
+    }
+
+    private static func rawScheme(in url: String) -> String? {
+        guard let colonIndex = url.firstIndex(of: ":") else {
+            return nil
+        }
+        let scheme = url[..<colonIndex]
+        guard let firstByte = scheme.utf8.first, isASCIIAlpha(firstByte) else {
+            return nil
+        }
+        guard scheme.utf8.dropFirst().allSatisfy(isASCIISchemeContinuation) else {
+            return nil
+        }
+        return String(scheme)
+    }
+
+    private static func asciiLowercased(_ value: String) -> String {
+        String(
+            decoding: value.utf8.map { byte in
+                switch byte {
+                case 0x41...0x5A:
+                    byte + 0x20
+                default:
+                    byte
+                }
+            }, as: UTF8.self)
+    }
+
+    private static func isASCIIAlpha(_ byte: UInt8) -> Bool {
+        (0x41...0x5A).contains(byte) || (0x61...0x7A).contains(byte)
+    }
+
+    private static func isASCIISchemeContinuation(_ byte: UInt8) -> Bool {
+        isASCIIAlpha(byte)
+            || (0x30...0x39).contains(byte)
+            || byte == 0x2B
+            || byte == 0x2D
+            || byte == 0x2E
+    }
+}

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -5612,15 +5612,33 @@
       "extractionState" : "stale",
       "localizations" : {
         "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show %lld More DNS Names"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Show %lld More DNS Name"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Show %lld More DNS Names"
+                }
+              }
+            }
           }
         },
         "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DNS名をあと%lld件表示"
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "DNS名をあと%lld件表示"
+                }
+              }
+            }
           }
         }
       }
@@ -5629,15 +5647,33 @@
       "extractionState" : "stale",
       "localizations" : {
         "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Show %lld More IP Addresses"
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Show %lld More IP Address"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Show %lld More IP Addresses"
+                }
+              }
+            }
           }
         },
         "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "IPアドレスをあと%lld件表示"
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "IPアドレスをあと%lld件表示"
+                }
+              }
+            }
           }
         }
       }

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -3164,6 +3164,23 @@
         }
       }
     },
+    "network.detail.mode.label" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail Mode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細モード"
+          }
+        }
+      }
+    },
     "network.detail.mode.preview" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3177,6 +3194,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プレビュー"
+          }
+        }
+      }
+    },
+    "network.detail.mode.security" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Security"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティ"
           }
         }
       }
@@ -5485,6 +5519,686 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "回應"
+          }
+        }
+      }
+    },
+    "network.security.accessibility.collapsed" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Collapsed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折りたたみ"
+          }
+        }
+      }
+    },
+    "network.security.accessibility.expanded" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expanded"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開済み"
+          }
+        }
+      }
+    },
+    "network.security.accessibility.toggle_hint" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Double-tap to show or hide reported values."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダブルタップして、報告された値の表示・非表示を切り替えます。"
+          }
+        }
+      }
+    },
+    "network.security.action.show_less" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show Less"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示を減らす"
+          }
+        }
+      }
+    },
+    "network.security.action.show_more" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show %lld More"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あと%lld件を表示"
+          }
+        }
+      }
+    },
+    "network.security.field.certificate_metadata" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Certificate Metadata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "証明書メタデータ"
+          }
+        }
+      }
+    },
+    "network.security.field.cipher" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cipher"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暗号スイート"
+          }
+        }
+      }
+    },
+    "network.security.field.connection_metadata" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection Metadata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続メタデータ"
+          }
+        }
+      }
+    },
+    "network.security.field.dns_name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DNS Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS名"
+          }
+        }
+      }
+    },
+    "network.security.field.dns_names" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DNS Names"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS名"
+          }
+        }
+      }
+    },
+    "network.security.field.ip_address" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "IP Address"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IPアドレス"
+          }
+        }
+      }
+    },
+    "network.security.field.ip_addresses" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "IP Addresses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IPアドレス"
+          }
+        }
+      }
+    },
+    "network.security.field.reason" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reason"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "理由"
+          }
+        }
+      }
+    },
+    "network.security.field.scheme" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheme"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキーム"
+          }
+        }
+      }
+    },
+    "network.security.field.security_metadata" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Security Metadata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティメタデータ"
+          }
+        }
+      }
+    },
+    "network.security.field.status" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータス"
+          }
+        }
+      }
+    },
+    "network.security.field.subject" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Subject"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブジェクト"
+          }
+        }
+      }
+    },
+    "network.security.field.tls_protocol" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "TLS Protocol"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLSプロトコル"
+          }
+        }
+      }
+    },
+    "network.security.field.valid_from" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Valid From"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期間開始"
+          }
+        }
+      }
+    },
+    "network.security.field.valid_until" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Valid Until"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期間終了"
+          }
+        }
+      }
+    },
+    "network.security.section.certificate" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Certificate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "証明書"
+          }
+        }
+      }
+    },
+    "network.security.section.connection" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続"
+          }
+        }
+      }
+    },
+    "network.security.section.status" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータス"
+          }
+        }
+      }
+    },
+    "network.security.status.canceled_before_response" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The request was canceled before a response was reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスが報告される前にリクエストがキャンセルされました。"
+          }
+        }
+      }
+    },
+    "network.security.status.completed_without_response" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loading completed without a reported response."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスが報告されずに読み込みが完了しました。"
+          }
+        }
+      }
+    },
+    "network.security.status.failed_before_response" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The request failed before a response was reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンスが報告される前にリクエストが失敗しました。"
+          }
+        }
+      }
+    },
+    "network.security.status.http" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "HTTP scheme reported; TLS does not apply."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTPスキームが報告されました。TLSは該当しません。"
+          }
+        }
+      }
+    },
+    "network.security.status.https_not_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "HTTPS scheme reported; security metadata was not reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTPSスキームが報告されました。セキュリティメタデータは未報告です。"
+          }
+        }
+      }
+    },
+    "network.security.status.https_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "HTTPS scheme and security metadata reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTPSスキームとセキュリティメタデータが報告されました。"
+          }
+        }
+      }
+    },
+    "network.security.status.not_classified" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "TLS applicability is not classified for this scheme."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このスキームではTLSの適用可否を分類できません。"
+          }
+        }
+      }
+    },
+    "network.security.status.ws" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WS scheme reported; TLS does not apply."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WSスキームが報告されました。TLSは該当しません。"
+          }
+        }
+      }
+    },
+    "network.security.status.wss_not_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WSS scheme reported; security metadata was not reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WSSスキームが報告されました。セキュリティメタデータは未報告です。"
+          }
+        }
+      }
+    },
+    "network.security.status.wss_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WSS scheme and security metadata reported."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WSSスキームとセキュリティメタデータが報告されました。"
+          }
+        }
+      }
+    },
+    "network.security.value.empty_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty value reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空の値が報告されました"
+          }
+        }
+      }
+    },
+    "network.security.value.no_values_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No values reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "値なしと報告されました"
+          }
+        }
+      }
+    },
+    "network.security.value.not_applicable" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not applicable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該当なし"
+          }
+        }
+      }
+    },
+    "network.security.value.not_reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未報告"
+          }
+        }
+      }
+    },
+    "network.security.value.pending" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Response pending"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レスポンス待機中"
+          }
+        }
+      }
+    },
+    "network.security.value.reported" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reported"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "報告あり"
+          }
+        }
+      }
+    },
+    "network.security.value.unavailable" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unavailable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用不可"
           }
         }
       }

--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -5574,36 +5574,70 @@
         }
       }
     },
-    "network.security.action.show_less" : {
+    "network.security.action.show_less_dns_names" : {
       "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Show Less"
+            "value" : "Show Less DNS Names"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "表示を減らす"
+            "value" : "DNS名の表示を減らす"
           }
         }
       }
     },
-    "network.security.action.show_more" : {
+    "network.security.action.show_less_ip_addresses" : {
       "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Show %lld More"
+            "value" : "Show Less IP Addresses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "あと%lld件を表示"
+            "value" : "IPアドレスの表示を減らす"
+          }
+        }
+      }
+    },
+    "network.security.action.show_more_dns_names" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show %lld More DNS Names"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS名をあと%lld件表示"
+          }
+        }
+      }
+    },
+    "network.security.action.show_more_ip_addresses" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show %lld More IP Addresses"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IPアドレスをあと%lld件表示"
           }
         }
       }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailMode.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailMode.swift
@@ -8,9 +8,10 @@ extension NetworkDetailViewController {
     package enum Mode: CaseIterable, Hashable {
         case preview
         case headers
+        case security
 
         nonisolated package static var allCases: [NetworkDetailViewController.Mode] {
-            [.headers, .preview]
+            [.headers, .preview, .security]
         }
 
         package var title: String {
@@ -19,6 +20,12 @@ extension NetworkDetailViewController {
                 String(localized: "network.detail.mode.preview", defaultValue: "Preview", bundle: WebInspectorUILocalization.bundle)
             case .headers:
                 String(localized: "network.section.headers", defaultValue: "Headers", bundle: WebInspectorUILocalization.bundle)
+            case .security:
+                String(
+                    localized: "network.detail.mode.security",
+                    defaultValue: "Security",
+                    bundle: WebInspectorUILocalization.bundle
+                )
             }
         }
     }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailSegmentedControlControllers.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailSegmentedControlControllers.swift
@@ -5,40 +5,174 @@ import UIKit
 
 @MainActor
 final class NetworkDetailModeControlController {
-    let view: UISegmentedControl
+    let view: NetworkDetailModeControlView
     var selectionHandler: ((NetworkDetailViewController.Mode) -> Void)?
+    private let segmentedControl: UISegmentedControl
+    private let menuButton: UIButton
     private var mode: NetworkDetailViewController.Mode
     private var isEnabled = false
 
     init(initialMode: NetworkDetailViewController.Mode) {
         mode = initialMode
-        view = UISegmentedControl(items: NetworkDetailViewController.Mode.allCases.map(\.title))
-        view.selectedSegmentIndex = Self.index(for: initialMode)
-        view.accessibilityIdentifier = "WebInspector.Network.DetailModeSegmentedControl"
-        view.addTarget(self, action: #selector(valueChanged(_:)), for: .valueChanged)
+        let segmentedControl = UISegmentedControl(
+            items: NetworkDetailViewController.Mode.allCases.map(\.title)
+        )
+        segmentedControl.accessibilityIdentifier = "WebInspector.Network.DetailModeSegmentedControl"
+        let menuButton = UIButton(type: .system)
+        menuButton.accessibilityIdentifier = "WebInspector.Network.DetailModeMenuButton"
+        menuButton.showsMenuAsPrimaryAction = true
+        self.segmentedControl = segmentedControl
+        self.menuButton = menuButton
+        view = NetworkDetailModeControlView(
+            segmentedControl: segmentedControl,
+            menuButton: menuButton
+        )
+        view.presentationChangeHandler = { [weak self] in
+            self?.renderControls()
+        }
+        segmentedControl.addTarget(self, action: #selector(valueChanged(_:)), for: .valueChanged)
+        renderControls()
     }
 
     func render(mode: NetworkDetailViewController.Mode, isEnabled: Bool) {
         self.mode = mode
         self.isEnabled = isEnabled
-        view.isEnabled = isEnabled
-        view.selectedSegmentIndex = Self.index(for: mode)
-        view.accessibilityLabel = mode.title
-        for index in NetworkDetailViewController.Mode.allCases.indices {
-            view.setEnabled(isEnabled, forSegmentAt: index)
-        }
+        renderControls()
     }
 
     @objc private func valueChanged(_ sender: UISegmentedControl) {
         guard NetworkDetailViewController.Mode.allCases.indices.contains(sender.selectedSegmentIndex) else {
-            render(mode: mode, isEnabled: isEnabled)
+            renderControls()
             return
         }
-        selectionHandler?(NetworkDetailViewController.Mode.allCases[sender.selectedSegmentIndex])
+        select(NetworkDetailViewController.Mode.allCases[sender.selectedSegmentIndex])
+    }
+
+    private func select(_ selectedMode: NetworkDetailViewController.Mode) {
+        guard isEnabled else {
+            renderControls()
+            return
+        }
+        selectionHandler?(selectedMode)
+    }
+
+    private func renderControls() {
+        let accessibilityLabel = String(
+            localized: "network.detail.mode.label",
+            defaultValue: "Detail Mode",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        segmentedControl.isEnabled = isEnabled
+        segmentedControl.selectedSegmentIndex = Self.index(for: mode)
+        segmentedControl.accessibilityLabel = accessibilityLabel
+        segmentedControl.accessibilityValue = mode.title
+        for index in NetworkDetailViewController.Mode.allCases.indices {
+            segmentedControl.setEnabled(isEnabled, forSegmentAt: index)
+        }
+
+        var buttonConfiguration = menuButton.configuration ?? .plain()
+        buttonConfiguration.title = mode.title
+        buttonConfiguration.image = UIImage(systemName: "chevron.down")
+        buttonConfiguration.imagePlacement = .trailing
+        buttonConfiguration.imagePadding = 6
+        menuButton.configuration = buttonConfiguration
+        menuButton.isEnabled = isEnabled
+        menuButton.accessibilityLabel = accessibilityLabel
+        menuButton.accessibilityValue = mode.title
+        menuButton.menu = UIMenu(
+            options: .singleSelection,
+            children: NetworkDetailViewController.Mode.allCases.map { candidate in
+                UIAction(
+                    title: candidate.title,
+                    state: candidate == mode ? .on : .off
+                ) { [weak self] _ in
+                    self?.select(candidate)
+                }
+            }
+        )
+        view.invalidateIntrinsicContentSize()
     }
 
     private static func index(for mode: NetworkDetailViewController.Mode) -> Int {
         NetworkDetailViewController.Mode.allCases.firstIndex(of: mode) ?? UISegmentedControl.noSegment
+    }
+}
+
+@MainActor
+final class NetworkDetailModeControlView: UIView {
+    enum Presentation: Equatable {
+        case segmented
+        case menu
+    }
+
+    var presentationChangeHandler: (() -> Void)?
+    private(set) var presentation: Presentation
+    private let segmentedControl: UISegmentedControl
+    private let menuButton: UIButton
+
+    init(segmentedControl: UISegmentedControl, menuButton: UIButton) {
+        self.segmentedControl = segmentedControl
+        self.menuButton = menuButton
+        presentation = Self.presentation(for: UITraitCollection())
+        super.init(frame: .zero)
+        let stackView = UIStackView(arrangedSubviews: [segmentedControl, menuButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        updatePresentation()
+        registerForTraitChanges([
+            UITraitHorizontalSizeClass.self,
+            UITraitPreferredContentSizeCategory.self,
+        ]) { (self: NetworkDetailModeControlView, _) in
+            self.updatePresentation()
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: CGSize {
+        activeControl.intrinsicContentSize
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        activeControl.sizeThatFits(size)
+    }
+
+    private var activeControl: UIControl {
+        switch presentation {
+        case .segmented:
+            segmentedControl
+        case .menu:
+            menuButton
+        }
+    }
+
+    private func updatePresentation() {
+        let nextPresentation = Self.presentation(for: traitCollection)
+        let didChange = presentation != nextPresentation
+        presentation = nextPresentation
+        segmentedControl.isHidden = presentation != .segmented
+        menuButton.isHidden = presentation != .menu
+        invalidateIntrinsicContentSize()
+        if didChange {
+            presentationChangeHandler?()
+        }
+    }
+
+    private static func presentation(for traitCollection: UITraitCollection) -> Presentation {
+        if traitCollection.horizontalSizeClass == .regular,
+           traitCollection.preferredContentSizeCategory.isAccessibilityCategory == false {
+            return .segmented
+        }
+        return .menu
     }
 }
 
@@ -169,16 +303,31 @@ final class NetworkDetailSegmentedControlContentView: UIView {
 #if DEBUG
 extension NetworkDetailModeControlController {
     var isEnabledForTesting: Bool {
-        view.isEnabled
+        isEnabled
     }
 
     func isModeEnabledForTesting(_ mode: NetworkDetailViewController.Mode) -> Bool {
-        view.isEnabledForSegment(at: Self.index(for: mode))
+        NetworkDetailViewController.Mode.allCases.contains(mode) && isEnabled
     }
 
     func selectModeForTesting(_ mode: NetworkDetailViewController.Mode) {
-        view.selectedSegmentIndex = Self.index(for: mode)
-        valueChanged(view)
+        select(mode)
+    }
+
+    var presentationForTesting: NetworkDetailModeControlView.Presentation {
+        view.presentation
+    }
+
+    var segmentedControlForTesting: UISegmentedControl {
+        segmentedControl
+    }
+
+    var menuButtonForTesting: UIButton {
+        menuButton
+    }
+
+    var menuActionTitlesForTesting: [String] {
+        menuButton.menu?.children.compactMap { ($0 as? UIAction)?.title } ?? []
     }
 }
 

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -83,6 +83,7 @@ package final class NetworkDetailViewController: UIViewController {
     private var isRenderingActive = false
     private var isBodyRenderingActive = false
     private lazy var bodyViewController = makeBodyViewController(scrollEdgeController)
+    private lazy var securityViewController = NetworkSecurityViewController()
     private lazy var modeControlController: NetworkDetailModeControlController = {
         let controller = NetworkDetailModeControlController(initialMode: mode)
         controller.selectionHandler = { [weak self] mode in
@@ -159,13 +160,13 @@ package final class NetworkDetailViewController: UIViewController {
 
     override package func viewDidLoad() {
         super.viewDidLoad()
+        installContentViews()
         applyBackgroundFromTraits()
         if #available(iOS 26.0, *) {
             webInspectorRegisterForBackgroundTraitChanges { viewController in
                 viewController.applyBackgroundFromTraits()
             }
         }
-        installContentViews()
         installModeTitleView()
         scrollEdgeController.install(previewRoleControlContainerView: previewRoleControlController.containerView)
     }
@@ -282,18 +283,25 @@ package final class NetworkDetailViewController: UIViewController {
         view.backgroundColor = backgroundColor
         bodyViewController.view.backgroundColor = backgroundColor
         headersTextView.backgroundColor = backgroundColor
+        securityViewController.view.backgroundColor = backgroundColor
+        securityViewController.collectionView.backgroundColor = backgroundColor
     }
 
     private func installContentViews() {
         addChild(bodyViewController)
+        addChild(securityViewController)
         view.addSubview(bodyViewController.view)
         view.addSubview(previewRoleControlController.containerView)
         view.addSubview(headersTextView)
+        view.addSubview(securityViewController.view)
         bodyViewController.view.translatesAutoresizingMaskIntoConstraints = false
         bodyViewController.view.isHidden = true
         bodyViewController.view.accessibilityIdentifier = "WebInspector.Network.DetailPreview"
         previewRoleControlController.containerView.translatesAutoresizingMaskIntoConstraints = false
+        securityViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        securityViewController.view.isHidden = true
         bodyViewController.didMove(toParent: self)
+        securityViewController.didMove(toParent: self)
 
         let bodyTopToPreviewContainerConstraint = bodyViewController.view.topAnchor.constraint(
             equalTo: view.topAnchor
@@ -322,6 +330,14 @@ package final class NetworkDetailViewController: UIViewController {
             headersTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             headersTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             headersTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            securityViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            securityViewController.view.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor
+            ),
+            securityViewController.view.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor
+            ),
+            securityViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
 
@@ -485,6 +501,29 @@ package final class NetworkDetailViewController: UIViewController {
                 }
                 renderHeadersSurface(request: request)
             }
+        case .security:
+            renderSecuritySurface(
+                request: activeRequest(for: selection, requests: requests)
+            )
+        }
+    }
+
+    private func activeRequest(
+        for selection: NetworkPanelSelection,
+        requests: [NetworkRequest]
+    ) -> NetworkRequest {
+        switch selection {
+        case .entry:
+            guard let request = requests.first else {
+                preconditionFailure("A selected Network entry must contain at least one request.")
+            }
+            return request
+        case .request:
+            guard requests.count == 1,
+                  let request = requests.first else {
+                preconditionFailure("An explicit Network request selection must render exactly one request.")
+            }
+            return request
         }
     }
 
@@ -512,6 +551,16 @@ package final class NetworkDetailViewController: UIViewController {
         title = request.displayName
         showHeaders()
         headersTextView.render(request: request)
+    }
+
+    private func renderSecuritySurface(request: NetworkRequest) {
+        observedRequest = request
+        title = request.displayName
+        showSecurity()
+        securityViewController.render(
+            request.securitySummary,
+            epoch: NetworkSecurityRequestEpoch(request: request)
+        )
     }
 
     private func setMode(_ nextMode: NetworkDetailViewController.Mode) {
@@ -621,6 +670,8 @@ package final class NetworkDetailViewController: UIViewController {
         previewRoleControlController.containerView.isHidden = true
         headersTextView.isHidden = true
         headersTextView.clear()
+        securityViewController.view.isHidden = true
+        securityViewController.clear()
         renderPreviewRoleControl(roles: [], selectedRole: nil)
         scrollEdgeController.contentScrollView = nil
 
@@ -636,6 +687,7 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func showPreview() {
         headersTextView.isHidden = true
+        securityViewController.view.isHidden = true
         bodyViewController.view.isHidden = false
     }
 
@@ -647,7 +699,22 @@ package final class NetworkDetailViewController: UIViewController {
         scrollEdgeController.isPreviewRoleControlVisible = false
         bodyViewController.setSurface(.none)
         headersTextView.isHidden = false
+        securityViewController.view.isHidden = true
         scrollEdgeController.contentScrollView = headersTextView.contentScrollView
+    }
+
+    private func showSecurity() {
+        setBodyRenderingActive(false)
+        bodyViewController.view.isHidden = true
+        bodyViewController.setSurface(.none)
+        unbindResponseBodyFetchObservation()
+        previewRoleControlController.containerView.isHidden = true
+        renderPreviewRoleControl(roles: [], selectedRole: nil)
+        updatePreviewRoleControlLayout(isVisible: false)
+        scrollEdgeController.isPreviewRoleControlVisible = false
+        headersTextView.isHidden = true
+        securityViewController.view.isHidden = false
+        scrollEdgeController.contentScrollView = securityViewController.collectionView
     }
 
     private func renderPreview(candidate: PreviewCandidate) {
@@ -1041,6 +1108,10 @@ extension NetworkDetailViewController {
         headersTextView
     }
 
+    var securityViewControllerForTesting: NetworkSecurityViewController {
+        securityViewController
+    }
+
     var bodyViewControllerForTesting: NetworkBodyPreviewViewController {
         bodyViewController
     }
@@ -1059,6 +1130,26 @@ extension NetworkDetailViewController {
 
     var isDetailModeControlEnabledForTesting: Bool {
         modeControlController.isEnabledForTesting
+    }
+
+    var detailModeControlViewForTesting: NetworkDetailModeControlView {
+        modeControlController.view
+    }
+
+    var detailModeControlPresentationForTesting: NetworkDetailModeControlView.Presentation {
+        modeControlController.presentationForTesting
+    }
+
+    var detailModeSegmentedControlForTesting: UISegmentedControl {
+        modeControlController.segmentedControlForTesting
+    }
+
+    var detailModeMenuButtonForTesting: UIButton {
+        modeControlController.menuButtonForTesting
+    }
+
+    var detailModeMenuActionTitlesForTesting: [String] {
+        modeControlController.menuActionTitlesForTesting
     }
 
     var isPreviewRoleControlHiddenForTesting: Bool {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
@@ -1,0 +1,651 @@
+#if canImport(UIKit)
+import Foundation
+import WebInspectorDataKit
+import WebInspectorProxyKit
+import WebInspectorUIBase
+
+enum NetworkSecuritySectionID: CaseIterable, Hashable {
+    case status
+    case connection
+    case certificate
+}
+
+enum NetworkSecurityListKind: Hashable {
+    case dnsNames
+    case ipAddresses
+}
+
+struct NetworkSecurityRequestEpoch: Hashable {
+    let requestID: NetworkRequest.ID
+    let requestIdentity: ObjectIdentifier
+    let lifecycleRevision: UInt64
+    let redirectCount: Int
+
+    @MainActor
+    init(request: NetworkRequest) {
+        requestID = request.id
+        requestIdentity = ObjectIdentifier(request)
+        lifecycleRevision = request.lifecycleRevision
+        redirectCount = request.redirects.count
+    }
+}
+
+struct NetworkSecurityItemID: Hashable {
+    enum Kind: Hashable {
+        case status
+        case scheme
+        case reason
+        case securityMetadata
+        case connectionMetadata
+        case tlsProtocol
+        case cipher
+        case certificateMetadata
+        case subject
+        case validFrom
+        case validUntil
+        case dnsState
+        case dnsName(Int)
+        case ipAddressState
+        case ipAddress(Int)
+        case disclosure(NetworkSecurityListKind)
+    }
+
+    let epoch: NetworkSecurityRequestEpoch
+    let kind: Kind
+}
+
+struct NetworkSecurityRowContent: Equatable {
+    let label: String
+    let value: String?
+    let usesTechnicalValueDirection: Bool
+    let disclosureList: NetworkSecurityListKind?
+    let isExpanded: Bool
+}
+
+struct NetworkSecurityDocument {
+    var itemsBySection: [NetworkSecuritySectionID: [NetworkSecurityItemID]]
+    var rowsByItemID: [NetworkSecurityItemID: NetworkSecurityRowContent]
+}
+
+@MainActor
+struct NetworkSecurityDocumentBuilder {
+    private static let collapsedValueLimit = 5
+
+    let summary: NetworkSecuritySummary
+    let epoch: NetworkSecurityRequestEpoch
+    let expandedLists: Set<NetworkSecurityListKind>
+
+    func makeDocument() -> NetworkSecurityDocument {
+        var builder = Builder(epoch: epoch)
+        switch summary {
+        case .plaintextScheme(let scheme):
+            builder.appendStatus(
+                value: plaintextStatus(for: scheme),
+                scheme: plaintextSchemeText(scheme)
+            )
+            builder.appendUnavailableMetadata(value: notApplicableText)
+        case .pending(let scheme):
+            builder.appendStatus(value: pendingText, scheme: encryptedSchemeText(scheme))
+            builder.appendUnavailableMetadata(value: pendingText)
+        case let .encryptedScheme(scheme, metadata):
+            builder.appendStatus(
+                value: metadataStatus(for: scheme, metadata: metadata),
+                scheme: encryptedSchemeText(scheme)
+            )
+            switch metadata {
+            case .notReported:
+                builder.appendMetadataNotReported()
+            case .reported(let security):
+                builder.append(
+                    section: .status,
+                    kind: .securityMetadata,
+                    label: securityMetadataLabel,
+                    value: reportedText
+                )
+                appendReportedSecurity(security, to: &builder)
+            }
+        case let .unavailable(scheme, reason):
+            builder.appendStatus(
+                value: unavailableStatus(for: reason),
+                scheme: encryptedSchemeText(scheme)
+            )
+            if let reasonText = rawUnavailableReason(reason) {
+                builder.append(
+                    section: .status,
+                    kind: .reason,
+                    label: reasonLabel,
+                    display: reportedScalar(reasonText)
+                )
+            }
+            builder.appendUnavailableMetadata(value: unavailableText)
+        case .notApplicable(let scheme):
+            builder.append(
+                section: .status,
+                kind: .status,
+                label: statusLabel,
+                value: notClassifiedText
+            )
+            builder.append(
+                section: .status,
+                kind: .scheme,
+                label: schemeLabel,
+                display: reportedScalar(scheme)
+            )
+            builder.appendUnavailableMetadata(value: notApplicableText)
+        }
+        return builder.document
+    }
+
+    private func appendReportedSecurity(
+        _ security: Network.Security,
+        to builder: inout Builder
+    ) {
+        if let connection = security.connection {
+            builder.append(
+                section: .connection,
+                kind: .connectionMetadata,
+                label: connectionMetadataLabel,
+                value: reportedText
+            )
+            builder.append(
+                section: .connection,
+                kind: .tlsProtocol,
+                label: tlsProtocolLabel,
+                display: reportedScalar(connection.tlsProtocol)
+            )
+            builder.append(
+                section: .connection,
+                kind: .cipher,
+                label: cipherLabel,
+                display: reportedScalar(connection.cipher)
+            )
+        } else {
+            builder.append(
+                section: .connection,
+                kind: .connectionMetadata,
+                label: connectionMetadataLabel,
+                value: notReportedText
+            )
+        }
+
+        guard let certificate = security.certificate else {
+            builder.append(
+                section: .certificate,
+                kind: .certificateMetadata,
+                label: certificateMetadataLabel,
+                value: notReportedText
+            )
+            return
+        }
+        builder.append(
+            section: .certificate,
+            kind: .certificateMetadata,
+            label: certificateMetadataLabel,
+            value: reportedText
+        )
+        builder.append(
+            section: .certificate,
+            kind: .subject,
+            label: subjectLabel,
+            display: reportedScalar(certificate.subject)
+        )
+        builder.append(
+            section: .certificate,
+            kind: .validFrom,
+            label: validFromLabel,
+            display: reportedDate(certificate.validFrom)
+        )
+        builder.append(
+            section: .certificate,
+            kind: .validUntil,
+            label: validUntilLabel,
+            display: reportedDate(certificate.validUntil)
+        )
+        append(
+            certificate.dnsNames,
+            kind: .dnsNames,
+            to: &builder
+        )
+        append(
+            certificate.ipAddresses,
+            kind: .ipAddresses,
+            to: &builder
+        )
+    }
+
+    private func append(
+        _ values: [String]?,
+        kind: NetworkSecurityListKind,
+        to builder: inout Builder
+    ) {
+        guard let values else {
+            builder.append(
+                section: .certificate,
+                kind: kind == .dnsNames ? .dnsState : .ipAddressState,
+                label: kind == .dnsNames ? dnsNamesLabel : ipAddressesLabel,
+                value: notReportedText
+            )
+            return
+        }
+        guard values.isEmpty == false else {
+            builder.append(
+                section: .certificate,
+                kind: kind == .dnsNames ? .dnsState : .ipAddressState,
+                label: kind == .dnsNames ? dnsNamesLabel : ipAddressesLabel,
+                value: noValuesReportedText
+            )
+            return
+        }
+
+        let isExpanded = expandedLists.contains(kind)
+        let visibleValues = isExpanded
+            ? values
+            : Array(values.prefix(Self.collapsedValueLimit))
+        for (ordinal, value) in visibleValues.enumerated() {
+            builder.append(
+                section: .certificate,
+                kind: kind == .dnsNames ? .dnsName(ordinal) : .ipAddress(ordinal),
+                label: listValueLabel(kind: kind, ordinal: ordinal),
+                display: reportedScalar(value)
+            )
+        }
+        guard values.count > Self.collapsedValueLimit else {
+            return
+        }
+        let hiddenValueCount = values.count - Self.collapsedValueLimit
+        builder.appendDisclosure(
+            kind: kind,
+            title: isExpanded ? showLessText : showMoreText(hiddenValueCount),
+            isExpanded: isExpanded
+        )
+    }
+
+    private func plaintextStatus(
+        for scheme: NetworkSecuritySummary.PlaintextScheme
+    ) -> String {
+        switch scheme {
+        case .http:
+            localized(
+                "network.security.status.http",
+                defaultValue: "HTTP scheme reported; TLS does not apply."
+            )
+        case .ws:
+            localized(
+                "network.security.status.ws",
+                defaultValue: "WS scheme reported; TLS does not apply."
+            )
+        }
+    }
+
+    private func metadataStatus(
+        for scheme: NetworkSecuritySummary.EncryptedScheme,
+        metadata: NetworkSecuritySummary.Metadata
+    ) -> String {
+        switch metadata {
+        case .notReported:
+            switch scheme {
+            case .https:
+                localized(
+                    "network.security.status.https_not_reported",
+                    defaultValue: "HTTPS scheme reported; security metadata was not reported."
+                )
+            case .wss:
+                localized(
+                    "network.security.status.wss_not_reported",
+                    defaultValue: "WSS scheme reported; security metadata was not reported."
+                )
+            }
+        case .reported:
+            switch scheme {
+            case .https:
+                localized(
+                    "network.security.status.https_reported",
+                    defaultValue: "HTTPS scheme and security metadata reported."
+                )
+            case .wss:
+                localized(
+                    "network.security.status.wss_reported",
+                    defaultValue: "WSS scheme and security metadata reported."
+                )
+            }
+        }
+    }
+
+    private func unavailableStatus(
+        for reason: NetworkSecuritySummary.UnavailableReason
+    ) -> String {
+        switch reason {
+        case .failedBeforeResponse:
+            localized(
+                "network.security.status.failed_before_response",
+                defaultValue: "The request failed before a response was reported."
+            )
+        case .canceledBeforeResponse:
+            localized(
+                "network.security.status.canceled_before_response",
+                defaultValue: "The request was canceled before a response was reported."
+            )
+        case .completedWithoutResponse:
+            localized(
+                "network.security.status.completed_without_response",
+                defaultValue: "Loading completed without a reported response."
+            )
+        }
+    }
+
+    private func rawUnavailableReason(
+        _ reason: NetworkSecuritySummary.UnavailableReason
+    ) -> String? {
+        switch reason {
+        case .failedBeforeResponse(let reason), .canceledBeforeResponse(let reason):
+            reason
+        case .completedWithoutResponse:
+            nil
+        }
+    }
+
+    private func plaintextSchemeText(
+        _ scheme: NetworkSecuritySummary.PlaintextScheme
+    ) -> String {
+        switch scheme {
+        case .http: "HTTP"
+        case .ws: "WS"
+        }
+    }
+
+    private func encryptedSchemeText(
+        _ scheme: NetworkSecuritySummary.EncryptedScheme
+    ) -> String {
+        switch scheme {
+        case .https: "HTTPS"
+        case .wss: "WSS"
+        }
+    }
+
+    private func listValueLabel(kind: NetworkSecurityListKind, ordinal: Int) -> String {
+        let base = kind == .dnsNames ? dnsNameLabel : ipAddressLabel
+        return "\(base) \((ordinal + 1).formatted())"
+    }
+
+    private func reportedScalar(_ value: String?) -> DisplayValue {
+        guard let value else {
+            return DisplayValue(value: notReportedText, isTechnical: false)
+        }
+        guard value.isEmpty == false else {
+            return DisplayValue(value: emptyValueReportedText, isTechnical: false)
+        }
+        return DisplayValue(value: value, isTechnical: true)
+    }
+
+    private func reportedDate(_ date: Date?) -> DisplayValue {
+        guard let date else {
+            return DisplayValue(value: notReportedText, isTechnical: false)
+        }
+        return DisplayValue(
+            value: date.formatted(date: .numeric, time: .complete),
+            isTechnical: false
+        )
+    }
+
+    private func showMoreText(_ count: Int) -> String {
+        String.localizedStringWithFormat(
+            localized(
+                "network.security.action.show_more",
+                defaultValue: "Show %lld More"
+            ),
+            Int64(count)
+        )
+    }
+
+    private var showLessText: String {
+        localized("network.security.action.show_less", defaultValue: "Show Less")
+    }
+
+    private var statusLabel: String {
+        localized("network.security.field.status", defaultValue: "Status")
+    }
+
+    private var schemeLabel: String {
+        localized("network.security.field.scheme", defaultValue: "Scheme")
+    }
+
+    private var reasonLabel: String {
+        localized("network.security.field.reason", defaultValue: "Reason")
+    }
+
+    private var securityMetadataLabel: String {
+        localized("network.security.field.security_metadata", defaultValue: "Security Metadata")
+    }
+
+    private var connectionMetadataLabel: String {
+        localized("network.security.field.connection_metadata", defaultValue: "Connection Metadata")
+    }
+
+    private var tlsProtocolLabel: String {
+        localized("network.security.field.tls_protocol", defaultValue: "TLS Protocol")
+    }
+
+    private var cipherLabel: String {
+        localized("network.security.field.cipher", defaultValue: "Cipher")
+    }
+
+    private var certificateMetadataLabel: String {
+        localized("network.security.field.certificate_metadata", defaultValue: "Certificate Metadata")
+    }
+
+    private var subjectLabel: String {
+        localized("network.security.field.subject", defaultValue: "Subject")
+    }
+
+    private var validFromLabel: String {
+        localized("network.security.field.valid_from", defaultValue: "Valid From")
+    }
+
+    private var validUntilLabel: String {
+        localized("network.security.field.valid_until", defaultValue: "Valid Until")
+    }
+
+    private var dnsNamesLabel: String {
+        localized("network.security.field.dns_names", defaultValue: "DNS Names")
+    }
+
+    private var dnsNameLabel: String {
+        localized("network.security.field.dns_name", defaultValue: "DNS Name")
+    }
+
+    private var ipAddressesLabel: String {
+        localized("network.security.field.ip_addresses", defaultValue: "IP Addresses")
+    }
+
+    private var ipAddressLabel: String {
+        localized("network.security.field.ip_address", defaultValue: "IP Address")
+    }
+
+    private var reportedText: String {
+        localized("network.security.value.reported", defaultValue: "Reported")
+    }
+
+    private var notReportedText: String {
+        localized("network.security.value.not_reported", defaultValue: "Not reported")
+    }
+
+    private var emptyValueReportedText: String {
+        localized("network.security.value.empty_reported", defaultValue: "Empty value reported")
+    }
+
+    private var noValuesReportedText: String {
+        localized("network.security.value.no_values_reported", defaultValue: "No values reported")
+    }
+
+    private var pendingText: String {
+        localized("network.security.value.pending", defaultValue: "Response pending")
+    }
+
+    private var unavailableText: String {
+        localized("network.security.value.unavailable", defaultValue: "Unavailable")
+    }
+
+    private var notApplicableText: String {
+        localized("network.security.value.not_applicable", defaultValue: "Not applicable")
+    }
+
+    private var notClassifiedText: String {
+        localized(
+            "network.security.status.not_classified",
+            defaultValue: "TLS applicability is not classified for this scheme."
+        )
+    }
+
+    private func localized(_ key: StaticString, defaultValue: String.LocalizationValue) -> String {
+        String(localized: key, defaultValue: defaultValue, bundle: WebInspectorUILocalization.bundle)
+    }
+
+    private struct DisplayValue {
+        let value: String
+        let isTechnical: Bool
+    }
+
+    private struct Builder {
+        let epoch: NetworkSecurityRequestEpoch
+        var document = NetworkSecurityDocument(
+            itemsBySection: Dictionary(
+                uniqueKeysWithValues: NetworkSecuritySectionID.allCases.map { ($0, []) }
+            ),
+            rowsByItemID: [:]
+        )
+
+        mutating func appendStatus(value: String, scheme: String) {
+            append(section: .status, kind: .status, label: statusLabel, value: value)
+            append(
+                section: .status,
+                kind: .scheme,
+                label: schemeLabel,
+                value: scheme,
+                usesTechnicalValueDirection: true
+            )
+        }
+
+        mutating func appendMetadataNotReported() {
+            append(
+                section: .status,
+                kind: .securityMetadata,
+                label: securityMetadataLabel,
+                value: notReportedText
+            )
+            append(
+                section: .connection,
+                kind: .connectionMetadata,
+                label: connectionMetadataLabel,
+                value: notReportedText
+            )
+            append(
+                section: .certificate,
+                kind: .certificateMetadata,
+                label: certificateMetadataLabel,
+                value: notReportedText
+            )
+        }
+
+        mutating func appendUnavailableMetadata(value: String) {
+            append(
+                section: .connection,
+                kind: .connectionMetadata,
+                label: connectionMetadataLabel,
+                value: value
+            )
+            append(
+                section: .certificate,
+                kind: .certificateMetadata,
+                label: certificateMetadataLabel,
+                value: value
+            )
+        }
+
+        mutating func append(
+            section: NetworkSecuritySectionID,
+            kind: NetworkSecurityItemID.Kind,
+            label: String,
+            display: DisplayValue
+        ) {
+            append(
+                section: section,
+                kind: kind,
+                label: label,
+                value: display.value,
+                usesTechnicalValueDirection: display.isTechnical
+            )
+        }
+
+        mutating func append(
+            section: NetworkSecuritySectionID,
+            kind: NetworkSecurityItemID.Kind,
+            label: String,
+            value: String,
+            usesTechnicalValueDirection: Bool = false
+        ) {
+            let itemID = NetworkSecurityItemID(epoch: epoch, kind: kind)
+            precondition(document.rowsByItemID[itemID] == nil)
+            document.itemsBySection[section, default: []].append(itemID)
+            document.rowsByItemID[itemID] = NetworkSecurityRowContent(
+                label: label,
+                value: value,
+                usesTechnicalValueDirection: usesTechnicalValueDirection,
+                disclosureList: nil,
+                isExpanded: false
+            )
+        }
+
+        mutating func appendDisclosure(
+            kind: NetworkSecurityListKind,
+            title: String,
+            isExpanded: Bool
+        ) {
+            let itemID = NetworkSecurityItemID(epoch: epoch, kind: .disclosure(kind))
+            precondition(document.rowsByItemID[itemID] == nil)
+            document.itemsBySection[.certificate, default: []].append(itemID)
+            document.rowsByItemID[itemID] = NetworkSecurityRowContent(
+                label: title,
+                value: nil,
+                usesTechnicalValueDirection: false,
+                disclosureList: kind,
+                isExpanded: isExpanded
+            )
+        }
+
+        private var statusLabel: String {
+            localized("network.security.field.status", defaultValue: "Status")
+        }
+
+        private var schemeLabel: String {
+            localized("network.security.field.scheme", defaultValue: "Scheme")
+        }
+
+        private var securityMetadataLabel: String {
+            localized("network.security.field.security_metadata", defaultValue: "Security Metadata")
+        }
+
+        private var connectionMetadataLabel: String {
+            localized("network.security.field.connection_metadata", defaultValue: "Connection Metadata")
+        }
+
+        private var certificateMetadataLabel: String {
+            localized("network.security.field.certificate_metadata", defaultValue: "Certificate Metadata")
+        }
+
+        private var notReportedText: String {
+            localized("network.security.value.not_reported", defaultValue: "Not reported")
+        }
+
+        private func localized(
+            _ key: StaticString,
+            defaultValue: String.LocalizationValue
+        ) -> String {
+            String(
+                localized: key,
+                defaultValue: defaultValue,
+                bundle: WebInspectorUILocalization.bundle
+            )
+        }
+    }
+}
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
@@ -255,7 +255,9 @@ struct NetworkSecurityDocumentBuilder {
         let hiddenValueCount = values.count - Self.collapsedValueLimit
         builder.appendDisclosure(
             kind: kind,
-            title: isExpanded ? showLessText : showMoreText(hiddenValueCount),
+            title: isExpanded
+                ? showLessText(for: kind)
+                : showMoreText(hiddenValueCount, for: kind),
             isExpanded: isExpanded
         )
     }
@@ -387,18 +389,38 @@ struct NetworkSecurityDocumentBuilder {
         )
     }
 
-    private func showMoreText(_ count: Int) -> String {
-        String.localizedStringWithFormat(
+    private func showMoreText(_ count: Int, for kind: NetworkSecurityListKind) -> String {
+        let format = switch kind {
+        case .dnsNames:
             localized(
-                "network.security.action.show_more",
-                defaultValue: "Show %lld More"
-            ),
+                "network.security.action.show_more_dns_names",
+                defaultValue: "Show %lld More DNS Names"
+            )
+        case .ipAddresses:
+            localized(
+                "network.security.action.show_more_ip_addresses",
+                defaultValue: "Show %lld More IP Addresses"
+            )
+        }
+        return String.localizedStringWithFormat(
+            format,
             Int64(count)
         )
     }
 
-    private var showLessText: String {
-        localized("network.security.action.show_less", defaultValue: "Show Less")
+    private func showLessText(for kind: NetworkSecurityListKind) -> String {
+        switch kind {
+        case .dnsNames:
+            localized(
+                "network.security.action.show_less_dns_names",
+                defaultValue: "Show Less DNS Names"
+            )
+        case .ipAddresses:
+            localized(
+                "network.security.action.show_less_ip_addresses",
+                defaultValue: "Show Less IP Addresses"
+            )
+        }
     }
 
     private var statusLabel: String {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
@@ -1,0 +1,376 @@
+#if canImport(UIKit)
+import UIKit
+import WebInspectorDataKit
+import WebInspectorUIBase
+
+@MainActor
+final class NetworkSecurityViewController: UICollectionViewController {
+    private lazy var dataSource = makeDataSource()
+    private var currentSummary: NetworkSecuritySummary?
+    private var currentEpoch: NetworkSecurityRequestEpoch?
+    private var currentDocument = NetworkSecurityDocument(
+        itemsBySection: [:],
+        rowsByItemID: [:]
+    )
+    private var expandedLists: Set<NetworkSecurityListKind> = []
+
+    init() {
+        super.init(collectionViewLayout: Self.makeLayout())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        _ = dataSource
+        collectionView.alwaysBounceVertical = true
+        collectionView.allowsSelection = true
+        collectionView.allowsMultipleSelection = false
+        collectionView.accessibilityIdentifier = "WebInspector.Network.Security"
+    }
+
+    override func collectionView(
+        _ collectionView: UICollectionView,
+        shouldSelectItemAt indexPath: IndexPath
+    ) -> Bool {
+        guard let itemID = dataSource.itemIdentifier(for: indexPath) else {
+            return false
+        }
+        return currentDocument.rowsByItemID[itemID]?.disclosureList != nil
+    }
+
+    override func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        defer {
+            collectionView.deselectItem(at: indexPath, animated: false)
+        }
+        guard let itemID = dataSource.itemIdentifier(for: indexPath),
+              let listKind = currentDocument.rowsByItemID[itemID]?.disclosureList else {
+            return
+        }
+        if expandedLists.remove(listKind) == nil {
+            expandedLists.insert(listKind)
+        }
+        renderCurrent(animatingDifferences: true)
+    }
+
+    func render(
+        _ summary: NetworkSecuritySummary,
+        epoch: NetworkSecurityRequestEpoch,
+        completion: (() -> Void)? = nil
+    ) {
+        loadViewIfNeeded()
+        let isSameEpoch = currentEpoch == epoch
+        if isSameEpoch == false {
+            expandedLists.removeAll(keepingCapacity: true)
+        }
+        currentSummary = summary
+        currentEpoch = epoch
+        renderCurrent(
+            animatingDifferences: isSameEpoch,
+            completion: completion
+        )
+    }
+
+    func clear(completion: (() -> Void)? = nil) {
+        loadViewIfNeeded()
+        currentSummary = nil
+        currentEpoch = nil
+        currentDocument = NetworkSecurityDocument(itemsBySection: [:], rowsByItemID: [:])
+        expandedLists.removeAll(keepingCapacity: false)
+        dataSource.apply(
+            NSDiffableDataSourceSnapshot<NetworkSecuritySectionID, NetworkSecurityItemID>(),
+            animatingDifferences: false,
+            completion: completion
+        )
+    }
+
+    private func renderCurrent(
+        animatingDifferences: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        guard let currentSummary, let currentEpoch else {
+            clear(completion: completion)
+            return
+        }
+        let previousItemIDs = Set(dataSource.snapshot().itemIdentifiers)
+        let document = NetworkSecurityDocumentBuilder(
+            summary: currentSummary,
+            epoch: currentEpoch,
+            expandedLists: expandedLists
+        ).makeDocument()
+        currentDocument = document
+
+        var snapshot = NSDiffableDataSourceSnapshot<NetworkSecuritySectionID, NetworkSecurityItemID>()
+        snapshot.appendSections(NetworkSecuritySectionID.allCases)
+        for section in NetworkSecuritySectionID.allCases {
+            snapshot.appendItems(document.itemsBySection[section] ?? [], toSection: section)
+        }
+        let retainedItemIDs = snapshot.itemIdentifiers.filter(previousItemIDs.contains)
+        snapshot.reconfigureItems(retainedItemIDs)
+        dataSource.apply(
+            snapshot,
+            animatingDifferences: animatingDifferences,
+            completion: completion
+        )
+    }
+
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<
+        NetworkSecuritySectionID,
+        NetworkSecurityItemID
+    > {
+        let cellRegistration = UICollectionView.CellRegistration<
+            UICollectionViewListCell,
+            NetworkSecurityItemID
+        > { [weak self] cell, _, itemID in
+            guard let self,
+                  let content = currentDocument.rowsByItemID[itemID] else {
+                cell.contentConfiguration = nil
+                cell.accessories = []
+                cell.accessibilityLabel = nil
+                cell.accessibilityValue = nil
+                cell.accessibilityHint = nil
+                cell.accessibilityTraits = []
+                return
+            }
+            configure(cell, content: content)
+        }
+        let dataSource = UICollectionViewDiffableDataSource<
+            NetworkSecuritySectionID,
+            NetworkSecurityItemID
+        >(collectionView: collectionView) { collectionView, indexPath, itemID in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: itemID
+            )
+        }
+
+        let headerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(
+            elementKind: UICollectionView.elementKindSectionHeader
+        ) { [weak dataSource] header, _, indexPath in
+            guard let dataSource,
+                  dataSource.snapshot().sectionIdentifiers.indices.contains(indexPath.section) else {
+                header.contentConfiguration = nil
+                return
+            }
+            let section = dataSource.snapshot().sectionIdentifiers[indexPath.section]
+            var content = UIListContentConfiguration.header()
+            content.text = Self.sectionTitle(section)
+            header.contentConfiguration = content
+        }
+        dataSource.supplementaryViewProvider = { collectionView, elementKind, indexPath in
+            guard elementKind == UICollectionView.elementKindSectionHeader else {
+                return nil
+            }
+            return collectionView.dequeueConfiguredReusableSupplementary(
+                using: headerRegistration,
+                for: indexPath
+            )
+        }
+        return dataSource
+    }
+
+    private func configure(
+        _ cell: UICollectionViewListCell,
+        content: NetworkSecurityRowContent
+    ) {
+        if let disclosureList = content.disclosureList {
+            var configuration = UIListContentConfiguration.cell()
+            configuration.text = content.label
+            configuration.textProperties.adjustsFontForContentSizeCategory = true
+            cell.contentConfiguration = configuration
+            let imageView = UIImageView(image: UIImage(
+                systemName: content.isExpanded ? "chevron.up" : "chevron.down"
+            ))
+            imageView.tintColor = .secondaryLabel
+            imageView.isAccessibilityElement = false
+            cell.accessories = [.customView(configuration: .init(
+                customView: imageView,
+                placement: .trailing()
+            ))]
+            cell.accessibilityLabel = content.label
+            cell.accessibilityValue = content.isExpanded ? expandedText : collapsedText
+            cell.accessibilityHint = toggleHint
+            cell.accessibilityTraits = .button
+            cell.accessibilityIdentifier = disclosureList == .dnsNames
+                ? "WebInspector.Network.Security.DNSDisclosure"
+                : "WebInspector.Network.Security.IPDisclosure"
+            return
+        }
+
+        var configuration = UIListContentConfiguration.valueCell()
+        configuration.text = content.label
+        configuration.textProperties.numberOfLines = 0
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
+        if let value = content.value {
+            if content.usesTechnicalValueDirection {
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.baseWritingDirection = .leftToRight
+                configuration.secondaryAttributedText = NSAttributedString(
+                    string: value,
+                    attributes: [.paragraphStyle: paragraphStyle]
+                )
+            } else {
+                configuration.secondaryText = value
+            }
+        }
+        configuration.secondaryTextProperties.numberOfLines = 0
+        configuration.secondaryTextProperties.lineBreakMode = content.usesTechnicalValueDirection
+            ? .byCharWrapping
+            : .byWordWrapping
+        configuration.secondaryTextProperties.adjustsFontForContentSizeCategory = true
+        cell.contentConfiguration = configuration
+        cell.accessories = []
+        cell.accessibilityLabel = [content.label, content.value]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+        cell.accessibilityValue = nil
+        cell.accessibilityHint = nil
+        cell.accessibilityTraits = .staticText
+        cell.accessibilityIdentifier = nil
+    }
+
+    private static func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, environment in
+            let configuration = listConfiguration
+            let section = NSCollectionLayoutSection.list(
+                using: configuration,
+                layoutEnvironment: environment
+            )
+            var insets = section.contentInsets
+            insets.top = 0
+            section.contentInsets = insets
+            return section
+        }
+    }
+
+    private static var listConfiguration: UICollectionLayoutListConfiguration {
+        var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        configuration.headerMode = .supplementary
+        configuration.showsSeparators = true
+        return configuration
+    }
+
+    private static func sectionTitle(_ section: NetworkSecuritySectionID) -> String {
+        switch section {
+        case .status:
+            String(
+                localized: "network.security.section.status",
+                defaultValue: "Status",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        case .connection:
+            String(
+                localized: "network.security.section.connection",
+                defaultValue: "Connection",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        case .certificate:
+            String(
+                localized: "network.security.section.certificate",
+                defaultValue: "Certificate",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        }
+    }
+
+    private var expandedText: String {
+        String(
+            localized: "network.security.accessibility.expanded",
+            defaultValue: "Expanded",
+            bundle: WebInspectorUILocalization.bundle
+        )
+    }
+
+    private var collapsedText: String {
+        String(
+            localized: "network.security.accessibility.collapsed",
+            defaultValue: "Collapsed",
+            bundle: WebInspectorUILocalization.bundle
+        )
+    }
+
+    private var toggleHint: String {
+        String(
+            localized: "network.security.accessibility.toggle_hint",
+            defaultValue: "Double-tap to show or hide reported values.",
+            bundle: WebInspectorUILocalization.bundle
+        )
+    }
+}
+
+#if DEBUG
+extension NetworkSecurityViewController {
+    var snapshotForTesting: NSDiffableDataSourceSnapshot<
+        NetworkSecuritySectionID,
+        NetworkSecurityItemID
+    > {
+        dataSource.snapshot()
+    }
+
+    var expandedListsForTesting: Set<NetworkSecurityListKind> {
+        expandedLists
+    }
+
+    var currentEpochForTesting: NetworkSecurityRequestEpoch? {
+        currentEpoch
+    }
+
+    func rowContentForTesting(_ itemID: NetworkSecurityItemID) -> NetworkSecurityRowContent? {
+        currentDocument.rowsByItemID[itemID]
+    }
+
+    func cellForTesting(_ itemID: NetworkSecurityItemID) -> UICollectionViewListCell? {
+        collectionView.layoutIfNeeded()
+        guard let indexPath = dataSource.indexPath(for: itemID) else {
+            return nil
+        }
+        return collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell
+    }
+
+    func technicalValueUsesLTRForTesting(_ itemID: NetworkSecurityItemID) -> Bool {
+        guard let cell = cellForTesting(itemID),
+              let content = cell.contentConfiguration as? UIListContentConfiguration,
+              let attributedText = content.secondaryAttributedText,
+              attributedText.length > 0 else {
+            return false
+        }
+        let paragraphStyle = unsafe attributedText.attribute(
+            .paragraphStyle,
+            at: 0,
+            effectiveRange: nil
+        ) as? NSParagraphStyle
+        return paragraphStyle?.baseWritingDirection == .leftToRight
+    }
+
+    func toggleDisclosureForTesting(
+        _ kind: NetworkSecurityListKind,
+        completion: (() -> Void)? = nil
+    ) {
+        guard dataSource.snapshot().itemIdentifiers.contains(where: {
+            $0.kind == .disclosure(kind)
+        }) else {
+            preconditionFailure("Expected a visible Network security disclosure.")
+        }
+        if expandedLists.remove(kind) == nil {
+            expandedLists.insert(kind)
+        }
+        renderCurrent(animatingDifferences: true, completion: completion)
+    }
+
+    static var listConfigurationForTesting: UICollectionLayoutListConfiguration {
+        listConfiguration
+    }
+
+    static func sectionTitleForTesting(_ section: NetworkSecuritySectionID) -> String {
+        sectionTitle(section)
+    }
+}
+#endif
+#endif

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
@@ -156,13 +156,11 @@ final class NetworkSecurityViewController: UICollectionViewController {
         ) { [weak dataSource] header, _, indexPath in
             guard let dataSource,
                   dataSource.snapshot().sectionIdentifiers.indices.contains(indexPath.section) else {
-                header.contentConfiguration = nil
+                Self.configure(header, for: nil)
                 return
             }
             let section = dataSource.snapshot().sectionIdentifiers[indexPath.section]
-            var content = UIListContentConfiguration.header()
-            content.text = Self.sectionTitle(section)
-            header.contentConfiguration = content
+            Self.configure(header, for: section)
         }
         dataSource.supplementaryViewProvider = { collectionView, elementKind, indexPath in
             guard elementKind == UICollectionView.elementKindSectionHeader else {
@@ -174,6 +172,26 @@ final class NetworkSecurityViewController: UICollectionViewController {
             )
         }
         return dataSource
+    }
+
+    private static func configure(
+        _ header: UICollectionViewListCell,
+        for section: NetworkSecuritySectionID?
+    ) {
+        guard let section else {
+            header.contentConfiguration = nil
+            header.isAccessibilityElement = false
+            header.accessibilityLabel = nil
+            header.accessibilityTraits = []
+            return
+        }
+        let title = sectionTitle(section)
+        var content = UIListContentConfiguration.header()
+        content.text = title
+        header.contentConfiguration = content
+        header.isAccessibilityElement = true
+        header.accessibilityLabel = title
+        header.accessibilityTraits = .header
     }
 
     private func configure(
@@ -370,6 +388,24 @@ extension NetworkSecurityViewController {
 
     static func sectionTitleForTesting(_ section: NetworkSecuritySectionID) -> String {
         sectionTitle(section)
+    }
+
+    func sectionHeaderForTesting(
+        _ section: NetworkSecuritySectionID
+    ) -> UICollectionViewListCell? {
+        collectionView.layoutIfNeeded()
+        guard let sectionIndex = dataSource.snapshot().sectionIdentifiers.firstIndex(of: section)
+        else {
+            return nil
+        }
+        return collectionView.supplementaryView(
+            forElementKind: UICollectionView.elementKindSectionHeader,
+            at: IndexPath(item: 0, section: sectionIndex)
+        ) as? UICollectionViewListCell
+    }
+
+    static func clearSectionHeaderForTesting(_ header: UICollectionViewListCell) {
+        configure(header, for: nil)
     }
 }
 #endif

--- a/Tests/WebInspectorDataKitTests/NetworkSecuritySummaryTests.swift
+++ b/Tests/WebInspectorDataKitTests/NetworkSecuritySummaryTests.swift
@@ -1,0 +1,549 @@
+import Foundation
+import Observation
+import Synchronization
+import Testing
+@testable import WebInspectorDataKit
+import WebInspectorProxyKit
+
+@MainActor
+@Test
+func networkSecuritySummaryParsesOnlyStrictRawASCIISchemes() {
+    let cases: [(url: String, expected: NetworkSecuritySummary)] = [
+        ("http://example.test", .plaintextScheme(.http)),
+        ("HTTP://example.test", .plaintextScheme(.http)),
+        ("ws://example.test/socket", .plaintextScheme(.ws)),
+        ("Ws://example.test/socket", .plaintextScheme(.ws)),
+        ("https://example.test", .pending(.https)),
+        ("WSS://example.test/socket", .pending(.wss)),
+        ("git+ssh://example.test/repository", .notApplicable(scheme: "git+ssh")),
+        ("CuStOm.1-2:value", .notApplicable(scheme: "CuStOm.1-2")),
+        (" https://example.test", .notApplicable(scheme: nil)),
+        ("1https://example.test", .notApplicable(scheme: nil)),
+        ("ht_tps://example.test", .notApplicable(scheme: nil)),
+        ("https：//example.test", .notApplicable(scheme: nil)),
+        ("éxample:value", .notApplicable(scheme: nil)),
+        ("relative/path", .notApplicable(scheme: nil)),
+        ("", .notApplicable(scheme: nil)),
+    ]
+
+    for (index, testCase) in cases.enumerated() {
+        let request = makeSecurityRequest(id: "scheme-\(index)", url: testCase.url)
+        #expect(request.securitySummary == testCase.expected)
+    }
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryUsesResponseURLWithoutFallingBackOrOverridingSchemeFacts() {
+    let reportedSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+    )
+    let redirectedToPlaintext = makeSecurityRequest(
+        id: "response-url-plaintext",
+        url: "https://origin.example.test"
+    )
+    redirectedToPlaintext.applyResponse(
+        Network.Response(url: "HTTP://final.example.test").reporting(security: reportedSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    redirectedToPlaintext.fail(errorText: "ignored", canceled: true, timestamp: 3)
+    #expect(redirectedToPlaintext.securitySummary == .plaintextScheme(.http))
+
+    let malformedResponseURL = makeSecurityRequest(
+        id: "response-url-malformed",
+        url: "https://origin.example.test"
+    )
+    malformedResponseURL.applyResponse(
+        Network.Response(url: " https://final.example.test").reporting(security: reportedSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    #expect(malformedResponseURL.securitySummary == .notApplicable(scheme: nil))
+
+    let emptyResponseURL = makeSecurityRequest(
+        id: "response-url-empty",
+        url: "https://origin.example.test"
+    )
+    emptyResponseURL.applyResponse(
+        Network.Response(url: "", status: 200).reporting(security: reportedSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    #expect(emptyResponseURL.securitySummary == .notApplicable(scheme: nil))
+
+    let otherResponseURL = makeSecurityRequest(
+        id: "response-url-other",
+        url: "https://origin.example.test"
+    )
+    otherResponseURL.applyResponse(
+        Network.Response(url: "Custom+Protocol:value").reporting(security: reportedSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    #expect(otherResponseURL.securitySummary == .notApplicable(scheme: "Custom+Protocol"))
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryDistinguishesEncryptedLifecycleStates() {
+    let pending = makeSecurityRequest(id: "pending", url: "https://example.test/pending")
+    #expect(pending.securitySummary == .pending(.https))
+
+    let respondedWithoutMetadata = makeSecurityRequest(
+        id: "responded-without-metadata",
+        url: "https://example.test/responded-without-metadata"
+    )
+    respondedWithoutMetadata.applyDataReceived(dataLength: 1, encodedDataLength: 1, timestamp: 2)
+    #expect(respondedWithoutMetadata.state == .responded)
+    #expect(respondedWithoutMetadata.hasResponse == false)
+    #expect(respondedWithoutMetadata.securitySummary == .pending(.https))
+
+    let failed = makeSecurityRequest(id: "failed", url: "https://example.test/failed")
+    failed.fail(errorText: "  transport failed  ", canceled: false, timestamp: 2)
+    #expect(
+        failed.securitySummary
+            == .unavailable(
+                .https,
+                reason: .failedBeforeResponse(reason: "  transport failed  ")
+            )
+    )
+
+    let canceled = makeSecurityRequest(id: "canceled", url: "wss://example.test/canceled")
+    canceled.fail(errorText: "", canceled: true, timestamp: 2)
+    #expect(
+        canceled.securitySummary
+            == .unavailable(
+                .wss,
+                reason: .canceledBeforeResponse(reason: "")
+            )
+    )
+
+    let finished = makeSecurityRequest(id: "finished", url: "https://example.test/finished")
+    finished.finish(timestamp: 2, sourceMapURL: nil, metrics: nil)
+    #expect(
+        finished.securitySummary
+            == .unavailable(
+                .https,
+                reason: .completedWithoutResponse
+            )
+    )
+
+    let responseWithoutSecurity = makeSecurityRequest(
+        id: "response-without-security",
+        url: "https://example.test/response-without-security"
+    )
+    responseWithoutSecurity.applyResponse(
+        Network.Response(status: 204),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    #expect(
+        responseWithoutSecurity.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .notReported
+            )
+    )
+    responseWithoutSecurity.fail(errorText: "after response", canceled: true, timestamp: 3)
+    #expect(
+        responseWithoutSecurity.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .notReported
+            )
+    )
+
+    let finishedAfterResponse = makeSecurityRequest(
+        id: "finished-after-response",
+        url: "https://example.test/finished-after-response"
+    )
+    finishedAfterResponse.applyResponse(
+        Network.Response(status: 200),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    finishedAfterResponse.finish(timestamp: 3, sourceMapURL: nil, metrics: nil)
+    #expect(
+        finishedAfterResponse.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .notReported
+            )
+    )
+
+    let presentEmpty = makeSecurityRequest(
+        id: "present-empty-security",
+        url: "https://example.test/present-empty-security"
+    )
+    let emptySecurity = Network.Security()
+    presentEmpty.applyResponse(
+        Network.Response().reporting(security: emptySecurity),
+        resourceType: .fetch,
+        timestamp: nil
+    )
+    #expect(
+        presentEmpty.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .reported(emptySecurity)
+            )
+    )
+
+    let nestedEmpty = makeSecurityRequest(
+        id: "nested-empty-security",
+        url: "https://example.test/nested-empty-security"
+    )
+    let nestedEmptySecurity = Network.Security(
+        connection: Network.Security.Connection(),
+        certificate: Network.Security.Certificate()
+    )
+    nestedEmpty.applyResponse(
+        Network.Response().reporting(security: nestedEmptySecurity),
+        resourceType: .fetch,
+        timestamp: nil
+    )
+    #expect(
+        nestedEmpty.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .reported(nestedEmptySecurity)
+            )
+    )
+
+    let metricsOnly = makeSecurityRequest(
+        id: "metrics-only-security",
+        url: "https://example.test/metrics-only-security"
+    )
+    let emptyConnection = Network.Security.Connection()
+    metricsOnly.finish(
+        timestamp: 2,
+        sourceMapURL: nil,
+        metrics: Network.Metrics().reporting(securityConnection: emptyConnection)
+    )
+    let metricsOnlySecurity = Network.Security(connection: emptyConnection)
+    #expect(
+        metricsOnly.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .reported(metricsOnlySecurity)
+            )
+    )
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryPreservesReportedMetadataExactly() throws {
+    let validFrom = Date(timeIntervalSince1970: 9.75)
+    let validUntil = Date(timeIntervalSince1970: -2.125)
+    let security = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "", cipher: ""),
+        certificate: Network.Security.Certificate(
+            subject: "",
+            validFrom: validFrom,
+            validUntil: validUntil,
+            dnsNames: ["z.example", "", "z.example", "a.example"],
+            ipAddresses: ["", "127.0.0.1", "127.0.0.1"]
+        )
+    )
+    let request = makeSecurityRequest(id: "lossless-security", url: "https://example.test")
+    request.applyResponse(
+        Network.Response(status: 200).reporting(security: security),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+
+    guard case let .encryptedScheme(.https, metadata: .reported(projected)) = request.securitySummary else {
+        Issue.record("Expected reported HTTPS security metadata.")
+        return
+    }
+    #expect(projected == security)
+    #expect(projected.connection?.tlsProtocol == "")
+    #expect(projected.connection?.cipher == "")
+    #expect(projected.certificate?.subject == "")
+    #expect(projected.certificate?.validFrom == validFrom)
+    #expect(projected.certificate?.validUntil == validUntil)
+    #expect(projected.certificate?.dnsNames == ["z.example", "", "z.example", "a.example"])
+    #expect(projected.certificate?.ipAddresses == ["", "127.0.0.1", "127.0.0.1"])
+
+    let nilCollectionsSecurity = Network.Security(
+        certificate: Network.Security.Certificate(dnsNames: nil, ipAddresses: nil)
+    )
+    let nilCollections = makeSecurityRequest(
+        id: "nil-security-collections",
+        url: "https://example.test/nil"
+    )
+    nilCollections.applyResponse(
+        Network.Response(status: 200).reporting(security: nilCollectionsSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    guard
+        case let .encryptedScheme(.https, metadata: .reported(projectedNilCollections)) =
+            nilCollections.securitySummary
+    else {
+        Issue.record("Expected reported HTTPS security metadata with nil collections.")
+        return
+    }
+    #expect(projectedNilCollections.certificate?.dnsNames == nil)
+    #expect(projectedNilCollections.certificate?.ipAddresses == nil)
+
+    let emptyCollectionsSecurity = Network.Security(
+        certificate: Network.Security.Certificate(dnsNames: [], ipAddresses: [])
+    )
+    let emptyCollections = makeSecurityRequest(
+        id: "empty-security-collections",
+        url: "https://example.test/empty"
+    )
+    emptyCollections.applyResponse(
+        Network.Response(status: 200).reporting(security: emptyCollectionsSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    guard
+        case let .encryptedScheme(.https, metadata: .reported(projectedEmptyCollections)) =
+            emptyCollections.securitySummary
+    else {
+        Issue.record("Expected reported HTTPS security metadata with empty collections.")
+        return
+    }
+    #expect(projectedEmptyCollections.certificate?.dnsNames == [])
+    #expect(projectedEmptyCollections.certificate?.ipAddresses == [])
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryTracksRedirectReuseAndMemoryCacheLifecycles() {
+    let id = Network.Request.ID("redirect-reuse-security-summary")
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let responseSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "TLS 1.2")
+    )
+    let request = NetworkRequest(
+        request: Network.Request(
+            id: id,
+            url: "https://example.test/start",
+            method: "GET"
+        ),
+        initiator: nil,
+        resourceType: .fetch,
+        timestamp: 1,
+        modelContext: context
+    )
+    request.applyResponse(
+        Network.Response(status: 302).reporting(security: responseSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    #expect(
+        request.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .reported(responseSecurity)
+            )
+    )
+
+    request.applyRedirect(
+        to: Network.Request(
+            id: id,
+            url: "wss://example.test/final",
+            method: "GET"
+        ),
+        redirectResponse: Network.Response(status: 302).reporting(security: responseSecurity),
+        timestamp: 3,
+        resourceType: .webSocket
+    )
+    #expect(request.securitySummary == .pending(.wss))
+    #expect(request.security == nil)
+    #expect(request.redirects.map(\.response.security) == [responseSecurity])
+
+    request.applyRequestWillBeSent(
+        request: Network.Request(
+            id: id,
+            url: "HTTP://example.test/reused",
+            method: "GET"
+        ),
+        initiator: nil,
+        navigationVisit: nil,
+        resourceType: .fetch,
+        timestamp: 4,
+        chronologySequence: 2
+    )
+    #expect(request.securitySummary == .plaintextScheme(.http))
+    #expect(request.redirects.isEmpty)
+
+    let cachedSecurity = Network.Security(
+        certificate: Network.Security.Certificate(subject: "cached.example.test")
+    )
+    request.applyMemoryCache(
+        response: Network.Response(
+            url: "https://example.test/cached",
+            status: 200
+        ).reporting(security: cachedSecurity),
+        initiator: Network.Initiator(kind: "other"),
+        resourceType: .fetch,
+        timestamp: 5
+    )
+    #expect(
+        request.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .reported(cachedSecurity)
+            )
+    )
+
+    request.applyMemoryCache(
+        response: Network.Response(
+            url: "https://example.test/cached-without-security",
+            status: 200
+        ),
+        initiator: Network.Initiator(kind: "other"),
+        resourceType: .fetch,
+        timestamp: 6
+    )
+    #expect(
+        request.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .notReported
+            )
+    )
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryTracksWebSocketAndResponseMetricsMerging() throws {
+    let plaintextWebSocket = makeSecurityRequest(
+        id: "plaintext-websocket",
+        url: "ws://example.test/socket",
+        resourceType: .webSocket
+    )
+    let webSocketSecurity = Network.Security(
+        connection: Network.Security.Connection(tlsProtocol: "unexpected")
+    )
+    plaintextWebSocket.applyWebSocketHandshakeResponse(
+        Network.Response(status: 101).reporting(security: webSocketSecurity),
+        timestamp: 2,
+        chronologySequence: 2
+    )
+    #expect(plaintextWebSocket.securitySummary == .plaintextScheme(.ws))
+
+    let encryptedWebSocket = makeSecurityRequest(
+        id: "encrypted-websocket",
+        url: "wss://example.test/socket",
+        resourceType: .webSocket
+    )
+    #expect(encryptedWebSocket.securitySummary == .pending(.wss))
+    encryptedWebSocket.applyWebSocketHandshakeResponse(
+        Network.Response(status: 101).reporting(security: webSocketSecurity),
+        timestamp: 2,
+        chronologySequence: 2
+    )
+    #expect(
+        encryptedWebSocket.securitySummary
+            == .encryptedScheme(
+                .wss,
+                metadata: .reported(webSocketSecurity)
+            )
+    )
+
+    let closedBeforeHandshake = makeSecurityRequest(
+        id: "closed-before-handshake",
+        url: "wss://example.test/closed",
+        resourceType: .webSocket
+    )
+    closedBeforeHandshake.closeWebSocket(timestamp: 2, chronologySequence: 2)
+    #expect(
+        closedBeforeHandshake.securitySummary
+            == .unavailable(
+                .wss,
+                reason: .completedWithoutResponse
+            )
+    )
+
+    let responseCertificate = Network.Security.Certificate(
+        subject: "example.test",
+        dnsNames: ["example.test", "example.test"]
+    )
+    let responseSecurity = Network.Security(
+        connection: Network.Security.Connection(
+            tlsProtocol: "TLS 1.2",
+            cipher: "response-cipher"
+        ),
+        certificate: responseCertificate
+    )
+    let merged = makeSecurityRequest(
+        id: "response-metrics-merge",
+        url: "https://example.test/merged"
+    )
+    merged.applyResponse(
+        Network.Response(status: 200).reporting(security: responseSecurity),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+    merged.finish(
+        timestamp: 3,
+        sourceMapURL: nil,
+        metrics: Network.Metrics().reporting(
+            securityConnection: Network.Security.Connection(tlsProtocol: "TLS 1.3")
+        )
+    )
+
+    guard case let .encryptedScheme(.https, metadata: .reported(projected)) = merged.securitySummary
+    else {
+        Issue.record("Expected merged HTTPS security metadata.")
+        return
+    }
+    #expect(projected.connection?.tlsProtocol == "TLS 1.3")
+    #expect(projected.connection?.cipher == "response-cipher")
+    #expect(projected.certificate == responseCertificate)
+}
+
+@MainActor
+@Test
+func networkSecuritySummaryParticipatesInNetworkRequestObservation() {
+    let request = makeSecurityRequest(
+        id: "observed-security-summary",
+        url: "https://example.test/observed"
+    )
+    let delivered = Mutex(false)
+    withObservationTracking {
+        _ = request.securitySummary
+    } onChange: {
+        delivered.withLock { $0 = true }
+    }
+
+    request.applyResponse(
+        Network.Response(status: 200),
+        resourceType: .fetch,
+        timestamp: 2
+    )
+
+    #expect(delivered.withLock { $0 })
+    #expect(
+        request.securitySummary
+            == .encryptedScheme(
+                .https,
+                metadata: .notReported
+            )
+    )
+}
+
+@MainActor
+private func makeSecurityRequest(
+    id: String,
+    url: String,
+    resourceType: Network.ResourceType? = .fetch
+) -> NetworkRequest {
+    NetworkRequest(
+        request: Network.Request(
+            id: Network.Request.ID(id),
+            url: url,
+            method: "GET"
+        ),
+        initiator: nil,
+        resourceType: resourceType,
+        timestamp: 1,
+        modelContext: WebInspectorContext.preview(isolation: MainActor.shared)
+    )
+}

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -2986,7 +2986,13 @@ struct NetworkDetailViewControllerTests {
                 == securityItems
         )
         #expect(viewController.selectedRequestRenderCountForTesting == renderCount)
+        await fixture.runtime.backend.enqueue((), for: "Console", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Runtime", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Network", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Page", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Inspector", method: "disable")
         await context.stop()
+        #expect(context.state == .detached)
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -65,6 +65,8 @@ struct NetworkDetailViewControllerTests {
 
         #expect(viewController.previewViewForTesting.isHidden)
         #expect(viewController.headersTextViewForTesting.isHidden)
+        #expect(viewController.securityViewControllerForTesting.view.isHidden)
+        #expect(viewController.securityViewControllerForTesting.snapshotForTesting.itemIdentifiers.isEmpty)
         #expect(viewController.contentUnavailableConfiguration != nil)
         let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
         #expect(configuration?.text?.isEmpty == false)
@@ -87,6 +89,7 @@ struct NetworkDetailViewControllerTests {
 
         #expect(viewController.view.backgroundColor == .clear)
         #expect(viewController.headersTextViewForTesting.backgroundColor == .clear)
+        #expect(viewController.securityViewControllerForTesting.collectionView.backgroundColor == .clear)
         #expect(viewController.syntaxBodyViewControllerForTesting.view.backgroundColor == .clear)
     }
 
@@ -209,16 +212,19 @@ struct NetworkDetailViewControllerTests {
         let topInset = viewController.view.safeAreaLayoutGuide.layoutFrame.minY
         let trailingInset = viewController.view.safeAreaLayoutGuide.layoutFrame.maxX
         let bounds = viewController.view.bounds
-        for contentView in [
+        let contentViews: [UIView] = [
             viewController.headersTextViewForTesting,
             viewController.previewViewForTesting,
-        ] {
+            viewController.securityViewControllerForTesting.view,
+        ]
+        for contentView in contentViews {
             #expect(contentView.frame.minX == leadingInset)
             #expect(contentView.frame.maxX == trailingInset)
             #expect(contentView.frame.maxY == bounds.maxY)
         }
         #expect(viewController.headersTextViewForTesting.frame.minY == bounds.minY)
         #expect(viewController.previewViewForTesting.frame.minY == bounds.minY)
+        #expect(viewController.securityViewControllerForTesting.view.frame.minY == bounds.minY)
         #expect(viewController.previewRoleControlContainerViewForTesting.frame.minY == topInset)
     }
 
@@ -259,6 +265,25 @@ struct NetworkDetailViewControllerTests {
 
         #expect(didRenderHeaders)
         #expect(viewController.contentUnavailableConfiguration == nil)
+        #expect(NetworkDetailViewController.Mode.allCases == [.headers, .preview, .security])
+
+        selectMode(.security, on: viewController)
+
+        let didRenderSecurity = await waitUntilRendered(in: viewController) {
+            viewController.currentModeForTesting == .security
+                && viewController.previewViewForTesting.isHidden
+                && viewController.headersTextViewForTesting.isHidden
+                && viewController.securityViewControllerForTesting.view.isHidden == false
+                && viewController.securityViewControllerForTesting.snapshotForTesting.sectionIdentifiers
+                    == NetworkSecuritySectionID.allCases
+        }
+        #expect(didRenderSecurity)
+        #expect(
+            viewController.contentScrollView(for: .top)
+                === viewController.securityViewControllerForTesting.collectionView
+        )
+        #expect(viewController.responseBodyFetchObservationDeliveryForTesting == nil)
+        #expect(request.responseBody.phase == .available)
 
         selectMode(.preview, on: viewController)
 
@@ -277,6 +302,362 @@ struct NetworkDetailViewControllerTests {
                 && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == "name=Jane Doe\ncity=Tokyo East"
         }
         #expect(didRenderRequestPreview)
+    }
+
+    @Test
+    func securityModeMergesCompletionConnectionWithoutReplacingCertificateRows() async throws {
+        let context = makeContext()
+        let requestID = Network.Request.ID("security-live-update")
+        let certificate = Network.Security.Certificate(
+            subject: "CN=live.example.test",
+            validFrom: Date(timeIntervalSince1970: 1_000.125),
+            validUntil: Date(timeIntervalSince1970: 2_000.875),
+            dnsNames: ["live.example.test"],
+            ipAddresses: []
+        )
+        await context.apply(.requestWillBeSent(
+            id: requestID,
+            request: Network.Request(
+                id: requestID,
+                url: "https://live.example.test/data",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 1
+        ))
+        await context.apply(.responseReceived(
+            id: requestID,
+            response: Network.Response(
+                url: "https://live.example.test/data",
+                status: 200,
+                mimeType: "application/json"
+            ).reporting(security: Network.Security(certificate: certificate)),
+            resourceType: .fetch,
+            timestamp: 2
+        ))
+        let request = try #require(context.registeredRequest(forProxyID: requestID))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(request)
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .security
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            let security = viewController.securityViewControllerForTesting
+            return security.view.isHidden == false
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .subject
+                        && security.rowContentForTesting($0)?.value == "CN=live.example.test"
+                })
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .connectionMetadata
+                        && security.rowContentForTesting($0)?.value == String(
+                            localized: "network.security.value.not_reported",
+                            defaultValue: "Not reported",
+                            bundle: WebInspectorUILocalization.bundle
+                        )
+                })
+        })
+        let securityController = viewController.securityViewControllerForTesting
+        let subjectID = try #require(
+            securityController.snapshotForTesting.itemIdentifiers.first { $0.kind == .subject }
+        )
+
+        await context.apply(.loadingFinished(
+            id: requestID,
+            timestamp: 3,
+            sourceMapURL: nil,
+            metrics: Network.Metrics().reporting(securityConnection: Network.Security.Connection(
+                tlsProtocol: "TLS 1.3",
+                cipher: "AES_128_GCM_SHA256"
+            ))
+        ))
+
+        #expect(await waitUntilRendered(in: viewController) {
+            let security = viewController.securityViewControllerForTesting
+            return security.snapshotForTesting.itemIdentifiers.contains(subjectID)
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .tlsProtocol
+                        && security.rowContentForTesting($0)?.value == "TLS 1.3"
+                })
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .cipher
+                        && security.rowContentForTesting($0)?.value == "AES_128_GCM_SHA256"
+                })
+        })
+        #expect(request.security?.certificate == certificate)
+        #expect(viewController.responseBodyFetchObservationDeliveryForTesting == nil)
+        #expect(request.responseBody.phase == .available)
+    }
+
+    @Test
+    func securityModeUsesGroupedRepresentativeThenExactExplicitMember() async throws {
+        let context = makeContext()
+        let frameID = FrameID("security-group-frame")
+        let nodeID = DOM.Node.ID("security-group-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let representative = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "security-group-http",
+            url: "http://example.test/plain",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        let explicit = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "security-group-https",
+            url: "https://example.test/encrypted",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        await context.apply(.responseReceived(
+            id: explicit.proxyID,
+            response: Network.Response(
+                url: explicit.url,
+                status: 200,
+                mimeType: "text/javascript"
+            ).reporting(security: Network.Security(
+                certificate: Network.Security.Certificate(subject: "CN=explicit.example.test")
+            )),
+            resourceType: .script,
+            timestamp: 7
+        ))
+        let model = NetworkPanelModel(context: context)
+        try selectEntry(containing: explicit, in: model)
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .security
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            let security = viewController.securityViewControllerForTesting
+            return model.selectedRequest === representative
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .scheme && security.rowContentForTesting($0)?.value == "HTTP"
+                })
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .subject
+                }) == false
+        })
+
+        model.selectRequest(explicit)
+        #expect(await waitUntilRendered(in: viewController) {
+            let security = viewController.securityViewControllerForTesting
+            return model.selectedRequest === explicit
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .scheme && security.rowContentForTesting($0)?.value == "HTTPS"
+                })
+                && security.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .subject
+                        && security.rowContentForTesting($0)?.value == "CN=explicit.example.test"
+                })
+        })
+        #expect(viewController.responseBodyFetchObservationDeliveryForTesting == nil)
+    }
+
+    @Test
+    func securityModePreservesExpansionAcrossHiddenUpdatesAndResetsForNewEpochs() async throws {
+        let context = makeContext()
+        let proxyID = Network.Request.ID("security-epoch")
+        let initialDNSNames = (1...7).map { "initial-\($0).example.test" }
+        await context.apply(.requestWillBeSent(
+            id: proxyID,
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.test/initial",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 1
+        ))
+        await context.apply(.responseReceived(
+            id: proxyID,
+            response: Network.Response(
+                url: "https://example.test/initial",
+                status: 200
+            ).reporting(security: Network.Security(
+                certificate: Network.Security.Certificate(
+                    subject: "CN=initial",
+                    dnsNames: initialDNSNames
+                )
+            )),
+            resourceType: .fetch,
+            timestamp: 2
+        ))
+        let original = try #require(context.registeredRequest(forProxyID: proxyID))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(original)
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .security
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.securityViewControllerForTesting.snapshotForTesting
+                .itemIdentifiers.contains { $0.kind == .disclosure(.dnsNames) }
+        })
+        let securityController = viewController.securityViewControllerForTesting
+        let originalEpoch = try #require(securityController.currentEpochForTesting)
+        await withCheckedContinuation { continuation in
+            securityController.toggleDisclosureForTesting(.dnsNames) {
+                continuation.resume()
+            }
+        }
+        #expect(securityController.expandedListsForTesting == [.dnsNames])
+        let expandedOriginalIDs = Set(securityController.snapshotForTesting.itemIdentifiers)
+        let modeControlIdentity = ObjectIdentifier(viewController.detailModeControlViewForTesting)
+        viewController.detailModeControlViewForTesting.traitOverrides.horizontalSizeClass = .compact
+        viewController.detailModeControlViewForTesting.updateTraitsIfNeeded()
+        #expect(viewController.detailModeControlPresentationForTesting == .menu)
+        #expect(securityController.expandedListsForTesting == [.dnsNames])
+        viewController.detailModeControlViewForTesting.traitOverrides.horizontalSizeClass = .regular
+        viewController.detailModeControlViewForTesting.traitOverrides.preferredContentSizeCategory = .large
+        viewController.detailModeControlViewForTesting.updateTraitsIfNeeded()
+        #expect(viewController.detailModeControlPresentationForTesting == .segmented)
+        #expect(ObjectIdentifier(viewController.detailModeControlViewForTesting) == modeControlIdentity)
+        #expect(securityController.expandedListsForTesting == [.dnsNames])
+
+        viewController.beginAppearanceTransition(false, animated: false)
+        viewController.endAppearanceTransition()
+        let hiddenDNSNames = initialDNSNames + ["hidden-8.example.test"]
+        let hiddenUpdateTransactionBaseline = model.rawTransactionDeliveryCountForTesting
+        await context.apply(.responseReceived(
+            id: proxyID,
+            response: Network.Response(
+                url: "https://example.test/initial",
+                status: 200
+            ).reporting(security: Network.Security(
+                certificate: Network.Security.Certificate(
+                    subject: "CN=hidden-update",
+                    dnsNames: hiddenDNSNames
+                )
+            )),
+            resourceType: .fetch,
+            timestamp: 3
+        ))
+        #expect(
+            await model.waitForRawTransactionDeliveryForTesting(
+                after: hiddenUpdateTransactionBaseline
+            )
+        )
+        #expect(
+            securityController.snapshotForTesting.itemIdentifiers.filter {
+                if case .dnsName = $0.kind { return true }
+                return false
+            }.count == 7
+        )
+
+        viewController.beginAppearanceTransition(true, animated: false)
+        viewController.endAppearanceTransition()
+        #expect(await waitUntilRendered(in: viewController) {
+            securityController.snapshotForTesting.itemIdentifiers.filter {
+                if case .dnsName = $0.kind { return true }
+                return false
+            }.count == 8
+                && securityController.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .subject
+                        && securityController.rowContentForTesting($0)?.value == "CN=hidden-update"
+                })
+        })
+        #expect(securityController.expandedListsForTesting == [.dnsNames])
+        #expect(securityController.currentEpochForTesting == originalEpoch)
+
+        let replacement = NetworkRequest(
+            request: Network.Request(
+                id: proxyID,
+                url: "https://example.test/replacement",
+                method: "GET"
+            ),
+            initiator: original.initiator,
+            navigationVisit: original.navigationVisit,
+            resourceType: original.resourceType,
+            timestamp: 4,
+            chronologySequence: original.chronologySequence + 1,
+            modelContext: context
+        )
+        replacement.applyResponse(
+            Network.Response(
+                url: "https://example.test/replacement",
+                status: 200
+            ).reporting(security: Network.Security(
+                certificate: Network.Security.Certificate(
+                    subject: "CN=replacement",
+                    dnsNames: hiddenDNSNames
+                )
+            )),
+            resourceType: .fetch,
+            timestamp: 5
+        )
+        model.upsertRequestForTesting(replacement)
+        #expect(model.selectedRequest === replacement)
+        #expect(
+            model.selectedEntry?.requests.contains(where: { $0 === replacement }) == true
+        )
+        #expect(await waitUntilRendered(in: viewController) {
+            model.selectedRequest === replacement
+                && securityController.currentEpochForTesting != originalEpoch
+                && securityController.expandedListsForTesting.isEmpty
+                && securityController.snapshotForTesting.itemIdentifiers.filter {
+                    if case .dnsName = $0.kind { return true }
+                    return false
+                }.count == 5
+        })
+        #expect(
+            expandedOriginalIDs.intersection(securityController.snapshotForTesting.itemIdentifiers)
+                .isEmpty
+        )
+        original.applyResponse(
+            Network.Response(
+                url: original.url,
+                status: 200
+            ).reporting(security: Network.Security(
+                certificate: Network.Security.Certificate(subject: "CN=stale-original")
+            )),
+            resourceType: .fetch,
+            timestamp: 5.5
+        )
+        #expect(
+            securityController.snapshotForTesting.itemIdentifiers.contains(where: {
+                $0.kind == .subject
+                    && securityController.rowContentForTesting($0)?.value == "CN=stale-original"
+            }) == false
+        )
+
+        let replacementEpoch = try #require(securityController.currentEpochForTesting)
+        replacement.applyRedirect(
+            to: Network.Request(
+                id: proxyID,
+                url: "https://example.test/redirected",
+                method: "GET"
+            ),
+            redirectResponse: Network.Response(status: 302),
+            timestamp: 6,
+            resourceType: .fetch
+        )
+        #expect(await waitUntilRendered(in: viewController) {
+            securityController.currentEpochForTesting != replacementEpoch
+                && securityController.expandedListsForTesting.isEmpty
+                && securityController.snapshotForTesting.itemIdentifiers.contains(where: {
+                    $0.kind == .status
+                })
+        })
+
+        context.clearNetworkRequests()
+        #expect(await waitUntilRendered(in: viewController) {
+            securityController.snapshotForTesting.itemIdentifiers.isEmpty
+                && securityController.expandedListsForTesting.isEmpty
+        })
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
@@ -76,6 +76,40 @@ struct NetworkSecurityViewControllerTests {
     }
 
     @Test
+    func sectionHeadersExposeHeadingSemanticsAndClearThemForReuse() async throws {
+        let request = makeRequest(id: "security-headings", url: "https://example.test")
+        let viewController = NetworkSecurityViewController()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        await render(
+            .pending(.https),
+            epoch: NetworkSecurityRequestEpoch(request: request),
+            in: viewController
+        )
+        for section in NetworkSecuritySectionID.allCases {
+            let header = try #require(viewController.sectionHeaderForTesting(section))
+            #expect(header.isAccessibilityElement)
+            #expect(
+                header.accessibilityLabel
+                    == NetworkSecurityViewController.sectionTitleForTesting(section)
+            )
+            #expect(header.accessibilityTraits.contains(.header))
+        }
+
+        let reusedHeader = UICollectionViewListCell()
+        reusedHeader.contentConfiguration = UIListContentConfiguration.header()
+        reusedHeader.isAccessibilityElement = true
+        reusedHeader.accessibilityLabel = "stale heading"
+        reusedHeader.accessibilityTraits = .header
+        NetworkSecurityViewController.clearSectionHeaderForTesting(reusedHeader)
+        #expect(reusedHeader.contentConfiguration == nil)
+        #expect(reusedHeader.isAccessibilityElement == false)
+        #expect(reusedHeader.accessibilityLabel == nil)
+        #expect(reusedHeader.accessibilityTraits.isEmpty)
+    }
+
+    @Test
     func reportedEmptyAndNestedEmptyMetadataRemainDistinct() async throws {
         let request = makeRequest(id: "security-empty", url: "https://example.test")
         let epoch = NetworkSecurityRequestEpoch(request: request)
@@ -137,7 +171,15 @@ struct NetworkSecurityViewControllerTests {
         defer { window.isHidden = true }
         let longHostname = String(repeating: "unbroken-hostname-", count: 12) + ".example"
         var dnsNames = ["one.example", "duplicate.example", "duplicate.example", "", longHostname, "six.example", "seven.example"]
-        let ipAddresses = ["192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4", "192.0.2.5", "192.0.2.6"]
+        let ipAddresses = [
+            "192.0.2.1",
+            "192.0.2.2",
+            "192.0.2.3",
+            "192.0.2.4",
+            "192.0.2.5",
+            "192.0.2.6",
+            "192.0.2.7",
+        ]
 
         await render(
             reportedSecurity(dnsNames: dnsNames, ipAddresses: ipAddresses),
@@ -157,25 +199,40 @@ struct NetworkSecurityViewControllerTests {
         )
         let dnsDisclosureID = try #require(itemID(.disclosure(.dnsNames), in: viewController))
         let ipDisclosureID = try #require(itemID(.disclosure(.ipAddresses), in: viewController))
-        let showMoreFormat = localized(
-            "network.security.action.show_more",
-            defaultValue: "Show %lld More"
+        let showMoreDNSFormat = localized(
+            "network.security.action.show_more_dns_names",
+            defaultValue: "Show %lld More DNS Names"
+        )
+        let showMoreIPFormat = localized(
+            "network.security.action.show_more_ip_addresses",
+            defaultValue: "Show %lld More IP Addresses"
         )
         #expect(
             viewController.rowContentForTesting(dnsDisclosureID)?.label
-                == String.localizedStringWithFormat(showMoreFormat, Int64(2))
+                == String.localizedStringWithFormat(showMoreDNSFormat, Int64(2))
         )
         #expect(
             viewController.rowContentForTesting(ipDisclosureID)?.label
-                == String.localizedStringWithFormat(showMoreFormat, Int64(1))
+                == String.localizedStringWithFormat(showMoreIPFormat, Int64(2))
         )
         let disclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
+        let dnsAccessibilityLabel = disclosureCell.accessibilityLabel
         #expect(disclosureCell.accessibilityTraits.contains(.button))
         #expect(disclosureCell.accessibilityValue == localized(
             "network.security.accessibility.collapsed",
             defaultValue: "Collapsed"
         ))
         #expect(disclosureCell.accessibilityHint?.isEmpty == false)
+        let ipDisclosureCell = try #require(visibleCell(ipDisclosureID, in: viewController))
+        #expect(dnsAccessibilityLabel != ipDisclosureCell.accessibilityLabel)
+        #expect(dnsAccessibilityLabel == String.localizedStringWithFormat(
+            showMoreDNSFormat,
+            Int64(2)
+        ))
+        #expect(ipDisclosureCell.accessibilityLabel == String.localizedStringWithFormat(
+            showMoreIPFormat,
+            Int64(2)
+        ))
 
         let longHostnameID = try #require(itemID(.dnsName(4), in: viewController))
         let longHostnameCell = try #require(visibleCell(longHostnameID, in: viewController))
@@ -193,7 +250,10 @@ struct NetworkSecurityViewControllerTests {
         #expect(itemID(.disclosure(.dnsNames), in: viewController) == dnsDisclosureID)
         #expect(
             viewController.rowContentForTesting(dnsDisclosureID)?.label
-                == localized("network.security.action.show_less", defaultValue: "Show Less")
+                == localized(
+                    "network.security.action.show_less_dns_names",
+                    defaultValue: "Show Less DNS Names"
+                )
         )
         let expandedDisclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
         #expect(expandedDisclosureCell.accessibilityValue == localized(
@@ -211,8 +271,15 @@ struct NetworkSecurityViewControllerTests {
         #expect(viewController.expandedListsForTesting == [.dnsNames])
 
         await toggle(.ipAddresses, in: viewController)
-        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 6)
+        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 7)
         #expect(viewController.expandedListsForTesting == [.dnsNames, .ipAddresses])
+        #expect(
+            viewController.rowContentForTesting(ipDisclosureID)?.label
+                == localized(
+                    "network.security.action.show_less_ip_addresses",
+                    defaultValue: "Show Less IP Addresses"
+                )
+        )
 
         await toggle(.dnsNames, in: viewController)
         #expect(itemIDs(prefix: .dnsName, in: viewController).count == 5)

--- a/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
@@ -170,7 +170,14 @@ struct NetworkSecurityViewControllerTests {
         let window = showInWindow(viewController)
         defer { window.isHidden = true }
         let longHostname = String(repeating: "unbroken-hostname-", count: 12) + ".example"
-        var dnsNames = ["one.example", "duplicate.example", "duplicate.example", "", longHostname, "six.example", "seven.example"]
+        var dnsNames = [
+            "one.example",
+            "duplicate.example",
+            "duplicate.example",
+            "",
+            longHostname,
+            "six.example",
+        ]
         let ipAddresses = [
             "192.0.2.1",
             "192.0.2.2",
@@ -178,7 +185,6 @@ struct NetworkSecurityViewControllerTests {
             "192.0.2.4",
             "192.0.2.5",
             "192.0.2.6",
-            "192.0.2.7",
         ]
 
         await render(
@@ -209,12 +215,34 @@ struct NetworkSecurityViewControllerTests {
         )
         #expect(
             viewController.rowContentForTesting(dnsDisclosureID)?.label
-                == String.localizedStringWithFormat(showMoreDNSFormat, Int64(2))
+                == String.localizedStringWithFormat(showMoreDNSFormat, Int64(1))
         )
         #expect(
             viewController.rowContentForTesting(ipDisclosureID)?.label
-                == String.localizedStringWithFormat(showMoreIPFormat, Int64(2))
+                == String.localizedStringWithFormat(showMoreIPFormat, Int64(1))
         )
+        let englishShowMoreDNSFormat = try #require(localized(
+            "network.security.action.show_more_dns_names",
+            defaultValue: "Show %lld More DNS Names",
+            locale: "en"
+        ))
+        let englishShowMoreIPFormat = try #require(localized(
+            "network.security.action.show_more_ip_addresses",
+            defaultValue: "Show %lld More IP Addresses",
+            locale: "en"
+        ))
+        let englishDNSLabel = unsafe String(
+            format: englishShowMoreDNSFormat,
+            locale: Locale(identifier: "en"),
+            arguments: [Int64(1)]
+        )
+        let englishIPLabel = unsafe String(
+            format: englishShowMoreIPFormat,
+            locale: Locale(identifier: "en"),
+            arguments: [Int64(1)]
+        )
+        #expect(englishDNSLabel == "Show 1 More DNS Name")
+        #expect(englishIPLabel == "Show 1 More IP Address")
         let disclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
         let dnsAccessibilityLabel = disclosureCell.accessibilityLabel
         #expect(disclosureCell.accessibilityTraits.contains(.button))
@@ -227,11 +255,11 @@ struct NetworkSecurityViewControllerTests {
         #expect(dnsAccessibilityLabel != ipDisclosureCell.accessibilityLabel)
         #expect(dnsAccessibilityLabel == String.localizedStringWithFormat(
             showMoreDNSFormat,
-            Int64(2)
+            Int64(1)
         ))
         #expect(ipDisclosureCell.accessibilityLabel == String.localizedStringWithFormat(
             showMoreIPFormat,
-            Int64(2)
+            Int64(1)
         ))
 
         let longHostnameID = try #require(itemID(.dnsName(4), in: viewController))
@@ -243,7 +271,7 @@ struct NetworkSecurityViewControllerTests {
         #expect(longHostnameContent.secondaryTextProperties.lineBreakMode == .byCharWrapping)
 
         await toggle(.dnsNames, in: viewController)
-        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 7)
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 6)
         #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 5)
         #expect(Set(collapsedDNSIDs).isSubset(of: Set(viewController.snapshotForTesting.itemIdentifiers)))
         #expect(viewController.expandedListsForTesting == [.dnsNames])
@@ -261,17 +289,17 @@ struct NetworkSecurityViewControllerTests {
             defaultValue: "Expanded"
         ))
 
-        dnsNames.append("eight.example")
+        dnsNames.append("seven.example")
         await render(
             reportedSecurity(dnsNames: dnsNames, ipAddresses: ipAddresses),
             epoch: epoch,
             in: viewController
         )
-        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 8)
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 7)
         #expect(viewController.expandedListsForTesting == [.dnsNames])
 
         await toggle(.ipAddresses, in: viewController)
-        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 7)
+        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 6)
         #expect(viewController.expandedListsForTesting == [.dnsNames, .ipAddresses])
         #expect(
             viewController.rowContentForTesting(ipDisclosureID)?.label
@@ -513,6 +541,20 @@ struct NetworkSecurityViewControllerTests {
 
     private func localized(_ key: StaticString, defaultValue: String.LocalizationValue) -> String {
         String(localized: key, defaultValue: defaultValue, bundle: WebInspectorUILocalization.bundle)
+    }
+
+    private func localized(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue,
+        locale: String
+    ) -> String? {
+        guard let bundleURL = WebInspectorUILocalization.bundle.url(
+            forResource: locale,
+            withExtension: "lproj"
+        ), let bundle = Bundle(url: bundleURL) else {
+            return nil
+        }
+        return String(localized: key, defaultValue: defaultValue, bundle: bundle)
     }
 
     private enum NetworkSecurityItemKindPrefix {

--- a/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
@@ -1,0 +1,457 @@
+#if canImport(UIKit)
+import Testing
+@testable import WebInspectorDataKit
+import WebInspectorProxyKit
+import UIKit
+@testable import WebInspectorUINetwork
+@testable import WebInspectorUIBase
+
+extension WebInspectorUIRenderingTests {
+@MainActor
+@Suite
+struct NetworkSecurityViewControllerTests {
+    @Test
+    func nativeListRendersEverySummaryStateWithoutVerdicts() async throws {
+        let request = makeRequest(id: "security-states", url: "https://example.test")
+        let epoch = NetworkSecurityRequestEpoch(request: request)
+        let viewController = NetworkSecurityViewController()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        await render(.plaintextScheme(.http), epoch: epoch, in: viewController)
+        #expect(
+            viewController.snapshotForTesting.sectionIdentifiers
+                == NetworkSecuritySectionID.allCases
+        )
+        #expect(row(.scheme, in: viewController)?.value == "HTTP")
+        #expect(
+            row(.status, in: viewController)?.value
+                == localized(
+                    "network.security.status.http",
+                    defaultValue: "HTTP scheme reported; TLS does not apply."
+                )
+        )
+        #expect(
+            row(.connectionMetadata, in: viewController)?.value
+                == localized("network.security.value.not_applicable", defaultValue: "Not applicable")
+        )
+
+        await render(.pending(.wss), epoch: epoch, in: viewController)
+        #expect(row(.scheme, in: viewController)?.value == "WSS")
+        #expect(
+            row(.status, in: viewController)?.value
+                == localized("network.security.value.pending", defaultValue: "Response pending")
+        )
+
+        await render(
+            .encryptedScheme(.https, metadata: .notReported),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(row(.scheme, in: viewController)?.value == "HTTPS")
+        #expect(
+            row(.securityMetadata, in: viewController)?.value
+                == localized("network.security.value.not_reported", defaultValue: "Not reported")
+        )
+
+        await render(
+            .unavailable(.https, reason: .canceledBeforeResponse(reason: "cancelled raw")),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(row(.reason, in: viewController)?.value == "cancelled raw")
+        #expect(row(.reason, in: viewController)?.usesTechnicalValueDirection == true)
+
+        await render(.notApplicable(scheme: "Custom+Scheme"), epoch: epoch, in: viewController)
+        #expect(row(.scheme, in: viewController)?.value == "Custom+Scheme")
+        let visibleText = viewController.snapshotForTesting.itemIdentifiers.compactMap {
+            viewController.rowContentForTesting($0)?.value
+        }.joined(separator: "\n").lowercased()
+        for verdict in ["trusted", "valid certificate", "hostname matched", "expired", "secure connection"] {
+            #expect(visibleText.contains(verdict) == false)
+        }
+        #expect(NetworkSecurityViewController.listConfigurationForTesting.appearance == .insetGrouped)
+        #expect(NetworkSecurityViewController.listConfigurationForTesting.headerMode == .supplementary)
+        #expect(viewController.collectionView.collectionViewLayout is UICollectionViewCompositionalLayout)
+    }
+
+    @Test
+    func reportedEmptyAndNestedEmptyMetadataRemainDistinct() async throws {
+        let request = makeRequest(id: "security-empty", url: "https://example.test")
+        let epoch = NetworkSecurityRequestEpoch(request: request)
+        let viewController = NetworkSecurityViewController()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        let notReported = localized(
+            "network.security.value.not_reported",
+            defaultValue: "Not reported"
+        )
+        let reported = localized("network.security.value.reported", defaultValue: "Reported")
+        let empty = localized(
+            "network.security.value.empty_reported",
+            defaultValue: "Empty value reported"
+        )
+        let noValues = localized(
+            "network.security.value.no_values_reported",
+            defaultValue: "No values reported"
+        )
+
+        await render(
+            .encryptedScheme(.https, metadata: .reported(Network.Security())),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(row(.securityMetadata, in: viewController)?.value == reported)
+        #expect(row(.connectionMetadata, in: viewController)?.value == notReported)
+        #expect(row(.certificateMetadata, in: viewController)?.value == notReported)
+        #expect(row(.tlsProtocol, in: viewController) == nil)
+
+        let security = Network.Security(
+            connection: Network.Security.Connection(),
+            certificate: Network.Security.Certificate(
+                subject: "",
+                dnsNames: nil,
+                ipAddresses: []
+            )
+        )
+        await render(
+            .encryptedScheme(.https, metadata: .reported(security)),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(row(.connectionMetadata, in: viewController)?.value == reported)
+        #expect(row(.tlsProtocol, in: viewController)?.value == notReported)
+        #expect(row(.cipher, in: viewController)?.value == notReported)
+        #expect(row(.certificateMetadata, in: viewController)?.value == reported)
+        #expect(row(.subject, in: viewController)?.value == empty)
+        #expect(row(.dnsState, in: viewController)?.value == notReported)
+        #expect(row(.ipAddressState, in: viewController)?.value == noValues)
+    }
+
+    @Test
+    func longListsPreserveOrdinalIdentityAndExpandIndependentlyWithinEpoch() async throws {
+        let request = makeRequest(id: "security-lists", url: "https://example.test")
+        let epoch = NetworkSecurityRequestEpoch(request: request)
+        let viewController = NetworkSecurityViewController()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        let longHostname = String(repeating: "unbroken-hostname-", count: 12) + ".example"
+        var dnsNames = ["one.example", "duplicate.example", "duplicate.example", "", longHostname, "six.example", "seven.example"]
+        let ipAddresses = ["192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4", "192.0.2.5", "192.0.2.6"]
+
+        await render(
+            reportedSecurity(dnsNames: dnsNames, ipAddresses: ipAddresses),
+            epoch: epoch,
+            in: viewController
+        )
+        let collapsedDNSIDs = itemIDs(prefix: .dnsName, in: viewController)
+        let collapsedIPIDs = itemIDs(prefix: .ipAddress, in: viewController)
+        #expect(collapsedDNSIDs.map(\.kind) == (0..<5).map(NetworkSecurityItemID.Kind.dnsName))
+        #expect(collapsedIPIDs.map(\.kind) == (0..<5).map(NetworkSecurityItemID.Kind.ipAddress))
+        #expect(
+            row(.dnsName(3), in: viewController)?.value
+                == localized(
+                    "network.security.value.empty_reported",
+                    defaultValue: "Empty value reported"
+                )
+        )
+        let dnsDisclosureID = try #require(itemID(.disclosure(.dnsNames), in: viewController))
+        let ipDisclosureID = try #require(itemID(.disclosure(.ipAddresses), in: viewController))
+        let showMoreFormat = localized(
+            "network.security.action.show_more",
+            defaultValue: "Show %lld More"
+        )
+        #expect(
+            viewController.rowContentForTesting(dnsDisclosureID)?.label
+                == String.localizedStringWithFormat(showMoreFormat, Int64(2))
+        )
+        #expect(
+            viewController.rowContentForTesting(ipDisclosureID)?.label
+                == String.localizedStringWithFormat(showMoreFormat, Int64(1))
+        )
+        let disclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
+        #expect(disclosureCell.accessibilityTraits.contains(.button))
+        #expect(disclosureCell.accessibilityValue == localized(
+            "network.security.accessibility.collapsed",
+            defaultValue: "Collapsed"
+        ))
+        #expect(disclosureCell.accessibilityHint?.isEmpty == false)
+
+        let longHostnameID = try #require(itemID(.dnsName(4), in: viewController))
+        let longHostnameCell = try #require(visibleCell(longHostnameID, in: viewController))
+        let longHostnameContent = try #require(
+            longHostnameCell.contentConfiguration as? UIListContentConfiguration
+        )
+        #expect(longHostnameContent.secondaryTextProperties.numberOfLines == 0)
+        #expect(longHostnameContent.secondaryTextProperties.lineBreakMode == .byCharWrapping)
+
+        await toggle(.dnsNames, in: viewController)
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 7)
+        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 5)
+        #expect(Set(collapsedDNSIDs).isSubset(of: Set(viewController.snapshotForTesting.itemIdentifiers)))
+        #expect(viewController.expandedListsForTesting == [.dnsNames])
+        #expect(itemID(.disclosure(.dnsNames), in: viewController) == dnsDisclosureID)
+        #expect(
+            viewController.rowContentForTesting(dnsDisclosureID)?.label
+                == localized("network.security.action.show_less", defaultValue: "Show Less")
+        )
+        let expandedDisclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
+        #expect(expandedDisclosureCell.accessibilityValue == localized(
+            "network.security.accessibility.expanded",
+            defaultValue: "Expanded"
+        ))
+
+        dnsNames.append("eight.example")
+        await render(
+            reportedSecurity(dnsNames: dnsNames, ipAddresses: ipAddresses),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 8)
+        #expect(viewController.expandedListsForTesting == [.dnsNames])
+
+        await toggle(.ipAddresses, in: viewController)
+        #expect(itemIDs(prefix: .ipAddress, in: viewController).count == 6)
+        #expect(viewController.expandedListsForTesting == [.dnsNames, .ipAddresses])
+
+        await toggle(.dnsNames, in: viewController)
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 5)
+        #expect(viewController.expandedListsForTesting == [.ipAddresses])
+
+        let replacement = makeRequest(id: "security-lists-replacement", url: "https://example.test")
+        let replacementEpoch = NetworkSecurityRequestEpoch(request: replacement)
+        await render(
+            reportedSecurity(dnsNames: dnsNames, ipAddresses: ipAddresses),
+            epoch: replacementEpoch,
+            in: viewController
+        )
+        #expect(viewController.expandedListsForTesting.isEmpty)
+        #expect(itemIDs(prefix: .dnsName, in: viewController).count == 5)
+        #expect(Set(collapsedDNSIDs).intersection(viewController.snapshotForTesting.itemIdentifiers).isEmpty)
+    }
+
+    @Test
+    func datesAreLocalizedFactsAndTechnicalValuesKeepLTRInRTL() async throws {
+        let request = makeRequest(id: "security-dates", url: "https://example.test")
+        let epoch = NetworkSecurityRequestEpoch(request: request)
+        let viewController = NetworkSecurityViewController()
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        let later = Date(timeIntervalSince1970: 2_000.875)
+        let earlier = Date(timeIntervalSince1970: 1_000.125)
+        let security = Network.Security(
+            connection: Network.Security.Connection(
+                tlsProtocol: "TLS 1.3",
+                cipher: "AES_128_GCM_SHA256"
+            ),
+            certificate: Network.Security.Certificate(
+                subject: "CN=example.test",
+                validFrom: later,
+                validUntil: earlier,
+                dnsNames: ["example.test"],
+                ipAddresses: ["2001:db8::1"]
+            )
+        )
+        await render(
+            .encryptedScheme(.https, metadata: .reported(security)),
+            epoch: epoch,
+            in: viewController
+        )
+        #expect(row(.validFrom, in: viewController)?.value == later.formatted(date: .numeric, time: .complete))
+        #expect(row(.validUntil, in: viewController)?.value == earlier.formatted(date: .numeric, time: .complete))
+
+        viewController.collectionView.semanticContentAttribute = .forceRightToLeft
+        #expect(viewController.collectionView.effectiveUserInterfaceLayoutDirection == .rightToLeft)
+        let subjectID = try #require(itemID(.subject, in: viewController))
+        let subjectCell = try #require(visibleCell(subjectID, in: viewController))
+        let content = try #require(subjectCell.contentConfiguration as? UIListContentConfiguration)
+        #expect(viewController.technicalValueUsesLTRForTesting(subjectID))
+        #expect(content.secondaryTextProperties.adjustsFontForContentSizeCategory)
+        #expect(
+            viewController.collectionView(
+                viewController.collectionView,
+                shouldSelectItemAt: try #require(indexPath(subjectID, in: viewController))
+            ) == false
+        )
+    }
+
+    @Test
+    func adaptiveModeControlUsesMenuForCompactAndAccessibilitySizes() {
+        let controller = NetworkDetailModeControlController(initialMode: .headers)
+        let host = UIViewController()
+        host.view.addSubview(controller.view)
+        let window = showInWindow(host)
+        defer { window.isHidden = true }
+        let stableViewIdentity = ObjectIdentifier(controller.view)
+        var selectedModes: [NetworkDetailViewController.Mode] = []
+        controller.selectionHandler = { mode in
+            selectedModes.append(mode)
+            controller.render(mode: mode, isEnabled: true)
+        }
+        controller.render(mode: .headers, isEnabled: true)
+
+        host.traitOverrides.horizontalSizeClass = .regular
+        host.traitOverrides.preferredContentSizeCategory = .large
+        host.updateTraitsIfNeeded()
+        controller.view.updateTraitsIfNeeded()
+        #expect(controller.presentationForTesting == .segmented)
+        #expect(controller.segmentedControlForTesting.isHidden == false)
+        #expect(controller.menuButtonForTesting.isHidden)
+        #expect(controller.segmentedControlForTesting.accessibilityValue == NetworkDetailViewController.Mode.headers.title)
+
+        host.traitOverrides.horizontalSizeClass = .compact
+        host.updateTraitsIfNeeded()
+        controller.view.updateTraitsIfNeeded()
+        #expect(controller.presentationForTesting == .menu)
+        #expect(controller.segmentedControlForTesting.isHidden)
+        #expect(controller.menuButtonForTesting.isHidden == false)
+        #expect(controller.view.intrinsicContentSize == controller.menuButtonForTesting.intrinsicContentSize)
+        #expect(controller.view.intrinsicContentSize.width < controller.segmentedControlForTesting.intrinsicContentSize.width)
+        #expect(controller.menuActionTitlesForTesting == NetworkDetailViewController.Mode.allCases.map(\.title))
+
+        for mode in NetworkDetailViewController.Mode.allCases {
+            controller.selectModeForTesting(mode)
+        }
+        #expect(selectedModes == NetworkDetailViewController.Mode.allCases)
+        #expect(controller.menuButtonForTesting.accessibilityValue == NetworkDetailViewController.Mode.security.title)
+
+        host.traitOverrides.horizontalSizeClass = .regular
+        host.traitOverrides.preferredContentSizeCategory = .accessibilityExtraExtraExtraLarge
+        host.updateTraitsIfNeeded()
+        controller.view.updateTraitsIfNeeded()
+        #expect(controller.presentationForTesting == .menu)
+        #expect(ObjectIdentifier(controller.view) == stableViewIdentity)
+    }
+
+    private func reportedSecurity(
+        dnsNames: [String],
+        ipAddresses: [String]
+    ) -> NetworkSecuritySummary {
+        .encryptedScheme(
+            .https,
+            metadata: .reported(Network.Security(
+                certificate: Network.Security.Certificate(
+                    subject: "CN=example.test",
+                    dnsNames: dnsNames,
+                    ipAddresses: ipAddresses
+                )
+            ))
+        )
+    }
+
+    private func makeRequest(id: String, url: String) -> NetworkRequest {
+        let context = WebInspectorContext.preview(isolation: MainActor.shared)
+        return NetworkRequest(
+            request: Network.Request(
+                id: Network.Request.ID(id),
+                url: url,
+                method: "GET"
+            ),
+            initiator: nil,
+            resourceType: .fetch,
+            timestamp: 1,
+            modelContext: context
+        )
+    }
+
+    private func render(
+        _ summary: NetworkSecuritySummary,
+        epoch: NetworkSecurityRequestEpoch,
+        in viewController: NetworkSecurityViewController
+    ) async {
+        await withCheckedContinuation { continuation in
+            viewController.render(summary, epoch: epoch) {
+                continuation.resume()
+            }
+        }
+        viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func toggle(
+        _ kind: NetworkSecurityListKind,
+        in viewController: NetworkSecurityViewController
+    ) async {
+        await withCheckedContinuation { continuation in
+            viewController.toggleDisclosureForTesting(kind) {
+                continuation.resume()
+            }
+        }
+        viewController.collectionView.layoutIfNeeded()
+    }
+
+    private func row(
+        _ kind: NetworkSecurityItemID.Kind,
+        in viewController: NetworkSecurityViewController
+    ) -> NetworkSecurityRowContent? {
+        guard let itemID = itemID(kind, in: viewController) else {
+            return nil
+        }
+        return viewController.rowContentForTesting(itemID)
+    }
+
+    private func itemID(
+        _ kind: NetworkSecurityItemID.Kind,
+        in viewController: NetworkSecurityViewController
+    ) -> NetworkSecurityItemID? {
+        viewController.snapshotForTesting.itemIdentifiers.first { $0.kind == kind }
+    }
+
+    private func itemIDs(
+        prefix: NetworkSecurityItemKindPrefix,
+        in viewController: NetworkSecurityViewController
+    ) -> [NetworkSecurityItemID] {
+        viewController.snapshotForTesting.itemIdentifiers.filter { itemID in
+            switch (prefix, itemID.kind) {
+            case (.dnsName, .dnsName), (.ipAddress, .ipAddress):
+                true
+            default:
+                false
+            }
+        }
+    }
+
+    private func visibleCell(
+        _ itemID: NetworkSecurityItemID,
+        in viewController: NetworkSecurityViewController
+    ) -> UICollectionViewListCell? {
+        guard let indexPath = indexPath(itemID, in: viewController) else {
+            return nil
+        }
+        viewController.collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        viewController.collectionView.layoutIfNeeded()
+        return viewController.collectionView.cellForItem(at: indexPath) as? UICollectionViewListCell
+    }
+
+    private func indexPath(
+        _ itemID: NetworkSecurityItemID,
+        in viewController: NetworkSecurityViewController
+    ) -> IndexPath? {
+        let snapshot = viewController.snapshotForTesting
+        for (sectionIndex, section) in snapshot.sectionIdentifiers.enumerated() {
+            if let itemIndex = snapshot.itemIdentifiers(inSection: section).firstIndex(of: itemID) {
+                return IndexPath(item: itemIndex, section: sectionIndex)
+            }
+        }
+        return nil
+    }
+
+    private func showInWindow(_ viewController: UIViewController) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = viewController
+        viewController.loadViewIfNeeded()
+        viewController.view.frame = window.bounds
+        window.layoutIfNeeded()
+        return window
+    }
+
+    private func localized(_ key: StaticString, defaultValue: String.LocalizationValue) -> String {
+        String(localized: key, defaultValue: defaultValue, bundle: WebInspectorUILocalization.bundle)
+    }
+
+    private enum NetworkSecurityItemKindPrefix {
+        case dnsName
+        case ipAddress
+    }
+}
+}
+#endif

--- a/Tests/WebInspectorUITests/ParentContainerTests.swift
+++ b/Tests/WebInspectorUITests/ParentContainerTests.swift
@@ -1308,7 +1308,19 @@ struct ParentContainerTests {
         let compactDetailViewController = try #require(
             compactNavigationController.viewControllers.last as? NetworkDetailViewController
         )
-        compactDetailViewController.setModeForTesting(.preview)
+        compactDetailViewController.setModeForTesting(.security)
+        let compactSecurityViewController = compactDetailViewController.securityViewControllerForTesting
+        #expect(await waitUntilNetworkDetailRendered(in: compactDetailViewController) {
+            compactSecurityViewController.snapshotForTesting.itemIdentifiers.contains(where: {
+                $0.kind == .disclosure(.dnsNames)
+            })
+        })
+        await withCheckedContinuation { continuation in
+            compactSecurityViewController.toggleDisclosureForTesting(.dnsNames) {
+                continuation.resume()
+            }
+        }
+        #expect(compactSecurityViewController.expandedListsForTesting == [.dnsNames])
         let selectedEntryID = try #require(model.entryID(containing: request.id))
         #expect(model.selection == .request(entryID: selectedEntryID, requestID: request.id))
 
@@ -1332,11 +1344,15 @@ struct ParentContainerTests {
         detailViewController.loadViewIfNeeded()
 
         #expect(detailViewController === compactDetailViewController)
-        #expect(detailViewController.currentModeForTesting == .preview)
+        #expect(detailViewController.currentModeForTesting == .security)
+        #expect(detailViewController.securityViewControllerForTesting === compactSecurityViewController)
+        #expect(compactSecurityViewController.expandedListsForTesting == [.dnsNames])
         #expect(model.selection == .request(entryID: selectedEntryID, requestID: request.id))
 
         let didRenderDetail = await waitUntilNetworkDetailRendered(in: detailViewController) {
-            detailViewController.previewRequestIDForTesting == request.id
+            compactSecurityViewController.snapshotForTesting.itemIdentifiers.contains(where: {
+                $0.kind == .dnsName(6)
+            })
         }
         #expect(didRenderDetail)
     }
@@ -1403,6 +1419,13 @@ struct ParentContainerTests {
                     statusText: "OK",
                     mimeType: "text/javascript",
                     headers: ["content-type": "text/javascript"]
+                ).reporting(
+                    security: WebInspectorProxyKit.Network.Security(
+                        certificate: WebInspectorProxyKit.Network.Security.Certificate(
+                            subject: "example.com",
+                            dnsNames: (0..<7).map { "host-\($0).example.com" }
+                        )
+                    )
                 ),
                 resourceType: .script,
                 timestamp: 2


### PR DESCRIPTION
## Purpose

Add a factual Security pane to Network request details so TLS connection and certificate metadata reported by WebKit can be inspected without inferring trust, validity, or hostname verdicts.

Closes #238

## Changes

- Project request security state in DataKit with explicit plaintext, pending, reported, unavailable, and not-applicable outcomes.
- Add a native inset-grouped Security pane for connection and certificate metadata, including stable expandable DNS/IP lists and accessible section/disclosure semantics.
- Integrate Security as the fourth permanent Network detail mode alongside Headers, Preview, and Cookies while preserving WebSocket preview and response-body lifecycle ownership.
- Adapt the detail mode control between a segmented control and a single-selection menu for compact widths and Accessibility Dynamic Type.
- Add English/Japanese localization and focused Data/UI lifecycle, grouping, identity, accessibility, and cross-surface regression coverage.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,id=ED93323E-A3D3-41BF-A570-87295684A606' -only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/NetworkDetailViewControllerTests -only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/NetworkSecurityViewControllerTests -only-testing:WebInspectorUITests/WebInspectorUIRenderingTests/ParentContainerTests` (183 tests)
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,id=ED93323E-A3D3-41BF-A570-87295684A606' -only-testing:WebInspectorDataKitTests -only-testing:WebInspectorProxyKitTests` (298 tests)
- `swift test --package-path ContractTests` (11 tests)
- `Scripts/check-datakit-symbol-boundary.sh`
- `xcrun xcstringstool compile Sources/WebInspectorUIBase/Localizable.xcstrings ...` (23 locales)
- `xcodebuild build -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'generic/platform=iOS Simulator'`
- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` (635 logical tests)
- Branch-wide Codex review against `origin/main@46aab3eb403402071d3b145c07b4551bf167cd37` (0 findings)

## Screenshots

Not included; the pane contents depend on security metadata from a live inspected request.
