### PR TITLE
Centralize terminal event failures in ProxyKit

### DIFF
--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StoryA2ProxyKitContractTests.swift
@@ -28,6 +28,29 @@ func webInspectorProxyPublicLifecycleAndCommandSurfaceWorksFromConsumerPackage()
 }
 
 @Test
+func webInspectorProxyTestingStreamsFinishForActiveAndLateCloseConsumers() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let target = try await runtime.proxy.waitForCurrentPage()
+    let activeStream = target.network.events
+    let activeTask = Task {
+        var iterator = activeStream.makeAsyncIterator()
+        return await iterator.next()
+    }
+    try await runtime.backend.waitForSubscribers(
+        domain: "Network",
+        target: target,
+        count: 1
+    )
+
+    await runtime.proxy.close()
+
+    #expect(await activeTask.value == nil)
+    var lateIterator = target.network.events.makeAsyncIterator()
+    #expect(await lateIterator.next() == nil)
+    try await runtime.proxy.waitUntilClosed()
+}
+
+@Test
 func webInspectorProxyNetworkEventsMulticastToConsumerSubscribers() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let target = try await runtime.proxy.waitForCurrentPage()

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -3034,16 +3034,28 @@ public final class WebInspectorContext {
         stopEventPumps()
         let subscriptionGeneration = orderedEventSubscriptionGeneration
         let feed = await target.orderedEventFeed()
-        let pump = WebInspectorEventPump(stream: feed.events, isolation: isolation) { [weak self, target] sequencedEvent in
-            guard let self else { return }
-            await self.applyOrderedEvent(
-                sequencedEvent,
-                target: target,
-                subscriptionGeneration: subscriptionGeneration,
-                beforeWatermarkUpdate: nil,
-                isolation: isolation
-            )
-        }
+        let pump = WebInspectorEventPump(
+            stream: feed.events,
+            isolation: isolation,
+            apply: { [weak self, target] sequencedEvent in
+                guard let self else { return }
+                await self.applyOrderedEvent(
+                    sequencedEvent,
+                    target: target,
+                    subscriptionGeneration: subscriptionGeneration,
+                    beforeWatermarkUpdate: nil,
+                    isolation: isolation
+                )
+            },
+            onFailure: { [weak self] error in
+                guard let self else { return }
+                self.handleOrderedEventStreamFailure(
+                    error,
+                    subscriptionGeneration: subscriptionGeneration,
+                    isolation: isolation
+                )
+            }
+        )
         if let beforeValidation {
             await beforeValidation()
         }
@@ -3057,6 +3069,29 @@ public final class WebInspectorContext {
         )
         lastOrderedEventSequence = feed.initialSequence
         eventPumps = [pump]
+    }
+
+    private func handleOrderedEventStreamFailure(
+        _ error: any Error,
+        subscriptionGeneration: UInt64,
+        isolation: isolated (any Actor)
+    ) {
+        requireOwner(isolation)
+        guard subscriptionGeneration == orderedEventSubscriptionGeneration else {
+            return
+        }
+        stopEventPumps()
+        startupTask?.cancel()
+        currentPageRetargetTask?.cancel()
+        currentPageCleanupTask?.cancel()
+        documentReloadTask?.cancel()
+        cancelDOMDocumentLoad()
+
+        if let proxyError = error as? WebInspectorProxyError {
+            fail(proxyError)
+        } else {
+            fail(.disconnected("Ordered event stream failed: \(error)"))
+        }
     }
 
     private func stopEventPumps() {

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -1042,8 +1042,23 @@ public final class WebInspectorContext {
     }
 
     #if DEBUG
+    package var inspectionProxyForTesting: WebInspectorProxy {
+        proxy
+    }
+
+    package var currentPageForTesting: WebInspectorTarget? {
+        currentPage
+    }
+
     package func installCurrentPageRetargetTaskForTesting(_ task: Task<Void, Never>) {
         currentPageRetargetTask = task
+    }
+
+    package func currentPageRetargetTaskForTesting(
+        isolation: isolated (any Actor) = #isolation
+    ) -> Task<Void, Never>? {
+        requireOwner(isolation)
+        return currentPageRetargetTask
     }
 
     package func startupTaskForTesting(isolation: isolated (any Actor) = #isolation) -> Task<Void, Never>? {
@@ -1075,6 +1090,32 @@ public final class WebInspectorContext {
             target: target,
             subscriptionGeneration: subscriptionGeneration,
             beforeWatermarkUpdate: beforeWatermarkUpdate,
+            isolation: isolation
+        )
+    }
+
+    package func handleOrderedEventStreamFailureForTesting(
+        _ error: any Error,
+        subscriptionGeneration: UInt64,
+        isolation: isolated (any Actor) = #isolation
+    ) {
+        handleOrderedEventStreamFailure(
+            error,
+            subscriptionGeneration: subscriptionGeneration,
+            isolation: isolation
+        )
+    }
+
+    package func waitForOrderedEventsForTesting(
+        through sequence: UInt64,
+        registration: ReplyPromise<Void>,
+        isolation: isolated (any Actor) = #isolation
+    ) async -> Bool {
+        await waitForOrderedEvents(
+            through: sequence,
+            waiterRegistered: {
+                registration.fulfill(.success(()))
+            },
             isolation: isolation
         )
     }
@@ -3179,6 +3220,7 @@ public final class WebInspectorContext {
 
     private func waitForOrderedEvents(
         through sequence: UInt64,
+        waiterRegistered: (@Sendable () -> Void)? = nil,
         isolation: isolated (any Actor)
     ) async -> Bool {
         _ = isolation
@@ -3190,6 +3232,7 @@ public final class WebInspectorContext {
                 sequence: sequence,
                 continuation: continuation
             ))
+            waiterRegistered?()
         }
     }
 

--- a/Sources/WebInspectorDataKit/WebInspectorEventPump.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorEventPump.swift
@@ -6,15 +6,26 @@ struct WebInspectorEventPump: Sendable {
     init<Event: Sendable, Events: AsyncSequence & Sendable>(
         stream: Events,
         isolation: isolated (any Actor),
-        apply: @escaping (Event) async -> Void
-    ) where Events.Element == Event, Events.Failure == Never {
-        let target = WebInspectorEventPumpTarget(apply: apply)
+        apply: @escaping (Event) async -> Void,
+        onFailure: @escaping (any Error) async -> Void
+    ) where Events.Element == Event {
+        let target = WebInspectorEventPumpTarget(
+            apply: apply,
+            onFailure: onFailure
+        )
         task = Task.detached(priority: .userInitiated) {
-            for await event in stream {
-                if Task.isCancelled {
-                    break
+            do {
+                for try await event in stream {
+                    if Task.isCancelled {
+                        return
+                    }
+                    await target.apply(event, isolation: isolation)
                 }
-                await target.apply(event, isolation: isolation)
+            } catch {
+                guard Task.isCancelled == false else {
+                    return
+                }
+                await target.handleFailure(error, isolation: isolation)
             }
         }
     }
@@ -29,13 +40,23 @@ struct WebInspectorEventPump: Sendable {
 // WebInspectorContext owner actor passed to the pump initializer.
 private final class WebInspectorEventPumpTarget<Event: Sendable>: @unchecked Sendable {
     private let applyEvent: (Event) async -> Void
+    private let failureHandler: (any Error) async -> Void
 
-    init(apply: @escaping (Event) async -> Void) {
+    init(
+        apply: @escaping (Event) async -> Void,
+        onFailure: @escaping (any Error) async -> Void
+    ) {
         applyEvent = apply
+        failureHandler = onFailure
     }
 
     func apply(_ event: Event, isolation: isolated (any Actor)) async {
         _ = isolation
         await applyEvent(event)
+    }
+
+    func handleFailure(_ error: any Error, isolation: isolated (any Actor)) async {
+        _ = isolation
+        await failureHandler(error)
     }
 }

--- a/Sources/WebInspectorProxyKit/LiveWebInspectorProxyBackend.swift
+++ b/Sources/WebInspectorProxyKit/LiveWebInspectorProxyBackend.swift
@@ -38,6 +38,10 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
         )
     }
 
+    package func finishEventSubscriptions(throwing error: WebInspectorProxyError?) async {
+        await eventSubscriptions.finish(throwing: error)
+    }
+
     package func orderedEvents(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
@@ -51,11 +55,13 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
             bufferingPolicy: .unbounded
         ) { continuation in
             let task = Task {
-                await eventSubscriptions.registerOrdered(
+                guard await eventSubscriptions.registerOrdered(
                     key,
                     id: subscriptionID,
                     continuation: continuation
-                )
+                ) else {
+                    return
+                }
                 for await event in transportFeed.events {
                     guard Task.isCancelled == false else {
                         break
@@ -74,21 +80,16 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                             method: event.method,
                             error: error
                         )
-                        await terminate(
-                            failure,
-                            terminalFailureHandler: terminalFailureHandler
-                        )
-                        await eventSubscriptions.unregister(key, id: subscriptionID)
+                        await terminalFailureHandler(failure)
                         return
                     }
                 }
-                await eventSubscriptions.unregister(key, id: subscriptionID)
                 continuation.finish()
             }
             continuation.onTermination = { _ in
                 task.cancel()
                 Task {
-                    await eventSubscriptions.unregister(key, id: subscriptionID)
+                    await eventSubscriptions.cancel(key, id: subscriptionID)
                 }
             }
         }
@@ -120,6 +121,56 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
         )
     }
 
+    package func eventSubscriptionBookkeepingCountForTesting() async -> Int {
+        await eventSubscriptions.bookkeepingCount
+    }
+
+    package func eventSubscriptionWaiterCountForTesting() async -> Int {
+        await eventSubscriptions.waiterCount
+    }
+
+    package func waitForEventSubscriptionWaiterForTesting() async {
+        await eventSubscriptions.waitForWaiterRegistration()
+    }
+
+    package func exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: Bool,
+        route: RoutingTargetID,
+        targetID: WebInspectorTarget.ID
+    ) async -> Bool {
+        let id = LiveProxyEventSubscriptionID()
+        if ordered {
+            let key = LiveProxyEventSubscriptionKey(
+                route: route,
+                targetID: targetID,
+                domain: .ordered
+            )
+            let pair = AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.makeStream()
+            await eventSubscriptions.cancel(key, id: id)
+            let registered = await eventSubscriptions.registerOrdered(
+                key,
+                id: id,
+                continuation: pair.continuation
+            )
+            let bookkeepingCount = await eventSubscriptions.bookkeepingCount
+            return registered == false && bookkeepingCount == 0
+        }
+        let key = LiveProxyEventSubscriptionKey(
+            route: route,
+            targetID: targetID,
+            domain: .network
+        )
+        let pair = AsyncStream<WebInspectorProxyEvent>.makeStream()
+        await eventSubscriptions.cancel(key, id: id)
+        let registered = await eventSubscriptions.registerDomain(
+            key,
+            id: id,
+            continuation: pair.continuation
+        )
+        let bookkeepingCount = await eventSubscriptions.bookkeepingCount
+        return registered == false && bookkeepingCount == 0
+    }
+
     package nonisolated func events(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
@@ -131,17 +182,16 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
             let subscriptionID = LiveProxyEventSubscriptionID()
             let task = Task {
                 let stream = await transport.events(for: protocolDomain(for: domain))
-                guard Task.isCancelled == false else {
-                    continuation.finish()
+                guard await eventSubscriptions.registerDomain(
+                    key,
+                    id: subscriptionID,
+                    continuation: continuation
+                ) else {
                     return
                 }
-                await eventSubscriptions.register(key, id: subscriptionID)
                 for await event in stream {
                     guard Task.isCancelled == false else {
                         break
-                    }
-                    guard await shouldDeliver(event, to: route) else {
-                        continue
                     }
                     do {
                         let lifecycleTarget = lifecycleTarget(for: event, route: route, targetID: targetID)
@@ -150,26 +200,25 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                             targetID: targetID,
                             lifecycleTarget: lifecycleTarget
                         )
+                        guard await shouldDeliver(event, to: route) else {
+                            continue
+                        }
                         continuation.yield(projectedEvent(proxyEvent, from: event, route: route))
                     } catch {
                         let failure = WebInspectorProxyTerminalFailure.eventDecodingFailed(
                             method: event.method,
                             error: error
                         )
-                        await terminate(
-                            failure,
-                            terminalFailureHandler: terminalFailureHandler
-                        )
+                        await terminalFailureHandler(failure)
                         break
                     }
                 }
-                await eventSubscriptions.unregister(key, id: subscriptionID)
                 continuation.finish()
             }
             continuation.onTermination = { _ in
                 task.cancel()
                 Task {
-                    await eventSubscriptions.unregister(key, id: subscriptionID)
+                    await eventSubscriptions.cancel(key, id: subscriptionID)
                 }
             }
         }
@@ -200,15 +249,6 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                 method: method,
                 message: "\(transportError)"
             )
-        }
-    }
-
-    private func terminate(
-        _ failure: WebInspectorProxyTerminalFailure,
-        terminalFailureHandler: WebInspectorProxyTerminalFailureHandler
-    ) async {
-        await terminalFailureHandler(failure) { terminalError in
-            await eventSubscriptions.finish(throwing: terminalError)
         }
     }
 
@@ -332,15 +372,15 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
         case .storage, .other:
             return nil
         }
-        guard shouldDeliverOrderedEvent(event, to: route) else {
-            return nil
-        }
         let lifecycleTarget = lifecycleTarget(for: event, route: route, targetID: targetID)
         let proxyEvent = try LiveProxyEventDecoder.proxyEvent(
             from: event,
             targetID: targetID,
             lifecycleTarget: lifecycleTarget
         )
+        guard shouldDeliverOrderedEvent(event, to: route) else {
+            return nil
+        }
         return projectedEvent(proxyEvent, from: event, route: route)
     }
 
@@ -885,6 +925,7 @@ private struct LiveProxyEventSubscriptionID: Hashable, Sendable {
 }
 
 private actor LiveProxyEventSubscriptions {
+    typealias DomainContinuation = AsyncStream<WebInspectorProxyEvent>.Continuation
     typealias OrderedContinuation = AsyncThrowingStream<
         WebInspectorProxyOrderedEvent,
         any Error
@@ -893,25 +934,89 @@ private actor LiveProxyEventSubscriptions {
     private struct Waiter {
         let id: UInt64
         let minimumCount: Int
-        let continuation: CheckedContinuation<Void, Never>
+        let promise: ReplyPromise<Void>
+    }
+
+    private struct WaiterRegistrationWaiter {
+        let id: UInt64
+        let promise: ReplyPromise<Void>
     }
 
     private var activeSubscriberIDs: [LiveProxyEventSubscriptionKey: Set<LiveProxyEventSubscriptionID>] = [:]
+    private var domainContinuations: [LiveProxyEventSubscriptionID: DomainContinuation] = [:]
     private var orderedContinuations: [LiveProxyEventSubscriptionID: OrderedContinuation] = [:]
+    private var cancelledSubscriptionIDs: Set<LiveProxyEventSubscriptionID> = []
     private var waiters: [LiveProxyEventSubscriptionKey: [Waiter]] = [:]
     private var nextWaiterID: UInt64 = 0
-    private var cancelledWaiterIDs: Set<UInt64> = []
+    private var waiterRegistrationWaiters: [WaiterRegistrationWaiter] = []
+    private var nextWaiterRegistrationWaiterID: UInt64 = 0
     private var isFinished = false
     private var terminalError: WebInspectorProxyError?
 
-    func register(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
+    var bookkeepingCount: Int {
+        activeSubscriberIDs.values.reduce(0) { $0 + $1.count }
+            + domainContinuations.count
+            + orderedContinuations.count
+            + cancelledSubscriptionIDs.count
+    }
+
+    var waiterCount: Int {
+        waiters.values.reduce(0) { $0 + $1.count }
+    }
+
+    func waitForWaiterRegistration() async {
+        guard waiterCount == 0, isFinished == false else {
+            return
+        }
+        let id = nextWaiterRegistrationWaiterID
+        nextWaiterRegistrationWaiterID += 1
+        let waiter = WaiterRegistrationWaiter(id: id, promise: ReplyPromise<Void>())
+        waiterRegistrationWaiters.append(waiter)
+        defer {
+            waiterRegistrationWaiters.removeAll { $0.id == id }
+        }
+        _ = try? await waiter.promise.value()
+    }
+
+    func registerDomain(
+        _ key: LiveProxyEventSubscriptionKey,
+        id: LiveProxyEventSubscriptionID,
+        continuation: DomainContinuation
+    ) -> Bool {
         guard isFinished == false else {
-            return
+            continuation.finish()
+            return false
         }
+        guard cancelledSubscriptionIDs.remove(id) == nil else {
+            continuation.finish()
+            return false
+        }
+        domainContinuations[id] = continuation
+        register(key, id: id)
+        return true
+    }
+
+    func registerOrdered(
+        _ key: LiveProxyEventSubscriptionKey,
+        id: LiveProxyEventSubscriptionID,
+        continuation: OrderedContinuation
+    ) -> Bool {
+        guard isFinished == false else {
+            continuation.finish(throwing: terminalError)
+            return false
+        }
+        guard cancelledSubscriptionIDs.remove(id) == nil else {
+            continuation.finish()
+            return false
+        }
+        orderedContinuations[id] = continuation
+        register(key, id: id)
+        return true
+    }
+
+    private func register(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
         let inserted = activeSubscriberIDs[key, default: []].insert(id).inserted
-        guard inserted else {
-            return
-        }
+        precondition(inserted, "Live event subscription identity was registered twice.")
         guard let pending = waiters.removeValue(forKey: key) else {
             return
         }
@@ -919,7 +1024,7 @@ private actor LiveProxyEventSubscriptions {
         var remaining: [Waiter] = []
         for waiter in pending {
             if count >= waiter.minimumCount {
-                waiter.continuation.resume()
+                waiter.promise.fulfill(.success(()))
             } else {
                 remaining.append(waiter)
             }
@@ -929,23 +1034,15 @@ private actor LiveProxyEventSubscriptions {
         }
     }
 
-    func registerOrdered(
-        _ key: LiveProxyEventSubscriptionKey,
-        id: LiveProxyEventSubscriptionID,
-        continuation: OrderedContinuation
-    ) {
+    func cancel(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
         guard isFinished == false else {
-            continuation.finish(throwing: terminalError)
             return
         }
-        orderedContinuations[id] = continuation
-        register(key, id: id)
-    }
-
-    func unregister(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
+        domainContinuations[id] = nil
         orderedContinuations[id] = nil
         guard var ids = activeSubscriberIDs[key],
               ids.remove(id) != nil else {
+            cancelledSubscriptionIDs.insert(id)
             return
         }
         if ids.isEmpty {
@@ -968,19 +1065,14 @@ private actor LiveProxyEventSubscriptions {
         }
         let waiterID = nextWaiterID
         nextWaiterID += 1
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                addWaiter(
-                    Waiter(id: waiterID, minimumCount: minimumCount, continuation: continuation),
-                    key: key
-                )
-            }
-        } onCancel: {
-            Task {
-                await self.cancelWaiter(waiterID, key: key)
-            }
-        }
-        cancelledWaiterIDs.remove(waiterID)
+        let waiter = Waiter(
+            id: waiterID,
+            minimumCount: minimumCount,
+            promise: ReplyPromise<Void>()
+        )
+        addWaiter(waiter, key: key)
+        _ = try? await waiter.promise.value()
+        removeWaiter(waiterID, key: key)
     }
 
     func finish(throwing error: WebInspectorProxyError?) {
@@ -990,13 +1082,23 @@ private actor LiveProxyEventSubscriptions {
         isFinished = true
         terminalError = error
         activeSubscriberIDs.removeAll()
-        let orderedContinuations = orderedContinuations.values
+        cancelledSubscriptionIDs.removeAll()
+        let domainContinuations = Array(domainContinuations.values)
+        self.domainContinuations.removeAll()
+        let orderedContinuations = Array(orderedContinuations.values)
         self.orderedContinuations.removeAll()
         let pending = waiters.values.flatMap { $0 }
         waiters.removeAll()
-        cancelledWaiterIDs.removeAll()
+        let registrationWaiters = waiterRegistrationWaiters
+        waiterRegistrationWaiters.removeAll()
         for waiter in pending {
-            waiter.continuation.resume()
+            waiter.promise.fulfill(.success(()))
+        }
+        for waiter in registrationWaiters {
+            waiter.promise.fulfill(.success(()))
+        }
+        for continuation in domainContinuations {
+            continuation.finish()
         }
         for continuation in orderedContinuations {
             continuation.finish(throwing: error)
@@ -1005,31 +1107,28 @@ private actor LiveProxyEventSubscriptions {
 
     private func addWaiter(_ waiter: Waiter, key: LiveProxyEventSubscriptionKey) {
         guard isFinished == false else {
-            waiter.continuation.resume()
-            return
-        }
-        guard cancelledWaiterIDs.remove(waiter.id) == nil else {
-            waiter.continuation.resume()
+            waiter.promise.fulfill(.success(()))
             return
         }
         waiters[key, default: []].append(waiter)
+        let registrationWaiters = waiterRegistrationWaiters
+        waiterRegistrationWaiters.removeAll()
+        for waiter in registrationWaiters {
+            waiter.promise.fulfill(.success(()))
+        }
     }
 
-    private func cancelWaiter(_ id: UInt64, key: LiveProxyEventSubscriptionKey) {
+    private func removeWaiter(_ id: UInt64, key: LiveProxyEventSubscriptionKey) {
         guard var pending = waiters[key],
               let index = pending.firstIndex(where: { $0.id == id }) else {
-            cancelledWaiterIDs.insert(id)
             return
         }
-        let waiter = pending.remove(at: index)
+        pending.remove(at: index)
         if pending.isEmpty {
             waiters[key] = nil
         } else {
             waiters[key] = pending
         }
-        // Resuming lets the cancelled caller return and observe its own
-        // Task.isCancelled state instead of staying suspended forever.
-        waiter.continuation.resume()
     }
 }
 

--- a/Sources/WebInspectorProxyKit/LiveWebInspectorProxyBackend.swift
+++ b/Sources/WebInspectorProxyKit/LiveWebInspectorProxyBackend.swift
@@ -40,15 +40,22 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
 
     package func orderedEvents(
         route: RoutingTargetID,
-        targetID: WebInspectorTarget.ID
+        targetID: WebInspectorTarget.ID,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) async -> WebInspectorProxyOrderedEventFeed {
         let transportFeed = await transport.orderedEventFeed()
         let key = LiveProxyEventSubscriptionKey(route: route, targetID: targetID, domain: .ordered)
         let subscriptionID = LiveProxyEventSubscriptionID()
-        await eventSubscriptions.register(key, id: subscriptionID)
 
-        let stream = AsyncStream<WebInspectorProxyOrderedEvent>(bufferingPolicy: .unbounded) { continuation in
+        let stream = AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>(
+            bufferingPolicy: .unbounded
+        ) { continuation in
             let task = Task {
+                await eventSubscriptions.registerOrdered(
+                    key,
+                    id: subscriptionID,
+                    continuation: continuation
+                )
                 for await event in transportFeed.events {
                     guard Task.isCancelled == false else {
                         break
@@ -63,7 +70,16 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                             )
                         ))
                     } catch {
-                        preconditionFailure("Failed to decode \(event.method): \(error)")
+                        let failure = WebInspectorProxyTerminalFailure.eventDecodingFailed(
+                            method: event.method,
+                            error: error
+                        )
+                        await terminate(
+                            failure,
+                            terminalFailureHandler: terminalFailureHandler
+                        )
+                        await eventSubscriptions.unregister(key, id: subscriptionID)
+                        return
                     }
                 }
                 await eventSubscriptions.unregister(key, id: subscriptionID)
@@ -107,7 +123,8 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
     package nonisolated func events(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
-        domain: WebInspectorProxyEventDomain
+        domain: WebInspectorProxyEventDomain,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) -> AsyncStream<WebInspectorProxyEvent> {
         AsyncStream<WebInspectorProxyEvent> { continuation in
             let key = LiveProxyEventSubscriptionKey(route: route, targetID: targetID, domain: domain)
@@ -135,7 +152,15 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                         )
                         continuation.yield(projectedEvent(proxyEvent, from: event, route: route))
                     } catch {
-                        preconditionFailure("Failed to decode \(event.method): \(error)")
+                        let failure = WebInspectorProxyTerminalFailure.eventDecodingFailed(
+                            method: event.method,
+                            error: error
+                        )
+                        await terminate(
+                            failure,
+                            terminalFailureHandler: terminalFailureHandler
+                        )
+                        break
                     }
                 }
                 await eventSubscriptions.unregister(key, id: subscriptionID)
@@ -157,6 +182,10 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
         switch transportError {
         case .transportClosed:
             return WebInspectorProxyError.closed
+        case let .eventDecodingFailed(method, message):
+            return WebInspectorProxyError.disconnected(
+                "Failed to decode \(method): \(message)"
+            )
         case let .replyTimeout(method, _):
             return WebInspectorProxyError.timeout(domain: domain, method: method)
         case let .remoteError(method, _, message):
@@ -171,6 +200,15 @@ package struct LiveWebInspectorProxyBackend: WebInspectorProxyBackend {
                 method: method,
                 message: "\(transportError)"
             )
+        }
+    }
+
+    private func terminate(
+        _ failure: WebInspectorProxyTerminalFailure,
+        terminalFailureHandler: WebInspectorProxyTerminalFailureHandler
+    ) async {
+        await terminalFailureHandler(failure) { terminalError in
+            await eventSubscriptions.finish(throwing: terminalError)
         }
     }
 
@@ -847,6 +885,11 @@ private struct LiveProxyEventSubscriptionID: Hashable, Sendable {
 }
 
 private actor LiveProxyEventSubscriptions {
+    typealias OrderedContinuation = AsyncThrowingStream<
+        WebInspectorProxyOrderedEvent,
+        any Error
+    >.Continuation
+
     private struct Waiter {
         let id: UInt64
         let minimumCount: Int
@@ -854,11 +897,17 @@ private actor LiveProxyEventSubscriptions {
     }
 
     private var activeSubscriberIDs: [LiveProxyEventSubscriptionKey: Set<LiveProxyEventSubscriptionID>] = [:]
+    private var orderedContinuations: [LiveProxyEventSubscriptionID: OrderedContinuation] = [:]
     private var waiters: [LiveProxyEventSubscriptionKey: [Waiter]] = [:]
     private var nextWaiterID: UInt64 = 0
     private var cancelledWaiterIDs: Set<UInt64> = []
+    private var isFinished = false
+    private var terminalError: WebInspectorProxyError?
 
     func register(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
+        guard isFinished == false else {
+            return
+        }
         let inserted = activeSubscriberIDs[key, default: []].insert(id).inserted
         guard inserted else {
             return
@@ -880,7 +929,21 @@ private actor LiveProxyEventSubscriptions {
         }
     }
 
+    func registerOrdered(
+        _ key: LiveProxyEventSubscriptionKey,
+        id: LiveProxyEventSubscriptionID,
+        continuation: OrderedContinuation
+    ) {
+        guard isFinished == false else {
+            continuation.finish(throwing: terminalError)
+            return
+        }
+        orderedContinuations[id] = continuation
+        register(key, id: id)
+    }
+
     func unregister(_ key: LiveProxyEventSubscriptionKey, id: LiveProxyEventSubscriptionID) {
+        orderedContinuations[id] = nil
         guard var ids = activeSubscriberIDs[key],
               ids.remove(id) != nil else {
             return
@@ -897,6 +960,9 @@ private actor LiveProxyEventSubscriptions {
     }
 
     func waitForActiveSubscribers(_ key: LiveProxyEventSubscriptionKey, minimumCount: Int) async {
+        guard isFinished == false else {
+            return
+        }
         guard activeSubscriberIDs[key, default: []].count < minimumCount else {
             return
         }
@@ -917,7 +983,31 @@ private actor LiveProxyEventSubscriptions {
         cancelledWaiterIDs.remove(waiterID)
     }
 
+    func finish(throwing error: WebInspectorProxyError?) {
+        guard isFinished == false else {
+            return
+        }
+        isFinished = true
+        terminalError = error
+        activeSubscriberIDs.removeAll()
+        let orderedContinuations = orderedContinuations.values
+        self.orderedContinuations.removeAll()
+        let pending = waiters.values.flatMap { $0 }
+        waiters.removeAll()
+        cancelledWaiterIDs.removeAll()
+        for waiter in pending {
+            waiter.continuation.resume()
+        }
+        for continuation in orderedContinuations {
+            continuation.finish(throwing: error)
+        }
+    }
+
     private func addWaiter(_ waiter: Waiter, key: LiveProxyEventSubscriptionKey) {
+        guard isFinished == false else {
+            waiter.continuation.resume()
+            return
+        }
         guard cancelledWaiterIDs.remove(waiter.id) == nil else {
             waiter.continuation.resume()
             return

--- a/Sources/WebInspectorProxyKit/NativeAttachment/NativeInspectablePage.swift
+++ b/Sources/WebInspectorProxyKit/NativeAttachment/NativeInspectablePage.swift
@@ -23,9 +23,11 @@ package struct NativeInspectorConnection: Sendable {
         self.cleanup = cleanup
     }
 
-    package func close() async {
+    package func close(
+        error: TransportSession.Error = .transportClosed
+    ) async {
         await receiver.close()
-        await transport.detach()
+        await transport.detach(error: error)
         await restoreInspectabilityIfNeeded()
     }
 

--- a/Sources/WebInspectorProxyKit/Transport/TransportSession.swift
+++ b/Sources/WebInspectorProxyKit/Transport/TransportSession.swift
@@ -29,7 +29,7 @@ package actor TransportSession {
     private var networkOriginRegistry: TransportNetworkOriginRegistry
     private var eventSubscribers: TransportEventSubscriberRegistry
     private var inboundMessageQueue: TransportInboundMessageQueue
-    private var closed: Bool
+    private var terminalError: TransportSession.Error?
 
     package init(
         backend: any TransportBackend,
@@ -59,11 +59,11 @@ package actor TransportSession {
         networkOriginRegistry = TransportNetworkOriginRegistry()
         eventSubscribers = TransportEventSubscriberRegistry()
         inboundMessageQueue = TransportInboundMessageQueue()
-        closed = false
+        terminalError = nil
     }
 
     package func events(for domain: ProtocolDomain) -> AsyncStream<ProtocolEvent> {
-        guard !closed else {
+        guard terminalError == nil else {
             return finishedStream(of: ProtocolEvent.self)
         }
         let pair = AsyncStream<ProtocolEvent>.makeStream(bufferingPolicy: .unbounded)
@@ -81,7 +81,7 @@ package actor TransportSession {
     }
 
     package func orderedEventFeed() -> ProtocolOrderedEventFeed {
-        guard !closed else {
+        guard terminalError == nil else {
             return ProtocolOrderedEventFeed(
                 initialSequence: eventSequences.current.sequence,
                 events: finishedStream(of: ProtocolEvent.self)
@@ -102,8 +102,8 @@ package actor TransportSession {
 
     package func send(_ command: ProtocolCommand) async throws -> ProtocolCommand.Result {
         try Task.checkCancellation()
-        guard !closed else {
-            throw TransportSession.Error.transportClosed
+        if let terminalError {
+            throw terminalError
         }
 
         if isLatestRootNetworkCommand(command) {
@@ -163,7 +163,7 @@ package actor TransportSession {
 
     @discardableResult
     package func receiveRootMessage(_ message: String) async -> UInt64 {
-        guard !closed else {
+        guard terminalError == nil else {
             return eventSequences.current.sequence
         }
         inboundMessageQueue.append(message)
@@ -172,7 +172,7 @@ package actor TransportSession {
     }
 
     package func currentPageProcessDidTerminate() async {
-        guard !closed else {
+        guard terminalError == nil else {
             return
         }
         let currentMainPageTargetID = targetRegistry.currentMainPageTargetID
@@ -219,16 +219,18 @@ package actor TransportSession {
         )
     }
 
-    package func detach() async {
-        guard !closed else {
+    package func detach(
+        error: TransportSession.Error = .transportClosed
+    ) async {
+        guard terminalError == nil else {
             return
         }
-        closed = true
+        terminalError = error
         for pending in replyStore.pendingReplies {
-            pending.promise.fulfill(.failure(TransportSession.Error.transportClosed))
+            pending.promise.fulfill(.failure(error))
         }
         for waiter in mainPageTargetWaiterStore.removeAll() {
-            waiter.fulfill(.failure(TransportSession.Error.transportClosed))
+            waiter.fulfill(.failure(error))
         }
         replyStore.removeAll()
         provisionalTargetMessageStore.removeAll()
@@ -238,8 +240,8 @@ package actor TransportSession {
     }
 
     package func waitForCurrentMainPageTarget(timeout: Duration? = nil) async throws -> TransportSession.MainPageTarget {
-        guard !closed else {
-            throw TransportSession.Error.transportClosed
+        if let terminalError {
+            throw terminalError
         }
         if let currentMainPageTargetID = targetRegistry.currentMainPageTargetID {
             return TransportSession.MainPageTarget(
@@ -292,8 +294,8 @@ package actor TransportSession {
     }
 
     package func requireOpen() throws {
-        guard !closed else {
-            throw TransportSession.Error.transportClosed
+        if let terminalError {
+            throw terminalError
         }
     }
 

--- a/Sources/WebInspectorProxyKit/Transport/TransportTypes.swift
+++ b/Sources/WebInspectorProxyKit/Transport/TransportTypes.swift
@@ -278,6 +278,7 @@ package extension TransportSession {
         case unsupportedDomain(ProtocolDomain, targetID: ProtocolTarget.ID)
         case replyTimeout(method: String, targetID: ProtocolTarget.ID?)
         case remoteError(method: String, targetID: ProtocolTarget.ID?, message: String)
+        case eventDecodingFailed(method: String, message: String)
         case inspectedPageProcessTerminated
         case transportClosed
     }

--- a/Sources/WebInspectorProxyKit/WebInspectorProxy.swift
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxy.swift
@@ -36,6 +36,10 @@ private struct ProtocolCommandTarget: Sendable {
 ///
 /// await proxy.close()
 /// ```
+///
+/// Domain event streams finish when the connection closes. Use
+/// ``waitUntilClosed()`` to distinguish an explicit close from an unexpected
+/// terminal connection failure.
 public actor WebInspectorProxy {
     /// Optional timeout configuration for command replies and current-page bootstrap.
     public struct Configuration: Equatable, Sendable {
@@ -66,7 +70,7 @@ public actor WebInspectorProxy {
     private let configuration: Configuration
     private let backend: (any WebInspectorProxyBackend)?
     private let transport: TransportSession?
-    private let closeConnection: (@Sendable () async -> Void)?
+    private let closeConnection: (@Sendable (TransportSession.Error) async -> Void)?
     private var pageTarget: WebInspectorTarget?
     private var nextTargetOrdinal: UInt64
     private var nextCloseWaiterID: UInt64
@@ -75,10 +79,51 @@ public actor WebInspectorProxy {
     private var cancelledCloseWaiterIDs: Set<UInt64>
     private var closeState: CloseState
 
+    private enum TerminationReason {
+        case requested
+        case failed(WebInspectorProxyTerminalFailure)
+
+        var publicResult: Result<Void, WebInspectorProxyError> {
+            switch self {
+            case .requested:
+                .success(())
+            case let .failed(failure):
+                .failure(failure.publicError)
+            }
+        }
+
+        var operationError: WebInspectorProxyError {
+            switch self {
+            case .requested:
+                .closed
+            case let .failed(failure):
+                failure.publicError
+            }
+        }
+
+        var transportError: TransportSession.Error {
+            switch self {
+            case .requested:
+                .transportClosed
+            case let .failed(failure):
+                failure.transportError
+            }
+        }
+
+        var failureError: WebInspectorProxyError? {
+            switch self {
+            case .requested:
+                nil
+            case let .failed(failure):
+                failure.publicError
+            }
+        }
+    }
+
     private enum CloseState {
         case open
-        case closing
-        case closed
+        case closing(TerminationReason)
+        case closed(TerminationReason)
     }
 
     /// Attaches a Web Inspector protocol connection to a web view.
@@ -106,8 +151,8 @@ public actor WebInspectorProxy {
         self.configuration = configuration
         backend = LiveWebInspectorProxyBackend(transport: nativeConnection.transport)
         transport = nativeConnection.transport
-        closeConnection = {
-            await nativeConnection.close()
+        closeConnection = { error in
+            await nativeConnection.close(error: error)
         }
         pageTarget = nil
         nextTargetOrdinal = 0
@@ -128,7 +173,7 @@ public actor WebInspectorProxy {
     package init(
         configuration: Configuration = .init(),
         backend: (any WebInspectorProxyBackend)? = nil,
-        closeConnection: (@Sendable () async -> Void)? = nil
+        closeConnection: (@Sendable (TransportSession.Error) async -> Void)? = nil
     ) {
         self.configuration = configuration
         self.backend = backend
@@ -146,13 +191,13 @@ public actor WebInspectorProxy {
     package init(
         transport: TransportSession,
         configuration: Configuration = .init(),
-        closeConnection: (@Sendable () async -> Void)? = nil
+        closeConnection: (@Sendable (TransportSession.Error) async -> Void)? = nil
     ) async throws {
         self.configuration = configuration
         self.transport = transport
         backend = LiveWebInspectorProxyBackend(transport: transport)
-        self.closeConnection = closeConnection ?? {
-            await transport.detach()
+        self.closeConnection = closeConnection ?? { error in
+            await transport.detach(error: error)
         }
         pageTarget = nil
         nextTargetOrdinal = 0
@@ -182,7 +227,10 @@ public actor WebInspectorProxy {
     /// A Boolean value indicating whether the proxy has an open page target
     /// that can receive reload commands.
     public var canReload: Bool {
-        pageTarget != nil && closeState == .open
+        guard case .open = closeState else {
+            return false
+        }
+        return pageTarget != nil
     }
 
     /// Waits for and returns the current page target.
@@ -196,7 +244,7 @@ public actor WebInspectorProxy {
             do {
                 try await refreshCurrentPage(from: transport, timeout: configuration.bootstrapTimeout)
             } catch {
-                throw Self.mapBootstrapTargetError(error)
+                throw operationError(replacing: Self.mapBootstrapTargetError(error))
             }
             if let pageTarget {
                 return pageTarget
@@ -224,7 +272,7 @@ public actor WebInspectorProxy {
         } catch TransportSession.Error.missingMainPageTarget {
             return nil
         } catch {
-            throw Self.mapBootstrapTargetError(error)
+            throw operationError(replacing: Self.mapBootstrapTargetError(error))
         }
         try ensureOpenForCurrentPageAccess()
         return pageTarget
@@ -236,6 +284,7 @@ public actor WebInspectorProxy {
 
     /// Reloads the currently inspected page without ignoring cache.
     public func reload() async throws {
+        try ensureOpenForCurrentPageAccess()
         guard let pageTarget else {
             throw WebInspectorProxyError.disconnected("WebInspectorProxyKit shell has no current page target.")
         }
@@ -255,26 +304,23 @@ public actor WebInspectorProxy {
     public func close() async {
         switch closeState {
         case .open:
-            break
+            await terminate(.requested)
         case .closing:
             try? await waitUntilClosed()
-            return
         case .closed:
-            return
+            break
         }
-        closeState = .closing
-        pageTarget = nil
-        await closeConnection?()
-        closeState = .closed
-        resumeCloseWaiters()
     }
 
     /// Suspends until ``close()`` has finished.
     ///
-    /// If the proxy is already closed, this method returns immediately. If the
-    /// waiting task is cancelled, only that waiter is cancelled.
+    /// If an explicit close has already completed, this method returns
+    /// immediately. If the connection terminated because of an inspector
+    /// failure, it throws that terminal error. Cancelling the waiting task
+    /// cancels only that waiter.
     public func waitUntilClosed() async throws {
-        guard closeState != .closed else {
+        if case let .closed(reason) = closeState {
+            try reason.publicResult.get()
             return
         }
         nextCloseWaiterID &+= 1
@@ -312,7 +358,7 @@ public actor WebInspectorProxy {
     }
 
     package func waitForCloseWaiterForTesting() async {
-        guard closeState != .closed else {
+        if case .closed = closeState {
             preconditionFailure("Cannot wait for a close waiter after WebInspectorProxy closed.")
         }
         guard closeWaiters.isEmpty else {
@@ -330,9 +376,7 @@ public actor WebInspectorProxy {
         method: String,
         payload: Payload
     ) async throws -> Result {
-        guard closeState == .open else {
-            throw WebInspectorProxyError.closed
-        }
+        try ensureOpenForOperation()
         guard let backend else {
             throw unimplementedCommand(domain: domain.rawValue, method: method)
         }
@@ -349,7 +393,11 @@ public actor WebInspectorProxy {
             method: method,
             payload: payload
         )
-        return try await backend.dispatchCommand(command)
+        do {
+            return try await backend.dispatchCommand(command)
+        } catch {
+            throw operationError(replacing: error)
+        }
     }
 
     package func dispatchCommandWithReplyBoundary<Payload: Sendable, Result: Sendable>(
@@ -359,9 +407,7 @@ public actor WebInspectorProxy {
         method: String,
         payload: Payload
     ) async throws -> WebInspectorProxyCommandReply<Result> {
-        guard closeState == .open else {
-            throw WebInspectorProxyError.closed
-        }
+        try ensureOpenForOperation()
         guard let backend else {
             throw unimplementedCommand(domain: domain.rawValue, method: method)
         }
@@ -378,7 +424,11 @@ public actor WebInspectorProxy {
             method: method,
             payload: payload
         )
-        return try await backend.dispatchCommandWithReplyBoundary(command)
+        do {
+            return try await backend.dispatchCommandWithReplyBoundary(command)
+        } catch {
+            throw operationError(replacing: error)
+        }
     }
 
     package nonisolated func orderedEvents(
@@ -388,20 +438,30 @@ public actor WebInspectorProxy {
         guard let backend else {
             preconditionFailure("WebInspectorProxy has no backend for ordered events.")
         }
-        let backendFeed = await backend.orderedEvents(route: route, targetID: targetID)
-        let stream = AsyncStream<WebInspectorProxyOrderedEvent>(bufferingPolicy: .unbounded) { continuation in
+        let backendFeed = await backend.orderedEvents(
+            route: route,
+            targetID: targetID,
+            terminalFailureHandler: terminalFailureHandler
+        )
+        let stream = AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>(
+            bufferingPolicy: .unbounded
+        ) { continuation in
             let task = Task {
-                for await sequencedEvent in backendFeed.events {
-                    let event = sequencedEvent.event
-                    if case let .targetLifecycle(lifecycleEvent) = event {
-                        await self.applyTargetLifecycleEventToProxyState(lifecycleEvent)
+                do {
+                    for try await sequencedEvent in backendFeed.events {
+                        let event = sequencedEvent.event
+                        if case let .targetLifecycle(lifecycleEvent) = event {
+                            await self.applyTargetLifecycleEventToProxyState(lifecycleEvent)
+                        }
+                        continuation.yield(WebInspectorProxyOrderedEvent(
+                            sequence: sequencedEvent.sequence,
+                            event: event
+                        ))
                     }
-                    continuation.yield(WebInspectorProxyOrderedEvent(
-                        sequence: sequencedEvent.sequence,
-                        event: event
-                    ))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
-                continuation.finish()
             }
             continuation.onTermination = { _ in
                 task.cancel()
@@ -424,7 +484,12 @@ public actor WebInspectorProxy {
             let task = Task {
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask {
-                        for await event in backend.events(route: route, targetID: targetID, domain: .dom) {
+                        for await event in backend.events(
+                            route: route,
+                            targetID: targetID,
+                            domain: .dom,
+                            terminalFailureHandler: self.terminalFailureHandler
+                        ) {
                             guard case let .dom(value) = event else {
                                 preconditionFailure("Backend emitted a mismatched event for DOM.")
                             }
@@ -432,7 +497,12 @@ public actor WebInspectorProxy {
                         }
                     }
                     group.addTask {
-                        for await event in backend.events(route: route, targetID: targetID, domain: .inspector) {
+                        for await event in backend.events(
+                            route: route,
+                            targetID: targetID,
+                            domain: .inspector,
+                            terminalFailureHandler: self.terminalFailureHandler
+                        ) {
                             guard case let .inspector(value) = event else {
                                 preconditionFailure("Backend emitted a mismatched event for Inspector.")
                             }
@@ -525,7 +595,12 @@ public actor WebInspectorProxy {
                 await withTaskGroup(of: Void.self) { group in
                     for domain in [WebInspectorProxyEventDomain.target, .page] {
                         group.addTask {
-                            for await event in backend.events(route: route, targetID: targetID, domain: domain) {
+                            for await event in backend.events(
+                                route: route,
+                                targetID: targetID,
+                                domain: domain,
+                                terminalFailureHandler: self.terminalFailureHandler
+                            ) {
                                 guard case let .targetLifecycle(value) = event else {
                                     preconditionFailure("Backend emitted a mismatched event for lifecycle.")
                                 }
@@ -566,7 +641,12 @@ public actor WebInspectorProxy {
         }
         return AsyncStream<Element> { continuation in
             let task = Task {
-                for await event in backend.events(route: route, targetID: targetID, domain: domain) {
+                for await event in backend.events(
+                    route: route,
+                    targetID: targetID,
+                    domain: domain,
+                    terminalFailureHandler: self.terminalFailureHandler
+                ) {
                     guard let value = extract(event) else {
                         preconditionFailure("Backend emitted a mismatched event for \(domain.rawValue).")
                     }
@@ -577,6 +657,12 @@ public actor WebInspectorProxy {
             continuation.onTermination = { _ in
                 task.cancel()
             }
+        }
+    }
+
+    private nonisolated var terminalFailureHandler: WebInspectorProxyTerminalFailureHandler {
+        { failure, broadcast in
+            await self.terminate(failure, broadcast: broadcast)
         }
     }
 
@@ -871,14 +957,68 @@ public actor WebInspectorProxy {
     }
 
     private func ensureOpenForCurrentPageAccess() throws {
-        guard closeState == .open else {
+        do {
+            try ensureOpenForOperation()
+        } catch {
             pageTarget = nil
-            throw WebInspectorProxyError.closed
+            throw error
         }
     }
 
+    private func ensureOpenForOperation() throws {
+        switch closeState {
+        case .open:
+            return
+        case let .closing(reason), let .closed(reason):
+            throw reason.operationError
+        }
+    }
+
+    private func operationError(replacing error: any Error) -> any Error {
+        switch closeState {
+        case .open:
+            return error
+        case let .closing(reason), let .closed(reason):
+            return reason.operationError
+        }
+    }
+
+    private func terminate(
+        _ failure: WebInspectorProxyTerminalFailure,
+        broadcast: WebInspectorProxyTerminalBroadcast
+    ) async {
+        switch closeState {
+        case .open:
+            _ = await terminate(.failed(failure), broadcast: broadcast)
+        case let .closing(reason), let .closed(reason):
+            await broadcast(reason.failureError)
+        }
+    }
+
+    @discardableResult
+    private func terminate(
+        _ reason: TerminationReason,
+        broadcast: WebInspectorProxyTerminalBroadcast = { _ in }
+    ) async -> Bool {
+        guard case .open = closeState else {
+            return false
+        }
+        closeState = .closing(reason)
+        pageTarget = nil
+        if case let .failed(failure) = reason {
+            logger.error(
+                "Inspector connection failed: \(String(describing: failure.publicError), privacy: .private)"
+            )
+        }
+        await broadcast(reason.failureError)
+        await closeConnection?(reason.transportError)
+        closeState = .closed(reason)
+        resumeCloseWaiters(with: reason)
+        return true
+    }
+
     private func applyTargetLifecycleEventToProxyState(_ event: WebInspectorTargetLifecycleEvent) {
-        guard closeState == .open else {
+        guard case .open = closeState else {
             return
         }
         switch event {
@@ -892,8 +1032,8 @@ public actor WebInspectorProxy {
     }
 
     private func registerCloseWaiter(id: UInt64, continuation: CheckedContinuation<Void, any Error>) {
-        guard closeState != .closed else {
-            continuation.resume()
+        if case let .closed(reason) = closeState {
+            resume(continuation, with: reason)
             return
         }
         guard cancelledCloseWaiterIDs.remove(id) == nil else {
@@ -906,7 +1046,9 @@ public actor WebInspectorProxy {
 
     private func cancelCloseWaiter(_ id: UInt64) {
         guard let continuation = closeWaiters.removeValue(forKey: id) else {
-            if closeState != .closed {
+            if case .closed = closeState {
+                return
+            } else {
                 cancelledCloseWaiterIDs.insert(id)
             }
             return
@@ -914,12 +1056,24 @@ public actor WebInspectorProxy {
         continuation.resume(throwing: CancellationError())
     }
 
-    private func resumeCloseWaiters() {
+    private func resumeCloseWaiters(with reason: TerminationReason) {
         let waiters = closeWaiters.values
         closeWaiters.removeAll()
         cancelledCloseWaiterIDs.removeAll()
         for waiter in waiters {
-            waiter.resume()
+            resume(waiter, with: reason)
+        }
+    }
+
+    private func resume(
+        _ continuation: CheckedContinuation<Void, any Error>,
+        with reason: TerminationReason
+    ) {
+        switch reason.publicResult {
+        case .success:
+            continuation.resume()
+        case let .failure(error):
+            continuation.resume(throwing: error)
         }
     }
 
@@ -971,6 +1125,10 @@ public actor WebInspectorProxy {
             return WebInspectorProxyError.timeout(domain: "Target", method: method)
         case let .remoteError(method, _, message):
             return WebInspectorProxyError.commandFailed(domain: "Target", method: method, message: message)
+        case let .eventDecodingFailed(method, message):
+            return WebInspectorProxyError.disconnected(
+                "Failed to decode \(method): \(message)"
+            )
         case let .missingTarget(targetID):
             return WebInspectorProxyError.disconnected("Target \(targetID.rawValue) disappeared during bootstrap.")
         case let .unsupportedDomain(domain, targetID):

--- a/Sources/WebInspectorProxyKit/WebInspectorProxy.swift
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxy.swift
@@ -75,7 +75,10 @@ public actor WebInspectorProxy {
     private var nextTargetOrdinal: UInt64
     private var nextCloseWaiterID: UInt64
     private var closeWaiters: [UInt64: CheckedContinuation<Void, any Error>]
-    private var closeWaiterRegistrationWaiters: [CheckedContinuation<Void, Never>]
+    private var closeWaiterRegistrationWaiters: [(
+        minimumCount: Int,
+        continuation: CheckedContinuation<Void, Never>
+    )]
     private var cancelledCloseWaiterIDs: Set<UInt64>
     private var closeState: CloseState
 
@@ -357,16 +360,20 @@ public actor WebInspectorProxy {
         return target
     }
 
-    package func waitForCloseWaiterForTesting() async {
+    package func waitForCloseWaiterForTesting(minimumCount: Int = 1) async {
         if case .closed = closeState {
             preconditionFailure("Cannot wait for a close waiter after WebInspectorProxy closed.")
         }
-        guard closeWaiters.isEmpty else {
+        guard closeWaiters.count < minimumCount else {
             return
         }
         await withCheckedContinuation { continuation in
-            closeWaiterRegistrationWaiters.append(continuation)
+            closeWaiterRegistrationWaiters.append((minimumCount, continuation))
         }
+    }
+
+    package var closeWaiterCountForTesting: Int {
+        closeWaiters.count
     }
 
     package func dispatchCommand<Payload: Sendable, Result: Sendable>(
@@ -661,8 +668,8 @@ public actor WebInspectorProxy {
     }
 
     private nonisolated var terminalFailureHandler: WebInspectorProxyTerminalFailureHandler {
-        { failure, broadcast in
-            await self.terminate(failure, broadcast: broadcast)
+        { failure in
+            await self.terminate(failure)
         }
     }
 
@@ -984,21 +991,14 @@ public actor WebInspectorProxy {
     }
 
     private func terminate(
-        _ failure: WebInspectorProxyTerminalFailure,
-        broadcast: WebInspectorProxyTerminalBroadcast
+        _ failure: WebInspectorProxyTerminalFailure
     ) async {
-        switch closeState {
-        case .open:
-            _ = await terminate(.failed(failure), broadcast: broadcast)
-        case let .closing(reason), let .closed(reason):
-            await broadcast(reason.failureError)
-        }
+        _ = await terminate(.failed(failure))
     }
 
     @discardableResult
     private func terminate(
-        _ reason: TerminationReason,
-        broadcast: WebInspectorProxyTerminalBroadcast = { _ in }
+        _ reason: TerminationReason
     ) async -> Bool {
         guard case .open = closeState else {
             return false
@@ -1010,7 +1010,7 @@ public actor WebInspectorProxy {
                 "Inspector connection failed: \(String(describing: failure.publicError), privacy: .private)"
             )
         }
-        await broadcast(reason.failureError)
+        await backend?.finishEventSubscriptions(throwing: reason.failureError)
         await closeConnection?(reason.transportError)
         closeState = .closed(reason)
         resumeCloseWaiters(with: reason)
@@ -1078,10 +1078,14 @@ public actor WebInspectorProxy {
     }
 
     private func resumeCloseWaiterRegistrationWaiters() {
-        let waiters = closeWaiterRegistrationWaiters
-        closeWaiterRegistrationWaiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
+        let ready = closeWaiterRegistrationWaiters.filter {
+            closeWaiters.count >= $0.minimumCount
+        }
+        closeWaiterRegistrationWaiters.removeAll {
+            closeWaiters.count >= $0.minimumCount
+        }
+        for waiter in ready {
+            waiter.continuation.resume()
         }
     }
 

--- a/Sources/WebInspectorProxyKit/WebInspectorProxyBackend.swift
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxyBackend.swift
@@ -22,6 +22,31 @@ package enum WebInspectorProxyEventDomain: String, Hashable, Sendable {
     case page = "Page"
 }
 
+package struct WebInspectorProxyTerminalFailure: Sendable {
+    package let publicError: WebInspectorProxyError
+    package let transportError: TransportSession.Error
+
+    package static func eventDecodingFailed(
+        method: String,
+        error: any Error
+    ) -> WebInspectorProxyTerminalFailure {
+        let message = String(describing: error)
+        return WebInspectorProxyTerminalFailure(
+            publicError: .disconnected("Failed to decode \(method): \(message)"),
+            transportError: .eventDecodingFailed(method: method, message: message)
+        )
+    }
+}
+
+package typealias WebInspectorProxyTerminalBroadcast = @Sendable (
+    WebInspectorProxyError?
+) async -> Void
+
+package typealias WebInspectorProxyTerminalFailureHandler = @Sendable (
+    WebInspectorProxyTerminalFailure,
+    WebInspectorProxyTerminalBroadcast
+) async -> Void
+
 package struct WebInspectorProxyCommandReply<Result: Sendable>: Sendable {
     package let value: Result
     package let receivedSequence: UInt64
@@ -76,9 +101,12 @@ package struct WebInspectorProxyOrderedEvent: Sendable {
 
 package struct WebInspectorProxyOrderedEventFeed: Sendable {
     package let initialSequence: UInt64
-    package let events: AsyncStream<WebInspectorProxyOrderedEvent>
+    package let events: AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>
 
-    package init(initialSequence: UInt64, events: AsyncStream<WebInspectorProxyOrderedEvent>) {
+    package init(
+        initialSequence: UInt64,
+        events: AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>
+    ) {
         self.initialSequence = initialSequence
         self.events = events
     }
@@ -95,13 +123,15 @@ package protocol WebInspectorProxyBackend: Sendable {
 
     func orderedEvents(
         route: RoutingTargetID,
-        targetID: WebInspectorTarget.ID
+        targetID: WebInspectorTarget.ID,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) async -> WebInspectorProxyOrderedEventFeed
 
     nonisolated func events(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
-        domain: WebInspectorProxyEventDomain
+        domain: WebInspectorProxyEventDomain,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) -> AsyncStream<WebInspectorProxyEvent>
 
     func waitForEventSubscription(

--- a/Sources/WebInspectorProxyKit/WebInspectorProxyBackend.swift
+++ b/Sources/WebInspectorProxyKit/WebInspectorProxyBackend.swift
@@ -38,13 +38,8 @@ package struct WebInspectorProxyTerminalFailure: Sendable {
     }
 }
 
-package typealias WebInspectorProxyTerminalBroadcast = @Sendable (
-    WebInspectorProxyError?
-) async -> Void
-
 package typealias WebInspectorProxyTerminalFailureHandler = @Sendable (
-    WebInspectorProxyTerminalFailure,
-    WebInspectorProxyTerminalBroadcast
+    WebInspectorProxyTerminalFailure
 ) async -> Void
 
 package struct WebInspectorProxyCommandReply<Result: Sendable>: Sendable {
@@ -120,6 +115,8 @@ package protocol WebInspectorProxyBackend: Sendable {
     func dispatchCommandWithReplyBoundary<Payload: Sendable, Result: Sendable>(
         _ command: WebInspectorProxyCommand<Payload, Result>
     ) async throws -> WebInspectorProxyCommandReply<Result>
+
+    func finishEventSubscriptions(throwing error: WebInspectorProxyError?) async
 
     func orderedEvents(
         route: RoutingTargetID,

--- a/Sources/WebInspectorProxyKitTesting/WebInspectorTestBackend.swift
+++ b/Sources/WebInspectorProxyKitTesting/WebInspectorTestBackend.swift
@@ -126,7 +126,11 @@ public actor WebInspectorTestBackend {
     private var completedCommands: [RecordedCommand]
     private var heldCommands: [HeldCommand]
     private var eventContinuations: [EventSubscriptionKey: [UUID: AsyncStream<WebInspectorProxyEvent>.Continuation]]
-    private var orderedEventContinuations: [OrderedEventSubscriptionKey: [UUID: AsyncStream<WebInspectorProxyOrderedEvent>.Continuation]]
+    private var orderedEventContinuations: [
+        OrderedEventSubscriptionKey: [
+            UUID: AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.Continuation
+        ]
+    ]
     private var orderedEventSequence: UInt64
     private var subscriberWaiters: [SubscriberWaiter]
     private var recordedCommandWaiters: [RecordedCommandWaiter]
@@ -382,7 +386,7 @@ public actor WebInspectorTestBackend {
     }
 
     private func addOrderedEventContinuation(
-        _ continuation: AsyncStream<WebInspectorProxyOrderedEvent>.Continuation,
+        _ continuation: AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.Continuation,
         id: UUID,
         key: OrderedEventSubscriptionKey
     ) {
@@ -625,10 +629,14 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
 
     package func orderedEvents(
         route: RoutingTargetID,
-        targetID: WebInspectorTarget.ID
+        targetID: WebInspectorTarget.ID,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) async -> WebInspectorProxyOrderedEventFeed {
+        _ = terminalFailureHandler
         let key = OrderedEventSubscriptionKey(route: route, targetID: targetID)
-        let pair = AsyncStream<WebInspectorProxyOrderedEvent>.makeStream(bufferingPolicy: .unbounded)
+        let pair = AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.makeStream(
+            bufferingPolicy: .unbounded
+        )
         let id = UUID()
         addOrderedEventContinuation(pair.continuation, id: id, key: key)
         pair.continuation.onTermination = { _ in
@@ -653,8 +661,10 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
     package nonisolated func events(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
-        domain: WebInspectorProxyEventDomain
+        domain: WebInspectorProxyEventDomain,
+        terminalFailureHandler: @escaping WebInspectorProxyTerminalFailureHandler
     ) -> AsyncStream<WebInspectorProxyEvent> {
+        _ = terminalFailureHandler
         _ = route
         let key = EventSubscriptionKey(route: route, targetID: targetID, domain: domain)
         return AsyncStream<WebInspectorProxyEvent> { continuation in

--- a/Sources/WebInspectorProxyKitTesting/WebInspectorTestBackend.swift
+++ b/Sources/WebInspectorProxyKitTesting/WebInspectorTestBackend.swift
@@ -96,7 +96,12 @@ private struct SubscriberWaiter: Sendable {
     var targetID: WebInspectorTarget.ID
     var domain: WebInspectorProxyEventDomain
     var count: Int
-    var continuation: CheckedContinuation<Void, Never>
+    var promise: ReplyPromise<Void>
+}
+
+private struct SubscriberWaiterRegistrationWaiter: Sendable {
+    var id: UInt64
+    var promise: ReplyPromise<Void>
 }
 
 private struct RecordedCommandWaiter: Sendable {
@@ -111,6 +116,14 @@ private struct CompletedCommandWaiter: Sendable {
     var method: String
     var count: Int
     var continuation: CheckedContinuation<[RecordedCommand], Never>
+}
+
+private struct EventTermination: Sendable {
+    var error: WebInspectorProxyError?
+
+    var operationError: WebInspectorProxyError {
+        error ?? .closed
+    }
 }
 
 /// Errors thrown by ``WebInspectorTestBackend`` helpers.
@@ -131,12 +144,15 @@ public actor WebInspectorTestBackend {
             UUID: AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.Continuation
         ]
     ]
+    private var cancelledEventSubscriptionIDs: Set<UUID>
+    private var eventTermination: EventTermination?
     private var orderedEventSequence: UInt64
     private var subscriberWaiters: [SubscriberWaiter]
+    private var subscriberWaiterRegistrationWaiters: [SubscriberWaiterRegistrationWaiter]
     private var recordedCommandWaiters: [RecordedCommandWaiter]
     private var completedCommandWaiters: [CompletedCommandWaiter]
     private var nextSubscriberWaiterID: UInt64
-    private var cancelledSubscriberWaiterIDs: Set<UInt64>
+    private var nextSubscriberWaiterRegistrationWaiterID: UInt64
 
     /// Creates an empty test backend.
     public init() {
@@ -146,12 +162,15 @@ public actor WebInspectorTestBackend {
         heldCommands = []
         eventContinuations = [:]
         orderedEventContinuations = [:]
+        cancelledEventSubscriptionIDs = []
+        eventTermination = nil
         orderedEventSequence = 0
         subscriberWaiters = []
+        subscriberWaiterRegistrationWaiters = []
         recordedCommandWaiters = []
         completedCommandWaiters = []
         nextSubscriberWaiterID = 0
-        cancelledSubscriberWaiterIDs = []
+        nextSubscriberWaiterRegistrationWaiterID = 0
     }
 
     /// Enqueues a successful reply for the next matching command.
@@ -310,7 +329,7 @@ public actor WebInspectorTestBackend {
         guard let eventDomain = WebInspectorProxyEventDomain(rawValue: domain) else {
             throw WebInspectorTestBackendError.unsupportedEventDomain(domain)
         }
-        await waitForSubscriber(route: nil, targetID: target, domain: eventDomain, count: count)
+        try await waitForSubscriber(route: nil, targetID: target, domain: eventDomain, count: count)
     }
 
     /// Waits until a target has at least the requested subscriber count.
@@ -322,7 +341,7 @@ public actor WebInspectorTestBackend {
         guard let eventDomain = WebInspectorProxyEventDomain(rawValue: domain) else {
             throw WebInspectorTestBackendError.unsupportedEventDomain(domain)
         }
-        await waitForSubscriber(route: target.route, targetID: target.id, domain: eventDomain, count: count)
+        try await waitForSubscriber(route: target.route, targetID: target.id, domain: eventDomain, count: count)
     }
 
     /// Returns the number of active ordered event subscribers for a target.
@@ -331,6 +350,57 @@ public actor WebInspectorTestBackend {
             route: target.route,
             targetID: target.id
         )]?.count ?? 0
+    }
+
+    package func eventSubscriptionBookkeepingCountForTesting() -> Int {
+        eventContinuations.values.reduce(0) { $0 + $1.count }
+            + orderedEventContinuations.values.reduce(0) { $0 + $1.count }
+            + cancelledEventSubscriptionIDs.count
+    }
+
+    package func eventSubscriptionWaiterCountForTesting() -> Int {
+        subscriberWaiters.count
+    }
+
+    package func waitForEventSubscriptionWaiterForTesting() async {
+        guard subscriberWaiters.isEmpty, eventTermination == nil else {
+            return
+        }
+        let id = nextSubscriberWaiterRegistrationWaiterID
+        nextSubscriberWaiterRegistrationWaiterID += 1
+        let waiter = SubscriberWaiterRegistrationWaiter(
+            id: id,
+            promise: ReplyPromise<Void>()
+        )
+        subscriberWaiterRegistrationWaiters.append(waiter)
+        defer {
+            subscriberWaiterRegistrationWaiters.removeAll { $0.id == id }
+        }
+        _ = try? await waiter.promise.value()
+    }
+
+    package func exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: Bool,
+        route: RoutingTargetID,
+        targetID: WebInspectorTarget.ID
+    ) -> Bool {
+        let id = UUID()
+        if ordered {
+            let key = OrderedEventSubscriptionKey(route: route, targetID: targetID)
+            let pair = AsyncThrowingStream<WebInspectorProxyOrderedEvent, any Error>.makeStream()
+            cancelOrderedEventContinuation(id: id, key: key)
+            addOrderedEventContinuation(pair.continuation, id: id, key: key)
+            return eventSubscriptionBookkeepingCountForTesting() == 0
+        }
+        let key = EventSubscriptionKey(
+            route: route,
+            targetID: targetID,
+            domain: .network
+        )
+        let pair = AsyncStream<WebInspectorProxyEvent>.makeStream()
+        cancelEventContinuation(id: id, key: key)
+        addEventContinuation(pair.continuation, id: id, key: key)
+        return eventSubscriptionBookkeepingCountForTesting() == 0
     }
 
     /// Holds matching commands until the supplied gate opens.
@@ -344,6 +414,9 @@ public actor WebInspectorTestBackend {
         route: RoutingTargetID?,
         domain: WebInspectorProxyEventDomain
     ) {
+        guard eventTermination == nil else {
+            return
+        }
         let (nextSequence, overflow) = orderedEventSequence.addingReportingOverflow(1)
         precondition(!overflow, "Test event sequence exhausted.")
         orderedEventSequence = nextSequence
@@ -374,14 +447,28 @@ public actor WebInspectorTestBackend {
         id: UUID,
         key: EventSubscriptionKey
     ) {
+        guard eventTermination == nil else {
+            continuation.finish()
+            return
+        }
+        guard cancelledEventSubscriptionIDs.remove(id) == nil else {
+            continuation.finish()
+            return
+        }
         eventContinuations[key, default: [:]][id] = continuation
         resolveSubscriberWaiters()
     }
 
-    private func removeEventContinuation(id: UUID, key: EventSubscriptionKey) {
-        eventContinuations[key]?[id] = nil
+    private func cancelEventContinuation(id: UUID, key: EventSubscriptionKey) {
+        guard eventTermination == nil else {
+            return
+        }
+        guard eventContinuations[key]?.removeValue(forKey: id) != nil else {
+            cancelledEventSubscriptionIDs.insert(id)
+            return
+        }
         if eventContinuations[key]?.isEmpty == true {
-            eventContinuations[key] = nil
+            eventContinuations.removeValue(forKey: key)
         }
     }
 
@@ -390,14 +477,28 @@ public actor WebInspectorTestBackend {
         id: UUID,
         key: OrderedEventSubscriptionKey
     ) {
-        orderedEventContinuations[key, default: [:]][id] = continuation
-        resolveSubscriberWaiters()
+        guard let termination = eventTermination else {
+            guard cancelledEventSubscriptionIDs.remove(id) == nil else {
+                continuation.finish()
+                return
+            }
+            orderedEventContinuations[key, default: [:]][id] = continuation
+            resolveSubscriberWaiters()
+            return
+        }
+        continuation.finish(throwing: termination.error)
     }
 
-    private func removeOrderedEventContinuation(id: UUID, key: OrderedEventSubscriptionKey) {
-        orderedEventContinuations[key]?[id] = nil
+    private func cancelOrderedEventContinuation(id: UUID, key: OrderedEventSubscriptionKey) {
+        guard eventTermination == nil else {
+            return
+        }
+        guard orderedEventContinuations[key]?.removeValue(forKey: id) != nil else {
+            cancelledEventSubscriptionIDs.insert(id)
+            return
+        }
         if orderedEventContinuations[key]?.isEmpty == true {
-            orderedEventContinuations[key] = nil
+            orderedEventContinuations.removeValue(forKey: key)
         }
     }
 
@@ -450,7 +551,7 @@ public actor WebInspectorTestBackend {
         var unresolved: [SubscriberWaiter] = []
         for waiter in subscriberWaiters {
             if subscriberCount(for: waiter) >= waiter.count {
-                waiter.continuation.resume()
+                waiter.promise.fulfill(.success(()))
             } else {
                 unresolved.append(waiter)
             }
@@ -463,47 +564,49 @@ public actor WebInspectorTestBackend {
         targetID: WebInspectorTarget.ID,
         domain: WebInspectorProxyEventDomain,
         count: Int
-    ) async {
+    ) async throws {
+        if let termination = eventTermination {
+            throw termination.operationError
+        }
         let waiterID = nextSubscriberWaiterID
         nextSubscriberWaiterID += 1
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                addSubscriberWaiter(SubscriberWaiter(
-                    id: waiterID,
-                    route: route,
-                    targetID: targetID,
-                    domain: domain,
-                    count: count,
-                    continuation: continuation
-                ))
-            }
-        } onCancel: {
-            Task {
-                await self.cancelSubscriberWaiter(waiterID)
-            }
+        let waiter = SubscriberWaiter(
+            id: waiterID,
+            route: route,
+            targetID: targetID,
+            domain: domain,
+            count: count,
+            promise: ReplyPromise<Void>()
+        )
+        addSubscriberWaiter(waiter)
+        defer {
+            removeSubscriberWaiter(waiterID)
         }
-        cancelledSubscriberWaiterIDs.remove(waiterID)
+        try await waiter.promise.value()
     }
 
     private func addSubscriberWaiter(_ waiter: SubscriberWaiter) {
-        guard cancelledSubscriberWaiterIDs.remove(waiter.id) == nil else {
-            waiter.continuation.resume()
+        if let termination = eventTermination {
+            waiter.promise.fulfill(.failure(termination.operationError))
             return
         }
         guard subscriberCount(for: waiter) < waiter.count else {
-            waiter.continuation.resume()
+            waiter.promise.fulfill(.success(()))
             return
         }
         subscriberWaiters.append(waiter)
+        let registrationWaiters = subscriberWaiterRegistrationWaiters
+        subscriberWaiterRegistrationWaiters.removeAll()
+        for waiter in registrationWaiters {
+            waiter.promise.fulfill(.success(()))
+        }
     }
 
-    private func cancelSubscriberWaiter(_ id: UInt64) {
+    private func removeSubscriberWaiter(_ id: UInt64) {
         guard let index = subscriberWaiters.firstIndex(where: { $0.id == id }) else {
-            cancelledSubscriberWaiterIDs.insert(id)
             return
         }
-        let waiter = subscriberWaiters.remove(at: index)
-        waiter.continuation.resume()
+        subscriberWaiters.remove(at: index)
     }
 
     private func subscriberCount(for waiter: SubscriberWaiter) -> Int {
@@ -586,6 +689,10 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
             await gate.wait()
         }
 
+        if let termination = eventTermination {
+            throw termination.error ?? WebInspectorProxyError.closed
+        }
+
         let key = CommandKey(domain: command.domain.rawValue, method: command.method)
         guard var results = enqueuedReplies[key], results.isEmpty == false else {
             throw WebInspectorProxyError.commandFailed(
@@ -627,6 +734,44 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
         )
     }
 
+    package func finishEventSubscriptions(throwing error: WebInspectorProxyError?) async {
+        guard eventTermination == nil else {
+            return
+        }
+        let termination = EventTermination(error: error)
+        eventTermination = termination
+        let domainContinuations = eventContinuations.values.flatMap { Array($0.values) }
+        eventContinuations.removeAll()
+        let orderedContinuations = orderedEventContinuations.values.flatMap { Array($0.values) }
+        orderedEventContinuations.removeAll()
+        cancelledEventSubscriptionIDs.removeAll()
+        let waiters = subscriberWaiters
+        subscriberWaiters.removeAll()
+        let registrationWaiters = subscriberWaiterRegistrationWaiters
+        subscriberWaiterRegistrationWaiters.removeAll()
+        let gates = Set(heldCommands.map { ObjectIdentifier($0.gate) })
+            .compactMap { identifier in
+                heldCommands.first { ObjectIdentifier($0.gate) == identifier }?.gate
+            }
+        heldCommands.removeAll()
+
+        for waiter in waiters {
+            waiter.promise.fulfill(.failure(termination.operationError))
+        }
+        for waiter in registrationWaiters {
+            waiter.promise.fulfill(.success(()))
+        }
+        for continuation in domainContinuations {
+            continuation.finish()
+        }
+        for continuation in orderedContinuations {
+            continuation.finish(throwing: error)
+        }
+        for gate in gates {
+            await gate.open()
+        }
+    }
+
     package func orderedEvents(
         route: RoutingTargetID,
         targetID: WebInspectorTarget.ID,
@@ -638,12 +783,12 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
             bufferingPolicy: .unbounded
         )
         let id = UUID()
-        addOrderedEventContinuation(pair.continuation, id: id, key: key)
         pair.continuation.onTermination = { _ in
             Task {
-                await self.removeOrderedEventContinuation(id: id, key: key)
+                await self.cancelOrderedEventContinuation(id: id, key: key)
             }
         }
+        addOrderedEventContinuation(pair.continuation, id: id, key: key)
         return WebInspectorProxyOrderedEventFeed(
             initialSequence: orderedEventSequence,
             events: pair.stream
@@ -655,7 +800,7 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
         targetID: WebInspectorTarget.ID,
         domain: WebInspectorProxyEventDomain
     ) async {
-        await waitForSubscriber(route: route, targetID: targetID, domain: domain, count: 1)
+        try? await waitForSubscriber(route: route, targetID: targetID, domain: domain, count: 1)
     }
 
     package nonisolated func events(
@@ -669,13 +814,13 @@ extension WebInspectorTestBackend: WebInspectorProxyBackend {
         let key = EventSubscriptionKey(route: route, targetID: targetID, domain: domain)
         return AsyncStream<WebInspectorProxyEvent> { continuation in
             let id = UUID()
-            Task {
-                await self.addEventContinuation(continuation, id: id, key: key)
-            }
             continuation.onTermination = { _ in
                 Task {
-                    await self.removeEventContinuation(id: id, key: key)
+                    await self.cancelEventContinuation(id: id, key: key)
                 }
+            }
+            Task {
+                await self.addEventContinuation(continuation, id: id, key: key)
             }
         }
     }

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -1316,6 +1316,35 @@ func malformedKnownOrderedEventFailsAttachedContext() async throws {
         targetID: targetID,
         documentID: "decode-failure-root"
     )
+    let proxy = context.inspectionProxyForTesting
+    let target = try #require(context.currentPageForTesting)
+    let failedStatusTask = Task<WebInspectorContext.Status?, Never> { @MainActor in
+        for await status in context.statusUpdates {
+            if case .failed = status.state {
+                return status
+            }
+        }
+        return nil
+    }
+    let proxyCloseTask = Task {
+        await terminalProxyError(from: proxy)
+    }
+    let retargetBoundary = context.eventPumpAppliedSequenceForTesting
+    await transport.receiveRootMessage(
+        #"{"method":"Target.targetDestroyed","params":{"targetId":"page-decode-failure"}}"#
+    )
+    #expect(await context.waitForEventPumpAppliedSequenceForTesting(after: retargetBoundary))
+    let retargetTask = try #require(context.currentPageRetargetTaskForTesting())
+    let subscriptionBeforeFailure = context.orderedEventSubscriptionStateForTesting
+    let appliedBeforeFailure = context.eventPumpAppliedSequenceForTesting
+    let boundaryRegistration = ReplyPromise<Void>()
+    let boundaryWaiter = Task { @MainActor in
+        await context.waitForOrderedEventsForTesting(
+            through: subscriptionBeforeFailure.sequence + 1,
+            registration: boundaryRegistration
+        )
+    }
+    try await boundaryRegistration.value()
 
     await receiveTransportTargetEvent(
         transport,
@@ -1324,18 +1353,46 @@ func malformedKnownOrderedEventFailsAttachedContext() async throws {
         params: "{}"
     )
 
-    try await waitUntil {
-        if case .failed = context.state {
-            return true
-        }
-        return false
-    }
-    guard case let .failed(error) = context.state,
+    let failedStatus = try #require(await failedStatusTask.value)
+    let proxyError = try #require(await proxyCloseTask.value)
+    guard case let .failed(error) = failedStatus.state,
           case let .disconnected(message) = error else {
         Issue.record("Expected the context to fail with a disconnected error.")
         return
     }
     #expect(message.contains("Network.loadingFinished"))
+    #expect(proxyError == error)
+    #expect(await boundaryWaiter.value == false)
+    await retargetTask.value
+    #expect(context.currentPageRetargetTaskForTesting() == nil)
+    #expect(context.currentPageForTesting?.id == target.id)
+    #expect(context.rootNode?.id == DOMNode.ID(DOM.Node.ID("decode-failure-root")))
+    let subscriptionAfterFailure = context.orderedEventSubscriptionStateForTesting
+    #expect(subscriptionAfterFailure.generation == subscriptionBeforeFailure.generation + 1)
+    #expect(subscriptionAfterFailure.sequence == subscriptionBeforeFailure.sequence)
+    #expect(context.eventPumpAppliedSequenceForTesting == appliedBeforeFailure)
+    await context.applyOrderedEventForTesting(
+        WebInspectorProxyOrderedEvent(
+            sequence: subscriptionBeforeFailure.sequence + 1,
+            event: .network(.dataReceived(
+                id: Network.Request.ID("stale-after-failure"),
+                dataLength: 1,
+                encodedDataLength: 1,
+                timestamp: 4
+            ))
+        ),
+        target: target,
+        subscriptionGeneration: subscriptionBeforeFailure.generation
+    )
+    #expect(context.eventPumpAppliedSequenceForTesting == appliedBeforeFailure)
+    #expect(context.orderedEventSubscriptionStateForTesting == subscriptionAfterFailure)
+    context.handleOrderedEventStreamFailureForTesting(
+        WebInspectorProxyError.disconnected("stale failure callback"),
+        subscriptionGeneration: subscriptionBeforeFailure.generation
+    )
+    #expect(context.eventPumpAppliedSequenceForTesting == appliedBeforeFailure)
+    #expect(context.orderedEventSubscriptionStateForTesting == subscriptionAfterFailure)
+    #expect(context.state == failedStatus.state)
     #expect(await backend.isDetached())
 }
 
@@ -1349,6 +1406,17 @@ func malformedKnownOrderedEventFailsAttachingContextWithoutHanging() async throw
     let proxy = try await WebInspectorProxy(transport: transport)
     let container = WebInspectorContainer(proxy: proxy)
     let context = container.mainContext
+    let failedStatusTask = Task<WebInspectorContext.Status?, Never> { @MainActor in
+        for await status in context.statusUpdates {
+            if case .failed = status.state {
+                return status
+            }
+        }
+        return nil
+    }
+    let proxyCloseTask = Task {
+        await terminalProxyError(from: proxy)
+    }
 
     _ = try await waitForTransportTargetMessage(backend, method: "Inspector.enable")
     await receiveTransportTargetEvent(
@@ -1358,18 +1426,15 @@ func malformedKnownOrderedEventFailsAttachingContextWithoutHanging() async throw
         params: "{}"
     )
 
-    try await waitUntil {
-        if case .failed = context.state {
-            return true
-        }
-        return false
-    }
-    guard case let .failed(error) = context.state,
+    let failedStatus = try #require(await failedStatusTask.value)
+    let proxyError = try #require(await proxyCloseTask.value)
+    guard case let .failed(error) = failedStatus.state,
           case let .disconnected(message) = error else {
         Issue.record("Expected startup to fail with a disconnected error.")
         return
     }
     #expect(message.contains("Network.loadingFinished"))
+    #expect(proxyError == error)
     #expect(await backend.isDetached())
 }
 
@@ -3308,7 +3373,7 @@ func currentPageCommitRetargetsDataKitStateToNewTransportTarget() async throws {
         transport,
         targetID: oldTargetID,
         method: "DOM.childNodeInserted",
-        params: ##"{"parentNodeId":"new-root","previousNodeId":null,"node":{"nodeId":"old-route-child","nodeType":1,"nodeName":"DIV","localName":"div","nodeValue":"","childNodeCount":0}}"##
+        params: ##"{"parentNodeId":"new-root","previousNodeId":0,"node":{"nodeId":"old-route-child","nodeType":1,"nodeName":"DIV","localName":"div","nodeValue":"","childNodeCount":0}}"##
     )
     await receiveTransportTargetEvent(
         transport,
@@ -14357,7 +14422,9 @@ private func startTransportBackedContext(
         result: "{}"
     )
 
-    try await waitUntil { context.state == .attached }
+    let startupTask = try #require(context.startupTaskForTesting())
+    await startupTask.value
+    #expect(context.state == .attached)
     return (backend, transport, context)
 }
 
@@ -14594,6 +14661,19 @@ private func receiveTransportTargetEvent(
         targetID: targetID,
         message: #"{"method":"\#(method)","params":\#(params)}"#
     ))
+}
+
+private func terminalProxyError(from proxy: WebInspectorProxy) async -> WebInspectorProxyError? {
+    do {
+        try await proxy.waitUntilClosed()
+        Issue.record("Expected the proxy to close with a terminal failure.")
+        return nil
+    } catch let error as WebInspectorProxyError {
+        return error
+    } catch {
+        Issue.record("Expected WebInspectorProxyError, got \(error).")
+        return nil
+    }
 }
 
 private func emitTransportNetworkRequest(

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -1310,6 +1310,71 @@ func consecutiveDocumentUpdatesReloadLatestDocumentWithinSingleLoad() async thro
 
 @MainActor
 @Test
+func malformedKnownOrderedEventFailsAttachedContext() async throws {
+    let targetID = ProtocolTarget.ID("page-decode-failure")
+    let (backend, transport, context) = try await startTransportBackedContext(
+        targetID: targetID,
+        documentID: "decode-failure-root"
+    )
+
+    await receiveTransportTargetEvent(
+        transport,
+        targetID: targetID,
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    try await waitUntil {
+        if case .failed = context.state {
+            return true
+        }
+        return false
+    }
+    guard case let .failed(error) = context.state,
+          case let .disconnected(message) = error else {
+        Issue.record("Expected the context to fail with a disconnected error.")
+        return
+    }
+    #expect(message.contains("Network.loadingFinished"))
+    #expect(await backend.isDetached())
+}
+
+@MainActor
+@Test
+func malformedKnownOrderedEventFailsAttachingContextWithoutHanging() async throws {
+    let targetID = ProtocolTarget.ID("page-startup-decode-failure")
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installTransportPageTarget(in: transport, targetID: targetID)
+    let proxy = try await WebInspectorProxy(transport: transport)
+    let container = WebInspectorContainer(proxy: proxy)
+    let context = container.mainContext
+
+    _ = try await waitForTransportTargetMessage(backend, method: "Inspector.enable")
+    await receiveTransportTargetEvent(
+        transport,
+        targetID: targetID,
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    try await waitUntil {
+        if case .failed = context.state {
+            return true
+        }
+        return false
+    }
+    guard case let .failed(error) = context.state,
+          case let .disconnected(message) = error else {
+        Issue.record("Expected startup to fail with a disconnected error.")
+        return
+    }
+    #expect(message.contains("Network.loadingFinished"))
+    #expect(await backend.isDetached())
+}
+
+@MainActor
+@Test
 func currentPageCommitBeforePageEnableAcquiresCommittedPageLease() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let target = try await runtime.proxy.waitForCurrentPage()

--- a/Tests/WebInspectorProxyKitTests/TransportSessionTests.swift
+++ b/Tests/WebInspectorProxyKitTests/TransportSessionTests.swift
@@ -1385,6 +1385,40 @@ func waitForCurrentMainPageTargetFailsAfterDetach() async throws {
 }
 
 @Test
+func terminalDecodeFailureResolvesCurrentPageWaitersWithWinningReason() async throws {
+    let backend = FakeTransportBackend()
+    let timeout = ManualResponseTimeout()
+    let session = TransportSession(
+        backend: backend,
+        responseTimeout: testResponseTimeout,
+        timeoutSleep: { duration in
+            try await timeout.sleep(for: duration)
+        }
+    )
+    let waiter = Task {
+        try await session.waitForCurrentMainPageTarget(timeout: .seconds(1))
+    }
+    await timeout.waitUntilSuspended()
+    let terminalError = TransportSession.Error.eventDecodingFailed(
+        method: "DOM.setChildNodes",
+        message: "missing parentId"
+    )
+
+    await session.detach(error: terminalError)
+
+    await #expect(throws: terminalError) {
+        try await waiter.value
+    }
+    await #expect(throws: terminalError) {
+        try await session.waitForCurrentMainPageTarget()
+    }
+    await #expect(throws: terminalError) {
+        try await session.requireOpen()
+    }
+    #expect(await backend.isDetached())
+}
+
+@Test
 func receiveRootMessageAfterDetachDoesNotMutateSnapshot() async throws {
     let backend = FakeTransportBackend()
     let session = TransportSession(backend: backend, responseTimeout: testResponseTimeout)

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import WebInspectorProxyKit
+import WebInspectorProxyKitTesting
 import WebInspectorTestSupport
 
 private let transportCommandBackendWaitTimeout: Duration = .milliseconds(750)
@@ -603,6 +604,185 @@ func transportBackedProxyCloseDetachesTransportAndFinishesEventStreams() async t
 }
 
 @Test
+func testRuntimeCloseFinishesActiveAndLateDomainAndOrderedStreams() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let target = try await runtime.proxy.waitForCurrentPage()
+    let activeDomainTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    let activeOrderedFeed = await target.orderedEventFeed()
+    let activeOrderedTask = Task {
+        var iterator = activeOrderedFeed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    try await runtime.backend.waitForSubscribers(
+        domain: "Network",
+        target: target,
+        count: 2
+    )
+
+    await runtime.proxy.close()
+
+    #expect(try await value(of: activeDomainTask) == nil)
+    #expect(try await throwingValue(of: activeOrderedTask) == nil)
+    var lateDomainIterator = target.network.events.makeAsyncIterator()
+    #expect(await lateDomainIterator.next() == nil)
+    let lateOrderedFeed = await target.orderedEventFeed()
+    var lateOrderedIterator = lateOrderedFeed.events.makeAsyncIterator()
+    #expect(try await lateOrderedIterator.next() == nil)
+    #expect(await runtime.backend.eventSubscriptionBookkeepingCountForTesting() == 0)
+}
+
+@Test
+func testRuntimeCloseReleasesPendingCommandsAndSubscriberWaiters() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let target = try await runtime.proxy.waitForCurrentPage()
+    let commandGate = WebInspectorProxyKitTesting.WebInspectorTestGate()
+    await runtime.backend.hold(domain: "Network", method: "enable", gate: commandGate)
+    await runtime.backend.enqueue((), for: "Network", method: "enable")
+    let commandTask = Task {
+        try await target.network.enable()
+    }
+    _ = await runtime.backend.waitForRecordedCommands(
+        domain: "Network",
+        method: "enable",
+        count: 1
+    )
+    let subscriberWaitTask = Task {
+        try await runtime.backend.waitForSubscribers(
+            domain: "Network",
+            target: target,
+            count: 1
+        )
+    }
+    await runtime.backend.waitForEventSubscriptionWaiterForTesting()
+    #expect(await runtime.backend.eventSubscriptionWaiterCountForTesting() == 1)
+
+    await runtime.proxy.close()
+
+    await #expect(throws: WebInspectorProxyError.closed) {
+        try await commandTask.value
+    }
+    await #expect(throws: WebInspectorProxyError.closed) {
+        try await subscriberWaitTask.value
+    }
+    await #expect(throws: WebInspectorProxyError.closed) {
+        try await runtime.backend.waitForSubscribers(
+            domain: "Network",
+            target: target,
+            count: 1
+        )
+    }
+    #expect(await runtime.backend.eventSubscriptionWaiterCountForTesting() == 0)
+    #expect(await runtime.backend.eventSubscriptionBookkeepingCountForTesting() == 0)
+}
+
+@Test
+func subscriptionCancellationBeforeRegistrationLeavesNoBookkeeping() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let target = pageTarget(proxy: proxy)
+
+    #expect(await liveBackend.exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: false,
+        route: target.route,
+        targetID: target.id
+    ))
+    #expect(await liveBackend.exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: true,
+        route: target.route,
+        targetID: target.id
+    ))
+
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let runtimeTarget = try await runtime.proxy.waitForCurrentPage()
+    #expect(await runtime.backend.exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: false,
+        route: runtimeTarget.route,
+        targetID: runtimeTarget.id
+    ))
+    #expect(await runtime.backend.exerciseCancelledSubscriptionRegistrationForTesting(
+        ordered: true,
+        route: runtimeTarget.route,
+        targetID: runtimeTarget.id
+    ))
+
+    let waiterTask = Task {
+        try await runtime.backend.waitForSubscribers(
+            domain: "Network",
+            target: runtimeTarget,
+            count: 1
+        )
+    }
+    await runtime.backend.waitForEventSubscriptionWaiterForTesting()
+    #expect(await runtime.backend.eventSubscriptionWaiterCountForTesting() == 1)
+    waiterTask.cancel()
+    await #expect(throws: CancellationError.self) {
+        try await waiterTask.value
+    }
+    #expect(await runtime.backend.eventSubscriptionWaiterCountForTesting() == 0)
+    #expect(await runtime.backend.eventSubscriptionBookkeepingCountForTesting() == 0)
+    await runtime.proxy.close()
+    await proxy.close()
+}
+
+@Test
+func liveSubscriptionWaitersReleaseOnCancellationAndExplicitClose() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let target = pageTarget(proxy: proxy)
+
+    let cancelledWaiter = Task {
+        await liveBackend.waitForEventSubscriptions(
+            route: target.route,
+            targetID: target.id,
+            domain: .network,
+            minimumCount: 1
+        )
+    }
+    await liveBackend.waitForEventSubscriptionWaiterForTesting()
+    #expect(await liveBackend.eventSubscriptionWaiterCountForTesting() == 1)
+    cancelledWaiter.cancel()
+    await cancelledWaiter.value
+    #expect(await liveBackend.eventSubscriptionWaiterCountForTesting() == 0)
+
+    let terminalWaiter = Task {
+        await liveBackend.waitForEventSubscriptions(
+            route: target.route,
+            targetID: target.id,
+            domain: .network,
+            minimumCount: 1
+        )
+    }
+    await liveBackend.waitForEventSubscriptionWaiterForTesting()
+    #expect(await liveBackend.eventSubscriptionWaiterCountForTesting() == 1)
+
+    await proxy.close()
+
+    await terminalWaiter.value
+    #expect(await liveBackend.eventSubscriptionWaiterCountForTesting() == 0)
+    #expect(await liveBackend.eventSubscriptionBookkeepingCountForTesting() == 0)
+    #expect(await backend.isDetached())
+}
+
+@Test
 func malformedKnownDomainEventTerminatesProxyAndPendingCommand() async throws {
     let backend = FakeTransportBackend()
     let transport = TransportSession(backend: backend, responseTimeout: nil)
@@ -679,7 +859,7 @@ func malformedKnownOrderedEventPropagatesTerminalFailure() async throws {
 }
 
 @Test
-func malformedKnownEventPropagatesFailureToEveryOrderedSubscriber() async throws {
+func malformedKnownDOMEventTerminatesFilteredDomainRouteWithoutDelivering() async throws {
     let backend = FakeTransportBackend()
     let transport = TransportSession(backend: backend, responseTimeout: nil)
     await installPageTarget(in: transport)
@@ -687,6 +867,185 @@ func malformedKnownEventPropagatesFailureToEveryOrderedSubscriber() async throws
     let proxy = WebInspectorProxy(
         backend: liveBackend,
         closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let filteredTarget = WebInspectorTarget(
+        id: WebInspectorTarget.ID("filtered-frame"),
+        kind: .frame,
+        frameID: FrameID("filtered-frame"),
+        isProvisional: false,
+        proxy: proxy,
+        route: RoutingTargetID("filtered-frame")
+    )
+    let eventTask = Task {
+        var iterator = filteredTarget.dom.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    await liveBackend.waitForEventSubscriptions(
+        route: filteredTarget.route,
+        targetID: filteredTarget.id,
+        domain: .dom,
+        minimumCount: 1
+    )
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "DOM.setChildNodes",
+        params: "{}"
+    )
+
+    #expect(try await value(of: eventTask) == nil)
+    let closeMessage = await disconnectedMessage(from: Task {
+        try await proxy.waitUntilClosed()
+    })
+    #expect(closeMessage?.contains("DOM.setChildNodes") == true)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func malformedKnownEventTerminatesFilteredOrderedRouteWithoutWatermark() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let filteredTarget = WebInspectorTarget(
+        id: WebInspectorTarget.ID("filtered-frame"),
+        kind: .frame,
+        frameID: FrameID("filtered-frame"),
+        isProvisional: false,
+        proxy: proxy,
+        route: RoutingTargetID("filtered-frame")
+    )
+    let feed = await filteredTarget.orderedEventFeed()
+    let eventTask = Task {
+        var iterator = feed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    await liveBackend.waitForEventSubscriptions(
+        route: filteredTarget.route,
+        targetID: filteredTarget.id,
+        domain: .ordered,
+        minimumCount: 1
+    )
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    let closeMessage = await disconnectedMessage(from: eventTask)
+    #expect(closeMessage?.contains("Network.loadingFinished") == true)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func domainSubscribersFinishBeforeGatedDetachAndFailureReasonWinsLaterClose() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let closeGate = CloseConnectionGate()
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await closeGate.waitUntilReleased()
+            await transport.detach(error: error)
+        }
+    )
+    let currentPage = WebInspectorTarget(
+        id: .currentPage,
+        kind: .page,
+        frameID: nil,
+        isProvisional: false,
+        proxy: proxy,
+        route: .currentPage
+    )
+    let filteredTarget = WebInspectorTarget(
+        id: WebInspectorTarget.ID("filtered-frame"),
+        kind: .frame,
+        frameID: FrameID("filtered-frame"),
+        isProvisional: false,
+        proxy: proxy,
+        route: RoutingTargetID("filtered-frame")
+    )
+    let currentTask = Task {
+        var iterator = currentPage.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    let filteredTask = Task {
+        var iterator = filteredTarget.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    await liveBackend.waitForEventSubscriptions(
+        route: currentPage.route,
+        targetID: currentPage.id,
+        domain: .network,
+        minimumCount: 1
+    )
+    await liveBackend.waitForEventSubscriptions(
+        route: filteredTarget.route,
+        targetID: filteredTarget.id,
+        domain: .network,
+        minimumCount: 1
+    )
+    let pendingCommandTask = Task {
+        try await currentPage.page.reload()
+    }
+    _ = try await waitForTargetMessage(backend, method: "Page.reload")
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+    await closeGate.waitUntilStarted()
+
+    #expect(try await value(of: currentTask) == nil)
+    #expect(try await value(of: filteredTask) == nil)
+    let lateTask = Task {
+        var iterator = filteredTarget.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    #expect(try await value(of: lateTask) == nil)
+    #expect(await backend.isDetached() == false)
+
+    let explicitCloseTask = Task {
+        await proxy.close()
+    }
+    await closeGate.release()
+    await explicitCloseTask.value
+    let closeMessage = await disconnectedMessage(from: Task {
+        try await proxy.waitUntilClosed()
+    })
+    let commandMessage = await disconnectedMessage(from: pendingCommandTask)
+    #expect(closeMessage?.contains("Network.loadingFinished") == true)
+    #expect(commandMessage == closeMessage)
+    #expect(await closeGate.invocationCount() == 1)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func malformedKnownEventPropagatesFailureToEveryOrderedSubscriber() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let closeGate = CloseConnectionGate()
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await closeGate.waitUntilReleased()
             await transport.detach(error: error)
         }
     )
@@ -727,6 +1086,14 @@ func malformedKnownEventPropagatesFailureToEveryOrderedSubscriber() async throws
     let secondMessage = await disconnectedMessage(from: secondTask)
     #expect(firstMessage?.contains("Network.loadingFinished") == true)
     #expect(secondMessage == firstMessage)
+    await closeGate.waitUntilStarted()
+    #expect(await closeGate.invocationCount() == 1)
+    #expect(await backend.isDetached() == false)
+    await closeGate.release()
+    let closeMessage = await disconnectedMessage(from: Task {
+        try await proxy.waitUntilClosed()
+    })
+    #expect(closeMessage == firstMessage)
     #expect(await backend.isDetached())
 }
 
@@ -838,6 +1205,46 @@ func explicitCloseReasonWinsConcurrentDecodeFailure() async throws {
     await closeGate.release()
     await closeTask.value
     try await proxy.waitUntilClosed()
+    #expect(await backend.isDetached())
+}
+
+@Test
+func closeWaiterCancellationIsIndependentFromDecodeFailure() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let proxy = try await WebInspectorProxy(transport: transport)
+    let target = try await proxy.waitForCurrentPage()
+    let eventTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    await waitForEventSubscription(target, domain: .network)
+    let cancelledWaiter = Task {
+        try await proxy.waitUntilClosed()
+    }
+    let terminalWaiter = Task {
+        try await proxy.waitUntilClosed()
+    }
+    await proxy.waitForCloseWaiterForTesting(minimumCount: 2)
+
+    cancelledWaiter.cancel()
+    await #expect(throws: CancellationError.self) {
+        try await cancelledWaiter.value
+    }
+    #expect(await proxy.closeWaiterCountForTesting == 1)
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    #expect(try await value(of: eventTask) == nil)
+    let terminalMessage = await disconnectedMessage(from: terminalWaiter)
+    #expect(terminalMessage?.contains("Network.loadingFinished") == true)
+    #expect(await proxy.closeWaiterCountForTesting == 0)
     #expect(await backend.isDetached())
 }
 
@@ -3858,13 +4265,13 @@ private func messageObject(_ message: String) throws -> [String: Any] {
 }
 
 private actor CloseConnectionGate {
-    private var started = false
+    private var startCount = 0
     private var released = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
     private var releaseContinuation: CheckedContinuation<Void, Never>?
 
     func waitUntilReleased() async {
-        started = true
+        startCount += 1
         let waiters = startWaiters
         startWaiters.removeAll()
         for waiter in waiters {
@@ -3879,7 +4286,7 @@ private actor CloseConnectionGate {
     }
 
     func waitUntilStarted() async {
-        guard started == false else {
+        guard startCount == 0 else {
             return
         }
         await withCheckedContinuation { continuation in
@@ -3891,6 +4298,10 @@ private actor CloseConnectionGate {
         released = true
         releaseContinuation?.resume()
         releaseContinuation = nil
+    }
+
+    func invocationCount() -> Int {
+        startCount
     }
 }
 

--- a/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
+++ b/Tests/WebInspectorProxyKitTests/WebInspectorProxyTransportCommandBackendTests.swift
@@ -603,6 +603,245 @@ func transportBackedProxyCloseDetachesTransportAndFinishesEventStreams() async t
 }
 
 @Test
+func malformedKnownDomainEventTerminatesProxyAndPendingCommand() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let proxy = try await WebInspectorProxy(transport: transport)
+    let target = try await proxy.waitForCurrentPage()
+
+    let eventTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    await waitForEventSubscription(target, domain: .network)
+
+    let closeWaitTask = Task {
+        try await proxy.waitUntilClosed()
+    }
+    await proxy.waitForCloseWaiterForTesting()
+
+    let reloadTask = Task {
+        try await target.page.reload()
+    }
+    _ = try await waitForTargetMessage(backend, method: "Page.reload")
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    #expect(try await value(of: eventTask) == nil)
+    let closeMessage = await disconnectedMessage(from: closeWaitTask)
+    let reloadMessage = await disconnectedMessage(from: reloadTask)
+    let subsequentCommandMessage = await disconnectedMessage(from: Task {
+        try await target.network.enable()
+    })
+    #expect(closeMessage?.contains("Network.loadingFinished") == true)
+    #expect(reloadMessage == closeMessage)
+    #expect(subsequentCommandMessage == closeMessage)
+    #expect(await backend.isDetached())
+    #expect(await proxy.canReload == false)
+    #expect(await proxy.currentPage == nil)
+}
+
+@Test
+func malformedKnownOrderedEventPropagatesTerminalFailure() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let proxy = try await WebInspectorProxy(transport: transport)
+    let target = try await proxy.waitForCurrentPage()
+    let feed = await target.orderedEventFeed()
+
+    let eventTask = Task {
+        var iterator = feed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    await target.waitForModelEventSubscriptions()
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    let eventMessage = await disconnectedMessage(from: eventTask)
+    let replayedCloseMessage = await disconnectedMessage(from: Task {
+        try await proxy.waitUntilClosed()
+    })
+    #expect(eventMessage?.contains("Network.loadingFinished") == true)
+    #expect(replayedCloseMessage == eventMessage)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func malformedKnownEventPropagatesFailureToEveryOrderedSubscriber() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let target = WebInspectorTarget(
+        id: .currentPage,
+        kind: .page,
+        frameID: nil,
+        isProvisional: false,
+        proxy: proxy,
+        route: .currentPage
+    )
+    let firstFeed = await target.orderedEventFeed()
+    let secondFeed = await target.orderedEventFeed()
+
+    let firstTask = Task {
+        var iterator = firstFeed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    let secondTask = Task {
+        var iterator = secondFeed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    await liveBackend.waitForEventSubscriptions(
+        route: .currentPage,
+        targetID: .currentPage,
+        domain: .ordered,
+        minimumCount: 2
+    )
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    let firstMessage = await disconnectedMessage(from: firstTask)
+    let secondMessage = await disconnectedMessage(from: secondTask)
+    #expect(firstMessage?.contains("Network.loadingFinished") == true)
+    #expect(secondMessage == firstMessage)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func malformedKnownEventPropagatesFailureToFilteredOrderedRoute() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let liveBackend = LiveWebInspectorProxyBackend(transport: transport)
+    let proxy = WebInspectorProxy(
+        backend: liveBackend,
+        closeConnection: { error in
+            await transport.detach(error: error)
+        }
+    )
+    let currentPage = WebInspectorTarget(
+        id: .currentPage,
+        kind: .page,
+        frameID: nil,
+        isProvisional: false,
+        proxy: proxy,
+        route: .currentPage
+    )
+    let frameID = WebInspectorTarget.ID("frame-route")
+    let frameRoute = RoutingTargetID("frame-route")
+    let frame = WebInspectorTarget(
+        id: frameID,
+        kind: .frame,
+        frameID: nil,
+        isProvisional: false,
+        proxy: proxy,
+        route: frameRoute
+    )
+    let pageFeed = await currentPage.orderedEventFeed()
+    let frameFeed = await frame.orderedEventFeed()
+
+    let pageTask = Task {
+        var iterator = pageFeed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    let frameTask = Task {
+        for try await _ in frameFeed.events {}
+    }
+    await liveBackend.waitForEventSubscriptions(
+        route: .currentPage,
+        targetID: .currentPage,
+        domain: .ordered,
+        minimumCount: 1
+    )
+    await liveBackend.waitForEventSubscriptions(
+        route: frameRoute,
+        targetID: frameID,
+        domain: .ordered,
+        minimumCount: 1
+    )
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+
+    let pageMessage = await disconnectedMessage(from: pageTask)
+    let frameMessage = await disconnectedMessage(from: frameTask)
+    #expect(pageMessage?.contains("Network.loadingFinished") == true)
+    #expect(frameMessage == pageMessage)
+    #expect(await backend.isDetached())
+}
+
+@Test
+func explicitCloseReasonWinsConcurrentDecodeFailure() async throws {
+    let backend = FakeTransportBackend()
+    let transport = TransportSession(backend: backend, responseTimeout: nil)
+    await installPageTarget(in: transport)
+    let closeGate = CloseConnectionGate()
+    let proxy = try await WebInspectorProxy(transport: transport, closeConnection: { error in
+        await closeGate.waitUntilReleased()
+        await transport.detach(error: error)
+    })
+    let target = try await proxy.waitForCurrentPage()
+    let orderedFeed = await target.orderedEventFeed()
+
+    let eventTask = Task {
+        var iterator = target.network.events.makeAsyncIterator()
+        return await iterator.next()
+    }
+    let orderedEventTask = Task {
+        var iterator = orderedFeed.events.makeAsyncIterator()
+        return try await iterator.next()
+    }
+    await waitForEventSubscription(target, domain: .network)
+    await target.waitForModelEventSubscriptions()
+
+    let closeTask = Task {
+        await proxy.close()
+    }
+    await closeGate.waitUntilStarted()
+
+    await receiveTargetEvent(
+        transport,
+        targetID: ProtocolTarget.ID("page-main"),
+        method: "Network.loadingFinished",
+        params: "{}"
+    )
+    #expect(try await value(of: eventTask) == nil)
+    #expect(try await throwingValue(of: orderedEventTask) == nil)
+
+    await closeGate.release()
+    await closeTask.value
+    try await proxy.waitUntilClosed()
+    #expect(await backend.isDetached())
+}
+
+@Test
 func transportBackedProxyWaitUntilClosedSuspendsUntilClose() async throws {
     let backend = FakeTransportBackend()
     let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(750))
@@ -637,7 +876,7 @@ func proxyWaitUntilClosedReturnsImmediatelyAfterClose() async throws {
 @Test
 func proxyWaitUntilClosedWaitsForInFlightCloseConnection() async throws {
     let closeGate = CloseConnectionGate()
-    let proxy = WebInspectorProxy(closeConnection: {
+    let proxy = WebInspectorProxy(closeConnection: { _ in
         await closeGate.waitUntilReleased()
     })
 
@@ -690,7 +929,7 @@ func transportBackedProxyDoesNotRefreshCurrentPageWhileClosing() async throws {
     let transport = TransportSession(backend: backend, responseTimeout: .milliseconds(750))
     await installPageTarget(in: transport)
     let closeGate = CloseConnectionGate()
-    let proxy = try await WebInspectorProxy(transport: transport, closeConnection: {
+    let proxy = try await WebInspectorProxy(transport: transport, closeConnection: { _ in
         await closeGate.waitUntilReleased()
     })
 
@@ -876,7 +1115,7 @@ func orderedCurrentPageFeedUsesEventTimeRoutingAcrossDelayedCommitDrain() async 
     )
 
     var tokens: [String] = []
-    for await sequencedEvent in feed.events {
+    for try await sequencedEvent in feed.events {
         guard let event = sequencedEvent.event else {
             continue
         }
@@ -2966,9 +3205,9 @@ func orderedCurrentPageFeedTreatsFrameDocumentUpdatedAsWatermarkOnly() async thr
     )
 
     var iterator = feed.events.makeAsyncIterator()
-    let frameWatermark = try #require(await iterator.next())
+    let frameWatermark = try #require(try await iterator.next())
     #expect(frameWatermark.event == nil)
-    let pageEvent = try #require(await iterator.next())
+    let pageEvent = try #require(try await iterator.next())
     guard case let .dom(.attributeModified(_, name, value)) = pageEvent.event else {
         Issue.record("Expected the following main-page DOM event.")
         return
@@ -2997,7 +3236,7 @@ func orderedCurrentPageFeedTreatsProvisionalRootRuntimeEventAsWatermarkOnly() as
     )
 
     var iterator = feed.events.makeAsyncIterator()
-    let watermark = try #require(await iterator.next())
+    let watermark = try #require(try await iterator.next())
     #expect(watermark.event == nil)
 }
 
@@ -3709,6 +3948,21 @@ private actor EventDeliveryProbe {
         for waiter in readyFirstWaiters + readySecondWaiters {
             waiter.continuation.resume()
         }
+    }
+}
+
+private func disconnectedMessage<Value: Sendable>(
+    from task: Task<Value, any Error>
+) async -> String? {
+    do {
+        _ = try await throwingValue(of: task)
+        Issue.record("Expected a disconnected terminal error.")
+        return nil
+    } catch let WebInspectorProxyError.disconnected(message) {
+        return message
+    } catch {
+        Issue.record("Expected WebInspectorProxyError.disconnected, got \(error).")
+        return nil
     }
 }
 


### PR DESCRIPTION
## Purpose

Make malformed known WebKit events terminate through the ProxyKit connection owner instead of trapping the host process or leaving sibling streams alive.

Closes #250

## Changes

- Preserve the first explicit-close or decode-failure reason in `WebInspectorProxy` and replay it through commands, page waiters, ordered feeds, and `waitUntilClosed()`.
- Finish active and late domain/ordered subscriptions through one backend terminal operation before physical connection teardown.
- Decode known events before route projection so filtered-only subscribers cannot hide malformed protocol payloads.
- Give the public Testing runtime the same close/stream semantics, including held commands and subscriber waiters.
- Propagate ordered-feed failure deterministically into attaching, attached, and retargeting DataKit contexts while rejecting stale-generation callbacks.
- Add external consumer coverage for active and late Testing-runtime streams.

## Testing

- Repository default iOS Simulator test: 849 logical tests / 905 concrete runs, 0 failures, 0 skipped
- ProxyKit + DataKit: 300/300
- Focused terminal lifecycle matrix: 13/13
- ContractTests: 12/12
- DataKit symbol-boundary check
- `git diff --check`
- Branch-wide Codex review against `origin/main`: 0 findings

## Screenshots

Not applicable; this changes connection and event-stream lifecycle behavior.