### PR TITLE
Define stale DataKit model semantics

### DIFF
--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StaleModelLifetimeContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StaleModelLifetimeContractTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import WebInspectorDataKit
+import WebInspectorProxyKit
+import WebInspectorProxyKitTesting
+
+@MainActor
+@Test
+func retainedFetchedResultsFinishStreamsAndReportStaleUpdatesFromConsumerPackage() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    var container: WebInspectorContainer? = WebInspectorContainer(proxy: runtime.proxy)
+    var context: WebInspectorContext? = WebInspectorContext(
+        try #require(container),
+        isolation: MainActor.shared
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    var activeTransactions = controller.transactions.makeAsyncIterator()
+    weak let releasedContext = context
+
+    context = nil
+    container = nil
+
+    #expect(releasedContext == nil)
+    #expect(await activeTransactions.next() == nil)
+    var lateTransactions = controller.transactions.makeAsyncIterator()
+    #expect(await lateTransactions.next() == nil)
+    #expect(results.items.isEmpty)
+    #expect(controller.snapshot.itemIDs.isEmpty)
+    let error = WebInspectorProxyError.disconnected(
+        "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+    )
+    #expect(throws: error) {
+        try results.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 1))
+    }
+    #expect(throws: error) {
+        try controller.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 1))
+    }
+    await runtime.proxy.close()
+}

--- a/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
+++ b/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
@@ -79,6 +79,10 @@ private actor DataKitImportOnlyActor {
         _ = messagesByLevel.sections.first?.id
         _ = messageController.snapshot
         _ = messageController.transactions
+        try requests.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 50))
+        try requestController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchOffset: 1))
+        try messages.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 50))
+        try messageController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchOffset: 1))
         _ = try await context.evaluate("1 + 1").object.description
 
         let request = NetworkRequestSnapshot(url: "https://example.com", method: "GET")

--- a/Sources/WebInspectorDataKit/DOMNode.swift
+++ b/Sources/WebInspectorDataKit/DOMNode.swift
@@ -5,7 +5,10 @@ import WebInspectorProxyKit
 /// Observable model for a DOM node owned by a ``WebInspectorContext``.
 @Observable
 public final class DOMNode: WebInspectorPersistentModel {
-    /// Stable identity for a DOM node within a context.
+    /// Stable identity for this DOM node model.
+    ///
+    /// WebKit can reuse the same protocol identity in a later document. A
+    /// retained model with that ID does not become the later document's node.
     public struct ID: Hashable, Sendable {
         let proxyID: DOM.Node.ID
 
@@ -198,41 +201,58 @@ public final class DOMNode: WebInspectorPersistentModel {
     }
 
     /// Requests regular child nodes for this node.
+    ///
+    /// This operation does nothing when the node is no longer registered in
+    /// its originating context. Retaining a node does not extend its document
+    /// registration lifetime, and a different node with the same ID from a
+    /// later document is not used as a replacement.
     public func requestChildren(
         depth: Int = 1,
         isolation: isolated (any Actor) = #isolation
     ) async {
         guard let modelContext else {
-            preconditionFailure("DOMNode is not registered in a WebInspectorContext.")
+            return
         }
         await modelContext.requestChildren(for: self, depth: depth, isolation: isolation)
     }
 
     /// Returns copied text for the node in the requested format.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when the node is
+    ///   no longer registered in its originating context.
     public func copyText(
         _ kind: CopyTextKind,
         isolation: isolated (any Actor) = #isolation
     ) async throws -> String {
-        guard let modelContext else {
-            preconditionFailure("DOMNode is not registered in a WebInspectorContext.")
-        }
+        let modelContext = try requiredModelContext()
         return try await modelContext.copyText(kind, for: self, isolation: isolation)
     }
 
     /// Removes this node from the inspected document.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when the node is
+    ///   no longer registered in its originating context.
     public func delete(isolation: isolated (any Actor) = #isolation) async throws {
-        guard let modelContext else {
-            preconditionFailure("DOMNode is not registered in a WebInspectorContext.")
-        }
+        let modelContext = try requiredModelContext()
         try await modelContext.delete(self, isolation: isolation)
     }
 
     /// Highlights this node in the inspected page.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when the node is
+    ///   no longer registered in its originating context.
     public func highlight(isolation: isolated (any Actor) = #isolation) async throws {
-        guard let modelContext else {
-            preconditionFailure("DOMNode is not registered in a WebInspectorContext.")
-        }
+        let modelContext = try requiredModelContext()
         try await modelContext.highlight(self, isolation: isolation)
+    }
+
+    private func requiredModelContext() throws -> WebInspectorContext {
+        guard let modelContext else {
+            throw WebInspectorProxyError.disconnected(
+                "DOMNode is not registered in this WebInspectorContext."
+            )
+        }
+        return modelContext
     }
 
     func update(from node: DOM.Node) {

--- a/Sources/WebInspectorDataKit/Fetching.swift
+++ b/Sources/WebInspectorDataKit/Fetching.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import WebInspectorProxyKit
 
 /// Value configuration for fetching DataKit model objects.
 ///
@@ -299,6 +300,9 @@ private enum WebInspectorKnownKeyPaths {
 }
 
 /// Observable collection of models produced by a fetch descriptor.
+///
+/// The collection can outlive its registration in a
+/// ``WebInspectorContext``. See <doc:ModelRegistrationLifetimes>.
 @Observable
 public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel> {
     /// The descriptor currently used by the results.
@@ -353,6 +357,11 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
         transactionRelay.makeStream()
     }
 
+    func invalidateRegistration() {
+        modelContext = nil
+        transactionRelay.finish()
+    }
+
     func setItems(_ items: [Model], updatedItemIDs: Set<Model.ID> = []) {
         let oldSnapshot = currentSnapshot
         self.items = items
@@ -396,14 +405,23 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
     }
 
     /// Replaces the fetch descriptor and updates the result contents.
+    ///
+    /// Retaining fetched results does not retain their originating context. If
+    /// that context has been released, the last descriptor, items, and sections
+    /// remain readable and transaction streams finish.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when these results
+    ///   are no longer registered in their originating context.
     public func updateFetchDescriptor(
         _ descriptor: WebInspectorFetchDescriptor<Model>,
         isolation: isolated (any Actor) = #isolation
-    ) {
+    ) throws {
         guard let modelContext else {
-            preconditionFailure("WebInspectorFetchedResults is not registered in a WebInspectorContext.")
+            throw WebInspectorProxyError.disconnected(
+                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+            )
         }
-        modelContext.updateFetchDescriptor(descriptor, for: self, isolation: isolation)
+        try modelContext.updateFetchDescriptor(descriptor, for: self, isolation: isolation)
     }
 
     private var currentSnapshot: WebInspectorFetchedResultsSnapshot<Model.ID> {

--- a/Sources/WebInspectorDataKit/RuntimeContext.swift
+++ b/Sources/WebInspectorDataKit/RuntimeContext.swift
@@ -10,7 +10,10 @@ public final class RuntimeContext: WebInspectorPersistentModel {
         var targetRevision: UInt64
     }
 
-    /// Stable identity for an execution context within a context.
+    /// Stable identity for this Runtime context model.
+    ///
+    /// A later Runtime generation can reuse the protocol identity for a
+    /// different model without reviving this instance.
     public struct ID: Hashable, Sendable {
         let proxyID: Runtime.ExecutionContext.ID
 

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -702,6 +702,7 @@ public final class WebInspectorContext {
     }
 
     deinit {
+        invalidateFetchedResultsRegistrations()
         startupTask?.cancel()
         currentPageRetargetTask?.cancel()
         currentPageCleanupTask?.cancel()
@@ -816,6 +817,14 @@ public final class WebInspectorContext {
         requireOwner(isolation)
         return await networkRequestIndex.fullProjectionRecordVisitCountForTesting
     }
+
+    package func domTreeRegistrationCountForTesting(
+        isolation: isolated (any Actor) = #isolation
+    ) -> Int {
+        requireOwner(isolation)
+        pruneReleasedTreeStates()
+        return treeStates.count
+    }
 #endif
 
     /// Clears retained Network requests and emits reset transactions.
@@ -834,6 +843,10 @@ public final class WebInspectorContext {
     }
 
     /// Selects a DOM node and reveals it in registered tree controllers.
+    ///
+    /// Passing `nil` clears the selection. Passing a node that is no longer
+    /// registered in this context, including a node from another context, does
+    /// nothing and preserves the current selection.
     public func select(_ node: DOMNode?, isolation: isolated (any Actor) = #isolation) {
         select(node, reveal: .selectAndScroll, isolation: isolation)
     }
@@ -845,7 +858,7 @@ public final class WebInspectorContext {
     ) {
         requireOwner(isolation)
         if let node, nodesByID[node.id] !== node {
-            preconditionFailure("DOMNode is not registered in this WebInspectorContext.")
+            return
         }
         pendingInspectedNodeID = nil
         inspectorInspectResolutionTask?.cancel()
@@ -1692,16 +1705,32 @@ public final class WebInspectorContext {
     }
 
     /// Creates a live DOM tree controller rooted at a node or the document root.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when an explicit
+    ///   root is no longer registered in this context or belongs to another
+    ///   context.
     public func treeController(
         root requestedRoot: DOMNode? = nil,
         isolation: isolated (any Actor) = #isolation
     ) async throws -> DOMTreeController {
         requireOwner(isolation)
-        guard let root = requestedRoot ?? rootNode else {
-            throw WebInspectorProxyError.disconnected("WebInspectorDataKit has no DOM root node.")
-        }
-        guard nodesByID[root.id] === root else {
-            preconditionFailure("DOMTreeController root is not registered in this WebInspectorContext.")
+        let root: DOMNode
+        if let requestedRoot {
+            guard nodesByID[requestedRoot.id] === requestedRoot else {
+                throw WebInspectorProxyError.disconnected(
+                    "DOMTreeController root is not registered in this WebInspectorContext."
+                )
+            }
+            root = requestedRoot
+        } else {
+            guard let currentRoot = rootNode else {
+                throw WebInspectorProxyError.disconnected("WebInspectorDataKit has no DOM root node.")
+            }
+            precondition(
+                nodesByID[currentRoot.id] === currentRoot,
+                "The current DOM root must remain registered in its WebInspectorContext."
+            )
+            root = currentRoot
         }
 
         let tree = DOMTreeState(rootNode: root, selectedNode: selectedNode)
@@ -1719,6 +1748,10 @@ public final class WebInspectorContext {
     }
 
     /// Selects the Runtime execution context used by default evaluation calls.
+    ///
+    /// Passing `nil` clears the selection. Passing a Runtime context that is no
+    /// longer registered in this context, including one from another context,
+    /// does nothing and preserves the current selection.
     public func selectContext(_ context: RuntimeContext?, isolation: isolated (any Actor) = #isolation) {
         requireOwner(isolation)
         guard let context else {
@@ -1726,7 +1759,7 @@ public final class WebInspectorContext {
             return
         }
         guard runtimeContextsByID[context.id] === context else {
-            preconditionFailure("RuntimeContext is not registered in this WebInspectorContext.")
+            return
         }
         selectedContext = context
     }
@@ -1957,11 +1990,13 @@ public final class WebInspectorContext {
         _ descriptor: WebInspectorFetchDescriptor<Model>,
         for results: WebInspectorFetchedResults<Model>,
         isolation: isolated (any Actor) = #isolation
-    ) {
+    ) throws {
         requireOwner(isolation)
         requireSupportedFetchDescriptor(descriptor)
         guard results.modelContext === self else {
-            preconditionFailure("WebInspectorFetchedResults is not registered in this WebInspectorContext.")
+            throw WebInspectorProxyError.disconnected(
+                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+            )
         }
         switch descriptor.kind {
         case .networkRequests:
@@ -1982,6 +2017,19 @@ public final class WebInspectorContext {
                 preconditionFailure("ConsoleMessage descriptors can only update ConsoleMessage fetched results.")
             }
             consoleResults.applyFetchDescriptor(consoleDescriptor, items: consoleMessages(for: consoleDescriptor))
+        }
+    }
+
+    private func invalidateFetchedResultsRegistrations() {
+        let networkResults = networkFetchedResults.compactMap(\.value)
+        let consoleResults = consoleFetchedResults.compactMap(\.value)
+        networkFetchedResults.removeAll()
+        consoleFetchedResults.removeAll()
+        for results in networkResults {
+            results.invalidateRegistration()
+        }
+        for results in consoleResults {
+            results.invalidateRegistration()
         }
     }
 

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/ModelRegistrationLifetimes.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/ModelRegistrationLifetimes.md
@@ -1,0 +1,65 @@
+# Model Registration Lifetimes
+
+Retain the last reported model state independently from the context registration
+that permits operations.
+
+## Model Objects and Current Registration
+
+DataKit model objects preserve identity and their last reported properties for as
+long as your code retains them. Their operational registration is shorter: a DOM
+document update, Runtime context destruction, or release of the originating
+``WebInspectorContext`` can end it.
+
+The context's current model registration is authoritative. DataKit never replaces
+a stale object with a different object that happens to have the same ID. An ID
+passed to a domain controller addresses the model currently registered in that
+controller's context; it is not a generation-spanning model handle.
+
+Operations use these stale semantics:
+
+- Throwing operations report `WebInspectorProxyError.disconnected` without
+  sending a protocol command.
+- Nonthrowing selection operations ignore a stale or foreign non-`nil` model and
+  preserve the current selection. Passing `nil` still clears the selection.
+- ``DOMNode/requestChildren(depth:isolation:)`` ignores a stale node. It never
+  redirects the request to a same-ID node from a later document.
+- The actor-owner requirement on ``WebInspectorContext`` remains independent of
+  registration lifetime. Call a context only from its owning actor.
+
+Resolve current models from the context or a current tree snapshot immediately
+before an operation:
+
+```swift
+if let nodeID = tree.snapshot.selectedNodeID,
+   let node = context.node(for: nodeID) {
+    try await node.highlight()
+}
+```
+
+## Fetched Results After Context Release
+
+``WebInspectorFetchedResults`` and ``WebInspectorFetchedResultsController`` do
+not retain their originating context. When that context is released:
+
+- their active transaction streams finish;
+- transaction streams created later are already finished;
+- their final descriptor, items, sections, and controller snapshot remain
+  readable;
+- changing the descriptor throws `WebInspectorProxyError.disconnected`.
+
+Detaching, restarting, or failing an inspection context does not itself
+invalidate fetched results while the context object remains alive.
+
+## Updating Fetch Descriptors
+
+Descriptor updates now report stale registration, so call them with `try`:
+
+```swift
+try results.updateFetchDescriptor(
+    WebInspectorFetchDescriptor(fetchLimit: 100)
+)
+
+try controller.updateFetchDescriptor(
+    WebInspectorFetchDescriptor(fetchOffset: 100)
+)
+```

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
@@ -67,6 +67,10 @@ access with no model layer.
 
 ## Topics
 
+### Essentials
+
+- <doc:ModelRegistrationLifetimes>
+
 ### Creating a Model Context
 
 - ``WebInspectorContainer``

--- a/Sources/WebInspectorDataKit/WebInspectorDomainControllers.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorDomainControllers.swift
@@ -72,6 +72,10 @@ public struct DOMMutationResult: Sendable, Hashable {
 ///
 /// Use this controller instead of dispatching ProxyKit DOM commands directly
 /// when working with DataKit-owned DOM nodes.
+///
+/// Node IDs address the currently registered model in this controller's
+/// context. They do not revive a retained ``DOMNode`` from an earlier document
+/// or from another context. See <doc:ModelRegistrationLifetimes>.
 public final class DOMModelController {
     private let context: WebInspectorContext
 

--- a/Sources/WebInspectorDataKit/WebInspectorFetchedResultsController.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorFetchedResultsController.swift
@@ -476,6 +476,9 @@ extension WebInspectorFetchedResultsIndexPath: Comparable {
 }
 
 /// Controller wrapper around ``WebInspectorFetchedResults``.
+///
+/// The controller shares the fetched results' registration and transaction
+/// stream lifetime. See <doc:ModelRegistrationLifetimes>.
 public final class WebInspectorFetchedResultsController<Model: WebInspectorFetchableModel> {
     /// The observable fetched-results model.
     public let fetchedResults: WebInspectorFetchedResults<Model>
@@ -496,6 +499,10 @@ public final class WebInspectorFetchedResultsController<Model: WebInspectorFetch
     }
 
     /// Stream of transactions emitted after result changes.
+    ///
+    /// The stream finishes when the fetched results are no longer registered
+    /// because their originating context was released. A stream created after
+    /// that point is already finished.
     public var transactions: AsyncStream<WebInspectorFetchedResultsTransaction<Model>> {
         fetchedResults.makeTransactionStream()
     }
@@ -506,10 +513,13 @@ public final class WebInspectorFetchedResultsController<Model: WebInspectorFetch
     }
 
     /// Replaces the fetch descriptor and updates the result contents.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when the underlying
+    ///   fetched results are no longer registered in their originating context.
     public func updateFetchDescriptor(
         _ descriptor: WebInspectorFetchDescriptor<Model>,
         isolation: isolated (any Actor) = #isolation
-    ) {
-        fetchedResults.updateFetchDescriptor(descriptor, isolation: isolation)
+    ) throws {
+        try fetchedResults.updateFetchDescriptor(descriptor, isolation: isolation)
     }
 }

--- a/Sources/WebInspectorDataKit/WebInspectorPersistentModel.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorPersistentModel.swift
@@ -1,9 +1,14 @@
 import Observation
 
 /// Base protocol for identity-preserving observable DataKit models.
+///
+/// A model object can outlive its registration in a ``WebInspectorContext``.
+/// Its last reported properties remain readable, but operations follow the
+/// stale behavior documented by the concrete model. See
+/// <doc:ModelRegistrationLifetimes>.
 public protocol WebInspectorPersistentModel: AnyObject, Observable, Hashable, Identifiable, SendableMetatype
 where ID: Hashable & Sendable {
-    /// Stable model identity within a ``WebInspectorContext``.
+    /// Stable identity for the lifetime of this model object.
     nonisolated var id: ID { get }
 }
 

--- a/Tests/WebInspectorDataKitTests/StaleModelSemanticsTests.swift
+++ b/Tests/WebInspectorDataKitTests/StaleModelSemanticsTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+@testable import WebInspectorDataKit
+import WebInspectorProxyKit
+import WebInspectorProxyKitTesting
+
+private let staleDOMNodeError = WebInspectorProxyError.disconnected(
+    "DOMNode is not registered in this WebInspectorContext."
+)
+private let staleFetchedResultsError = WebInspectorProxyError.disconnected(
+    "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+)
+
+@MainActor
+@Test
+func retainedDOMNodeAfterContextReleaseKeepsSnapshotAndFailsWithoutTrapping() async throws {
+    var context: WebInspectorContext? = WebInspectorContext.preview(isolation: MainActor.shared)
+    context?.seedDOMDocument(
+        DOM.Node(
+            id: DOM.Node.ID("released-node"),
+            nodeType: 1,
+            nodeName: "ARTICLE",
+            localName: "article",
+            attributes: ["data-state": "retained"]
+        ))
+    let node = try #require(context?.rootNode)
+    weak let releasedContext = context
+
+    context = nil
+
+    #expect(releasedContext == nil)
+    #expect(node.nodeName == "ARTICLE")
+    #expect(node.attributes["data-state"] == "retained")
+    await node.requestChildren()
+    await #expect(throws: staleDOMNodeError) {
+        try await node.copyText(.selectorPath)
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await node.delete()
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await node.highlight()
+    }
+}
+
+@MainActor
+@Test
+func staleAndForeignDOMNodesNeverRebindToSameIDReplacement() async throws {
+    let runtime = try await WebInspectorProxyTestRuntime.start()
+    let container = WebInspectorContainer(proxy: runtime.proxy)
+    let context = WebInspectorContext(container, isolation: MainActor.shared)
+    let foreignContext = WebInspectorContext(container, isolation: MainActor.shared)
+    let sharedID = DOM.Node.ID("same-node-id")
+    context.seedDOMDocument(
+        DOM.Node(
+            id: sharedID,
+            nodeType: 1,
+            nodeName: "OLD",
+            localName: "old"
+        ))
+    foreignContext.seedDOMDocument(
+        DOM.Node(
+            id: sharedID,
+            nodeType: 1,
+            nodeName: "FOREIGN",
+            localName: "foreign",
+            childNodeCount: 1,
+            children: [
+                DOM.Node(
+                    id: DOM.Node.ID("foreign-distinct-id"),
+                    nodeType: 1,
+                    nodeName: "DISTINCT",
+                    localName: "distinct"
+                )
+            ]
+        ))
+    let staleNode = try #require(context.rootNode)
+    let foreignNode = try #require(foreignContext.rootNode)
+    let foreignDistinctNode = try #require(
+        foreignContext.node(for: DOMNode.ID(DOM.Node.ID("foreign-distinct-id")))
+    )
+
+    context.apply(DOM.Event.documentUpdated)
+    context.seedDOMDocument(
+        DOM.Node(
+            id: sharedID,
+            nodeType: 1,
+            nodeName: "FRESH",
+            localName: "fresh"
+        ))
+    let freshNode = try #require(context.rootNode)
+    #expect(freshNode !== staleNode)
+    #expect(freshNode.id == staleNode.id)
+    context.select(freshNode)
+    let selectionTree = context.dom.treeController()
+    let selectionRevision = selectionTree.revision
+    let selectedNodeID = selectionTree.snapshot.selectedNodeID
+    let commandsBeforeStaleOperations = await runtime.backend.recordedCommands()
+
+    await staleNode.requestChildren()
+    context.select(staleNode)
+    context.select(foreignNode)
+    context.select(foreignDistinctNode)
+
+    #expect(context.selectedNode === freshNode)
+    #expect(selectionTree.revision == selectionRevision)
+    #expect(selectionTree.snapshot.selectedNodeID == selectedNodeID)
+    #expect(await runtime.backend.recordedCommands() == commandsBeforeStaleOperations)
+    await #expect(throws: staleDOMNodeError) {
+        try await staleNode.copyText(.selectorPath)
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await staleNode.delete()
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await staleNode.highlight()
+    }
+    #expect(throws: staleDOMNodeError) {
+        try context.selectorPath(for: staleNode)
+    }
+    #expect(throws: staleDOMNodeError) {
+        try context.xPath(for: foreignNode)
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await context.copyText(.selectorPath, for: foreignNode)
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await context.delete(foreignNode)
+    }
+    await #expect(throws: staleDOMNodeError) {
+        try await context.highlight(foreignNode)
+    }
+
+    let staleRootError = WebInspectorProxyError.disconnected(
+        "DOMTreeController root is not registered in this WebInspectorContext."
+    )
+    #expect(context.domTreeRegistrationCountForTesting() == 1)
+    await #expect(throws: staleRootError) {
+        _ = try await context.treeController(root: staleNode)
+    }
+    await #expect(throws: staleRootError) {
+        _ = try await context.treeController(root: foreignDistinctNode)
+    }
+    #expect(context.domTreeRegistrationCountForTesting() == 1)
+
+    #expect(try context.selectorPath(for: freshNode) == "fresh")
+    let currentTree = try await context.treeController(root: freshNode)
+    #expect(currentTree.snapshot.rootNodeID == freshNode.id)
+    #expect(context.domTreeRegistrationCountForTesting() == 2)
+    context.select(nil)
+    #expect(context.selectedNode == nil)
+    #expect(await runtime.backend.recordedCommands() == commandsBeforeStaleOperations)
+    #expect(context.state == .attaching)
+}
+
+@MainActor
+@Test
+func staleAndForeignRuntimeContextsPreserveTheCurrentSelection() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let foreignContext = WebInspectorContext.preview(isolation: MainActor.shared)
+    let sharedID = Runtime.ExecutionContext.ID("same-runtime-id")
+    context.apply(
+        .executionContextCreated(
+            Runtime.ExecutionContext(
+                id: sharedID,
+                name: "Old",
+                kind: .normal
+            )))
+    let staleContext = try #require(context.executionContexts.first)
+    context.apply(.executionContextDestroyed(sharedID))
+    context.apply(
+        .executionContextCreated(
+            Runtime.ExecutionContext(
+                id: sharedID,
+                name: "Fresh",
+                kind: .normal
+            )))
+    foreignContext.apply(
+        .executionContextCreated(
+            Runtime.ExecutionContext(
+                id: sharedID,
+                name: "Foreign",
+                kind: .normal
+            )))
+    let freshContext = try #require(context.executionContexts.first)
+    let foreignRuntimeContext = try #require(foreignContext.executionContexts.first)
+    #expect(freshContext !== staleContext)
+    #expect(freshContext.id == staleContext.id)
+
+    context.selectContext(freshContext)
+    context.selectContext(staleContext)
+    context.selectContext(foreignRuntimeContext)
+
+    #expect(context.selectedContext === freshContext)
+    let error = WebInspectorProxyError.disconnected(
+        "RuntimeContext is not registered in this WebInspectorContext."
+    )
+    await #expect(throws: error) {
+        _ = try await context.evaluate("1", in: staleContext)
+    }
+    await #expect(throws: error) {
+        _ = try await context.evaluate("1", in: foreignRuntimeContext)
+    }
+    #expect(context.selectedContext === freshContext)
+    context.selectContext(nil)
+    #expect(context.selectedContext == nil)
+    #expect(context.state == .attached)
+}
+
+@MainActor
+@Test
+func contextReleaseFinishesEveryFetchedResultsStreamAndRetainsFinalSnapshots() async throws {
+    var context: WebInspectorContext? = WebInspectorContext.preview(isolation: MainActor.shared)
+    context?.seedNetworkRequest(
+        requestID: "retained-request",
+        url: "https://example.test/data.json",
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 1
+    )
+    context?.apply(
+        .messageAdded(
+            Console.Message(
+                source: Console.Source(rawValue: "console-api"),
+                level: Console.Level(rawValue: "warning"),
+                text: "retained message"
+            )))
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
+    let secondNetworkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = try #require(context?.fetchedResults())
+    let networkController = WebInspectorFetchedResultsController(fetchedResults: networkResults)
+    let consoleController = WebInspectorFetchedResultsController(fetchedResults: consoleResults)
+    let retainedNetworkSnapshot = networkController.snapshot
+    let retainedConsoleSnapshot = consoleController.snapshot
+    var activeNetworkIterator = networkController.transactions.makeAsyncIterator()
+    var secondActiveIterator = WebInspectorFetchedResultsController(
+        fetchedResults: secondNetworkResults
+    ).transactions.makeAsyncIterator()
+    var activeConsoleIterator = consoleController.transactions.makeAsyncIterator()
+    weak let releasedContext = context
+
+    context = nil
+
+    #expect(releasedContext == nil)
+    #expect(await activeNetworkIterator.next() == nil)
+    #expect(await secondActiveIterator.next() == nil)
+    #expect(await activeConsoleIterator.next() == nil)
+    var lateNetworkIterator = networkController.transactions.makeAsyncIterator()
+    var lateConsoleIterator = consoleController.transactions.makeAsyncIterator()
+    #expect(await lateNetworkIterator.next() == nil)
+    #expect(await lateConsoleIterator.next() == nil)
+    #expect(networkController.snapshot == retainedNetworkSnapshot)
+    #expect(consoleController.snapshot == retainedConsoleSnapshot)
+    #expect(networkResults.items.map(\.url) == ["https://example.test/data.json"])
+    #expect(consoleResults.items.map(\.text) == ["retained message"])
+
+    let networkDescriptor = WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 1)
+    #expect(throws: staleFetchedResultsError) {
+        try networkResults.updateFetchDescriptor(networkDescriptor)
+    }
+    #expect(throws: staleFetchedResultsError) {
+        try networkResults.updateFetchDescriptor(networkDescriptor)
+    }
+    #expect(throws: staleFetchedResultsError) {
+        try networkController.updateFetchDescriptor(networkDescriptor)
+    }
+}
+
+@MainActor
+@Test
+func liveFetchedResultsRemainRegisteredAcrossContextStatesAndRejectForeignUpdates() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let foreignContext = WebInspectorContext.preview(isolation: MainActor.shared)
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let networkController = WebInspectorFetchedResultsController(fetchedResults: networkResults)
+    let consoleController = WebInspectorFetchedResultsController(fetchedResults: consoleResults)
+    let firstNetworkDescriptor = WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 2)
+    let firstConsoleDescriptor = WebInspectorFetchDescriptor<ConsoleMessage>(fetchLimit: 2)
+
+    try networkResults.updateFetchDescriptor(firstNetworkDescriptor)
+    try consoleController.updateFetchDescriptor(firstConsoleDescriptor)
+    #expect(networkResults.fetchDescriptor.fetchLimit == 2)
+    #expect(consoleResults.fetchDescriptor.fetchLimit == 2)
+
+    await context.stop()
+    #expect(context.state == .detached)
+    try networkController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 3))
+    try consoleResults.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 3))
+    #expect(networkResults.fetchDescriptor.fetchLimit == 3)
+    #expect(consoleResults.fetchDescriptor.fetchLimit == 3)
+
+    context.start()
+    #expect(context.state == .attaching)
+    try networkResults.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 4))
+    try consoleController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 4))
+    #expect(networkResults.fetchDescriptor.fetchLimit == 4)
+    #expect(consoleResults.fetchDescriptor.fetchLimit == 4)
+
+    #expect(throws: staleFetchedResultsError) {
+        try foreignContext.updateFetchDescriptor(
+            WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 1),
+            for: networkResults
+        )
+    }
+    #expect(networkResults.fetchDescriptor.fetchLimit == 4)
+}

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -12802,7 +12802,7 @@ func consoleFetchedResultsHonorDescriptorsForInitialUpdatesAndDescriptorChanges(
         warningResults.items.map(\.text) == ["zebra", "omega"]
     }
 
-    warningResults.updateFetchDescriptor(WebInspectorFetchDescriptor<ConsoleMessage>(
+    try warningResults.updateFetchDescriptor(WebInspectorFetchDescriptor<ConsoleMessage>(
         sortBy: [SortDescriptor(\.text)],
         fetchLimit: 2,
         fetchOffset: 1

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -1399,7 +1399,7 @@ func removedExplicitRequestClearsSelectionInsteadOfSelectingGroupedSibling() asy
     let model = NetworkPanelModel(context: context)
     let groupedEntryID = try #require(model.entryID(containing: firstID))
     var rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
-    model.requests.updateFetchDescriptor(WebInspectorFetchDescriptor(
+    try model.requests.updateFetchDescriptor(WebInspectorFetchDescriptor(
         predicate: #Predicate { request in
             request.method == "GET"
         }


### PR DESCRIPTION
## Purpose

Make retained DataKit model handles fail predictably after their context or registration lifetime ends instead of trapping the host process or rebinding to a same-ID replacement.

Closes #251

## Changes

- Treat the context's ID-plus-object-identity registry as the canonical current-model authority.
- Make stale and foreign nonthrowing selections and child requests no-op before any presentation side effects.
- Report stale throwing DOM, Runtime, tree-root, and fetched-results operations as the existing `WebInspectorProxyError.disconnected`.
- Make fetched-results descriptor updates throwing and finish active and late transaction streams when the originating context is released while retaining the final snapshot.
- Preserve fetched-results registration while a live context is attached, detached, failed, or restarting.
- Document model-object versus registration lifetime and the required `try updateFetchDescriptor` migration in DocC.
- Add DataKit and separate-package consumer coverage for context release, same-ID replacement, foreign models, stream termination, and retained snapshots.

## Breaking Change

Both `WebInspectorFetchedResults.updateFetchDescriptor` and `WebInspectorFetchedResultsController.updateFetchDescriptor` now throw when the results are no longer registered. Existing calls must add `try`. The migration is documented in the new Model Registration Lifetimes article.

## Testing

- Repository default iOS Simulator test: 854 logical tests / 910 concrete runs, 0 failures, 0 skipped
- DataKit + UI: 642 logical tests / 684 concrete runs
- Focused stale-lifetime tests: 5/5
- ContractTests: 13/13
- Combined DocC build
- DataKit symbol-boundary check
- `git diff --check`
- Branch-wide Codex review against `main`: 0 findings

## Screenshots

Not applicable; this changes model and query lifecycle semantics.