### PR TITLE
Close fetched-results query capabilities

### DIFF
--- a/ContractTests/Tests/WebInspectorConsumerContractTests/ContractTestSupport.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/ContractTestSupport.swift
@@ -128,16 +128,16 @@ actor ContractDataKitActor {
 
     func assertPublicSurfaceIsUsable() async throws {
         let context = modelContext()
-        let requestResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
-        let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+        let requestResults = context.network.fetchedResults()
+        let consoleResults = context.console.fetchedResults()
         let sectionedRequests: WebInspectorFetchedResults<NetworkRequest> =
-            context.fetchedResults(sectionBy: \.method)
+            context.network.fetchedResults(for: NetworkRequestQuery(sectionBy: .method))
         let sectionedConsole: WebInspectorFetchedResults<ConsoleMessage> =
-            context.fetchedResults(sectionBy: \.level)
+            context.console.fetchedResults(for: ConsoleMessageQuery(sectionBy: .level))
         let requestController: WebInspectorFetchedResultsController<NetworkRequest> =
-            context.fetchedResultsController()
+            context.network.fetchedResultsController()
         let consoleController: WebInspectorFetchedResultsController<ConsoleMessage> =
-            context.fetchedResultsController()
+            context.console.fetchedResultsController()
 
         #expect(requestResults.items.isEmpty)
         #expect(consoleResults.items.isEmpty)
@@ -250,7 +250,7 @@ actor ContractDataKitActor {
             headers: ["Accept": "application/json"]
         )
         let requestController: WebInspectorFetchedResultsController<NetworkRequest> =
-            context.fetchedResultsController()
+            context.network.fetchedResultsController()
         var requestTransactions = requestController.transactions.makeAsyncIterator()
         await ContractTestSupport.emitFinishedRequest(request, target: target, backend: runtime.backend)
 
@@ -332,7 +332,7 @@ actor ContractDataKitActor {
             return consoleController
         }
         let controller: WebInspectorFetchedResultsController<ConsoleMessage> =
-            modelContext().fetchedResultsController()
+            modelContext().console.fetchedResultsController()
         consoleController = controller
         return controller
     }

--- a/ContractTests/Tests/WebInspectorConsumerContractTests/StaleModelLifetimeContractTests.swift
+++ b/ContractTests/Tests/WebInspectorConsumerContractTests/StaleModelLifetimeContractTests.swift
@@ -12,7 +12,16 @@ func retainedFetchedResultsFinishStreamsAndReportStaleUpdatesFromConsumerPackage
         try #require(container),
         isolation: MainActor.shared
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
+    let retainedQuery = NetworkRequestQuery(
+        filter: .method(equals: "GET"),
+        sortBy: [.requestSentTimestamp(order: .reverse)],
+        sectionBy: .method,
+        fetchLimit: 10,
+        fetchOffset: 1
+    )
+    let results: WebInspectorFetchedResults<NetworkRequest> = try #require(
+        context?.network.fetchedResults(for: retainedQuery)
+    )
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     var activeTransactions = controller.transactions.makeAsyncIterator()
     weak let releasedContext = context
@@ -26,14 +35,16 @@ func retainedFetchedResultsFinishStreamsAndReportStaleUpdatesFromConsumerPackage
     #expect(await lateTransactions.next() == nil)
     #expect(results.items.isEmpty)
     #expect(controller.snapshot.itemIDs.isEmpty)
+    #expect(results.query == retainedQuery)
+    #expect(controller.query == retainedQuery)
     let error = WebInspectorProxyError.disconnected(
         "WebInspectorFetchedResults is not registered in this WebInspectorContext."
     )
     #expect(throws: error) {
-        try results.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 1))
+        try results.updateQuery(NetworkRequestQuery(fetchLimit: 1))
     }
     #expect(throws: error) {
-        try controller.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 1))
+        try controller.updateQuery(NetworkRequestQuery(fetchLimit: 1))
     }
     await runtime.proxy.close()
 }

--- a/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
+++ b/ContractTests/Tests/WebInspectorDataKitImportOnlyContractTests/StoryADataKitImportOnlyContract.swift
@@ -17,16 +17,68 @@ func dataKitLegacyNetworkResponseSnapshotInitializerFunctionReferenceRemainsUsab
 
 private actor DataKitImportOnlyActor {
     func consume(_ context: WebInspectorContext) async throws {
-        let requests: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
-        let messages: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+        let requests = context.network.fetchedResults()
+        let messages = context.console.fetchedResults()
         let requestsByMethod: WebInspectorFetchedResults<NetworkRequest> =
-            context.fetchedResults(sectionBy: \.method)
+            context.network.fetchedResults(for: NetworkRequestQuery(sectionBy: .method))
         let messagesByLevel: WebInspectorFetchedResults<ConsoleMessage> =
-            context.fetchedResults(sectionBy: \.level)
+            context.console.fetchedResults(for: ConsoleMessageQuery(sectionBy: .level))
         let requestController: WebInspectorFetchedResultsController<NetworkRequest> =
-            context.fetchedResultsController()
+            context.network.fetchedResultsController()
         let messageController: WebInspectorFetchedResultsController<ConsoleMessage> =
-            context.fetchedResultsController()
+            context.console.fetchedResultsController()
+        let networkFilters: [NetworkRequestQuery.Filter] = [
+            .method(equals: "GET"),
+            .method(containing: "get"),
+            .url(equals: "https://example.com"),
+            .url(containing: "example"),
+            .searchableText(equals: "GET"),
+            .searchableText(containing: "GET"),
+            .mimeType(equals: nil),
+            .resourceCategory(.image),
+            .resourceCategories([.image, .media]),
+            .statusCode(atLeast: 400),
+            .statusCode(greaterThan: 399),
+            .statusCode(lessThan: 500),
+            .statusCode(atMost: 499),
+        ]
+        let networkQuery = NetworkRequestQuery(
+            filter: .all(networkFilters),
+            sortBy: [
+                .requestSentTimestamp(order: .forward),
+                .requestSentTimestamp(order: .reverse),
+            ],
+            sectionBy: .resourceType,
+            fetchLimit: 50,
+            fetchOffset: 1
+        )
+        _ = NetworkRequestQuery.Section.method
+        _ = NetworkRequestQuery.Section.resourceCategory
+        _ = NetworkRequestQuery.Section.mimeType
+        _ = NetworkRequestQuery.Filter.any(networkFilters)
+        let consoleFilters: [ConsoleMessageQuery.Filter] = [
+            .source(.init(rawValue: "console-api")),
+            .level(.init(rawValue: "warning")),
+            .kind(.init(rawValue: "log")),
+            .url("https://example.com/app.js"),
+            .text(containing: "warning"),
+        ]
+        let consoleQuery = ConsoleMessageQuery(
+            filter: .all(consoleFilters),
+            sortBy: [
+                .text(comparison: .localizedStandard, order: .forward),
+                .text(comparison: .lexical, order: .reverse),
+                .level(order: .forward),
+                .level(order: .reverse),
+            ],
+            sectionBy: .source,
+            fetchLimit: 50,
+            fetchOffset: 1
+        )
+        _ = ConsoleMessageQuery.Section.level
+        _ = ConsoleMessageQuery.Section.kind
+        _ = ConsoleMessageQuery.Section.url
+        _ = ConsoleMessageQuery.Filter.any(consoleFilters)
 
         _ = context.state
         _ = context.rootNode?.children
@@ -79,10 +131,12 @@ private actor DataKitImportOnlyActor {
         _ = messagesByLevel.sections.first?.id
         _ = messageController.snapshot
         _ = messageController.transactions
-        try requests.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 50))
-        try requestController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchOffset: 1))
-        try messages.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 50))
-        try messageController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchOffset: 1))
+        try requests.updateQuery(networkQuery)
+        try messages.updateQuery(consoleQuery)
+        try requests.updateQuery(NetworkRequestQuery(fetchLimit: 50))
+        try requestController.updateQuery(NetworkRequestQuery(fetchOffset: 1))
+        try messages.updateQuery(ConsoleMessageQuery(fetchLimit: 50))
+        try messageController.updateQuery(ConsoleMessageQuery(fetchOffset: 1))
         _ = try await context.evaluate("1 + 1").object.description
 
         let request = NetworkRequestSnapshot(url: "https://example.com", method: "GET")

--- a/Scripts/check-datakit-symbol-boundary.sh
+++ b/Scripts/check-datakit-symbol-boundary.sh
@@ -27,10 +27,48 @@ if [[ "${dump_status}" -ne 0 ]]; then
   echo "warning: symbol graph dump reported failures outside WebInspectorDataKit; continuing with generated DataKit graph." >&2
 fi
 
-denylist='Network\.Request|Network\.Response|WebInspectorSortOrder|WebInspectorSortDescriptor|WebInspectorFetchPredicate|WebInspectorDataPhase|WebInspectorModelActor|WebInspectorModelExecutor|WebInspectorTargetChanges|RawEvent|\bWebView[A-Za-z0-9_]*|WebViewKit|@WebView'
+denylist='Network\.Request|Network\.Response|WebInspectorSortOrder|WebInspectorSortDescriptor|WebInspectorFetchPredicate|WebInspectorFetchableModel|WebInspectorFetchDescriptor|WebInspectorFetchRequest|WebInspectorSectionDescriptor|WebInspectorDataPhase|WebInspectorModelActor|WebInspectorModelExecutor|WebInspectorTargetChanges|RawEvent|\bWebView[A-Za-z0-9_]*|WebViewKit|@WebView'
 
 if rg -n "${denylist}" "${graph}"; then
   echo "error: WebInspectorDataKit public symbol graph exposes forbidden boundary symbols." >&2
+  exit 1
+fi
+
+foundation_query_pattern='s:10Foundation(9PredicateV|14SortDescriptorV)'
+foundation_query_hits="$(
+  jq -r --arg pattern "${foundation_query_pattern}" '
+    .symbols[]
+    | select(.accessLevel == "public")
+    | select(
+        ((.declarationFragments // []) + (.names.subHeading // []))
+        | any((.preciseIdentifier? // "") | test($pattern))
+      )
+    | "  - " + (.pathComponents | join("."))
+  ' "${graph}"
+)"
+
+if [[ -n "${foundation_query_hits}" ]]; then
+  echo "error: WebInspectorDataKit public query surface exposes Foundation Predicate or SortDescriptor." >&2
+  echo "${foundation_query_hits}" >&2
+  exit 1
+fi
+
+open_query_surface_hits="$(
+  jq -r '
+    .symbols[]
+    | select(.accessLevel == "public")
+    | (.pathComponents | join(".")) as $path
+    | select(
+        ($path | test("^WebInspectorContext\\.fetchedResults"))
+        or ($path | test("^(NetworkRequestQuery|ConsoleMessageQuery)\\.(Filter|Sort|Section)\\.init"))
+      )
+    | "  - " + $path
+  ' "${graph}"
+)"
+
+if [[ -n "${open_query_surface_hits}" ]]; then
+  echo "error: WebInspectorDataKit public query surface exposes an open generic or capability initializer." >&2
+  echo "${open_query_surface_hits}" >&2
   exit 1
 fi
 

--- a/Sources/WebInspectorDataKit/ConsoleMessage.swift
+++ b/Sources/WebInspectorDataKit/ConsoleMessage.swift
@@ -4,7 +4,7 @@ import WebInspectorProxyKit
 
 /// Observable model for one console message.
 @Observable
-public final class ConsoleMessage: WebInspectorFetchableModel {
+public final class ConsoleMessage: WebInspectorPersistentModel {
     /// Stable identity for a console message within a context.
     public struct ID: Comparable, Hashable, Sendable {
         let ordinal: Int

--- a/Sources/WebInspectorDataKit/Fetching.swift
+++ b/Sources/WebInspectorDataKit/Fetching.swift
@@ -500,29 +500,27 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
         _ delta: NetworkResultSetDelta,
         lookup: (NetworkRequest.ID) -> NetworkRequest?
     ) {
-#if DEBUG
-        networkFullMembershipVisitCountForTesting &+= delta.snapshot.itemIDs.count
-#endif
         let oldSnapshot = networkSnapshotForDelta
-        items = delta.snapshot.itemIDs.compactMap(lookup)
-        sections = delta.snapshot.sections.map { section in
-            WebInspectorFetchSection(
-                id: section.id,
-                title: section.title,
-                items: section.itemIDs.compactMap(lookup)
-            )
-        }
-        networkUnfilteredSnapshotLedger = nil
-        networkResultSnapshot = delta.snapshot
         if oldSnapshot != delta.snapshot {
+#if DEBUG
+            networkFullMembershipVisitCountForTesting &+= delta.snapshot.itemIDs.count
+#endif
+            items = delta.snapshot.itemIDs.compactMap(lookup)
+            sections = delta.snapshot.sections.map { section in
+                WebInspectorFetchSection(
+                    id: section.id,
+                    title: section.title,
+                    items: section.itemIDs.compactMap(lookup)
+                )
+            }
+            networkUnfilteredSnapshotLedger = nil
+            networkResultSnapshot = delta.snapshot
             bumpTopologyRevision()
         }
-        guard transactionRelay.hasContinuations,
-              let transaction = delta.transaction,
-              transaction.hasChanges else {
+        guard transactionRelay.hasContinuations else {
             return
         }
-        transactionRelay.yield(transaction)
+        transactionRelay.yield(delta.transaction)
     }
 
     func insertUnfilteredNetworkRequest(_ request: NetworkRequest) {

--- a/Sources/WebInspectorDataKit/Fetching.swift
+++ b/Sources/WebInspectorDataKit/Fetching.swift
@@ -2,151 +2,7 @@ import Foundation
 import Observation
 import WebInspectorProxyKit
 
-/// Value configuration for fetching DataKit model objects.
-///
-/// A descriptor describes predicate, sort, limit, and offset behavior for
-/// models such as ``NetworkRequest`` and ``ConsoleMessage``.
-///
-/// Example:
-///
-/// ```swift
-/// let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-///     predicate: #Predicate { request in
-///         request.method == "POST"
-///     },
-///     sortBy: [
-///         SortDescriptor(\.requestSentTimestamp, order: .reverse)
-///     ],
-///     fetchLimit: 100
-/// )
-///
-/// let results = context.network.fetchedResults(for: descriptor)
-/// ```
-public struct WebInspectorFetchDescriptor<Model: WebInspectorFetchableModel>: Sendable {
-    enum Kind: Hashable, Sendable {
-        case networkRequests
-        case consoleMessages
-    }
-
-    let kind: Kind
-    /// Predicate used to filter fetched models.
-    public var predicate: Predicate<Model>?
-
-    /// Sort descriptors used to order fetched models.
-    public var sortBy: [SortDescriptor<Model>]
-
-    /// Maximum number of models to fetch.
-    public var fetchLimit: Int? {
-        didSet {
-            Self.validate(fetchLimit: fetchLimit)
-        }
-    }
-    /// Number of models to skip before returning results.
-    public var fetchOffset: Int {
-        didSet {
-            Self.validate(fetchOffset: fetchOffset)
-        }
-    }
-
-    /// Creates a fetch descriptor.
-    public init(
-        predicate: Predicate<Model>? = nil,
-        sortBy: [SortDescriptor<Model>] = [],
-        fetchLimit: Int? = nil,
-        fetchOffset: Int = 0
-    ) {
-        Self.validate(fetchLimit: fetchLimit)
-        Self.validate(fetchOffset: fetchOffset)
-        self.kind = Self.requireKnownKind()
-        self.predicate = predicate
-        self.sortBy = sortBy
-        self.fetchLimit = fetchLimit
-        self.fetchOffset = fetchOffset
-    }
-
-    private static func requireKnownKind() -> Kind {
-        if Model.self == NetworkRequest.self {
-            return .networkRequests
-        }
-        if Model.self == ConsoleMessage.self {
-            return .consoleMessages
-        }
-        preconditionFailure("WebInspectorFetchDescriptor does not support fetching \(Model.self).")
-    }
-
-    private static func validate(fetchLimit: Int?) {
-        if let fetchLimit {
-            precondition(fetchLimit >= 0, "WebInspectorFetchDescriptor fetchLimit must be non-negative.")
-        }
-    }
-
-    private static func validate(fetchOffset: Int) {
-        precondition(fetchOffset >= 0, "WebInspectorFetchDescriptor fetchOffset must be non-negative.")
-    }
-
-    var requiresRecordBackedQuery: Bool {
-        predicate != nil || sortBy.isEmpty == false || fetchLimit != nil || fetchOffset > 0
-    }
-}
-
-/// Mutable builder for a ``WebInspectorFetchDescriptor``.
-public final class WebInspectorFetchRequest<Model: WebInspectorFetchableModel> {
-    /// Predicate used to filter fetched models.
-    public var predicate: Predicate<Model>?
-
-    /// Sort descriptors used to order fetched models.
-    public var sortDescriptors: [SortDescriptor<Model>]
-
-    /// Maximum number of models to fetch.
-    public var fetchLimit: Int? {
-        didSet {
-            Self.validate(fetchLimit: fetchLimit)
-        }
-    }
-    /// Number of models to skip before returning results.
-    public var fetchOffset: Int {
-        didSet {
-            Self.validate(fetchOffset: fetchOffset)
-        }
-    }
-
-    /// Creates a mutable fetch request.
-    public init(
-        predicate: Predicate<Model>? = nil,
-        sortDescriptors: [SortDescriptor<Model>] = [],
-        fetchLimit: Int? = nil,
-        fetchOffset: Int = 0
-    ) {
-        Self.validate(fetchLimit: fetchLimit)
-        Self.validate(fetchOffset: fetchOffset)
-        self.predicate = predicate
-        self.sortDescriptors = sortDescriptors
-        self.fetchLimit = fetchLimit
-        self.fetchOffset = fetchOffset
-    }
-
-    /// Immutable descriptor representing the request's current values.
-    public var fetchDescriptor: WebInspectorFetchDescriptor<Model> {
-        WebInspectorFetchDescriptor(
-            predicate: predicate,
-            sortBy: sortDescriptors,
-            fetchLimit: fetchLimit,
-            fetchOffset: fetchOffset
-        )
-    }
-
-    private static func validate(fetchLimit: Int?) {
-        if let fetchLimit {
-            precondition(fetchLimit >= 0, "WebInspectorFetchRequest fetchLimit must be non-negative.")
-        }
-    }
-
-    private static func validate(fetchOffset: Int) {
-        precondition(fetchOffset >= 0, "WebInspectorFetchRequest fetchOffset must be non-negative.")
-    }
-}
-
-final class WeakWebInspectorFetchedResults<Model: WebInspectorFetchableModel> {
+final class WeakWebInspectorFetchedResults<Model: WebInspectorPersistentModel> {
     weak var value: WebInspectorFetchedResults<Model>?
 
     init(_ value: WebInspectorFetchedResults<Model>) {
@@ -181,7 +37,7 @@ public struct WebInspectorFetchSectionID: RawRepresentable, Hashable, Sendable, 
 }
 
 /// One fetched-results section and its models.
-public struct WebInspectorFetchSection<Model: WebInspectorFetchableModel>: Identifiable {
+public struct WebInspectorFetchSection<Model: WebInspectorPersistentModel>: Identifiable {
     /// The stable section identity.
     public var id: WebInspectorFetchSectionID
 
@@ -199,117 +55,13 @@ public struct WebInspectorFetchSection<Model: WebInspectorFetchableModel>: Ident
     }
 }
 
-enum WebInspectorSectionKey: Hashable, Sendable {
-    case networkMethod
-    case networkResourceType
-    case networkResourceCategory
-    case networkMIMEType
-    case consoleSource
-    case consoleLevel
-    case consoleKind
-    case consoleURL
-}
-
-/// Descriptor for sectioning fetched results by a supported model key path.
-public struct WebInspectorSectionDescriptor<Model: WebInspectorFetchableModel>: Hashable, Sendable {
-    let key: WebInspectorSectionKey
-
-    /// Creates a section descriptor from a non-optional string key path.
-    public init(_ keyPath: KeyPath<Model, String>) {
-        key = Self.requireKnownSectionKey(for: keyPath)
-    }
-
-    /// Creates a section descriptor from an optional string key path.
-    public init(_ keyPath: KeyPath<Model, String?>) {
-        key = Self.requireKnownSectionKey(for: keyPath)
-    }
-
-    /// Creates a section descriptor from a raw-representable string value key path.
-    public init<Value: RawRepresentable & Hashable & Sendable>(
-        _ keyPath: KeyPath<Model, Value>
-    ) where Value.RawValue == String {
-        key = Self.requireKnownSectionKey(for: keyPath)
-    }
-
-    /// Creates a section descriptor from an optional raw-representable string value key path.
-    public init<Value: RawRepresentable & Hashable & Sendable>(
-        _ keyPath: KeyPath<Model, Value?>
-    ) where Value.RawValue == String {
-        key = Self.requireKnownSectionKey(for: keyPath)
-    }
-
-    private static func requireKnownSectionKey(for keyPath: AnyKeyPath) -> WebInspectorSectionKey {
-        guard let key = WebInspectorKnownKeyPaths.sectionKey(for: Model.self, keyPath: keyPath) else {
-            preconditionFailure(
-                "WebInspectorSectionDescriptor does not support sectioning \(Model.self) by key path \(keyPath)."
-            )
-        }
-        return key
-    }
-}
-
-private enum WebInspectorKnownKeyPaths {
-    static func sectionKey<Model: WebInspectorFetchableModel>(
-        for _: Model.Type,
-        keyPath: AnyKeyPath
-    ) -> WebInspectorSectionKey? {
-        if Model.self == NetworkRequest.self {
-            return networkSectionKey(keyPath)
-        }
-        if Model.self == ConsoleMessage.self {
-            return consoleSectionKey(keyPath)
-        }
-        return nil
-    }
-
-    private static func networkSectionKey(
-        _ keyPath: AnyKeyPath
-    ) -> WebInspectorSectionKey? {
-        if keyPath == (\NetworkRequest.method as AnyKeyPath) {
-            return .networkMethod
-        }
-        if keyPath == (\NetworkRequest.resourceType as AnyKeyPath) {
-            return .networkResourceType
-        }
-        if keyPath == (\NetworkRequest.resourceCategory as AnyKeyPath) {
-            return .networkResourceCategory
-        }
-        if keyPath == (\NetworkRequest.mimeType as AnyKeyPath) {
-            return .networkMIMEType
-        }
-        return nil
-    }
-
-    private static func consoleSectionKey(
-        _ keyPath: AnyKeyPath
-    ) -> WebInspectorSectionKey? {
-        if keyPath == (\ConsoleMessage.source as AnyKeyPath) {
-            return .consoleSource
-        }
-        if keyPath == (\ConsoleMessage.level as AnyKeyPath) {
-            return .consoleLevel
-        }
-        if keyPath == (\ConsoleMessage.kind as AnyKeyPath) {
-            return .consoleKind
-        }
-        if keyPath == (\ConsoleMessage.url as AnyKeyPath) {
-            return .consoleURL
-        }
-        return nil
-    }
-}
-
-/// Observable collection of models produced by a fetch descriptor.
+/// Observable collection of models produced by a query.
 ///
 /// The collection can outlive its registration in a
 /// ``WebInspectorContext``. See <doc:ModelRegistrationLifetimes>.
 @Observable
-public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel> {
-    /// The descriptor currently used by the results.
-    public private(set) var fetchDescriptor: WebInspectorFetchDescriptor<Model>
-
-    /// The section descriptor currently used by the results.
-    public private(set) var sectionBy: WebInspectorSectionDescriptor<Model>?
+public final class WebInspectorFetchedResults<Model: WebInspectorPersistentModel> {
+    private var queryStorage: WebInspectorQueryStorage
 
     /// The fetched models in display order.
     public private(set) var items: [Model]
@@ -331,16 +83,14 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
     @ObservationIgnored package private(set) var networkFullMembershipVisitCountForTesting = 0
 #endif
 
-    init(
-        fetchDescriptor: WebInspectorFetchDescriptor<Model>,
-        sectionBy: WebInspectorSectionDescriptor<Model>? = nil,
+    private init(
+        queryStorage: WebInspectorQueryStorage,
         items: [Model] = [],
         modelContext: WebInspectorContext? = nil
     ) {
-        self.fetchDescriptor = fetchDescriptor
-        self.sectionBy = sectionBy
+        self.queryStorage = queryStorage
         self.items = items
-        sections = Self.sections(for: items, sectionBy: sectionBy)
+        sections = Self.sections(for: items, queryStorage: queryStorage)
         self.modelContext = modelContext
         topologyRevision = 0
         networkQueryPlan = nil
@@ -365,7 +115,7 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
     func setItems(_ items: [Model], updatedItemIDs: Set<Model.ID> = []) {
         let oldSnapshot = currentSnapshot
         self.items = items
-        sections = Self.sections(for: items, sectionBy: sectionBy)
+        sections = Self.sections(for: items, queryStorage: queryStorage)
         bumpTopologyRevisionIfNeeded(oldSnapshot: oldSnapshot)
         yieldTransaction(oldSnapshot: oldSnapshot, updatedItemIDs: updatedItemIDs)
     }
@@ -374,7 +124,7 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
         precondition(items.contains { $0.id == item.id } == false, "WebInspectorFetchedResults cannot insert a duplicate item ID.")
         let oldSnapshot = currentSnapshot
         items.append(item)
-        sections = Self.sections(for: items, sectionBy: sectionBy)
+        sections = Self.sections(for: items, queryStorage: queryStorage)
         bumpTopologyRevisionIfNeeded(oldSnapshot: oldSnapshot)
         yieldTransaction(oldSnapshot: oldSnapshot, updatedItemIDs: [])
     }
@@ -384,8 +134,8 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
             return
         }
         let oldSnapshot = currentSnapshot
-        if sectionBy != nil {
-            sections = Self.sections(for: items, sectionBy: sectionBy)
+        if queryStorage.isSectioned {
+            sections = Self.sections(for: items, queryStorage: queryStorage)
         }
         bumpTopologyRevisionIfNeeded(oldSnapshot: oldSnapshot)
         yieldTransaction(oldSnapshot: oldSnapshot, updatedItemIDs: [item.id])
@@ -394,34 +144,9 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
     func resetItems(_ items: [Model]) {
         let oldSnapshot = currentSnapshot
         self.items = items
-        sections = Self.sections(for: items, sectionBy: sectionBy)
+        sections = Self.sections(for: items, queryStorage: queryStorage)
         bumpTopologyRevision()
         yieldResetTransaction(oldSnapshot: oldSnapshot)
-    }
-
-    func applyFetchDescriptor(_ descriptor: WebInspectorFetchDescriptor<Model>, items: [Model]) {
-        fetchDescriptor = descriptor
-        resetItems(items)
-    }
-
-    /// Replaces the fetch descriptor and updates the result contents.
-    ///
-    /// Retaining fetched results does not retain their originating context. If
-    /// that context has been released, the last descriptor, items, and sections
-    /// remain readable and transaction streams finish.
-    ///
-    /// - Throws: `WebInspectorProxyError.disconnected` when these results
-    ///   are no longer registered in their originating context.
-    public func updateFetchDescriptor(
-        _ descriptor: WebInspectorFetchDescriptor<Model>,
-        isolation: isolated (any Actor) = #isolation
-    ) throws {
-        guard let modelContext else {
-            throw WebInspectorProxyError.disconnected(
-                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
-            )
-        }
-        try modelContext.updateFetchDescriptor(descriptor, for: self, isolation: isolation)
     }
 
     private var currentSnapshot: WebInspectorFetchedResultsSnapshot<Model.ID> {
@@ -474,12 +199,12 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
 
     private static func sections(
         for items: [Model],
-        sectionBy: WebInspectorSectionDescriptor<Model>?
+        queryStorage: WebInspectorQueryStorage
     ) -> [WebInspectorFetchSection<Model>] {
         guard items.isEmpty == false else {
             return []
         }
-        guard let sectionBy else {
+        guard queryStorage.isSectioned else {
             return [
                 WebInspectorFetchSection(
                     id: .defaultSection,
@@ -491,7 +216,7 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
 
         var sections: [(id: WebInspectorFetchSectionID, title: String?, items: [Model])] = []
         for item in items {
-            let section = sectionIdentity(for: item, sectionBy: sectionBy)
+            let section = sectionIdentity(for: item, queryStorage: queryStorage)
             if let index = sections.firstIndex(where: { $0.id == section.id }) {
                 sections[index].items.append(item)
             } else {
@@ -505,26 +230,32 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
 
     private static func sectionIdentity(
         for item: Model,
-        sectionBy: WebInspectorSectionDescriptor<Model>
+        queryStorage: WebInspectorQueryStorage
     ) -> (id: WebInspectorFetchSectionID, title: String?) {
         let value: String?
-        switch sectionBy.key {
-        case .networkMethod:
-            value = (item as? NetworkRequest)?.method
-        case .networkResourceType:
-            value = (item as? NetworkRequest)?.resourceType?.rawValue
-        case .networkResourceCategory:
-            value = (item as? NetworkRequest)?.resourceCategory.rawValue
-        case .networkMIMEType:
-            value = (item as? NetworkRequest)?.mimeType
-        case .consoleSource:
-            value = (item as? ConsoleMessage)?.source.rawValue
-        case .consoleLevel:
-            value = (item as? ConsoleMessage)?.level.rawValue
-        case .consoleKind:
-            value = (item as? ConsoleMessage)?.kind?.rawValue
-        case .consoleURL:
-            value = (item as? ConsoleMessage)?.url
+        switch queryStorage {
+        case let .network(query):
+            guard let request = item as? NetworkRequest,
+                  let section = query.sectionBy else {
+                preconditionFailure("Network query storage must section NetworkRequest models.")
+            }
+            switch section.storage {
+            case .method: value = request.method
+            case .resourceType: value = request.resourceType?.rawValue
+            case .resourceCategory: value = request.resourceCategory.rawValue
+            case .mimeType: value = request.mimeType
+            }
+        case let .console(query):
+            guard let message = item as? ConsoleMessage,
+                  let section = query.sectionBy else {
+                preconditionFailure("Console query storage must section ConsoleMessage models.")
+            }
+            switch section.storage {
+            case .source: value = message.source.rawValue
+            case .level: value = message.level.rawValue
+            case .kind: value = message.kind?.rawValue
+            case .url: value = message.url
+            }
         }
 
         let title = value ?? ""
@@ -532,7 +263,74 @@ public final class WebInspectorFetchedResults<Model: WebInspectorFetchableModel>
     }
 }
 
+public extension WebInspectorFetchedResults where Model == NetworkRequest {
+    /// The last query installed for these Network request results.
+    ///
+    /// The value remains readable after registration in the originating
+    /// context ends.
+    var query: NetworkRequestQuery {
+        networkQuery
+    }
+
+    /// Replaces the query and updates the result contents atomically.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when these results are
+    ///   no longer registered in their originating context.
+    func updateQuery(
+        _ query: NetworkRequestQuery,
+        isolation: isolated (any Actor) = #isolation
+    ) throws {
+        guard let modelContext else {
+            throw WebInspectorProxyError.disconnected(
+                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+            )
+        }
+        try modelContext.updateNetworkQuery(query, for: self, isolation: isolation)
+    }
+}
+
+public extension WebInspectorFetchedResults where Model == ConsoleMessage {
+    /// The last query installed for these Console message results.
+    ///
+    /// The value remains readable after registration in the originating
+    /// context ends.
+    var query: ConsoleMessageQuery {
+        consoleQuery
+    }
+
+    /// Replaces the query and updates the result contents atomically.
+    ///
+    /// - Throws: `WebInspectorProxyError.disconnected` when these results are
+    ///   no longer registered in their originating context.
+    func updateQuery(
+        _ query: ConsoleMessageQuery,
+        isolation: isolated (any Actor) = #isolation
+    ) throws {
+        guard let modelContext else {
+            throw WebInspectorProxyError.disconnected(
+                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
+            )
+        }
+        try modelContext.updateConsoleQuery(query, for: self, isolation: isolation)
+    }
+}
+
 extension WebInspectorFetchedResults where Model == NetworkRequest {
+    convenience init(
+        query: NetworkRequestQuery,
+        items: [NetworkRequest] = [],
+        modelContext: WebInspectorContext? = nil
+    ) {
+        self.init(queryStorage: .network(query), items: items, modelContext: modelContext)
+    }
+
+    var networkQuery: NetworkRequestQuery {
+        guard case let .network(query) = queryStorage else {
+            preconditionFailure("NetworkRequest results must own a NetworkRequestQuery.")
+        }
+        return query
+    }
+
     var networkSnapshotForDelta: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID> {
         if let networkUnfilteredSnapshotLedger {
             return networkUnfilteredSnapshotLedger.snapshot(at: items.count)
@@ -545,11 +343,11 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
         return snapshot
     }
 
-    func currentNetworkQueryPlan(context: WebInspectorContext) -> NetworkRequestQueryPlan {
+    func currentNetworkQueryPlan() -> NetworkRequestQueryPlan {
         if let networkQueryPlan {
             return networkQueryPlan
         }
-        let plan = NetworkRequestQueryPlan(descriptor: fetchDescriptor, context: context)
+        let plan = NetworkRequestQueryPlan(query: networkQuery)
         networkQueryPlan = plan
         return plan
     }
@@ -571,13 +369,13 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
         configureNetworkSnapshotStorage(plan: plan)
     }
 
-    func applyNetworkFetchDescriptor(
-        _ descriptor: WebInspectorFetchDescriptor<NetworkRequest>,
+    func applyNetworkQuery(
+        _ query: NetworkRequestQuery,
         plan: NetworkRequestQueryPlan,
         requests: [NetworkRequest],
         lookup: (NetworkRequest.ID) -> NetworkRequest?
     ) {
-        fetchDescriptor = descriptor
+        queryStorage = .network(query)
         networkQueryPlan = plan
         if plan.requiresQuery {
             let state = NetworkRequestQueryState(plan: plan, requests: requests)
@@ -595,7 +393,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             networkQueryState = NetworkRequestQueryState(plan: state.plan, requests: [])
         }
         resetItems([])
-        if networkQueryPlan?.requiresQuery == false, sectionBy == nil {
+        if networkQueryPlan?.requiresQuery == false, networkQuery.sectionBy == nil {
             networkUnfilteredSnapshotLedger = WebInspectorFetchedResultsSingleSectionSnapshotLedger(
                 itemIDs: []
             )
@@ -611,7 +409,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
         lookup: (NetworkRequest.ID) -> NetworkRequest?
     ) {
         guard var state = networkQueryState else {
-            if sectionBy == nil, networkQueryPlan?.requiresQuery == false {
+            if networkQuery.sectionBy == nil, networkQueryPlan?.requiresQuery == false {
                 insertUnfilteredNetworkRequest(request)
             } else {
                 insertItem(request)
@@ -654,8 +452,8 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             "An unfiltered Network change cannot have query state."
         )
         precondition(
-            sectionBy == nil,
-            "An unfiltered Network change must not have a section descriptor."
+            networkQuery.sectionBy == nil,
+            "An unfiltered Network change must not have a section query."
         )
         precondition(itemIndex >= 0, "An unfiltered Network change must have a valid item index.")
 
@@ -734,8 +532,8 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             "An unfiltered Network insert must not require query evaluation."
         )
         precondition(
-            sectionBy == nil,
-            "An unfiltered Network insert must not have a section descriptor."
+            networkQuery.sectionBy == nil,
+            "An unfiltered Network insert must not have a section query."
         )
         guard let networkUnfilteredSnapshotLedger else {
             preconditionFailure("An unfiltered Network insert must have append-only snapshot storage.")
@@ -794,7 +592,7 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
     }
 
     private func configureNetworkSnapshotStorage(plan: NetworkRequestQueryPlan) {
-        if plan.requiresQuery == false, sectionBy == nil {
+        if plan.requiresQuery == false, networkQuery.sectionBy == nil {
             networkUnfilteredSnapshotLedger = WebInspectorFetchedResultsSingleSectionSnapshotLedger(
                 itemIDs: items.map(\.id)
             )
@@ -803,5 +601,27 @@ extension WebInspectorFetchedResults where Model == NetworkRequest {
             networkUnfilteredSnapshotLedger = nil
             networkResultSnapshot = WebInspectorFetchedResultsSnapshot(sections: sections)
         }
+    }
+}
+
+extension WebInspectorFetchedResults where Model == ConsoleMessage {
+    convenience init(
+        query: ConsoleMessageQuery,
+        items: [ConsoleMessage] = [],
+        modelContext: WebInspectorContext? = nil
+    ) {
+        self.init(queryStorage: .console(query), items: items, modelContext: modelContext)
+    }
+
+    var consoleQuery: ConsoleMessageQuery {
+        guard case let .console(query) = queryStorage else {
+            preconditionFailure("ConsoleMessage results must own a ConsoleMessageQuery.")
+        }
+        return query
+    }
+
+    func applyConsoleQuery(_ query: ConsoleMessageQuery, items: [ConsoleMessage]) {
+        queryStorage = .console(query)
+        resetItems(items)
     }
 }

--- a/Sources/WebInspectorDataKit/NetworkRequest.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequest.swift
@@ -1230,7 +1230,7 @@ package enum NetworkResponseCookieSection: Equatable, Sendable {
 
 /// Observable model for one network request.
 @Observable
-public final class NetworkRequest: WebInspectorFetchableModel {
+public final class NetworkRequest: WebInspectorPersistentModel {
     /// Stable identity for a network request within a context.
     public struct ID: Hashable, Sendable {
         let proxyID: Network.Request.ID
@@ -1551,7 +1551,7 @@ public final class NetworkRequest: WebInspectorFetchableModel {
         .joined(separator: "\n")
     }
 
-    /// The HTTP status code, exposed as a stable fetch key path.
+    /// The HTTP status code used by query filters and display.
     public var statusCode: Int? {
         status
     }

--- a/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
@@ -2,7 +2,7 @@ import Foundation
 
 package struct NetworkResultSetDelta: Sendable {
     package var snapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>
-    package var transaction: WebInspectorFetchedResultsTransaction<NetworkRequest>?
+    package var transaction: WebInspectorFetchedResultsTransaction<NetworkRequest>
 }
 
 package actor NetworkRequestIndex {
@@ -65,14 +65,13 @@ package actor NetworkRequestIndex {
         changedID: NetworkRequest.ID?
     ) -> NetworkResultSetDelta? {
         let newSnapshot = snapshot(plan: plan, sectionBy: sectionBy)
-        guard oldSnapshot != newSnapshot else {
-            return nil
-        }
-        let transaction = NetworkResultSetTransactionBuilder.transaction(
+        guard let transaction = NetworkResultSetTransactionBuilder.transaction(
             oldSnapshot: oldSnapshot,
             newSnapshot: newSnapshot,
             changedID: changedID
-        )
+        ) else {
+            return nil
+        }
         return NetworkResultSetDelta(snapshot: newSnapshot, transaction: transaction)
     }
 
@@ -270,8 +269,28 @@ private enum NetworkResultSetTransactionBuilder {
             changedID: changedID,
             excludedItemIDs: Set(sectionMembershipChanges.map(itemID))
         )
+        let updates = updateChanges(
+            from: oldPositions,
+            to: newPositions,
+            changedID: changedID
+        )
 
-        return deletes + inserts + sectionMembershipChanges + moves
+        return deletes + inserts + sectionMembershipChanges + moves + updates
+    }
+
+    private static func updateChanges(
+        from oldPositions: [ItemID: ItemPosition],
+        to newPositions: [ItemID: ItemPosition],
+        changedID: ItemID?
+    ) -> [WebInspectorFetchedResultsItemChange<ItemID>] {
+        guard let changedID,
+              let oldPosition = oldPositions[changedID],
+              let newPosition = newPositions[changedID],
+              oldPosition.sectionID == newPosition.sectionID,
+              oldPosition.indexPath == newPosition.indexPath else {
+            return []
+        }
+        return [.update(itemID: changedID, indexPath: newPosition.indexPath)]
     }
 
     private static func sectionMembershipChanges(

--- a/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestIndex.swift
@@ -60,13 +60,10 @@ package actor NetworkRequestIndex {
 
     package func delta(
         plan: NetworkRequestQueryPlan,
-        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>?,
+        sectionBy: NetworkRequestQuery.Section?,
         oldSnapshot: WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>,
         changedID: NetworkRequest.ID?
     ) -> NetworkResultSetDelta? {
-        guard plan.requiresModelPredicate == false else {
-            return nil
-        }
         let newSnapshot = snapshot(plan: plan, sectionBy: sectionBy)
         guard oldSnapshot != newSnapshot else {
             return nil
@@ -81,7 +78,7 @@ package actor NetworkRequestIndex {
 
     private func snapshot(
         plan: NetworkRequestQueryPlan,
-        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>?
+        sectionBy: NetworkRequestQuery.Section?
     ) -> WebInspectorFetchedResultsSnapshot<NetworkRequest.ID> {
         let matchingRecords = visibleRecords(plan: plan)
         guard matchingRecords.isEmpty == false else {
@@ -140,34 +137,26 @@ package actor NetworkRequestIndex {
         }
 
         let lowerBound = min(plan.fetchOffset, records.count)
-        let upperBound: Int
-        if let fetchLimit = plan.fetchLimit {
-            upperBound = min(lowerBound + fetchLimit, records.count)
-        } else {
-            upperBound = records.count
-        }
+        let remainingCount = records.count - lowerBound
+        let visibleCount = min(plan.fetchLimit ?? remainingCount, remainingCount)
+        let upperBound = lowerBound + visibleCount
         return Array(records[lowerBound..<upperBound])
     }
 
     private func sectionIdentity(
         for record: NetworkRequestRecord,
-        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>
+        sectionBy: NetworkRequestQuery.Section
     ) -> (id: WebInspectorFetchSectionID, title: String?) {
         let value: String?
-        switch sectionBy.key {
-        case .networkMethod:
+        switch sectionBy.storage {
+        case .method:
             value = record.method
-        case .networkResourceType:
+        case .resourceType:
             value = record.resourceTypeRawValue
-        case .networkResourceCategory:
+        case .resourceCategory:
             value = record.resourceCategory.rawValue
-        case .networkMIMEType:
+        case .mimeType:
             value = record.mimeType
-        case .consoleSource,
-             .consoleLevel,
-             .consoleKind,
-             .consoleURL:
-            preconditionFailure("Console section descriptors cannot be applied to NetworkRequest results.")
         }
 
         let title = value ?? ""

--- a/Sources/WebInspectorDataKit/NetworkRequestQuery.swift
+++ b/Sources/WebInspectorDataKit/NetworkRequestQuery.swift
@@ -75,79 +75,33 @@ package struct NetworkRequestRecord: Hashable, Sendable {
 }
 
 package struct NetworkRequestQueryPlan: Sendable {
-    package typealias RecordPredicate = @Sendable (NetworkRequestRecord) -> Bool
-
-    package enum Filter: Sendable {
-        case record(RecordPredicate)
-        case model(Predicate<NetworkRequest>)
-
-        package func matches(record: NetworkRequestRecord) -> Bool? {
-            switch self {
-            case let .record(predicate):
-                return predicate(record)
-            case .model:
-                return nil
-            }
-        }
-
-        package func matches(record: NetworkRequestRecord, request: NetworkRequest) -> Bool {
-            switch self {
-            case let .record(predicate):
-                return predicate(record)
-            case let .model(predicate):
-                do {
-                    return try predicate.evaluate(request)
-                } catch {
-                    preconditionFailure("NetworkRequest predicate evaluation failed: \(error)")
-                }
-            }
-        }
-    }
-
-    package var filter: Filter?
+    package var filter: NetworkRequestQuery.Filter?
     package var sortComparators: [NetworkRequestRecordSortComparator]
     package var fetchLimit: Int?
     package var fetchOffset: Int
 
     package init(
-        descriptor: WebInspectorFetchDescriptor<NetworkRequest>,
-        context: WebInspectorContext
+        query: NetworkRequestQuery
     ) {
-        filter = descriptor.predicate.map(makeNetworkRequestFilter)
-        sortComparators = descriptor.sortBy.map {
-            NetworkRequestRecordSortComparator(descriptor: $0, context: context)
-        }
-        fetchLimit = descriptor.fetchLimit
-        fetchOffset = descriptor.fetchOffset
+        filter = query.filter
+        sortComparators = query.sortBy.map(NetworkRequestRecordSortComparator.init)
+        fetchLimit = query.fetchLimitAsInt
+        fetchOffset = query.fetchOffsetAsInt
     }
 
     package var requiresQuery: Bool {
         filter != nil || sortComparators.isEmpty == false || fetchLimit != nil || fetchOffset > 0
     }
 
-    package var requiresModelPredicate: Bool {
-        guard case .model = filter else {
-            return false
-        }
-        return true
-    }
-
-    package func matches(record: NetworkRequestRecord) -> Bool? {
+    package func matches(record: NetworkRequestRecord) -> Bool {
         filter?.matches(record: record) ?? true
-    }
-
-    package func matches(record: NetworkRequestRecord, request: NetworkRequest) -> Bool {
-        filter?.matches(record: record, request: request) ?? true
     }
 
     package func visibleIDs(from matchingIDs: [NetworkRequest.ID]) -> ArraySlice<NetworkRequest.ID> {
         let lowerBound = min(fetchOffset, matchingIDs.count)
-        let upperBound: Int
-        if let fetchLimit {
-            upperBound = min(lowerBound + fetchLimit, matchingIDs.count)
-        } else {
-            upperBound = matchingIDs.count
-        }
+        let remainingCount = matchingIDs.count - lowerBound
+        let visibleCount = min(fetchLimit ?? remainingCount, remainingCount)
+        let upperBound = lowerBound + visibleCount
         return matchingIDs[lowerBound..<upperBound]
     }
 
@@ -189,7 +143,7 @@ package struct NetworkRequestQueryState {
         let record = NetworkRequestRecord(request: request, orderIndex: orderIndex)
         recordsByID[record.id] = record
         matchingIDs.removeAll { $0 == record.id }
-        guard plan.matches(record: record, request: request) else {
+        guard plan.matches(record: record) else {
             return
         }
         insertMatchingID(record.id)
@@ -236,15 +190,12 @@ package struct NetworkRequestRecordSortComparator: Sendable {
     private var key: Key
     private var order: SortOrder
 
-    fileprivate init(
-        descriptor: SortDescriptor<NetworkRequest>,
-        context: WebInspectorContext
-    ) {
-        guard let key = Self.key(for: descriptor, context: context) else {
-            preconditionFailure("Unsupported NetworkRequest sort descriptor: \(descriptor)")
+    fileprivate init(_ sort: NetworkRequestQuery.Sort) {
+        switch sort.storage {
+        case let .requestSentTimestamp(order):
+            key = .requestSentTimestamp
+            self.order = order
         }
-        self.key = key
-        order = descriptor.order
     }
 
     fileprivate func compare(
@@ -266,52 +217,6 @@ package struct NetworkRequestRecordSortComparator: Sendable {
 
     fileprivate var usesReverseOrder: Bool {
         order == .reverse
-    }
-
-    private static func key(
-        for descriptor: SortDescriptor<NetworkRequest>,
-        context: WebInspectorContext
-    ) -> Key? {
-        let timestampPair = sentinelPair(
-            lhsTimestamp: 1,
-            rhsTimestamp: 2,
-            context: context
-        )
-        if descriptor.compare(timestampPair.lhs, timestampPair.rhs) != .orderedSame {
-            return .requestSentTimestamp
-        }
-        return nil
-    }
-
-    private static func sentinelPair(
-        lhsTimestamp: Double,
-        rhsTimestamp: Double,
-        context: WebInspectorContext
-    ) -> (lhs: NetworkRequest, rhs: NetworkRequest) {
-        (
-            lhs: NetworkRequest(
-                request: Network.Request(
-                    id: Network.Request.ID("__sort-lhs"),
-                    url: "https://example.test/resource",
-                    method: "GET"
-                ),
-                initiator: nil,
-                resourceType: .fetch,
-                timestamp: lhsTimestamp,
-                modelContext: context
-            ),
-            rhs: NetworkRequest(
-                request: Network.Request(
-                    id: Network.Request.ID("__sort-rhs"),
-                    url: "https://example.test/resource",
-                    method: "GET"
-                ),
-                initiator: nil,
-                resourceType: .fetch,
-                timestamp: rhsTimestamp,
-                modelContext: context
-            )
-        )
     }
 
     private func compareOptional<Value: Comparable>(
@@ -350,291 +255,38 @@ private extension ComparisonResult {
     }
 }
 
-private protocol NetworkRequestRecordPredicateExpression {
-    func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate
-}
-
-private protocol NetworkRequestRecordStringExpression {
-    func networkRequestStringExpression() throws -> @Sendable (NetworkRequestRecord) -> String
-}
-
-private protocol NetworkRequestRecordIntExpression {
-    func networkRequestIntExpression() throws -> @Sendable (NetworkRequestRecord) -> Int
-}
-
-private protocol NetworkRequestRecordOptionalIntExpression {
-    func networkRequestOptionalIntExpression() throws -> @Sendable (NetworkRequestRecord) -> Int?
-}
-
-private protocol NetworkRequestRecordResourceCategoryExpression {
-    func networkRequestResourceCategoryExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequest.ResourceCategory
-}
-
-private protocol NetworkRequestRecordResourceCategorySequenceExpression {
-    func networkRequestResourceCategorySequenceExpression() throws -> [NetworkRequest.ResourceCategory]
-}
-
-private enum NetworkRequestRecordPredicateValue: Equatable, Sendable {
-    case string(String)
-    case optionalString(String?)
-    case resourceCategory(NetworkRequest.ResourceCategory)
-}
-
-private protocol NetworkRequestRecordEquatableExpression {
-    func networkRequestEquatableExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequestRecordPredicateValue
-}
-
-private struct UnsupportedNetworkRequestRecordPredicate: Error {}
-
-private func makeNetworkRequestFilter(
-    _ predicate: Predicate<NetworkRequest>
-) -> NetworkRequestQueryPlan.Filter {
-    guard let expression = predicate.expression as? any NetworkRequestRecordPredicateExpression else {
-        return .model(predicate)
-    }
-    do {
-        return .record(try expression.networkRequestRecordPredicate())
-    } catch is UnsupportedNetworkRequestRecordPredicate {
-        return .model(predicate)
-    } catch {
-        preconditionFailure("NetworkRequest predicate planning failed: \(error)")
-    }
-}
-
-extension PredicateExpressions.Conjunction: NetworkRequestRecordPredicateExpression
-    where LHS: NetworkRequestRecordPredicateExpression, RHS: NetworkRequestRecordPredicateExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let lhsPredicate = try lhs.networkRequestRecordPredicate()
-        let rhsPredicate = try rhs.networkRequestRecordPredicate()
-        return { record in
-            lhsPredicate(record) && rhsPredicate(record)
-        }
-    }
-}
-
-extension PredicateExpressions.Disjunction: NetworkRequestRecordPredicateExpression
-    where LHS: NetworkRequestRecordPredicateExpression, RHS: NetworkRequestRecordPredicateExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let lhsPredicate = try lhs.networkRequestRecordPredicate()
-        let rhsPredicate = try rhs.networkRequestRecordPredicate()
-        return { record in
-            lhsPredicate(record) || rhsPredicate(record)
-        }
-    }
-}
-
-extension PredicateExpressions.Equal: NetworkRequestRecordPredicateExpression
-    where LHS: NetworkRequestRecordEquatableExpression, RHS: NetworkRequestRecordEquatableExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let lhsExpression = try lhs.networkRequestEquatableExpression()
-        let rhsExpression = try rhs.networkRequestEquatableExpression()
-        return { record in
-            networkRequestRecordPredicateValuesEqual(lhsExpression(record), rhsExpression(record))
-        }
-    }
-}
-
-private func networkRequestRecordPredicateValuesEqual(
-    _ lhs: NetworkRequestRecordPredicateValue,
-    _ rhs: NetworkRequestRecordPredicateValue
-) -> Bool {
-    switch (lhs, rhs) {
-    case let (.string(lhs), .string(rhs)):
-        return lhs == rhs
-    case let (.optionalString(lhs), .optionalString(rhs)):
-        return lhs == rhs
-    case let (.optionalString(lhs), .string(rhs)):
-        return lhs == rhs
-    case let (.string(lhs), .optionalString(rhs)):
-        return lhs == rhs
-    case let (.resourceCategory(lhs), .resourceCategory(rhs)):
-        return lhs == rhs
-    case (.string, _),
-         (.optionalString, _),
-         (.resourceCategory, _):
-        return false
-    }
-}
-
-extension PredicateExpressions.StringLocalizedStandardContains: NetworkRequestRecordPredicateExpression
-    where Root: NetworkRequestRecordStringExpression, Other: NetworkRequestRecordStringExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let rootExpression = try root.networkRequestStringExpression()
-        let otherExpression = try other.networkRequestStringExpression()
-        return { record in
-            rootExpression(record).localizedStandardContains(otherExpression(record))
-        }
-    }
-}
-
-extension PredicateExpressions.SequenceContains: NetworkRequestRecordPredicateExpression
-    where LHS: NetworkRequestRecordResourceCategorySequenceExpression,
-          RHS: NetworkRequestRecordResourceCategoryExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let categories = Set(try sequence.networkRequestResourceCategorySequenceExpression())
-        let elementExpression = try element.networkRequestResourceCategoryExpression()
-        return { record in
-            categories.contains(elementExpression(record))
-        }
-    }
-}
-
-extension PredicateExpressions.Comparison: NetworkRequestRecordPredicateExpression
-    where LHS: NetworkRequestRecordIntExpression, RHS: NetworkRequestRecordIntExpression
-{
-    fileprivate func networkRequestRecordPredicate() throws -> NetworkRequestQueryPlan.RecordPredicate {
-        let lhsExpression = try lhs.networkRequestIntExpression()
-        let rhsExpression = try rhs.networkRequestIntExpression()
-        let op = op
-        return { record in
-            let lhs = lhsExpression(record)
-            let rhs = rhsExpression(record)
-            switch op {
-            case .lessThan:
-                return lhs < rhs
-            case .lessThanOrEqual:
-                return lhs <= rhs
-            case .greaterThan:
-                return lhs > rhs
-            case .greaterThanOrEqual:
-                return lhs >= rhs
-            @unknown default:
-                preconditionFailure("Unsupported NetworkRequest comparison operator: \(op)")
+extension NetworkRequestQuery.Filter {
+    func matches(record: NetworkRequestRecord) -> Bool {
+        switch storage {
+        case let .method(method):
+            return record.method == method
+        case let .methodContains(text):
+            return record.method.localizedStandardContains(text)
+        case let .urlEquals(url):
+            return record.url == url
+        case let .urlContains(text):
+            return record.url.localizedStandardContains(text)
+        case let .searchableTextEquals(text):
+            return record.searchableText == text
+        case let .searchableTextContains(text):
+            return record.searchableText.localizedStandardContains(text)
+        case let .mimeType(mimeType):
+            return record.mimeType == mimeType
+        case let .resourceCategories(categories):
+            return categories.contains(record.resourceCategory)
+        case let .statusCode(comparison, missingValue):
+            let statusCode = record.statusCode ?? missingValue
+            switch comparison {
+            case let .lessThan(value): return statusCode < value
+            case let .atMost(value): return statusCode <= value
+            case let .greaterThan(value): return statusCode > value
+            case let .atLeast(value): return statusCode >= value
             }
+        case let .all(filters):
+            return filters.allSatisfy { $0.matches(record: record) }
+        case let .any(filters):
+            return filters.contains { $0.matches(record: record) }
         }
     }
-}
 
-extension PredicateExpressions.NilCoalesce: NetworkRequestRecordIntExpression
-    where LHS: NetworkRequestRecordOptionalIntExpression, RHS: NetworkRequestRecordIntExpression
-{
-    fileprivate func networkRequestIntExpression() throws -> @Sendable (NetworkRequestRecord) -> Int {
-        let lhsExpression = try lhs.networkRequestOptionalIntExpression()
-        let rhsExpression = try rhs.networkRequestIntExpression()
-        return { record in
-            lhsExpression(record) ?? rhsExpression(record)
-        }
-    }
-}
-
-extension PredicateExpressions.KeyPath: NetworkRequestRecordStringExpression
-    where Root == PredicateExpressions.Variable<NetworkRequest>, Output == String
-{
-    fileprivate func networkRequestStringExpression() throws -> @Sendable (NetworkRequestRecord) -> String {
-        if keyPath == \NetworkRequest.url {
-            return { $0.url }
-        }
-        if keyPath == \NetworkRequest.method {
-            return { $0.method }
-        }
-        if keyPath == \NetworkRequest.searchableText {
-            return { $0.searchableText }
-        }
-        throw UnsupportedNetworkRequestRecordPredicate()
-    }
-}
-
-extension PredicateExpressions.KeyPath: NetworkRequestRecordEquatableExpression
-    where Root == PredicateExpressions.Variable<NetworkRequest>
-{
-    fileprivate func networkRequestEquatableExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequestRecordPredicateValue {
-        if keyPath == \NetworkRequest.url || keyPath == \NetworkRequest.method || keyPath == \NetworkRequest.searchableText {
-            let stringExpression: @Sendable (NetworkRequestRecord) -> String
-            if keyPath == \NetworkRequest.url {
-                stringExpression = { $0.url }
-            } else if keyPath == \NetworkRequest.method {
-                stringExpression = { $0.method }
-            } else {
-                stringExpression = { $0.searchableText }
-            }
-            return { record in
-                .string(stringExpression(record))
-            }
-        }
-        if keyPath == \NetworkRequest.mimeType {
-            return { record in
-                .optionalString(record.mimeType)
-            }
-        }
-        if keyPath == \NetworkRequest.resourceCategory {
-            return { record in
-                .resourceCategory(record.resourceCategory)
-            }
-        }
-        throw UnsupportedNetworkRequestRecordPredicate()
-    }
-}
-
-extension PredicateExpressions.KeyPath: NetworkRequestRecordOptionalIntExpression
-    where Root == PredicateExpressions.Variable<NetworkRequest>, Output == Int?
-{
-    fileprivate func networkRequestOptionalIntExpression() throws -> @Sendable (NetworkRequestRecord) -> Int? {
-        if keyPath == \NetworkRequest.statusCode {
-            return { $0.statusCode }
-        }
-        throw UnsupportedNetworkRequestRecordPredicate()
-    }
-}
-
-extension PredicateExpressions.KeyPath: NetworkRequestRecordResourceCategoryExpression
-    where Root == PredicateExpressions.Variable<NetworkRequest>, Output == NetworkRequest.ResourceCategory
-{
-    fileprivate func networkRequestResourceCategoryExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequest.ResourceCategory {
-        if keyPath == \NetworkRequest.resourceCategory {
-            return { $0.resourceCategory }
-        }
-        throw UnsupportedNetworkRequestRecordPredicate()
-    }
-}
-
-extension PredicateExpressions.Value: NetworkRequestRecordStringExpression where Output == String {
-    fileprivate func networkRequestStringExpression() throws -> @Sendable (NetworkRequestRecord) -> String {
-        let value = value
-        return { _ in value }
-    }
-}
-
-extension PredicateExpressions.Value: NetworkRequestRecordEquatableExpression {
-    fileprivate func networkRequestEquatableExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequestRecordPredicateValue {
-        if let value = value as? String {
-            return { _ in .string(value) }
-        }
-        if Output.self == Optional<String>.self {
-            let value = value as! String?
-            return { _ in .optionalString(value) }
-        }
-        if let value = value as? NetworkRequest.ResourceCategory {
-            return { _ in .resourceCategory(value) }
-        }
-        throw UnsupportedNetworkRequestRecordPredicate()
-    }
-}
-
-extension PredicateExpressions.Value: NetworkRequestRecordIntExpression where Output == Int {
-    fileprivate func networkRequestIntExpression() throws -> @Sendable (NetworkRequestRecord) -> Int {
-        let value = value
-        return { _ in value }
-    }
-}
-
-extension PredicateExpressions.Value: NetworkRequestRecordResourceCategoryExpression
-    where Output == NetworkRequest.ResourceCategory
-{
-    fileprivate func networkRequestResourceCategoryExpression() throws -> @Sendable (NetworkRequestRecord) -> NetworkRequest.ResourceCategory {
-        let value = value
-        return { _ in value }
-    }
-}
-
-extension PredicateExpressions.Value: NetworkRequestRecordResourceCategorySequenceExpression
-    where Output == [NetworkRequest.ResourceCategory]
-{
-    fileprivate func networkRequestResourceCategorySequenceExpression() throws -> [NetworkRequest.ResourceCategory] {
-        value
-    }
 }

--- a/Sources/WebInspectorDataKit/Queries.swift
+++ b/Sources/WebInspectorDataKit/Queries.swift
@@ -1,0 +1,465 @@
+import Foundation
+import WebInspectorProxyKit
+
+/// Query capabilities supported for Network request results.
+public struct NetworkRequestQuery: Hashable, Sendable {
+    /// A nonthrowing Network request membership test.
+    public struct Filter: Hashable, Sendable {
+        package indirect enum Storage: Hashable, Sendable {
+            case method(String)
+            case methodContains(String)
+            case urlEquals(String)
+            case urlContains(String)
+            case searchableTextEquals(String)
+            case searchableTextContains(String)
+            case mimeType(String?)
+            case resourceCategories(Set<NetworkRequest.ResourceCategory>)
+            case statusCode(StatusCodeComparison, missingValue: Int)
+            case all([Filter])
+            case any([Filter])
+        }
+
+        package let storage: Storage
+
+        /// Matches one HTTP method.
+        public static func method(equals method: String) -> Filter {
+            Filter(storage: .method(method))
+        }
+
+        /// Matches HTTP methods using localized standard containment.
+        public static func method(containing text: String) -> Filter {
+            Filter(storage: .methodContains(text))
+        }
+
+        /// Matches one request URL.
+        public static func url(equals url: String) -> Filter {
+            Filter(storage: .urlEquals(url))
+        }
+
+        /// Matches request URLs using localized standard containment.
+        public static func url(containing text: String) -> Filter {
+            Filter(storage: .urlContains(text))
+        }
+
+        /// Matches the request's aggregate searchable text.
+        public static func searchableText(containing text: String) -> Filter {
+            Filter(storage: .searchableTextContains(text))
+        }
+
+        /// Matches the request's aggregate searchable text exactly.
+        public static func searchableText(equals text: String) -> Filter {
+            Filter(storage: .searchableTextEquals(text))
+        }
+
+        /// Matches one reported MIME type, including an unreported value.
+        public static func mimeType(equals mimeType: String?) -> Filter {
+            Filter(storage: .mimeType(mimeType))
+        }
+
+        /// Matches one resource category.
+        public static func resourceCategory(_ category: NetworkRequest.ResourceCategory) -> Filter {
+            resourceCategories([category])
+        }
+
+        /// Matches any resource category in the supplied sequence.
+        public static func resourceCategories(
+            _ categories: some Sequence<NetworkRequest.ResourceCategory>
+        ) -> Filter {
+            Filter(storage: .resourceCategories(Set(categories)))
+        }
+
+        /// Matches status codes greater than or equal to a value.
+        ///
+        /// The filter substitutes `whenMissing` when WebKit has not reported a
+        /// status code before applying the comparison.
+        public static func statusCode(
+            atLeast minimum: Int,
+            whenMissing missingValue: Int = 0
+        ) -> Filter {
+            Filter(storage: .statusCode(.atLeast(minimum), missingValue: missingValue))
+        }
+
+        /// Matches status codes greater than a value.
+        ///
+        /// The filter substitutes `whenMissing` when WebKit has not reported a
+        /// status code before applying the comparison.
+        public static func statusCode(
+            greaterThan minimum: Int,
+            whenMissing missingValue: Int = 0
+        ) -> Filter {
+            Filter(storage: .statusCode(.greaterThan(minimum), missingValue: missingValue))
+        }
+
+        /// Matches status codes less than a value.
+        ///
+        /// The filter substitutes `whenMissing` when WebKit has not reported a
+        /// status code before applying the comparison.
+        public static func statusCode(
+            lessThan maximum: Int,
+            whenMissing missingValue: Int = 0
+        ) -> Filter {
+            Filter(storage: .statusCode(.lessThan(maximum), missingValue: missingValue))
+        }
+
+        /// Matches status codes less than or equal to a value.
+        ///
+        /// The filter substitutes `whenMissing` when WebKit has not reported a
+        /// status code before applying the comparison.
+        public static func statusCode(
+            atMost maximum: Int,
+            whenMissing missingValue: Int = 0
+        ) -> Filter {
+            Filter(storage: .statusCode(.atMost(maximum), missingValue: missingValue))
+        }
+
+        /// Matches when every filter matches. An empty collection matches.
+        public static func all(_ filters: [Filter]) -> Filter {
+            Filter(storage: .all(filters))
+        }
+
+        /// Matches when any filter matches. An empty collection does not match.
+        public static func any(_ filters: [Filter]) -> Filter {
+            Filter(storage: .any(filters))
+        }
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    package enum StatusCodeComparison: Hashable, Sendable {
+        case lessThan(Int)
+        case atMost(Int)
+        case greaterThan(Int)
+        case atLeast(Int)
+    }
+
+    /// A supported Network request ordering.
+    public struct Sort: Hashable, Sendable {
+        package enum Storage: Hashable, Sendable {
+            case requestSentTimestamp(SortOrder)
+        }
+
+        package let storage: Storage
+
+        /// Orders requests by the timestamp at which WebKit reported them sent.
+        ///
+        /// Unreported timestamps precede reported timestamps in forward order
+        /// and follow them in reverse order. Equal timestamps retain insertion
+        /// order in forward order and reverse insertion order in reverse order.
+        public static func requestSentTimestamp(order: SortOrder = .forward) -> Sort {
+            Sort(storage: .requestSentTimestamp(order))
+        }
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// A supported Network request section identity.
+    public struct Section: Hashable, Sendable {
+        package enum Storage: Hashable, Sendable {
+            case method
+            case resourceType
+            case resourceCategory
+            case mimeType
+        }
+
+        package let storage: Storage
+
+        /// Sections requests by HTTP method.
+        public static let method = Section(storage: .method)
+
+        /// Sections requests by WebKit's reported resource type.
+        public static let resourceType = Section(storage: .resourceType)
+
+        /// Sections requests by DataKit's coarse resource category.
+        public static let resourceCategory = Section(storage: .resourceCategory)
+
+        /// Sections requests by reported MIME type.
+        public static let mimeType = Section(storage: .mimeType)
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// Membership test applied to each current request.
+    public var filter: Filter?
+
+    /// Sort criteria applied in order.
+    public var sortBy: [Sort]
+
+    /// Optional result sectioning.
+    public var sectionBy: Section?
+
+    /// Maximum number of visible requests.
+    public var fetchLimit: UInt?
+
+    /// Number of matching requests skipped before results begin.
+    public var fetchOffset: UInt
+
+    /// Creates a Network request query.
+    public init(
+        filter: Filter? = nil,
+        sortBy: [Sort] = [],
+        sectionBy: Section? = nil,
+        fetchLimit: UInt? = nil,
+        fetchOffset: UInt = 0
+    ) {
+        self.filter = filter
+        self.sortBy = sortBy
+        self.sectionBy = sectionBy
+        self.fetchLimit = fetchLimit
+        self.fetchOffset = fetchOffset
+    }
+
+    package var fetchLimitAsInt: Int? {
+        fetchLimit.map { Int(clamping: $0) }
+    }
+
+    package var fetchOffsetAsInt: Int {
+        Int(clamping: fetchOffset)
+    }
+}
+
+/// Query capabilities supported for Console message results.
+public struct ConsoleMessageQuery: Hashable, Sendable {
+    /// A nonthrowing Console message membership test.
+    public struct Filter: Hashable, Sendable {
+        package indirect enum Storage: Hashable, Sendable {
+            case source(Console.Source)
+            case level(Console.Level)
+            case kind(Console.Kind?)
+            case url(String?)
+            case textContains(String)
+            case all([Filter])
+            case any([Filter])
+        }
+
+        package let storage: Storage
+
+        /// Matches one Console source.
+        public static func source(_ source: Console.Source) -> Filter {
+            Filter(storage: .source(source))
+        }
+
+        /// Matches one Console severity level.
+        public static func level(_ level: Console.Level) -> Filter {
+            Filter(storage: .level(level))
+        }
+
+        /// Matches one reported Console message kind, including an unreported value.
+        public static func kind(_ kind: Console.Kind?) -> Filter {
+            Filter(storage: .kind(kind))
+        }
+
+        /// Matches one source URL, including an unreported value.
+        public static func url(_ url: String?) -> Filter {
+            Filter(storage: .url(url))
+        }
+
+        /// Matches message text using localized standard containment.
+        public static func text(containing text: String) -> Filter {
+            Filter(storage: .textContains(text))
+        }
+
+        /// Matches when every filter matches. An empty collection matches.
+        public static func all(_ filters: [Filter]) -> Filter {
+            Filter(storage: .all(filters))
+        }
+
+        /// Matches when any filter matches. An empty collection does not match.
+        public static func any(_ filters: [Filter]) -> Filter {
+            Filter(storage: .any(filters))
+        }
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// String comparison used by a text sort.
+    public struct TextComparison: Hashable, Sendable {
+        package enum Storage: Hashable, Sendable {
+            case localizedStandard
+            case lexical
+        }
+
+        package let storage: Storage
+
+        /// Localized, Finder-style comparison.
+        public static let localizedStandard = TextComparison(storage: .localizedStandard)
+
+        /// Unicode lexical comparison.
+        public static let lexical = TextComparison(storage: .lexical)
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// A supported Console message ordering.
+    public struct Sort: Hashable, Sendable {
+        package enum Storage: Hashable, Sendable {
+            case text(TextComparison, SortOrder)
+            case level(SortOrder)
+        }
+
+        package let storage: Storage
+
+        /// Orders messages by their text.
+        ///
+        /// Equal text retains message insertion order in either direction.
+        public static func text(
+            comparison: TextComparison = .localizedStandard,
+            order: SortOrder = .forward
+        ) -> Sort {
+            Sort(storage: .text(comparison, order))
+        }
+
+        /// Orders messages by their severity level's raw value using localized
+        /// standard comparison. Equal values retain insertion order in either
+        /// direction.
+        public static func level(order: SortOrder = .forward) -> Sort {
+            Sort(storage: .level(order))
+        }
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// A supported Console message section identity.
+    public struct Section: Hashable, Sendable {
+        package enum Storage: Hashable, Sendable {
+            case source
+            case level
+            case kind
+            case url
+        }
+
+        package let storage: Storage
+
+        /// Sections messages by source.
+        public static let source = Section(storage: .source)
+
+        /// Sections messages by severity level.
+        public static let level = Section(storage: .level)
+
+        /// Sections messages by reported kind.
+        public static let kind = Section(storage: .kind)
+
+        /// Sections messages by source URL.
+        public static let url = Section(storage: .url)
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+    }
+
+    /// Membership test applied to each current message.
+    public var filter: Filter?
+
+    /// Sort criteria applied in order.
+    public var sortBy: [Sort]
+
+    /// Optional result sectioning.
+    public var sectionBy: Section?
+
+    /// Maximum number of visible messages.
+    public var fetchLimit: UInt?
+
+    /// Number of matching messages skipped before results begin.
+    public var fetchOffset: UInt
+
+    /// Creates a Console message query.
+    public init(
+        filter: Filter? = nil,
+        sortBy: [Sort] = [],
+        sectionBy: Section? = nil,
+        fetchLimit: UInt? = nil,
+        fetchOffset: UInt = 0
+    ) {
+        self.filter = filter
+        self.sortBy = sortBy
+        self.sectionBy = sectionBy
+        self.fetchLimit = fetchLimit
+        self.fetchOffset = fetchOffset
+    }
+
+    package var fetchLimitAsInt: Int? {
+        fetchLimit.map { Int(clamping: $0) }
+    }
+
+    package var fetchOffsetAsInt: Int {
+        Int(clamping: fetchOffset)
+    }
+}
+
+extension ConsoleMessageQuery.Filter {
+    package func matches(_ message: ConsoleMessage) -> Bool {
+        switch storage {
+        case let .source(source):
+            return message.source == source
+        case let .level(level):
+            return message.level == level
+        case let .kind(kind):
+            return message.kind == kind
+        case let .url(url):
+            return message.url == url
+        case let .textContains(text):
+            return message.text.localizedStandardContains(text)
+        case let .all(filters):
+            return filters.allSatisfy { $0.matches(message) }
+        case let .any(filters):
+            return filters.contains { $0.matches(message) }
+        }
+    }
+}
+
+extension ConsoleMessageQuery.Sort {
+    package func compare(_ lhs: ConsoleMessage, _ rhs: ConsoleMessage) -> ComparisonResult {
+        let comparison: ComparisonResult
+        let order: SortOrder
+        switch storage {
+        case let .text(textComparison, sortOrder):
+            order = sortOrder
+            switch textComparison.storage {
+            case .localizedStandard:
+                comparison = lhs.text.localizedStandardCompare(rhs.text)
+            case .lexical:
+                if lhs.text < rhs.text {
+                    comparison = .orderedAscending
+                } else if lhs.text > rhs.text {
+                    comparison = .orderedDescending
+                } else {
+                    comparison = .orderedSame
+                }
+            }
+        case let .level(sortOrder):
+            order = sortOrder
+            comparison = lhs.level.rawValue.localizedStandardCompare(rhs.level.rawValue)
+        }
+        guard order == .reverse else {
+            return comparison
+        }
+        switch comparison {
+        case .orderedAscending: return .orderedDescending
+        case .orderedDescending: return .orderedAscending
+        case .orderedSame: return .orderedSame
+        }
+    }
+}
+
+package enum WebInspectorQueryStorage: Sendable {
+    case network(NetworkRequestQuery)
+    case console(ConsoleMessageQuery)
+
+    package var isSectioned: Bool {
+        switch self {
+        case let .network(query): query.sectionBy != nil
+        case let .console(query): query.sectionBy != nil
+        }
+    }
+}

--- a/Sources/WebInspectorDataKit/WebInspectorContext.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorContext.swift
@@ -1815,209 +1815,71 @@ public final class WebInspectorContext {
         )
     }
 
-    /// Creates observable fetched results for a supported model type.
-    public func fetchedResults<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy: WebInspectorSectionDescriptor<Model>? = nil,
+    package func networkFetchedResults(
+        for query: NetworkRequestQuery,
         isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> {
+    ) -> WebInspectorFetchedResults<NetworkRequest> {
         requireOwner(isolation)
-        requireSupportedFetchDescriptor(descriptor)
-        let results = WebInspectorFetchedResults(fetchDescriptor: descriptor, sectionBy: sectionBy, modelContext: self)
-        switch descriptor.kind {
-        case .networkRequests:
-            guard let networkResults = results as? WebInspectorFetchedResults<NetworkRequest> else {
-                preconditionFailure("NetworkRequest descriptors can only fetch NetworkRequest models.")
-            }
-            let plan = NetworkRequestQueryPlan(descriptor: networkResults.fetchDescriptor, context: self)
-            networkResults.setNetworkItems(
-                currentNetworkRequests(),
-                plan: plan,
-                lookup: { id in self.requestsByID[id] }
-            )
-            networkFetchedResults.append(WeakWebInspectorFetchedResults(networkResults))
-        case .consoleMessages:
-            guard let consoleResults = results as? WebInspectorFetchedResults<ConsoleMessage> else {
-                preconditionFailure("ConsoleMessage descriptors can only fetch ConsoleMessage models.")
-            }
-            consoleResults.setItems(consoleMessages(for: consoleResults.fetchDescriptor))
-            consoleFetchedResults.append(WeakWebInspectorFetchedResults(consoleResults))
-        }
+        let results = WebInspectorFetchedResults<NetworkRequest>(
+            query: query,
+            modelContext: self
+        )
+        let plan = NetworkRequestQueryPlan(query: query)
+        results.setNetworkItems(
+            currentNetworkRequests(),
+            plan: plan,
+            lookup: { id in self.requestsByID[id] }
+        )
+        networkFetchedResults.append(WeakWebInspectorFetchedResults(results))
         return results
     }
 
-    /// Creates observable fetched results from a mutable fetch request.
-    public func fetchedResults<Model: WebInspectorFetchableModel>(
-        for request: WebInspectorFetchRequest<Model>,
-        sectionBy: WebInspectorSectionDescriptor<Model>? = nil,
+    package func consoleFetchedResults(
+        for query: ConsoleMessageQuery,
         isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> {
-        fetchedResults(for: request.fetchDescriptor, sectionBy: sectionBy, isolation: isolation)
-    }
-
-    /// Creates observable fetched results sectioned by a string key path.
-    public func fetchedResults<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, String>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> {
-        fetchedResults(
-            for: descriptor,
-            sectionBy: WebInspectorSectionDescriptor(keyPath),
-            isolation: isolation
-        )
-    }
-
-    /// Creates observable fetched results sectioned by an optional string key path.
-    public func fetchedResults<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, String?>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> {
-        fetchedResults(
-            for: descriptor,
-            sectionBy: WebInspectorSectionDescriptor(keyPath),
-            isolation: isolation
-        )
-    }
-
-    /// Creates observable fetched results sectioned by a raw-representable string key path.
-    public func fetchedResults<
-        Model: WebInspectorFetchableModel,
-        Value: RawRepresentable & Hashable & Sendable
-    >(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, Value>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> where Value.RawValue == String {
-        fetchedResults(
-            for: descriptor,
-            sectionBy: WebInspectorSectionDescriptor(keyPath),
-            isolation: isolation
-        )
-    }
-
-    /// Creates observable fetched results sectioned by an optional raw-representable string key path.
-    public func fetchedResults<
-        Model: WebInspectorFetchableModel,
-        Value: RawRepresentable & Hashable & Sendable
-    >(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, Value?>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResults<Model> where Value.RawValue == String {
-        fetchedResults(
-            for: descriptor,
-            sectionBy: WebInspectorSectionDescriptor(keyPath),
-            isolation: isolation
-        )
-    }
-
-    /// Creates a fetched-results controller for a supported model type.
-    public func fetchedResultsController<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy: WebInspectorSectionDescriptor<Model>? = nil,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> {
+    ) -> WebInspectorFetchedResults<ConsoleMessage> {
         requireOwner(isolation)
-        return WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: sectionBy, isolation: isolation)
+        let results = WebInspectorFetchedResults<ConsoleMessage>(
+            query: query,
+            modelContext: self
         )
+        results.setItems(consoleMessages(for: query))
+        consoleFetchedResults.append(WeakWebInspectorFetchedResults(results))
+        return results
     }
 
-    /// Creates a fetched-results controller from a mutable fetch request.
-    public func fetchedResultsController<Model: WebInspectorFetchableModel>(
-        for request: WebInspectorFetchRequest<Model>,
-        sectionBy: WebInspectorSectionDescriptor<Model>? = nil,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> {
-        WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: request, sectionBy: sectionBy, isolation: isolation)
-        )
-    }
-
-    /// Creates a fetched-results controller sectioned by a string key path.
-    public func fetchedResultsController<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, String>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> {
-        WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: keyPath, isolation: isolation)
-        )
-    }
-
-    /// Creates a fetched-results controller sectioned by an optional string key path.
-    public func fetchedResultsController<Model: WebInspectorFetchableModel>(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, String?>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> {
-        WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: keyPath, isolation: isolation)
-        )
-    }
-
-    /// Creates a fetched-results controller sectioned by a raw-representable string key path.
-    public func fetchedResultsController<
-        Model: WebInspectorFetchableModel,
-        Value: RawRepresentable & Hashable & Sendable
-    >(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, Value>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> where Value.RawValue == String {
-        WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: keyPath, isolation: isolation)
-        )
-    }
-
-    /// Creates a fetched-results controller sectioned by an optional raw-representable string key path.
-    public func fetchedResultsController<
-        Model: WebInspectorFetchableModel,
-        Value: RawRepresentable & Hashable & Sendable
-    >(
-        for descriptor: WebInspectorFetchDescriptor<Model> = .init(),
-        sectionBy keyPath: KeyPath<Model, Value?>,
-        isolation: isolated (any Actor) = #isolation
-    ) -> WebInspectorFetchedResultsController<Model> where Value.RawValue == String {
-        WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: keyPath, isolation: isolation)
-        )
-    }
-
-    func updateFetchDescriptor<Model: WebInspectorFetchableModel>(
-        _ descriptor: WebInspectorFetchDescriptor<Model>,
-        for results: WebInspectorFetchedResults<Model>,
+    package func updateNetworkQuery(
+        _ query: NetworkRequestQuery,
+        for results: WebInspectorFetchedResults<NetworkRequest>,
         isolation: isolated (any Actor) = #isolation
     ) throws {
         requireOwner(isolation)
-        requireSupportedFetchDescriptor(descriptor)
         guard results.modelContext === self else {
             throw WebInspectorProxyError.disconnected(
                 "WebInspectorFetchedResults is not registered in this WebInspectorContext."
             )
         }
-        switch descriptor.kind {
-        case .networkRequests:
-            guard let networkDescriptor = descriptor as? WebInspectorFetchDescriptor<NetworkRequest>,
-                  let networkResults = results as? WebInspectorFetchedResults<NetworkRequest> else {
-                preconditionFailure("NetworkRequest descriptors can only update NetworkRequest fetched results.")
-            }
-            let plan = NetworkRequestQueryPlan(descriptor: networkDescriptor, context: self)
-            networkResults.applyNetworkFetchDescriptor(
-                networkDescriptor,
-                plan: plan,
-                requests: currentNetworkRequests(),
-                lookup: { id in self.requestsByID[id] }
+        let plan = NetworkRequestQueryPlan(query: query)
+        results.applyNetworkQuery(
+            query,
+            plan: plan,
+            requests: currentNetworkRequests(),
+            lookup: { id in self.requestsByID[id] }
+        )
+    }
+
+    package func updateConsoleQuery(
+        _ query: ConsoleMessageQuery,
+        for results: WebInspectorFetchedResults<ConsoleMessage>,
+        isolation: isolated (any Actor) = #isolation
+    ) throws {
+        requireOwner(isolation)
+        guard results.modelContext === self else {
+            throw WebInspectorProxyError.disconnected(
+                "WebInspectorFetchedResults is not registered in this WebInspectorContext."
             )
-        case .consoleMessages:
-            guard let consoleDescriptor = descriptor as? WebInspectorFetchDescriptor<ConsoleMessage>,
-                  let consoleResults = results as? WebInspectorFetchedResults<ConsoleMessage> else {
-                preconditionFailure("ConsoleMessage descriptors can only update ConsoleMessage fetched results.")
-            }
-            consoleResults.applyFetchDescriptor(consoleDescriptor, items: consoleMessages(for: consoleDescriptor))
         }
+        results.applyConsoleQuery(query, items: consoleMessages(for: query))
     }
 
     private func invalidateFetchedResultsRegistrations() {
@@ -2030,19 +1892,6 @@ public final class WebInspectorContext {
         }
         for results in consoleResults {
             results.invalidateRegistration()
-        }
-    }
-
-    private func requireSupportedFetchDescriptor<Model: WebInspectorFetchableModel>(
-        _ descriptor: WebInspectorFetchDescriptor<Model>
-    ) {
-        if descriptor.kind == .networkRequests || descriptor.kind == .consoleMessages {
-            return
-        }
-        guard descriptor.requiresRecordBackedQuery == false else {
-            preconditionFailure(
-                "Predicate, sort, limit, and offset fetch descriptors require a record-backed DataKit query index."
-            )
         }
     }
 
@@ -5999,8 +5848,8 @@ extension WebInspectorContext {
             guard let results = registration.value else {
                 continue
             }
-            let plan = results.currentNetworkQueryPlan(context: self)
-            if plan.requiresQuery == false, results.sectionBy == nil {
+            let plan = results.currentNetworkQueryPlan()
+            if plan.requiresQuery == false, results.networkQuery.sectionBy == nil {
                 guard let itemIndex = networkRequestOrderIndicesByID[request.id] else {
                     preconditionFailure("An unfiltered Network request must have a registered order index.")
                 }
@@ -6651,8 +6500,8 @@ extension WebInspectorContext {
             guard let results = registration.value else {
                 continue
             }
-            let plan = results.currentNetworkQueryPlan(context: self)
-            if plan.requiresQuery == false, results.sectionBy == nil {
+            let plan = results.currentNetworkQueryPlan()
+            if plan.requiresQuery == false, results.networkQuery.sectionBy == nil {
                 guard let itemIndex = networkRequestOrderIndicesByID[request.id] else {
                     preconditionFailure("An unfiltered Network request must have a registered order index.")
                 }
@@ -6664,26 +6513,12 @@ extension WebInspectorContext {
                 )
                 continue
             }
-            if plan.requiresModelPredicate {
-                if inserted {
-                    results.insertNetworkRequest(
-                        request,
-                        lookup: { id in self.requestsByID[id] }
-                    )
-                } else {
-                    results.refreshNetworkRequestAfterMutation(
-                        request,
-                        lookup: { id in self.requestsByID[id] }
-                    )
-                }
-                continue
-            }
             let oldSnapshot = results.networkSnapshotForDelta
             let resultTopologyRevision = results.topologyRevision
             let indexSequence = networkRequestIndexSequence
             guard let delta = await networkRequestIndex.delta(
                 plan: plan,
-                sectionBy: results.sectionBy,
+                sectionBy: results.networkQuery.sectionBy,
                 oldSnapshot: oldSnapshot,
                 changedID: request.id
             ) else {
@@ -6840,21 +6675,15 @@ extension WebInspectorContext {
         orderedConsoleMessageIDs.compactMap { consoleMessagesByID[$0] }
     }
 
-    private func consoleMessages(for descriptor: WebInspectorFetchDescriptor<ConsoleMessage>) -> [ConsoleMessage] {
+    private func consoleMessages(for query: ConsoleMessageQuery) -> [ConsoleMessage] {
         var items = currentConsoleMessages()
-        if let predicate = descriptor.predicate {
-            items = items.filter { message in
-                do {
-                    return try predicate.evaluate(message)
-                } catch {
-                    preconditionFailure("ConsoleMessage predicate evaluation failed: \(error)")
-                }
-            }
+        if let filter = query.filter {
+            items = items.filter(filter.matches)
         }
-        if descriptor.sortBy.isEmpty == false {
+        if query.sortBy.isEmpty == false {
             items.sort { lhs, rhs in
-                for sortDescriptor in descriptor.sortBy {
-                    switch sortDescriptor.compare(lhs, rhs) {
+                for sort in query.sortBy {
+                    switch sort.compare(lhs, rhs) {
                     case .orderedAscending:
                         return true
                     case .orderedDescending:
@@ -6866,13 +6695,10 @@ extension WebInspectorContext {
                 return lhs.id < rhs.id
             }
         }
-        let lowerBound = min(descriptor.fetchOffset, items.count)
-        let upperBound: Int
-        if let fetchLimit = descriptor.fetchLimit {
-            upperBound = min(lowerBound + fetchLimit, items.count)
-        } else {
-            upperBound = items.count
-        }
+        let lowerBound = min(query.fetchOffsetAsInt, items.count)
+        let remainingCount = items.count - lowerBound
+        let visibleCount = min(query.fetchLimitAsInt ?? remainingCount, remainingCount)
+        let upperBound = lowerBound + visibleCount
         return Array(items[lowerBound..<upperBound])
     }
 
@@ -6882,7 +6708,7 @@ extension WebInspectorContext {
             guard let results = registration.value else {
                 continue
             }
-            results.setItems(consoleMessages(for: results.fetchDescriptor), updatedItemIDs: updatedItemIDs)
+            results.setItems(consoleMessages(for: results.consoleQuery), updatedItemIDs: updatedItemIDs)
         }
     }
 }

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/ModelRegistrationLifetimes.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/ModelRegistrationLifetimes.md
@@ -43,23 +43,23 @@ not retain their originating context. When that context is released:
 
 - their active transaction streams finish;
 - transaction streams created later are already finished;
-- their final descriptor, items, sections, and controller snapshot remain
+- their final query, items, sections, and controller snapshot remain
   readable;
-- changing the descriptor throws `WebInspectorProxyError.disconnected`.
+- changing the query throws `WebInspectorProxyError.disconnected`.
 
 Detaching, restarting, or failing an inspection context does not itself
 invalidate fetched results while the context object remains alive.
 
-## Updating Fetch Descriptors
+## Updating Queries
 
-Descriptor updates now report stale registration, so call them with `try`:
+Query updates report stale registration, so call them with `try`:
 
 ```swift
-try results.updateFetchDescriptor(
-    WebInspectorFetchDescriptor(fetchLimit: 100)
+try results.updateQuery(
+    NetworkRequestQuery(fetchLimit: 100)
 )
 
-try controller.updateFetchDescriptor(
-    WebInspectorFetchDescriptor(fetchOffset: 100)
+try controller.updateQuery(
+    NetworkRequestQuery(fetchOffset: 100)
 )
 ```

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/QueryCapabilities.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/QueryCapabilities.md
@@ -1,0 +1,116 @@
+# Query Capabilities
+
+Create Network and Console result sets with concrete, closed query values.
+
+## Query Network Requests
+
+Use ``NetworkModelController/fetchedResults(for:isolation:)`` with a
+``NetworkRequestQuery``. A query atomically defines membership, ordering,
+sectioning, and its visible window:
+
+```swift
+let query = NetworkRequestQuery(
+    filter: .all([
+        .resourceCategory(.xhrFetch),
+        .searchableText(containing: "graphql"),
+    ]),
+    sortBy: [.requestSentTimestamp(order: .reverse)],
+    sectionBy: .method,
+    fetchLimit: 100
+)
+let requests = context.network.fetchedResults(for: query)
+```
+
+Network filters support method and URL equality or containment, searchable-text
+equality or containment, MIME equality, one or many resource categories, status
+code comparisons, and `all`/`any` composition. Network sorting supports the
+request-sent timestamp in either direction. Sections support method, resource
+type, resource category, and MIME type.
+
+DataKit applies a query in this order: filter membership, ordered sort criteria
+and their tie rule, offset, limit, then sectioning of the visible window. Section
+order follows each section's first visible item. Limits apply to the whole
+result, not separately to each section. With no sort criteria, Network requests
+and Console messages remain in insertion order.
+
+A status-code filter substitutes its `whenMissing` value before comparison when
+WebKit has not reported a status. The default substitution is zero.
+
+## Query Console Messages
+
+Use ``ConsoleModelController/fetchedResults(for:isolation:)`` with a
+``ConsoleMessageQuery``:
+
+```swift
+let query = ConsoleMessageQuery(
+    filter: .level(.init(rawValue: "warning")),
+    sortBy: [.text(comparison: .lexical, order: .reverse)],
+    sectionBy: .source,
+    fetchLimit: 100
+)
+let messages = context.console.fetchedResults(for: query)
+```
+
+Console filters support source, level, kind, URL, text containment, and
+`all`/`any` composition. Console sorting supports text with localized-standard
+or lexical comparison and severity-level raw values, in either direction.
+Sections support source, level, kind, and URL.
+
+Network timestamps without a reported value sort before reported timestamps in
+forward order and after them in reverse order. Equal Network timestamps follow
+insertion direction. Console text uses the selected comparison; severity raw
+values use localized-standard comparison. Equal Console sort values retain
+message insertion order in either direction.
+
+Filters are closed, nonthrowing values. DataKit does not evaluate arbitrary
+Foundation predicate or sort expressions, and a query cannot fail later because
+an expression was unsupported. `all` and `any` compose membership declaratively;
+`all([])` matches and `any([])` does not.
+
+`fetchLimit` and `fetchOffset` use unsigned counts. Values larger than the
+current collection safely describe the remaining prefix or an empty result.
+
+## Update a Live Query
+
+Call `updateQuery(_:)` on a ``WebInspectorFetchedResults`` or
+``WebInspectorFetchedResultsController`` to replace the filter, sort, section,
+limit, and offset in one reset transaction:
+
+```swift
+try requests.updateQuery(
+    NetworkRequestQuery(
+        filter: .statusCode(atLeast: 400),
+        sortBy: [.requestSentTimestamp(order: .reverse)]
+    )
+)
+```
+
+## Migrate Generic Fetch Construction
+
+The previous generic construction surface accepted values DataKit could not
+execute. Migrate each operation as one semantic query:
+
+| Previous construction | Concrete query |
+| --- | --- |
+| `WebInspectorFetchDescriptor<NetworkRequest>` | `NetworkRequestQuery` |
+| `WebInspectorFetchDescriptor<ConsoleMessage>` | `ConsoleMessageQuery` |
+| Foundation `Predicate` | A model-specific `Filter` factory |
+| Foundation `SortDescriptor` | A model-specific `Sort` factory |
+| `sectionBy: \.method` | `NetworkRequestQuery(sectionBy: .method)` |
+| `sectionBy: \.level` | `ConsoleMessageQuery(sectionBy: .level)` |
+| `context.fetchedResults(...)` | `context.network.fetchedResults(...)` or `context.console.fetchedResults(...)` |
+| `updateFetchDescriptor` | `updateQuery` |
+| `WebInspectorFetchRequest` | Mutate and submit a query value |
+
+Replace a mutable fetch request by copying and resubmitting the current query:
+
+```swift
+var query = requests.query
+query.fetchLimit = 200
+query.fetchOffset = 100
+try requests.updateQuery(query)
+```
+
+Only ``NetworkRequest`` and ``ConsoleMessage`` are registered query models.
+Consumer-defined ``WebInspectorPersistentModel`` types can still participate in
+generic snapshots and transactions, but cannot be fetched from a context.

--- a/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
+++ b/Sources/WebInspectorDataKit/WebInspectorDataKit.docc/WebInspectorDataKit.md
@@ -70,6 +70,7 @@ access with no model layer.
 ### Essentials
 
 - <doc:ModelRegistrationLifetimes>
+- <doc:QueryCapabilities>
 
 ### Creating a Model Context
 
@@ -87,7 +88,8 @@ access with no model layer.
 
 - ``NetworkRequest``
 - ``ConsoleMessage``
-- ``WebInspectorFetchRequest``
+- ``NetworkRequestQuery``
+- ``ConsoleMessageQuery``
 - ``WebInspectorFetchedResultsController``
 
 ### Runtime and CSS Models

--- a/Sources/WebInspectorDataKit/WebInspectorDomainControllers.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorDomainControllers.swift
@@ -293,21 +293,19 @@ public final class NetworkModelController {
 
     /// Creates observable network request results.
     public func fetchedResults(
-        for descriptor: WebInspectorFetchDescriptor<NetworkRequest> = .init(),
-        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>? = nil,
+        for query: NetworkRequestQuery = .init(),
         isolation: isolated (any Actor) = #isolation
     ) -> WebInspectorFetchedResults<NetworkRequest> {
-        context.fetchedResults(for: descriptor, sectionBy: sectionBy, isolation: isolation)
+        context.networkFetchedResults(for: query, isolation: isolation)
     }
 
     /// Creates a controller for observable network request results.
     public func fetchedResultsController(
-        for descriptor: WebInspectorFetchDescriptor<NetworkRequest> = .init(),
-        sectionBy: WebInspectorSectionDescriptor<NetworkRequest>? = nil,
+        for query: NetworkRequestQuery = .init(),
         isolation: isolated (any Actor) = #isolation
     ) -> WebInspectorFetchedResultsController<NetworkRequest> {
         WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, sectionBy: sectionBy, isolation: isolation)
+            fetchedResults: fetchedResults(for: query, isolation: isolation)
         )
     }
 
@@ -327,19 +325,19 @@ public final class ConsoleModelController {
 
     /// Creates observable console message results.
     public func fetchedResults(
-        for descriptor: WebInspectorFetchDescriptor<ConsoleMessage> = .init(),
+        for query: ConsoleMessageQuery = .init(),
         isolation: isolated (any Actor) = #isolation
     ) -> WebInspectorFetchedResults<ConsoleMessage> {
-        context.fetchedResults(for: descriptor, isolation: isolation)
+        context.consoleFetchedResults(for: query, isolation: isolation)
     }
 
     /// Creates a controller for observable console message results.
     public func fetchedResultsController(
-        for descriptor: WebInspectorFetchDescriptor<ConsoleMessage> = .init(),
+        for query: ConsoleMessageQuery = .init(),
         isolation: isolated (any Actor) = #isolation
     ) -> WebInspectorFetchedResultsController<ConsoleMessage> {
         WebInspectorFetchedResultsController(
-            fetchedResults: fetchedResults(for: descriptor, isolation: isolation)
+            fetchedResults: fetchedResults(for: query, isolation: isolation)
         )
     }
 }

--- a/Sources/WebInspectorDataKit/WebInspectorFetchedResultsController.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorFetchedResultsController.swift
@@ -137,7 +137,7 @@ public struct WebInspectorFetchedResultsSnapshot<ItemID: Hashable & Sendable>: H
 }
 
 extension WebInspectorFetchedResultsSnapshot {
-    init<Model: WebInspectorFetchableModel>(
+    init<Model: WebInspectorPersistentModel>(
         sections: [WebInspectorFetchSection<Model>]
     ) where Model.ID == ItemID {
         self.init(sections: sections.map { section in
@@ -184,7 +184,7 @@ public enum WebInspectorFetchedResultsItemChange<ItemID: Hashable & Sendable>: H
 }
 
 /// A batch of fetched-results changes between two snapshots.
-public struct WebInspectorFetchedResultsTransaction<Model: WebInspectorFetchableModel>: Hashable, Sendable {
+public struct WebInspectorFetchedResultsTransaction<Model: WebInspectorPersistentModel>: Hashable, Sendable {
     /// Item identity type for the model.
     public typealias ItemID = Model.ID
 
@@ -479,14 +479,9 @@ extension WebInspectorFetchedResultsIndexPath: Comparable {
 ///
 /// The controller shares the fetched results' registration and transaction
 /// stream lifetime. See <doc:ModelRegistrationLifetimes>.
-public final class WebInspectorFetchedResultsController<Model: WebInspectorFetchableModel> {
+public final class WebInspectorFetchedResultsController<Model: WebInspectorPersistentModel> {
     /// The observable fetched-results model.
     public let fetchedResults: WebInspectorFetchedResults<Model>
-
-    /// The descriptor currently used by the results.
-    public var fetchDescriptor: WebInspectorFetchDescriptor<Model> {
-        fetchedResults.fetchDescriptor
-    }
 
     /// The fetched models in display order.
     public var items: [Model] {
@@ -512,14 +507,30 @@ public final class WebInspectorFetchedResultsController<Model: WebInspectorFetch
         self.fetchedResults = fetchedResults
     }
 
-    /// Replaces the fetch descriptor and updates the result contents.
-    ///
-    /// - Throws: `WebInspectorProxyError.disconnected` when the underlying
-    ///   fetched results are no longer registered in their originating context.
-    public func updateFetchDescriptor(
-        _ descriptor: WebInspectorFetchDescriptor<Model>,
+}
+
+public extension WebInspectorFetchedResultsController where Model == NetworkRequest {
+    /// The last query installed for the results.
+    var query: NetworkRequestQuery { fetchedResults.query }
+
+    /// Replaces the query and updates the result contents atomically.
+    func updateQuery(
+        _ query: NetworkRequestQuery,
         isolation: isolated (any Actor) = #isolation
     ) throws {
-        try fetchedResults.updateFetchDescriptor(descriptor, isolation: isolation)
+        try fetchedResults.updateQuery(query, isolation: isolation)
+    }
+}
+
+public extension WebInspectorFetchedResultsController where Model == ConsoleMessage {
+    /// The last query installed for the results.
+    var query: ConsoleMessageQuery { fetchedResults.query }
+
+    /// Replaces the query and updates the result contents atomically.
+    func updateQuery(
+        _ query: ConsoleMessageQuery,
+        isolation: isolated (any Actor) = #isolation
+    ) throws {
+        try fetchedResults.updateQuery(query, isolation: isolation)
     }
 }

--- a/Sources/WebInspectorDataKit/WebInspectorPersistentModel.swift
+++ b/Sources/WebInspectorDataKit/WebInspectorPersistentModel.swift
@@ -23,6 +23,3 @@ extension WebInspectorPersistentModel {
         hasher.combine(ObjectIdentifier(self))
     }
 }
-
-/// Marker protocol for DataKit models that can be returned by fetch descriptors.
-public protocol WebInspectorFetchableModel: WebInspectorPersistentModel {}

--- a/Tests/WebInspectorDataKitTests/ClosedQueryCapabilitiesTests.swift
+++ b/Tests/WebInspectorDataKitTests/ClosedQueryCapabilitiesTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import Observation
+import Synchronization
+import Testing
+@testable import WebInspectorDataKit
+import WebInspectorProxyKit
+
+@MainActor
+@Test
+func networkFilterFactoriesMatchTheirDocumentedCapabilities() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let id = context.seedNetworkRequest(
+        requestID: "closed-network-filter",
+        url: "https://api.example.test/graphql",
+        method: "POST",
+        resourceTypeRawValue: "Image",
+        responseMIMEType: "image/png",
+        responseStatus: 404,
+        responseStatusText: "Not Found",
+        timestamp: 1
+    )
+    let request = try #require(context.registeredRequest(for: id))
+    let record = NetworkRequestRecord(request: request, orderIndex: 0)
+
+    let matchingFilters: [NetworkRequestQuery.Filter] = [
+        .method(equals: "POST"),
+        .method(containing: "post"),
+        .url(equals: request.url),
+        .url(containing: "API"),
+        .searchableText(equals: request.searchableText),
+        .searchableText(containing: "graphql"),
+        .mimeType(equals: "image/png"),
+        .resourceCategory(request.resourceCategory),
+        .resourceCategories([.image, .media]),
+        .statusCode(atLeast: 400),
+        .statusCode(greaterThan: 403),
+        .statusCode(lessThan: 405),
+        .statusCode(atMost: 404),
+        .all([.method(equals: "POST"), .statusCode(atLeast: 400)]),
+        .any([.method(equals: "GET"), .statusCode(atLeast: 400)]),
+    ]
+    #expect(matchingFilters.allSatisfy { $0.matches(record: record) })
+    #expect(NetworkRequestQuery.Filter.statusCode(greaterThan: 404).matches(record: record) == false)
+    #expect(NetworkRequestQuery.Filter.statusCode(lessThan: 404).matches(record: record) == false)
+    #expect(NetworkRequestQuery.Filter.statusCode(atLeast: 404).matches(record: record))
+    #expect(NetworkRequestQuery.Filter.statusCode(atMost: 404).matches(record: record))
+    #expect(NetworkRequestQuery.Filter.all([]).matches(record: record))
+    #expect(NetworkRequestQuery.Filter.any([]).matches(record: record) == false)
+
+    let pendingID = Network.Request.ID("closed-network-missing-status")
+    await context.apply(
+        .requestWillBeSent(
+            id: pendingID,
+            request: Network.Request(id: pendingID, url: "https://example.test/pending", method: "GET"),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 2
+        ))
+    let pending = try #require(context.registeredRequest(for: NetworkRequest.ID(pendingID)))
+    let pendingRecord = NetworkRequestRecord(request: pending, orderIndex: 1)
+    #expect(NetworkRequestQuery.Filter.statusCode(atLeast: 500).matches(record: pendingRecord) == false)
+    #expect(
+        NetworkRequestQuery.Filter.statusCode(atLeast: 500, whenMissing: 500)
+            .matches(record: pendingRecord)
+    )
+}
+
+@MainActor
+@Test
+func consoleFilterFactoriesAndSortsMatchTheirDocumentedCapabilities() throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    context.apply(
+        .messageAdded(
+            Console.Message(
+                source: Console.Source(rawValue: "console-api"),
+                level: Console.Level(rawValue: "warning"),
+                text: "Alpha warning"
+            )))
+    context.apply(
+        .messageAdded(
+            Console.Message(
+                source: Console.Source(rawValue: "javascript"),
+                level: Console.Level(rawValue: "error"),
+                text: "beta error"
+            )))
+    let all = context.console.fetchedResults().items
+    let warning = try #require(all.first)
+    let error = try #require(all.last)
+
+    let matchingFilters: [ConsoleMessageQuery.Filter] = [
+        .source(warning.source),
+        .level(warning.level),
+        .kind(nil),
+        .url(nil),
+        .text(containing: "warning"),
+        .all([.source(warning.source), .level(warning.level)]),
+        .any([.level(error.level), .text(containing: "Alpha")]),
+    ]
+    #expect(matchingFilters.allSatisfy { $0.matches(warning) })
+    #expect(ConsoleMessageQuery.Filter.all([]).matches(warning))
+    #expect(ConsoleMessageQuery.Filter.any([]).matches(warning) == false)
+
+    #expect(ConsoleMessageQuery.Sort.text().compare(warning, error) == .orderedAscending)
+    #expect(
+        ConsoleMessageQuery.Sort.text(comparison: .lexical, order: .reverse)
+            .compare(warning, error) == .orderedDescending
+    )
+    let levelForward = ConsoleMessageQuery.Sort.level().compare(warning, error)
+    let levelReverse = ConsoleMessageQuery.Sort.level(order: .reverse).compare(warning, error)
+    #expect(levelForward != .orderedSame)
+    #expect(levelReverse != .orderedSame)
+    #expect(levelForward != levelReverse)
+}
+
+@MainActor
+@Test
+func everyClosedSectionCapabilityProducesCurrentSections() {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    context.seedNetworkRequest(
+        requestID: "closed-section-request",
+        url: "https://example.test/image.png",
+        method: "GET",
+        resourceTypeRawValue: "Image",
+        responseMIMEType: "image/png",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 1
+    )
+    context.apply(
+        .messageAdded(
+            Console.Message(
+                source: Console.Source(rawValue: "console-api"),
+                level: Console.Level(rawValue: "warning"),
+                type: Console.Kind(rawValue: "log"),
+                text: "sectioned",
+                url: "https://example.test/app.js"
+            )))
+
+    for (section, expectedID) in [
+        (NetworkRequestQuery.Section.method, "GET"),
+        (.resourceType, "Image"),
+        (.resourceCategory, "image"),
+        (.mimeType, "image/png"),
+    ] {
+        let results = context.network.fetchedResults(for: NetworkRequestQuery(sectionBy: section))
+        #expect(results.sections.map(\.id.rawValue) == [expectedID])
+    }
+    for (section, expectedID) in [
+        (ConsoleMessageQuery.Section.source, "console-api"),
+        (.level, "warning"),
+        (.kind, "log"),
+        (.url, "https://example.test/app.js"),
+    ] {
+        let results = context.console.fetchedResults(for: ConsoleMessageQuery(sectionBy: section))
+        #expect(results.sections.map(\.id.rawValue) == [expectedID])
+    }
+}
+
+@MainActor
+@Test
+func maximumQueryWindowsCannotOverflowNetworkOrConsoleBounds() {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    for index in 0..<3 {
+        context.seedNetworkRequest(
+            requestID: "closed-window-\(index)",
+            url: "https://example.test/\(index)",
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: Double(index)
+        )
+        context.apply(
+            .messageAdded(
+                Console.Message(
+                    source: Console.Source(rawValue: "console-api"),
+                    level: Console.Level(rawValue: "log"),
+                    text: "message-\(index)"
+                )))
+    }
+
+    #expect(
+        context.network.fetchedResults(
+            for: NetworkRequestQuery(
+                sortBy: [.requestSentTimestamp()],
+                fetchLimit: .max,
+                fetchOffset: 1
+            )
+        ).items.count == 2
+    )
+    #expect(
+        context.network.fetchedResults(
+            for: NetworkRequestQuery(
+                sortBy: [.requestSentTimestamp()],
+                fetchLimit: .max,
+                fetchOffset: .max
+            )
+        ).items.isEmpty
+    )
+    #expect(
+        context.console.fetchedResults(
+            for: ConsoleMessageQuery(
+                sortBy: [.text()],
+                fetchLimit: .max,
+                fetchOffset: 1
+            )
+        ).items.count == 2
+    )
+    #expect(
+        context.console.fetchedResults(
+            for: ConsoleMessageQuery(
+                sortBy: [.text()],
+                fetchLimit: .max,
+                fetchOffset: .max
+            )
+        ).items.isEmpty
+    )
+}
+
+@MainActor
+@Test
+func maximumNetworkWindowCannotOverflowTheRecordIndexPath() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    var inputs: [NetworkRequestRecordInput] = []
+    for index in 0..<3 {
+        let id = context.seedNetworkRequest(
+            requestID: "closed-index-window-\(index)",
+            url: "https://example.test/index/\(index)",
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: Double(index)
+        )
+        let request = try #require(context.registeredRequest(for: id))
+        inputs.append(NetworkRequestRecordInput(request: request, orderIndex: index))
+    }
+    let index = NetworkRequestIndex()
+    await index.replace(with: inputs, sequence: 1)
+    let plan = NetworkRequestQueryPlan(
+        query: NetworkRequestQuery(
+            sortBy: [.requestSentTimestamp()],
+            fetchLimit: .max,
+            fetchOffset: 1
+        ))
+
+    let delta = try #require(
+        await index.delta(
+            plan: plan,
+            sectionBy: nil,
+            oldSnapshot: WebInspectorFetchedResultsSnapshot(),
+            changedID: nil
+        ))
+
+    #expect(delta.snapshot.itemIDs.count == 2)
+}
+
+@MainActor
+@Test
+func updateQueryAppliesFilterSortSectionAndWindowAtomically() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    for (index, method) in ["GET", "POST", "GET"].enumerated() {
+        context.seedNetworkRequest(
+            requestID: "closed-update-\(index)",
+            url: "https://example.test/\(index)",
+            method: method,
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: Double(index)
+        )
+    }
+    let results = context.network.fetchedResults()
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    var transactions = controller.transactions.makeAsyncIterator()
+    let query = NetworkRequestQuery(
+        filter: .method(equals: "GET"),
+        sortBy: [.requestSentTimestamp(order: .reverse)],
+        sectionBy: .method,
+        fetchLimit: 1,
+        fetchOffset: 0
+    )
+
+    try controller.updateQuery(query)
+
+    let reset = try #require(await transactions.next())
+    #expect(reset.isReset)
+    #expect(reset.newSnapshot.sectionIDs == [WebInspectorFetchSectionID(rawValue: "GET")])
+    #expect(controller.query == query)
+    #expect(controller.items.map(\.url) == ["https://example.test/2"])
+    #expect(controller.snapshot.sectionIDs == [WebInspectorFetchSectionID(rawValue: "GET")])
+
+    context.seedNetworkRequest(
+        requestID: "closed-update-next",
+        url: "https://example.test/next",
+        method: "GET",
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 4
+    )
+    let next = try #require(await transactions.next())
+    #expect(next.isReset == false)
+}
+
+@MainActor
+@Test
+func queryOnlyUpdateInvalidatesObservedQueryWhenMembershipDoesNotChange() throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    context.seedNetworkRequest(
+        requestID: "closed-query-observation",
+        url: "https://example.test/observed",
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 1
+    )
+    let results = context.network.fetchedResults()
+    let changed = Mutex(false)
+    withObservationTracking {
+        _ = results.query
+    } onChange: {
+        changed.withLock { $0 = true }
+    }
+    let query = NetworkRequestQuery(fetchLimit: .max)
+
+    try results.updateQuery(query)
+
+    #expect(changed.withLock { $0 })
+    #expect(results.query == query)
+    #expect(results.items.count == 1)
+}

--- a/Tests/WebInspectorDataKitTests/ClosedQueryCapabilitiesTests.swift
+++ b/Tests/WebInspectorDataKitTests/ClosedQueryCapabilitiesTests.swift
@@ -158,6 +158,323 @@ func everyClosedSectionCapabilityProducesCurrentSections() {
 
 @MainActor
 @Test
+func closedNetworkQueryPublishesOnlyVisibleContentUpdatesExactlyOnce() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let results = context.network.fetchedResults(
+        for: NetworkRequestQuery(
+            filter: .method(equals: "GET"),
+            sortBy: [.requestSentTimestamp()],
+            fetchLimit: 2
+        )
+    )
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    var transactions = controller.transactions.makeAsyncIterator()
+    let firstID = Network.Request.ID("closed-visible-first")
+    let filteredID = Network.Request.ID("closed-filtered")
+    let secondID = Network.Request.ID("closed-visible-second")
+    let outsideWindowID = Network.Request.ID("closed-outside-window")
+
+    await context.apply(
+        .requestWillBeSent(
+            id: firstID,
+            request: Network.Request(
+                id: firstID,
+                url: "https://example.test/first",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 1
+        ))
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .insert(
+                itemID: NetworkRequest.ID(firstID),
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+
+    await context.apply(
+        .requestWillBeSent(
+            id: filteredID,
+            request: Network.Request(
+                id: filteredID,
+                url: "https://example.test/filtered",
+                method: "POST"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 2
+        ))
+    await context.apply(
+        .requestWillBeSent(
+            id: secondID,
+            request: Network.Request(
+                id: secondID,
+                url: "https://example.test/second",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 3
+        ))
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .insert(
+                itemID: NetworkRequest.ID(secondID),
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
+            )
+        ])
+
+    await context.apply(
+        .requestWillBeSent(
+            id: outsideWindowID,
+            request: Network.Request(
+                id: outsideWindowID,
+                url: "https://example.test/outside",
+                method: "GET"
+            ),
+            resourceType: .fetch,
+            redirectResponse: nil,
+            timestamp: 4
+        ))
+    await context.apply(
+        .responseReceived(
+            id: firstID,
+            response: Network.Response(
+                url: "https://example.test/first",
+                status: 201,
+                mimeType: "application/json"
+            ),
+            resourceType: .fetch,
+            timestamp: 5
+        ))
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: NetworkRequest.ID(firstID),
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+
+    await context.apply(
+        .responseReceived(
+            id: filteredID,
+            response: Network.Response(
+                url: "https://example.test/filtered",
+                status: 202
+            ),
+            resourceType: .fetch,
+            timestamp: 6
+        ))
+    await context.apply(
+        .dataReceived(
+            id: outsideWindowID,
+            dataLength: 7,
+            encodedDataLength: 7,
+            timestamp: 7
+        ))
+    await context.apply(
+        .responseReceived(
+            id: secondID,
+            response: Network.Response(
+                url: "https://example.test/second",
+                status: 203
+            ),
+            resourceType: .fetch,
+            timestamp: 8
+        ))
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: NetworkRequest.ID(secondID),
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
+            )
+        ])
+
+    await context.apply(
+        .dataReceived(
+            id: firstID,
+            dataLength: 9,
+            encodedDataLength: 9,
+            timestamp: 9
+        ))
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: NetworkRequest.ID(firstID),
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+    #expect(results.items.map(\.id) == [NetworkRequest.ID(firstID), NetworkRequest.ID(secondID)])
+}
+
+@MainActor
+@Test
+func contentOnlyNetworkDeltaKeepsMaterializedTopologyAndLookupWorkUnchanged() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let visibleID = context.seedNetworkRequest(
+        requestID: "closed-index-visible",
+        url: "https://example.test/visible",
+        method: "GET",
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 1
+    )
+    let filteredID = context.seedNetworkRequest(
+        requestID: "closed-index-filtered",
+        url: "https://example.test/filtered",
+        method: "POST",
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: 2
+    )
+    let visibleRequest = try #require(context.registeredRequest(for: visibleID))
+    let filteredRequest = try #require(context.registeredRequest(for: filteredID))
+    let query = NetworkRequestQuery(filter: .method(equals: "GET"))
+    let plan = NetworkRequestQueryPlan(query: query)
+    let index = NetworkRequestIndex()
+    await index.replace(
+        with: [
+            NetworkRequestRecordInput(request: visibleRequest, orderIndex: 0),
+            NetworkRequestRecordInput(request: filteredRequest, orderIndex: 1),
+        ],
+        sequence: 1
+    )
+    let oldSnapshot = WebInspectorFetchedResultsSnapshot<NetworkRequest.ID>(
+        itemIDs: [visibleID]
+    )
+    let delta = try #require(
+        await index.delta(
+            plan: plan,
+            sectionBy: nil,
+            oldSnapshot: oldSnapshot,
+            changedID: visibleID
+        ))
+    #expect(delta.snapshot == oldSnapshot)
+    #expect(delta.transaction.oldSnapshot == oldSnapshot)
+    #expect(delta.transaction.newSnapshot == oldSnapshot)
+    #expect(
+        delta.transaction.itemChanges == [
+            .update(
+                itemID: visibleID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+    #expect(
+        await index.delta(
+            plan: plan,
+            sectionBy: nil,
+            oldSnapshot: oldSnapshot,
+            changedID: filteredID
+        ) == nil)
+
+    let results = WebInspectorFetchedResults<NetworkRequest>(
+        query: query,
+        items: [visibleRequest]
+    )
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    var transactions = controller.transactions.makeAsyncIterator()
+    let topologyRevision = results.topologyRevision
+    let membershipVisits = results.networkFullMembershipVisitCountForTesting
+    var lookupCount = 0
+
+    results.applyNetworkDelta(delta) { id in
+        lookupCount += 1
+        return context.registeredRequest(for: id)
+    }
+
+    #expect(try #require(await transactions.next()) == delta.transaction)
+    #expect(results.items.first === visibleRequest)
+    #expect(results.topologyRevision == topologyRevision)
+    #expect(results.networkFullMembershipVisitCountForTesting == membershipVisits)
+    #expect(lookupCount == 0)
+}
+
+@MainActor
+@Test
+func closedConsoleQueryPublishesOnlyVisibleContentUpdatesExactlyOnce() async throws {
+    let context = WebInspectorContext.preview(isolation: MainActor.shared)
+    let warning = Console.Level(rawValue: "warning")
+    let log = Console.Level(rawValue: "log")
+    let results = context.console.fetchedResults(
+        for: ConsoleMessageQuery(
+            filter: .level(warning),
+            sectionBy: .level,
+            fetchLimit: 2
+        )
+    )
+    let controller = WebInspectorFetchedResultsController(fetchedResults: results)
+    var transactions = controller.transactions.makeAsyncIterator()
+    let firstTarget = WebInspectorTarget.ID("closed-console-first")
+    let filteredTarget = WebInspectorTarget.ID("closed-console-filtered")
+    let secondTarget = WebInspectorTarget.ID("closed-console-second")
+
+    context.apply(
+        .messageAdded(Console.Message(source: .init(rawValue: "console-api"), level: warning, text: "first")),
+        targetID: firstTarget
+    )
+    let firstID = try #require(results.items.first?.id)
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .insert(
+                itemID: firstID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+
+    context.apply(
+        .messageAdded(Console.Message(source: .init(rawValue: "console-api"), level: log, text: "filtered")),
+        targetID: filteredTarget
+    )
+    context.apply(
+        .messageAdded(Console.Message(source: .init(rawValue: "console-api"), level: warning, text: "second")),
+        targetID: secondTarget
+    )
+    let secondID = try #require(results.items.last?.id)
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .insert(
+                itemID: secondID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
+            )
+        ])
+
+    context.apply(.messageRepeatCountUpdated(count: 2, timestamp: 2), targetID: firstTarget)
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: firstID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+
+    context.apply(.messageRepeatCountUpdated(count: 3, timestamp: 3), targetID: filteredTarget)
+    context.apply(.messageRepeatCountUpdated(count: 4, timestamp: 4), targetID: secondTarget)
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: secondID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 1)
+            )
+        ])
+
+    context.apply(.messageRepeatCountUpdated(count: 5, timestamp: 5), targetID: firstTarget)
+    #expect(
+        try #require(await transactions.next()).itemChanges == [
+            .update(
+                itemID: firstID,
+                indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+            )
+        ])
+}
+
+@MainActor
+@Test
 func maximumQueryWindowsCannotOverflowNetworkOrConsoleBounds() {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     for index in 0..<3 {

--- a/Tests/WebInspectorDataKitTests/StaleModelSemanticsTests.swift
+++ b/Tests/WebInspectorDataKitTests/StaleModelSemanticsTests.swift
@@ -227,9 +227,29 @@ func contextReleaseFinishesEveryFetchedResultsStreamAndRetainsFinalSnapshots() a
                 level: Console.Level(rawValue: "warning"),
                 text: "retained message"
             )))
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
-    let secondNetworkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(context?.fetchedResults())
-    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = try #require(context?.fetchedResults())
+    let retainedNetworkQuery = NetworkRequestQuery(
+        filter: .method(equals: "GET"),
+        sortBy: [.requestSentTimestamp(order: .reverse)],
+        sectionBy: .method,
+        fetchLimit: 4,
+        fetchOffset: 0
+    )
+    let retainedConsoleQuery = ConsoleMessageQuery(
+        filter: .level(Console.Level(rawValue: "warning")),
+        sortBy: [.text(comparison: .lexical)],
+        sectionBy: .level,
+        fetchLimit: 4,
+        fetchOffset: 0
+    )
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(
+        context?.network.fetchedResults(for: retainedNetworkQuery)
+    )
+    let secondNetworkResults: WebInspectorFetchedResults<NetworkRequest> = try #require(
+        context?.network.fetchedResults()
+    )
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = try #require(
+        context?.console.fetchedResults(for: retainedConsoleQuery)
+    )
     let networkController = WebInspectorFetchedResultsController(fetchedResults: networkResults)
     let consoleController = WebInspectorFetchedResultsController(fetchedResults: consoleResults)
     let retainedNetworkSnapshot = networkController.snapshot
@@ -255,16 +275,24 @@ func contextReleaseFinishesEveryFetchedResultsStreamAndRetainsFinalSnapshots() a
     #expect(consoleController.snapshot == retainedConsoleSnapshot)
     #expect(networkResults.items.map(\.url) == ["https://example.test/data.json"])
     #expect(consoleResults.items.map(\.text) == ["retained message"])
+    #expect(networkResults.query == retainedNetworkQuery)
+    #expect(networkController.query == retainedNetworkQuery)
+    #expect(consoleResults.query == retainedConsoleQuery)
+    #expect(consoleController.query == retainedConsoleQuery)
 
-    let networkDescriptor = WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 1)
+    let networkQuery = NetworkRequestQuery(fetchLimit: 1)
+    let consoleQuery = ConsoleMessageQuery(fetchLimit: 1)
     #expect(throws: staleFetchedResultsError) {
-        try networkResults.updateFetchDescriptor(networkDescriptor)
+        try consoleResults.updateQuery(consoleQuery)
     }
     #expect(throws: staleFetchedResultsError) {
-        try networkResults.updateFetchDescriptor(networkDescriptor)
+        try networkResults.updateQuery(networkQuery)
     }
     #expect(throws: staleFetchedResultsError) {
-        try networkController.updateFetchDescriptor(networkDescriptor)
+        try networkController.updateQuery(networkQuery)
+    }
+    #expect(throws: staleFetchedResultsError) {
+        try consoleController.updateQuery(consoleQuery)
     }
 }
 
@@ -273,37 +301,37 @@ func contextReleaseFinishesEveryFetchedResultsStreamAndRetainsFinalSnapshots() a
 func liveFetchedResultsRemainRegisteredAcrossContextStatesAndRejectForeignUpdates() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     let foreignContext = WebInspectorContext.preview(isolation: MainActor.shared)
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
-    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let networkResults = context.network.fetchedResults()
+    let consoleResults = context.console.fetchedResults()
     let networkController = WebInspectorFetchedResultsController(fetchedResults: networkResults)
     let consoleController = WebInspectorFetchedResultsController(fetchedResults: consoleResults)
-    let firstNetworkDescriptor = WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 2)
-    let firstConsoleDescriptor = WebInspectorFetchDescriptor<ConsoleMessage>(fetchLimit: 2)
+    let firstNetworkQuery = NetworkRequestQuery(fetchLimit: 2)
+    let firstConsoleQuery = ConsoleMessageQuery(fetchLimit: 2)
 
-    try networkResults.updateFetchDescriptor(firstNetworkDescriptor)
-    try consoleController.updateFetchDescriptor(firstConsoleDescriptor)
-    #expect(networkResults.fetchDescriptor.fetchLimit == 2)
-    #expect(consoleResults.fetchDescriptor.fetchLimit == 2)
+    try networkResults.updateQuery(firstNetworkQuery)
+    try consoleController.updateQuery(firstConsoleQuery)
+    #expect(networkResults.query.fetchLimit == 2)
+    #expect(consoleResults.query.fetchLimit == 2)
 
     await context.stop()
     #expect(context.state == .detached)
-    try networkController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 3))
-    try consoleResults.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 3))
-    #expect(networkResults.fetchDescriptor.fetchLimit == 3)
-    #expect(consoleResults.fetchDescriptor.fetchLimit == 3)
+    try networkController.updateQuery(NetworkRequestQuery(fetchLimit: 3))
+    try consoleResults.updateQuery(ConsoleMessageQuery(fetchLimit: 3))
+    #expect(networkResults.query.fetchLimit == 3)
+    #expect(consoleResults.query.fetchLimit == 3)
 
     context.start()
     #expect(context.state == .attaching)
-    try networkResults.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 4))
-    try consoleController.updateFetchDescriptor(WebInspectorFetchDescriptor(fetchLimit: 4))
-    #expect(networkResults.fetchDescriptor.fetchLimit == 4)
-    #expect(consoleResults.fetchDescriptor.fetchLimit == 4)
+    try networkResults.updateQuery(NetworkRequestQuery(fetchLimit: 4))
+    try consoleController.updateQuery(ConsoleMessageQuery(fetchLimit: 4))
+    #expect(networkResults.query.fetchLimit == 4)
+    #expect(consoleResults.query.fetchLimit == 4)
 
     #expect(throws: staleFetchedResultsError) {
-        try foreignContext.updateFetchDescriptor(
-            WebInspectorFetchDescriptor<NetworkRequest>(fetchLimit: 1),
+        try foreignContext.updateNetworkQuery(
+            NetworkRequestQuery(fetchLimit: 1),
             for: networkResults
         )
     }
-    #expect(networkResults.fetchDescriptor.fetchLimit == 4)
+    #expect(networkResults.query.fetchLimit == 4)
 }

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -1606,7 +1606,7 @@ func supersededOrderedFeedSubscriptionReleasesItsProducer() async throws {
 func currentPageCommitOnSameProtocolAgentRetainsRequiredDomainLeases() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await runtime.backend.enqueue(
         DOM.Node(id: DOM.Node.ID("same-agent-root"), nodeType: 9, nodeName: "#document"),
@@ -1654,7 +1654,7 @@ func currentPageCommitOnSameProtocolAgentRetainsRequiredDomainLeases() async thr
 func currentPageCommitInitializesNewAgentWithoutReenablingPage() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await enqueueStartupReplies(
         on: runtime.backend,
@@ -1870,7 +1870,7 @@ func frameNavigationAndRuntimeContextApplyInSourceOrder() async throws {
 func frameNavigationPrecedesFollowingNetworkRequestInSourceOrder() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitOriginatedNetworkRequest(
         id: "before-navigation",
@@ -2196,8 +2196,8 @@ func closeAfterAttachedClearsAttachmentBackedModels() async throws {
 
     let container = WebInspectorContainer(proxy: runtime.proxy)
     let context = container.mainContext
-    networkResults = context.fetchedResults()
-    consoleResults = context.fetchedResults()
+    networkResults = context.network.fetchedResults()
+    consoleResults = context.console.fetchedResults()
     try await waitForStartupSubscribers(runtime: runtime, target: target)
     try await waitUntil { context.state == .attached }
 
@@ -2404,8 +2404,8 @@ func restartSynchronouslyRejectsSupersededOrderedEventsAcrossDomains() async thr
         ]
     )
     let (target, context) = try await startContext(runtime: runtime, document: oldDocument)
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
-    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
 
     let seedAppliedBaseline = context.eventPumpAppliedSequenceForTesting
     await runtime.backend.emit(
@@ -2651,7 +2651,7 @@ func consoleEnableReplayIsCapturedBeforeCommandReturns() async throws {
 
     let container = WebInspectorContainer(proxy: runtime.proxy)
     let context = container.mainContext
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     try await waitUntil {
         await runtime.backend.recordedCommands() == startupCommands
     }
@@ -2737,7 +2737,7 @@ func transportBackedStartupCapturesRuntimeAndConsoleReplayBeforeEnableReplies() 
     #expect(target.id == .currentPage)
     let container = WebInspectorContainer(proxy: proxy)
     let context = container.mainContext
-    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
 
     try await replyTransportInspectorAndPageInitialization(backend, transport: transport, targetID: ProtocolTarget.ID("page-main"))
 
@@ -3045,7 +3045,7 @@ func transportBackedFrameRuntimeAndConsoleEventsKeepTargetScope() async throws {
         documentID: "1",
         protocolProfile: .latest
     )
-    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     let startupMessageCount = await backend.sentTargetMessages().count
 
     await installTransportFrameTarget(
@@ -3194,7 +3194,7 @@ func currentPageCommitRetargetsDataKitStateToNewTransportTarget() async throws {
         targetID: oldTargetID,
         documentID: "old-root"
     )
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let domTreeController = try await context.treeController()
     let domUpdates = DOMTreeUpdateRecorder(stream: domTreeController.updates)
     defer { domUpdates.cancel() }
@@ -3405,7 +3405,7 @@ func currentPageProcessTerminationInterruptsPickerAndRetargetsWithoutClearingNet
         targetID: oldTargetID,
         documentID: "destroyed-root"
     )
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let startupMessageCount = await backend.sentTargetMessages().count
 
     #expect(context.state == .attached)
@@ -3551,7 +3551,7 @@ func currentPageProcessTerminationInterruptsPickerAndRetargetsWithoutClearingNet
 func startBeginsFreshNetworkAttachmentEpoch() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let staleRequestID = Network.Request.ID("stale-before-restart")
 
     await emitFinishedRequest(id: staleRequestID, target: target, backend: runtime.backend)
@@ -3580,7 +3580,7 @@ func startBeginsFreshNetworkAttachmentEpoch() async throws {
 func networkNavigationVisitIdentityDoesNotRepeatAcrossRestart() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -3867,7 +3867,7 @@ func mainFrameNavigatedReloadsDOMAndClearsRuntimeContexts() async throws {
         targetID: targetID,
         documentID: "initial-root"
     )
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let undoCommands = try context.domUndoRedoCommands()
     let startupMessageCount = await backend.sentTargetMessages().count
 
@@ -3926,7 +3926,7 @@ func networkNavigationGroupsEachAtoBtoAFrameVisitSeparately() async throws {
         targetID: targetID,
         documentID: "navigation-visit-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     for (index, visit) in [
         ("loader-a", "a-first", 1.0),
@@ -3980,7 +3980,7 @@ func networkRequestBeforeFrameCommitSharesVisitWithCommittedRequest() async thro
         targetID: targetID,
         documentID: "provisional-visit-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitTransportNetworkRequest(
         id: "before-commit",
@@ -4016,7 +4016,7 @@ func networkRequestBeforeFrameCommitSharesVisitWithCommittedRequest() async thro
 @Test
 func ambiguousFrameCommitDoesNotGuessBetweenPendingNetworkTargets() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await applyOriginatedNetworkRequest(
         id: "ambiguous-current",
@@ -4078,7 +4078,7 @@ func ambiguousFrameCommitDoesNotGuessBetweenPendingNetworkTargets() async throws
 @Test
 func frameCommitUsesExactPageBindingForPendingNetworkTarget() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await applyOriginatedNetworkRequest(
         id: "exact-current",
@@ -4135,7 +4135,7 @@ func frameDetachmentRetainsNetworkHistoryAndLateTerminalEvents() async throws {
         targetID: targetID,
         documentID: "detached-frame-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitTransportNetworkRequest(
         id: "detached-request",
@@ -4202,7 +4202,7 @@ func memoryCacheOnlyRequestSharesFrameNavigationVisit() async throws {
         targetID: targetID,
         documentID: "memory-cache-visit-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitTransportFrameNavigated(
         frameID: "child-frame",
@@ -4240,7 +4240,7 @@ func responseOnlyRequestSharesFrameNavigationVisit() async throws {
         targetID: targetID,
         documentID: "response-only-visit-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitTransportFrameNavigated(
         frameID: "child-frame",
@@ -4278,7 +4278,7 @@ func subframeDetachmentDoesNotAdvanceTopLevelNetworkVisit() async throws {
         targetID: targetID,
         documentID: "subframe-detach-top-level-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitTransportNetworkRequest(
         id: "top-level-before-detach",
@@ -4326,7 +4326,7 @@ func networkEventWithoutFrameMembershipHasNoNavigationVisit() async throws {
         targetID: targetID,
         documentID: "missing-frame-membership-root"
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await receiveTransportTargetEvent(
         transport,
@@ -4606,7 +4606,7 @@ func delayedNetworkConsumerUsesEventTimeTargetAfterFrameRetarget() async throws 
     }
 
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     await context.apply(oldNetworkEvent)
     let newID = Network.Request.ID("event-time-new")
     await context.apply(.requestWillBeSent(
@@ -4657,7 +4657,7 @@ func workerInitiatedRequestSharesOwningFrameNavigationVisit() async throws {
     )
 
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     for _ in 0..<2 {
         let protocolEvent = try #require(await iterator.next())
         let proxyEvent = try LiveProxyEventDecoder.proxyEvent(
@@ -4681,7 +4681,7 @@ func workerInitiatedRequestSharesOwningFrameNavigationVisit() async throws {
 func abandonedProvisionalTargetDoesNotReuseNetworkNavigationVisit() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitOriginatedNetworkRequest(
         id: "abandoned-provisional",
@@ -4781,7 +4781,7 @@ func frameCommitBeforeTargetCommitPreservesUnattributedNetworkVisit() async thro
 func ambiguousFrameCommitPreservesCandidatesUntilExactTargetCommit() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitOriginatedNetworkRequest(
         id: "candidate-current",
@@ -4845,7 +4845,7 @@ func ambiguousFrameCommitPreservesCandidatesUntilExactTargetCommit() async throw
 func networkTargetCommitCommitsPendingNavigationVisit() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitOriginatedNetworkRequest(
         id: "a-first",
@@ -5004,7 +5004,7 @@ func restartClearsRuntimeContextsBeforeEnableReplay() async throws {
 func restartClearsConsoleMessagesBeforeConsoleReplay() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     let enableGate = WebInspectorTestGate()
 
     await runtime.backend.emit(
@@ -5802,7 +5802,7 @@ func setChildNodesReplacementPublishesSelectionClearingForRemovedDescendant() as
 func fetchedResultsControllerPublishesNetworkInsertAndContentUpdateTransactions() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6028,7 +6028,7 @@ func unfilteredNetworkContentUpdateDoesNotVisitFullMembership() async throws {
         ))
     }
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6064,7 +6064,7 @@ func unfilteredNetworkContentUpdateDoesNotVisitFullMembership() async throws {
 func sectionedNetworkResultsPublishTopologyWhenSectionKeyChanges() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(sectionBy: \.mimeType)
+    let results = context.network.fetchedResults(for: NetworkRequestQuery(sectionBy: .mimeType))
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6119,7 +6119,9 @@ func sectionedNetworkResultsPublishTopologyWhenSectionKeyChanges() async throws 
 @Test
 func sectionedNetworkResultsPublishItemMoveWhenSectionKeyChangesBetweenExistingSections() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(sectionBy: \.resourceCategory)
+    let results = context.network.fetchedResults(
+        for: NetworkRequestQuery(sectionBy: .resourceCategory)
+    )
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6183,7 +6185,7 @@ func sectionedNetworkResultsPublishItemMoveWhenSectionKeyChangesBetweenExistingS
 
 @MainActor
 @Test
-func networkFetchDescriptorAppliesPredicateSortAndLimit() async throws {
+func networkQueryAppliesFilterSortAndLimit() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     await context.apply(.requestWillBeSent(
         id: Network.Request.ID("graphql-old"),
@@ -6209,23 +6211,23 @@ func networkFetchDescriptorAppliesPredicateSortAndLimit() async throws {
 
     let xhrFetch = NetworkRequest.ResourceCategory.xhrFetch
     let search = "graphql"
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        predicate: #Predicate { request in
-            request.resourceCategory == xhrFetch
-                && request.searchableText.localizedStandardContains(search)
-        },
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .reverse)],
+    let query = NetworkRequestQuery(
+        filter: .all([
+            .resourceCategory(xhrFetch),
+            .searchableText(containing: search),
+        ]),
+        sortBy: [.requestSentTimestamp(order: .reverse)],
         fetchLimit: 1
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
 
     #expect(results.items.map(\.id) == [NetworkRequest.ID(Network.Request.ID("graphql-new"))])
 }
 
 @MainActor
 @Test
-func networkFetchDescriptorPlansURLAndMIMETypePredicates() async throws {
+func networkQueryCombinesURLAndMIMETypeFilters() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
     await context.apply(.requestWillBeSent(
         id: Network.Request.ID("api"),
@@ -6259,14 +6261,14 @@ func networkFetchDescriptorPlansURLAndMIMETypePredicates() async throws {
         timestamp: 4
     ))
 
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        predicate: #Predicate { request in
-            request.url.localizedStandardContains("api")
-                || request.mimeType == "image/png"
-        },
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .forward)]
+    let query = NetworkRequestQuery(
+        filter: .any([
+            .url(containing: "api"),
+            .mimeType(equals: "image/png"),
+        ]),
+        sortBy: [.requestSentTimestamp(order: .forward)]
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
 
     #expect(results.items.map(\.id) == [
         NetworkRequest.ID(Network.Request.ID("api")),
@@ -6276,13 +6278,13 @@ func networkFetchDescriptorPlansURLAndMIMETypePredicates() async throws {
 
 @MainActor
 @Test
-func clearNetworkRequestsResetsDescriptorBackedQueryState() async throws {
+func clearNetworkRequestsResetsConfiguredQueryState() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .forward)],
+    let query = NetworkRequestQuery(
+        sortBy: [.requestSentTimestamp(order: .forward)],
         fetchLimit: 2
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
 
     for (index, name) in ["stale-a", "stale-b", "stale-c"].enumerated() {
         await context.apply(.requestWillBeSent(
@@ -6315,14 +6317,14 @@ func clearNetworkRequestsResetsDescriptorBackedQueryState() async throws {
 
 @MainActor
 @Test
-func startResetsDescriptorBackedNetworkQueryState() async throws {
+func startResetsConfiguredNetworkQueryState() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .forward)],
+    let query = NetworkRequestQuery(
+        sortBy: [.requestSentTimestamp(order: .forward)],
         fetchLimit: 1
     )
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let networkResults = context.network.fetchedResults(for: query)
     let staleRequestID = Network.Request.ID("stale-query-before-restart")
 
     await emitFinishedRequest(id: staleRequestID, target: target, backend: runtime.backend)
@@ -6351,12 +6353,12 @@ func startResetsDescriptorBackedNetworkQueryState() async throws {
 
 @MainActor
 @Test
-func networkFetchDescriptorOrdersEqualTimestampsByNewestInsertionFirst() async throws {
+func networkQueryOrdersEqualTimestampsByNewestInsertionFirst() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .reverse)]
+    let query = NetworkRequestQuery(
+        sortBy: [.requestSentTimestamp(order: .reverse)]
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6394,14 +6396,12 @@ func networkFetchDescriptorOrdersEqualTimestampsByNewestInsertionFirst() async t
 
 @MainActor
 @Test
-func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
+func networkQueryPublishesFilterEnterAndLeave() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        predicate: #Predicate { request in
-            (request.statusCode ?? 0) >= 400
-        }
+    let query = NetworkRequestQuery(
+        filter: .statusCode(atLeast: 400)
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6449,7 +6449,7 @@ func networkFetchDescriptorPublishesPredicateEnterAndLeave() async throws {
 
 @MainActor
 @Test
-func networkFetchDescriptorSupportsResourceCategorySets() async throws {
+func networkQuerySupportsResourceCategorySets() async throws {
     let context = WebInspectorContext.preview(isolation: MainActor.shared)
 
     await context.apply(.requestWillBeSent(
@@ -6482,13 +6482,11 @@ func networkFetchDescriptorSupportsResourceCategorySets() async throws {
     ))
 
     let mediaCategories: [NetworkRequest.ResourceCategory] = [.image, .media]
-    let descriptor = WebInspectorFetchDescriptor<NetworkRequest>(
-        predicate: #Predicate { request in
-            mediaCategories.contains(request.resourceCategory)
-        },
-        sortBy: [SortDescriptor(\.requestSentTimestamp, order: .reverse)]
+    let query = NetworkRequestQuery(
+        filter: .resourceCategories(mediaCategories),
+        sortBy: [.requestSentTimestamp(order: .reverse)]
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(for: descriptor)
+    let results = context.network.fetchedResults(for: query)
 
     #expect(results.items.map(\.id) == [
         NetworkRequest.ID(Network.Request.ID("image")),
@@ -6583,7 +6581,7 @@ func networkRequestResourceCategoryUsesResponseHeadersWithoutPendingURLInference
 func clearNetworkRequestsPublishesResetAndIgnoresClearedEvents() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6713,7 +6711,7 @@ func clearNetworkRequestsPublishesResetAndIgnoresClearedEvents() async throws {
 func clearNetworkRequestsPreservesRetainedSecurityWithoutLeakingIntoReusedID() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     let requestID = Network.Request.ID("clear-security-request")
     let initialSecurity = Network.Security(
         connection: Network.Security.Connection(tlsProtocol: "TLS 1.2")
@@ -6791,7 +6789,7 @@ func clearNetworkRequestsPreservesRetainedSecurityWithoutLeakingIntoReusedID() a
 func networkRequestExposesDataKitQueryableProperties() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     let apiRequestID = Network.Request.ID("queryable-api-request")
     await runtime.backend.emit(
@@ -6859,7 +6857,7 @@ func networkRequestExposesDataKitQueryableProperties() async throws {
 func fetchedResultsControllerPublishesConsoleInsertUpdateAndDeleteTransactions() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6914,10 +6912,10 @@ func fetchedResultsControllerPublishesConsoleInsertUpdateAndDeleteTransactions()
 
 @MainActor
 @Test
-func fetchedResultsCanBeSectionedByStringKeyPath() async throws {
+func networkResultsCanBeSectionedByMethod() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults(sectionBy: \.method)
+    let results = context.network.fetchedResults(for: NetworkRequestQuery(sectionBy: .method))
     let controller = WebInspectorFetchedResultsController(fetchedResults: results)
     let recorder = FetchedResultsTransactionRecorder(stream: controller.transactions)
     defer { recorder.cancel() }
@@ -6997,10 +6995,10 @@ func fetchedResultsCanBeSectionedByStringKeyPath() async throws {
 
 @MainActor
 @Test
-func fetchedResultsCanBeSectionedByRawRepresentableKeyPath() async throws {
+func consoleResultsCanBeSectionedByLevel() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults(sectionBy: \.level)
+    let results = context.console.fetchedResults(for: ConsoleMessageQuery(sectionBy: .level))
 
     await runtime.backend.emit(
         .messageAdded(Console.Message(
@@ -9969,7 +9967,7 @@ func networkEventsPopulateAllRequestsInOrder() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.count == 1 && results.items.first?.state == .finished
     }
@@ -10034,7 +10032,7 @@ func responseReceivedWithoutRequestWillBeSentCreatesRequest() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.first?.state == .finished
     }
@@ -10123,7 +10121,7 @@ func loadingFinishedStoresTerminalMetadataAndOverridesDataTotals() async throws 
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.first?.state == .finished
     }
@@ -10170,7 +10168,7 @@ func loadingFinishedClampsNegativeMetricTotals() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.first?.state == .finished
     }
@@ -10369,7 +10367,7 @@ func repeatedRequestWillBeSentClearsStaleResponseFields() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.first?.status == 302
     }
@@ -10418,7 +10416,7 @@ func networkRequestPreservesInitialInitiatorAcrossRedirects() async throws {
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("initiator-redirect")
     let initialNodeID = DOM.Node.ID("17")
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await runtime.backend.emit(
         .requestWillBeSent(
@@ -10506,7 +10504,7 @@ func completedRequestDoesNotTreatLaterRequestWillBeSentAsRedirect() async throws
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.first?.state == .finished }
     let request = try #require(results.items.first)
     #expect(request.lifecycleRevision == 0)
@@ -10564,7 +10562,7 @@ func loadingFailedStoresFailureTimestampAndClampsDataLength() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.first?.state == .failed(errorText: "cancelled", canceled: true) }
     let request = try #require(results.items.first)
     #expect(request.requestSentTimestamp == 1)
@@ -10605,7 +10603,7 @@ func memoryCacheEventCreatesFinishedCachedRequestFromResponse() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.count == 1 && results.items.first?.state == .finished
     }
@@ -10711,7 +10709,7 @@ func memoryCacheEventWithoutURLForNewRequestIsSkipped() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     #expect(results.items.first?.url == "https://example.com/cached.css")
     #expect(context.state == .attached)
@@ -10729,7 +10727,7 @@ func webSocketCreatedCreatesRequestWithConnectingState() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     #expect(request.url == "wss://example.com/socket")
@@ -10787,7 +10785,7 @@ func webSocketCreatedPreservesExistingNetworkLifecycleMetadata() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.first?.decodedDataLength == 7 }
     let request = try #require(results.items.first)
     let webSocket = try #require(request.webSocket)
@@ -10862,7 +10860,7 @@ func webSocketLifecycleStoresHandshakeFramesErrorAndClosedState() async throws {
         .webSocket(.created(id: requestID, url: "wss://example.com/socket")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
 
@@ -10992,7 +10990,7 @@ func webSocketTimelinePreservesArrivalOrderStableIDsAndExactFrameSemantics() asy
         .webSocket(.created(id: requestID, url: "wss://example.com/timeline")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
 
@@ -11187,7 +11185,7 @@ func webSocketFirstCloseAndHandshakeAreTerminalAndDuplicateEventsDoNotNotify() a
         .webSocket(.created(id: requestID, url: "wss://example.com/terminal")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     await runtime.backend.emit(
@@ -11268,7 +11266,7 @@ func webSocketRejectedHandshakePreservesResponseWithoutOpeningAndOrdersTerminalE
         .webSocket(.created(id: requestID, url: "wss://example.com/rejected")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     await runtime.backend.emit(
@@ -11440,7 +11438,7 @@ func activeDuplicateWebSocketCreatedPreservesStateIdentityAndTimeline() async th
         .webSocket(.created(id: requestID, url: "wss://example.com/initial")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     await runtime.backend.emit(
@@ -11639,7 +11637,7 @@ func terminalWebSocketCreatedRestartsSameRequestThroughCommonLifecycleReset() as
         ),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     let responseBody = request.responseBody
@@ -11766,7 +11764,7 @@ func webSocketCreatedRestartsLifecycleClosedByErrorWithoutClosedEvent(
         .webSocket(.created(id: requestID, url: "wss://example.com/first")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     if hasHandshakeResponse {
@@ -11966,7 +11964,7 @@ func closedWebSocketCannotFetchResponseBodyOrSendProtocolCommand() async throws 
         .webSocket(.created(id: requestID, url: "wss://example.com/no-body")),
         target: target
     )
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     await runtime.backend.emit(
@@ -12016,7 +12014,7 @@ func webSocketEventForUnknownRequestIsSkipped() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     #expect(results.items.first?.webSocket?.readyState == .connecting)
     #expect(results.items.first?.webSocket?.handshakeResponse == nil)
@@ -12028,7 +12026,7 @@ func webSocketEventForUnknownRequestIsSkipped() async throws {
 func webSocketOtherEventDoesNotMutateRequests() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     let baseline = context.eventPumpAppliedSequenceForTesting
     await runtime.backend.emit(
@@ -12066,7 +12064,7 @@ func requestPostDataCreatesNetworkBodyWithFormRepresentation() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     let body = try #require(request.requestBody)
@@ -12107,7 +12105,7 @@ func responseRequestHeadersRefreshRequestBodyHints() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.count == 1 }
     let request = try #require(results.items.first)
     let body = try #require(request.requestBody)
@@ -12315,7 +12313,7 @@ func responseBodyPublishesHintsAndFetchLifecycle() async throws {
         target: target
     )
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil { results.items.first?.state == .responded }
     let request = try #require(results.items.first)
     let body = request.responseBody
@@ -12368,7 +12366,7 @@ func fetchResponseBodyStoresLoadedAndFailedPhases() async throws {
     await emitFinishedRequest(id: loadedID, target: target, backend: runtime.backend)
     await emitFinishedRequest(id: failedID, target: target, backend: runtime.backend)
 
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
     try await waitUntil {
         results.items.count == 2 && results.items.allSatisfy { $0.state == .finished }
     }
@@ -12644,7 +12642,7 @@ func consoleEventsPopulateRepeatAndClearFetchedMessages() async throws {
     let (target, context) = try await startContext(runtime: runtime)
     let requestID = Network.Request.ID("request-1")
 
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     await runtime.backend.emit(
         .messageAdded(Console.Message(
             source: Console.Source(rawValue: "console-api"),
@@ -12727,7 +12725,7 @@ func consoleRepeatUpdatesStayWithinTheirTarget() throws {
         targetID: secondTargetID
     )
 
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
     let first = try #require(results.items.first { $0.targetID == firstTargetID })
     let second = try #require(results.items.first { $0.targetID == secondTargetID })
 
@@ -12748,10 +12746,10 @@ func consoleRepeatUpdatesStayWithinTheirTarget() throws {
 
 @MainActor
 @Test
-func consoleFetchedResultsHonorDescriptorsForInitialUpdatesAndDescriptorChanges() async throws {
+func consoleFetchedResultsHonorQueriesForInitialUpdatesAndQueryChanges() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let allResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let allResults = context.console.fetchedResults()
 
     await runtime.backend.emit(
         .messageAdded(Console.Message(
@@ -12779,14 +12777,12 @@ func consoleFetchedResultsHonorDescriptorsForInitialUpdatesAndDescriptorChanges(
     )
     try await waitUntil { allResults.items.count == 3 }
 
-    let warningDescriptor = WebInspectorFetchDescriptor<ConsoleMessage>(
-        predicate: #Predicate { message in
-            message.level.rawValue == "warning"
-        },
-        sortBy: [SortDescriptor(\.text, order: .reverse)],
+    let warningQuery = ConsoleMessageQuery(
+        filter: .level(Console.Level(rawValue: "warning")),
+        sortBy: [.text(order: .reverse)],
         fetchLimit: 2
     )
-    let warningResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults(for: warningDescriptor)
+    let warningResults = context.console.fetchedResults(for: warningQuery)
 
     #expect(warningResults.items.map(\.text) == ["omega", "middle"])
 
@@ -12802,8 +12798,8 @@ func consoleFetchedResultsHonorDescriptorsForInitialUpdatesAndDescriptorChanges(
         warningResults.items.map(\.text) == ["zebra", "omega"]
     }
 
-    try warningResults.updateFetchDescriptor(WebInspectorFetchDescriptor<ConsoleMessage>(
-        sortBy: [SortDescriptor(\.text)],
+    try warningResults.updateQuery(ConsoleMessageQuery(
+        sortBy: [.text()],
         fetchLimit: 2,
         fetchOffset: 1
     ))
@@ -12825,15 +12821,15 @@ func consoleFetchedResultsPreserveTieOrderAndCustomComparators() {
         )))
     }
 
-    let reverseTieResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults(
-        for: WebInspectorFetchDescriptor(
-            sortBy: [SortDescriptor(\.level.rawValue, order: .reverse)],
+    let reverseTieResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults(
+        for: ConsoleMessageQuery(
+            sortBy: [.level(order: .reverse)],
             fetchLimit: 1
         )
     )
-    let lexicalResults: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults(
-        for: WebInspectorFetchDescriptor(
-            sortBy: [SortDescriptor(\.text, comparator: .lexical)]
+    let lexicalResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults(
+        for: ConsoleMessageQuery(
+            sortBy: [.text(comparison: .lexical)]
         )
     )
 
@@ -12847,7 +12843,7 @@ func consoleMessageParametersRegisterRuntimeObjects() async throws {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let objectID = Runtime.RemoteObject.ID("console-object")
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
 
     await runtime.backend.emit(
         .messageAdded(Console.Message(
@@ -12890,7 +12886,7 @@ func consoleMessagesClearedInvalidatesRuntimeObjectsWithoutRuntimeCommand() asyn
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
     let objectID = Runtime.RemoteObject.ID("console-stale-object")
-    let results: WebInspectorFetchedResults<ConsoleMessage> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
 
     await runtime.backend.emit(
         .messageAdded(Console.Message(
@@ -14765,7 +14761,7 @@ private func networkVisitsAcrossTopLevelCommit(
 ) async throws -> (provisional: NetworkNavigationVisit, committed: NetworkNavigationVisit) {
     let runtime = try await WebInspectorProxyTestRuntime.start()
     let (target, context) = try await startContext(runtime: runtime)
-    let results: WebInspectorFetchedResults<NetworkRequest> = context.fetchedResults()
+    let results: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
 
     await emitOriginatedNetworkRequest(
         id: "commit-order-current",
@@ -15020,7 +15016,7 @@ private final class DOMTreeRevealRequestRecorder {
 }
 
 @MainActor
-private final class FetchedResultsTransactionRecorder<Model: WebInspectorFetchableModel> {
+private final class FetchedResultsTransactionRecorder<Model: WebInspectorPersistentModel> {
     private(set) var transactions: [WebInspectorFetchedResultsTransaction<Model>] = []
 
     private var task: Task<Void, Never>?
@@ -15054,7 +15050,7 @@ private final class FetchedResultsTransactionRecorder<Model: WebInspectorFetchab
 }
 
 @MainActor
-private final class FetchedResultsTransactionCounter<Model: WebInspectorFetchableModel> {
+private final class FetchedResultsTransactionCounter<Model: WebInspectorPersistentModel> {
     private(set) var transactionCount = 0
 
     private var task: Task<Void, Never>?

--- a/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
+++ b/Tests/WebInspectorDataKitTests/WebInspectorDataKitTests.swift
@@ -2404,7 +2404,11 @@ func restartSynchronouslyRejectsSupersededOrderedEventsAcrossDomains() async thr
         ]
     )
     let (target, context) = try await startContext(runtime: runtime, document: oldDocument)
-    let networkResults: WebInspectorFetchedResults<NetworkRequest> = context.network.fetchedResults()
+    let networkResults = context.network.fetchedResults(
+        for: NetworkRequestQuery(filter: .all([]))
+    )
+    let networkController = WebInspectorFetchedResultsController(fetchedResults: networkResults)
+    var networkTransactions = networkController.transactions.makeAsyncIterator()
     let consoleResults: WebInspectorFetchedResults<ConsoleMessage> = context.console.fetchedResults()
 
     let seedAppliedBaseline = context.eventPumpAppliedSequenceForTesting
@@ -2459,6 +2463,12 @@ func restartSynchronouslyRejectsSupersededOrderedEventsAcrossDomains() async thr
     #expect(oldElement.attributes["data-generation"] == "old")
     #expect(oldConsoleMessage.text == "old-console")
     #expect(oldRuntimeContext.id == RuntimeContext.ID(oldRuntimeID))
+    #expect(try #require(await networkTransactions.next()).itemChanges == [
+        .insert(
+            itemID: NetworkRequest.ID(oldRequestID),
+            indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+        ),
+    ])
 
     let supersededSubscription = context.orderedEventSubscriptionStateForTesting
     let appliedBaseline = context.eventPumpAppliedSequenceForTesting
@@ -2475,6 +2485,9 @@ func restartSynchronouslyRejectsSupersededOrderedEventsAcrossDomains() async thr
     #expect(linearizedSubscription.sequence == supersededSubscription.sequence)
     #expect(networkResults.items.isEmpty)
     #expect(context.registeredRequest(forProxyID: oldRequestID) == nil)
+    let resetTransaction = try #require(await networkTransactions.next())
+    #expect(resetTransaction.isReset)
+    #expect(resetTransaction.newSnapshot.itemIDs.isEmpty)
 
     _ = await runtime.backend.waitForRecordedCommands(
         domain: "Console",
@@ -2598,6 +2611,12 @@ func restartSynchronouslyRejectsSupersededOrderedEventsAcrossDomains() async thr
     #expect(freshSubscription.sequence > supersededSubscription.sequence)
     #expect(networkResults.items.count == 1)
     #expect(context.registeredRequest(forProxyID: freshRequestID) != nil)
+    #expect(try #require(await networkTransactions.next()).itemChanges == [
+        .insert(
+            itemID: NetworkRequest.ID(freshRequestID),
+            indexPath: WebInspectorFetchedResultsIndexPath(section: 0, item: 0)
+        ),
+    ])
     #expect(freshElement.attributes["data-generation"] == "fresh")
     #expect(freshStyles.phase == .needsRefresh)
     #expect(consoleResults.items.map(\.text) == ["fresh-console"])

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -1399,11 +1399,7 @@ func removedExplicitRequestClearsSelectionInsteadOfSelectingGroupedSibling() asy
     let model = NetworkPanelModel(context: context)
     let groupedEntryID = try #require(model.entryID(containing: firstID))
     var rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
-    try model.requests.updateFetchDescriptor(WebInspectorFetchDescriptor(
-        predicate: #Predicate { request in
-            request.method == "GET"
-        }
-    ))
+    try model.requests.updateQuery(NetworkRequestQuery(filter: .method(equals: "GET")))
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
 
     model.selectRequest(context.registeredRequest(for: secondID))


### PR DESCRIPTION
## Purpose

Close the public fetched-results query surface over the two model families DataKit actually stores, eliminating runtime traps from unsupported external models, arbitrary predicates, sort descriptors, and section key paths.

## Changes

- Replace the generic fetch descriptor/request surface with concrete `NetworkRequestQuery` and `ConsoleMessageQuery` values.
- Expose closed, model-specific filter, sort, and section capabilities with atomic unsigned windowing.
- Publish exactly one content update for visible query items whose topology is unchanged, without rematerializing stable snapshots.
- Preserve the default Network unfiltered O(1) ledger path and existing fetched-results observation/lifetime behavior.
- Remove Foundation predicate evaluation, sort sentinel inference, generic context factories, and false external fetch-model extensibility.
- Add query migration DocC, exhaustive separate-package contracts, capability tests, and public symbol-boundary checks.

## Breaking changes

Callers must migrate generic descriptors, Foundation predicates/sort descriptors, key-path sectioning, and `updateFetchDescriptor` to the concrete query values and `updateQuery`. The migration table is included in the DataKit DocC catalog.

## Testing

- Focused stable-query regressions: 8/8
- ContractTests: 13/13
- DataKit + UI: 652 logical / 694 concrete, 0 failures
- Repository default suite: 864 logical / 920 concrete, 0 failures
- Combined four-target DocC build
- DataKit public symbol-boundary check
- `git diff --check`
- Branch-wide Codex review: 0 findings

Closes #252
