### PR TITLE
Resolve Network detail subjects at the model boundary

### DIFF
--- a/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
@@ -13,15 +13,15 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     private enum SelectionCommit {
         case none
-        case clearIfStillSelected(NetworkPanelSelection)
+        case clearIfStillSelected(NetworkPanelSelectionIntent.ID)
 
         @MainActor
         func apply(to model: NetworkPanelModel) {
             switch self {
             case .none:
                 return
-            case .clearIfStillSelected(let selection):
-                model.clearSelection(ifUnchanged: selection)
+            case .clearIfStillSelected(let intentID):
+                model.clearSelection(ifIntentUnchanged: intentID)
             }
         }
     }
@@ -58,8 +58,8 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         navigationBar.compactScrollEdgeAppearance = navigationBar.compactAppearance ?? navigationBar.standardAppearance
         webInspectorApplyNavigationControllerBackground(to: self)
         delegate = self
-        listViewController.setEntrySelectionAction { [weak model] entryID in
-            model?.selectEntry(entryID)
+        listViewController.setEntrySelectionAction { [weak model] entry in
+            model?.selectEntry(entry)
         }
     }
 
@@ -249,7 +249,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
 
     private func finishUntrackedDetailRemovalIfNeeded(shownTarget: StackTarget?) {
         guard shownTarget == .list,
-              model.selection != nil else {
+              model.detailSubject != nil else {
             return
         }
         commit(
@@ -270,7 +270,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func desiredStackTarget() -> StackTarget {
-        model.selection == nil ? .list : .detail
+        model.detailSubject == nil ? .list : .detail
     }
 
     private func currentStackTarget() -> StackTarget {
@@ -288,10 +288,10 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     }
 
     private func userPopSelectionCommit() -> SelectionCommit {
-        guard let selection = model.selection else {
+        guard let intentID = model.detailSubject?.intentID else {
             return .none
         }
-        return .clearIfStillSelected(selection)
+        return .clearIfStillSelected(intentID)
     }
 
     private func applyBackgroundFromTraits() {

--- a/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
@@ -6,30 +6,34 @@ import UIKit
 
 @MainActor
 package final class NetworkCompactNavigationController: UINavigationController, UINavigationControllerDelegate {
-    private enum StackTarget {
+    private enum StackTarget: Equatable {
         case list
         case detail
     }
 
-    private enum SelectionCommit {
-        case none
-        case clearIfStillSelected(NetworkPanelSelectionIntent.ID)
+    private enum StackTransition {
+        case showingList
+        case showingDetail
+        case removingDetailForModel
+        case removingDetailForUser(capturedIntentID: NetworkPanelSelectionIntent.ID?)
 
-        @MainActor
-        func apply(to model: NetworkPanelModel) {
+        var target: StackTarget {
             switch self {
-            case .none:
-                return
-            case .clearIfStillSelected(let intentID):
-                model.clearSelection(ifIntentUnchanged: intentID)
+            case .showingDetail:
+                .detail
+            case .showingList, .removingDetailForModel, .removingDetailForUser:
+                .list
             }
         }
-    }
 
-    private struct StackTransition {
-        var target: StackTarget
-        var removesDetail: Bool
-        var selectionCommit: SelectionCommit
+        var removesDetail: Bool {
+            switch self {
+            case .showingList, .showingDetail:
+                false
+            case .removingDetailForModel, .removingDetailForUser:
+                true
+            }
+        }
     }
 
     private struct DeferredStackSync {
@@ -98,15 +102,22 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         willShow viewController: UIViewController,
         animated: Bool
     ) {
-        guard viewController === listViewController,
-              activeTransition == nil,
-              transitionCoordinator?.viewController(forKey: .from) === detailViewController else {
+        guard viewController === listViewController else {
             return
         }
-        activeTransition = StackTransition(
-            target: .list,
-            removesDetail: true,
-            selectionCommit: userPopSelectionCommit()
+        let sourceViewController = activeTransition?.target == .detail
+            ? detailViewController
+            : transitionCoordinator?.viewController(forKey: .from)
+        beginUserDetailRemovalIfNeeded(from: sourceViewController)
+    }
+
+    private func beginUserDetailRemovalIfNeeded(from sourceViewController: UIViewController?) {
+        guard sourceViewController === detailViewController,
+              activeTransition?.target != .list else {
+            return
+        }
+        activeTransition = .removingDetailForUser(
+            capturedIntentID: model.detailSubject?.intentID
         )
     }
 
@@ -116,10 +127,12 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         animated: Bool
     ) {
         let shownTarget = stackTarget(for: viewController)
-        if finishActiveTransitionIfNeeded(shownTarget: shownTarget) == false {
-            finishUntrackedDetailRemovalIfNeeded(shownTarget: shownTarget)
-        }
+        finishActiveTransitionIfNeeded(shownTarget: shownTarget)
+        let hadDeferredStackSync = deferredStackSync != nil
         performDeferredStackSyncIfNeeded()
+        if hadDeferredStackSync == false {
+            syncStack(to: desiredStackTarget(), animated: false)
+        }
     }
 
     private func startObservingSelection() {
@@ -161,11 +174,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         }
         detailViewController.webInspectorDetachFromContainerForReuse()
         let shouldAnimate = animated && viewControllers.first === listViewController
-        activeTransition = StackTransition(
-            target: .detail,
-            removesDetail: false,
-            selectionCommit: .none
-        )
+        activeTransition = .showingDetail
         if viewControllers.first === listViewController {
             setViewControllers([listViewController, detailViewController], animated: shouldAnimate)
         } else {
@@ -178,11 +187,9 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         guard viewControllers.count != 1 || viewControllers.first !== listViewController else {
             return
         }
-        activeTransition = StackTransition(
-            target: .list,
-            removesDetail: viewControllers.contains { $0 === detailViewController },
-            selectionCommit: .none
-        )
+        activeTransition = viewControllers.contains { $0 === detailViewController }
+            ? .removingDetailForModel
+            : .showingList
         setViewControllers([listViewController], animated: animated)
         finishActiveTransitionIfNoCoordinator()
     }
@@ -230,39 +237,26 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         guard transitionCoordinator == nil else {
             return
         }
-        _ = finishActiveTransitionIfNeeded(shownTarget: currentStackTarget())
+        finishActiveTransitionIfNeeded(shownTarget: currentStackTarget())
     }
 
-    @discardableResult
-    private func finishActiveTransitionIfNeeded(shownTarget: StackTarget?) -> Bool {
+    private func finishActiveTransitionIfNeeded(shownTarget: StackTarget?) {
         guard let transition = activeTransition else {
-            return false
+            return
         }
         activeTransition = nil
         guard shownTarget == transition.target else {
-            return false
+            return
         }
 
         commit(transition)
-        return true
-    }
-
-    private func finishUntrackedDetailRemovalIfNeeded(shownTarget: StackTarget?) {
-        guard shownTarget == .list,
-              model.detailSubject != nil else {
-            return
-        }
-        commit(
-            StackTransition(
-                target: .list,
-                removesDetail: true,
-                selectionCommit: userPopSelectionCommit()
-            )
-        )
     }
 
     private func commit(_ transition: StackTransition) {
-        transition.selectionCommit.apply(to: model)
+        if case .removingDetailForUser(let capturedIntentID) = transition,
+           let capturedIntentID {
+            model.clearSelection(ifIntentUnchanged: capturedIntentID)
+        }
         guard transition.removesDetail else {
             return
         }
@@ -287,13 +281,6 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         return nil
     }
 
-    private func userPopSelectionCommit() -> SelectionCommit {
-        guard let intentID = model.detailSubject?.intentID else {
-            return .none
-        }
-        return .clearIfStillSelected(intentID)
-    }
-
     private func applyBackgroundFromTraits() {
         webInspectorApplyNavigationControllerBackground(to: self)
     }
@@ -316,24 +303,23 @@ extension NetworkCompactNavigationController {
     }
 
     @discardableResult
-    package func popDetailWhilePushTransitionIsStillTrackedForTesting()
+    package func popDetailWhilePushTransitionIsStillTrackedForTesting(
+        beforeTransitionCompletion: () -> Void = {}
+    )
         -> UIViewController?
     {
         guard viewControllers.last === detailViewController else {
             return nil
         }
 
-        activeTransition = StackTransition(
-            target: .detail,
-            removesDetail: false,
-            selectionCommit: .none
-        )
+        activeTransition = .showingDetail
         navigationController(
             self,
             willShow: listViewController,
             animated: false
         )
         let poppedViewController = popViewController(animated: false)
+        beforeTransitionCompletion()
         navigationController(
             self,
             didShow: listViewController,
@@ -350,14 +336,12 @@ extension NetworkCompactNavigationController {
             return nil
         }
 
-        activeTransition = StackTransition(
-            target: .list,
-            removesDetail: true,
-            selectionCommit: userPopSelectionCommit()
+        activeTransition = .removingDetailForUser(
+            capturedIntentID: model.detailSubject?.intentID
         )
         let poppedViewController = popViewController(animated: false)
         beforeTransitionCompletion()
-        _ = finishActiveTransitionIfNeeded(shownTarget: .list)
+        finishActiveTransitionIfNeeded(shownTarget: .list)
         performDeferredStackSyncIfNeeded()
         return poppedViewController
     }
@@ -369,14 +353,33 @@ extension NetworkCompactNavigationController {
             return
         }
 
-        activeTransition = StackTransition(
-            target: .list,
-            removesDetail: true,
-            selectionCommit: userPopSelectionCommit()
+        activeTransition = .removingDetailForUser(
+            capturedIntentID: model.detailSubject?.intentID
         )
         beforeTransitionCompletion()
-        _ = finishActiveTransitionIfNeeded(shownTarget: .detail)
+        finishActiveTransitionIfNeeded(shownTarget: .detail)
         performDeferredStackSyncIfNeeded()
+    }
+
+    package func cancelDetailPopWhilePushTransitionIsStillTrackedForTesting(
+        beforeTransitionCompletion: () -> Void = {}
+    ) {
+        guard viewControllers.last === detailViewController else {
+            return
+        }
+
+        activeTransition = .showingDetail
+        navigationController(
+            self,
+            willShow: listViewController,
+            animated: false
+        )
+        beforeTransitionCompletion()
+        navigationController(
+            self,
+            didShow: detailViewController,
+            animated: false
+        )
     }
 }
 #endif

--- a/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
+++ b/Sources/WebInspectorUINetwork/Containers/NetworkCompactNavigationController.swift
@@ -46,6 +46,7 @@ package final class NetworkCompactNavigationController: UINavigationController, 
     private var selectionObservation: PortableObservationTracking.Token?
     private var activeTransition: StackTransition?
     private var deferredStackSync: DeferredStackSync?
+    private var lastShownTarget = StackTarget.list
 
     package init(
         model: NetworkPanelModel,
@@ -105,14 +106,17 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         guard viewController === listViewController else {
             return
         }
-        let sourceViewController = activeTransition?.target == .detail
-            ? detailViewController
-            : transitionCoordinator?.viewController(forKey: .from)
-        beginUserDetailRemovalIfNeeded(from: sourceViewController)
+        let coordinatorSource = stackTarget(
+            for: transitionCoordinator?.viewController(forKey: .from)
+        )
+        let sourceTarget = activeTransition?.target == .detail
+            ? StackTarget.detail
+            : coordinatorSource ?? lastShownTarget
+        beginUserDetailRemovalIfNeeded(from: sourceTarget)
     }
 
-    private func beginUserDetailRemovalIfNeeded(from sourceViewController: UIViewController?) {
-        guard sourceViewController === detailViewController,
+    private func beginUserDetailRemovalIfNeeded(from sourceTarget: StackTarget?) {
+        guard sourceTarget == .detail,
               activeTransition?.target != .list else {
             return
         }
@@ -127,6 +131,9 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         animated: Bool
     ) {
         let shownTarget = stackTarget(for: viewController)
+        if let shownTarget {
+            lastShownTarget = shownTarget
+        }
         finishActiveTransitionIfNeeded(shownTarget: shownTarget)
         let hadDeferredStackSync = deferredStackSync != nil
         performDeferredStackSyncIfNeeded()
@@ -237,7 +244,9 @@ package final class NetworkCompactNavigationController: UINavigationController, 
         guard transitionCoordinator == nil else {
             return
         }
-        finishActiveTransitionIfNeeded(shownTarget: currentStackTarget())
+        let shownTarget = currentStackTarget()
+        lastShownTarget = shownTarget
+        finishActiveTransitionIfNeeded(shownTarget: shownTarget)
     }
 
     private func finishActiveTransitionIfNeeded(shownTarget: StackTarget?) {
@@ -369,6 +378,51 @@ extension NetworkCompactNavigationController {
         }
 
         activeTransition = .showingDetail
+        navigationController(
+            self,
+            willShow: listViewController,
+            animated: false
+        )
+        beforeTransitionCompletion()
+        navigationController(
+            self,
+            didShow: detailViewController,
+            animated: false
+        )
+    }
+
+    @discardableResult
+    package func popDetailWithoutTrackedTransitionForTesting(
+        beforeTransitionCompletion: () -> Void = {}
+    ) -> UIViewController? {
+        guard viewControllers.last === detailViewController else {
+            return nil
+        }
+
+        activeTransition = nil
+        navigationController(
+            self,
+            willShow: listViewController,
+            animated: false
+        )
+        let poppedViewController = popViewController(animated: false)
+        beforeTransitionCompletion()
+        navigationController(
+            self,
+            didShow: listViewController,
+            animated: false
+        )
+        return poppedViewController
+    }
+
+    package func cancelDetailPopWithoutTrackedTransitionForTesting(
+        beforeTransitionCompletion: () -> Void = {}
+    ) {
+        guard viewControllers.last === detailViewController else {
+            return
+        }
+
+        activeTransition = nil
         navigationController(
             self,
             willShow: listViewController,

--- a/Sources/WebInspectorUINetwork/Containers/NetworkSplitViewController.swift
+++ b/Sources/WebInspectorUINetwork/Containers/NetworkSplitViewController.swift
@@ -20,8 +20,8 @@ package final class NetworkSplitViewController: UISplitViewController {
             hidesNavigationBar: false
         )
         super.init(style: .doubleColumn)
-        listViewController.setEntrySelectionAction { [weak model] entryID in
-            model?.selectEntry(entryID)
+        listViewController.setEntrySelectionAction { [weak model] entry in
+            model?.selectEntry(entry)
         }
         configureSplitViewLayout()
     }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerCell.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerCell.swift
@@ -81,6 +81,10 @@ final class NetworkDetailRequestPickerCell: UICollectionViewListCell {
         render(title: nil, subtitle: nil)
     }
 
+    var boundRequest: NetworkRequest? {
+        observedRequest
+    }
+
     private func startRequestObservationIfNeeded() {
         guard requestObservation == nil,
               let observedRequest else {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -9,6 +9,11 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     UISearchResultsUpdating,
     UIPopoverPresentationControllerDelegate
 {
+    private struct RenderedProjection {
+        let subject: NetworkDetailSubject
+        let visibleRequestsByID: [NetworkRequest.ID: NetworkRequest]
+    }
+
     enum ItemID: Hashable {
         case entry(NetworkListEntry.ID)
         case request(NetworkRequest.ID)
@@ -20,14 +25,21 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
 
     private let model: NetworkPanelModel
     private let boundEntryID: NetworkListEntry.ID
+    private var renderedProjection: RenderedProjection?
     private var modelObservation: PortableObservationTracking.Token?
     private var isRenderingActive = false
     private var searchText = ""
     private lazy var dataSource = makeDataSource()
 
-    init(model: NetworkPanelModel, entryID: NetworkListEntry.ID) {
+    init(model: NetworkPanelModel, subject: NetworkDetailSubject) {
         self.model = model
-        boundEntryID = entryID
+        boundEntryID = subject.entry.id
+        renderedProjection = RenderedProjection(
+            subject: subject,
+            visibleRequestsByID: Dictionary(
+                uniqueKeysWithValues: subject.entryRequests.map { ($0.id, $0) }
+            )
+        )
 
         var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
         configuration.showsSeparators = true
@@ -96,20 +108,40 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         guard let itemID = dataSource.itemIdentifier(for: indexPath) else {
             return
         }
+        guard let renderedProjection,
+              model.detailSubject?.hasSameIdentity(as: renderedProjection.subject) == true else {
+            renderCurrentEntry(animatingDifferences: false)
+            return
+        }
+        let subject = renderedProjection.subject
+        let resolvedSubject: NetworkDetailSubject?
         switch itemID {
         case .entry(let entryID):
             guard entryID == boundEntryID,
-                  model.entry(for: entryID) != nil else {
+                  subject.entry.id == entryID else {
                 renderCurrentEntry(animatingDifferences: false)
                 return
             }
-            model.selectEntry(entryID)
+            resolvedSubject = model.selectEntry(
+                subject.entry,
+                ifSubjectUnchanged: subject
+            )
         case .request(let requestID):
-            guard model.entryID(containing: requestID) == boundEntryID else {
+            guard let cell = collectionView.cellForItem(at: indexPath)
+                    as? NetworkDetailRequestPickerCell,
+                  let request = cell.boundRequest,
+                  request.id == requestID else {
                 renderCurrentEntry(animatingDifferences: false)
                 return
             }
-            model.selectRequest(id: requestID)
+            resolvedSubject = model.selectRequest(
+                request,
+                ifSubjectUnchanged: subject
+            )
+        }
+        guard resolvedSubject != nil else {
+            renderCurrentEntry(animatingDifferences: false)
+            return
         }
         dismissPicker(animated: true)
     }
@@ -125,20 +157,23 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         isRenderingActive = true
         setVisibleCellRenderingActive(true)
         modelObservation?.cancel()
-        modelObservation = withPortableContinuousObservation { [weak self] event in
+        let token = withPortableContinuousObservation { [weak self] event in
             guard let self else {
                 return
             }
-            let selection = model.selection
-            let entry = model.selectedEntry
-            let requests = entry?.requests ?? []
+            let subject = model.detailSubject
+            _ = subject?.entryRequests
             render(
-                selection: selection,
-                entry: entry,
-                requests: requests,
+                subject: subject,
                 animatingDifferences: event.kind != .initial
             )
         }
+        guard isRenderingActive else {
+            token.cancel()
+            modelObservation = nil
+            return
+        }
+        modelObservation = token
     }
 
     private func stopObservingSelection() {
@@ -160,45 +195,46 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
     }
 
     private func renderCurrentEntry(animatingDifferences: Bool) {
-        let selection = model.selection
-        let entry = model.selectedEntry
         render(
-            selection: selection,
-            entry: entry,
-            requests: entry?.requests ?? [],
+            subject: model.detailSubject,
             animatingDifferences: animatingDifferences
         )
     }
 
     private func render(
-        selection: NetworkPanelSelection?,
-        entry: NetworkListEntry?,
-        requests: [NetworkRequest],
+        subject: NetworkDetailSubject?,
         animatingDifferences: Bool
     ) {
-        guard let selection,
-              let entry,
-              requests.count > 1 else {
+        guard let subject,
+              subject.entryRequests.count > 1 else {
             dismissPicker(animated: true)
             return
         }
 
-        guard selection.entryID == boundEntryID else {
+        guard subject.entry.id == boundEntryID else {
             dismissPicker(animated: true)
             return
         }
-        guard entry.id == boundEntryID else {
-            preconditionFailure("The Network request picker must render the selected entry.")
+        if let previousSubject = renderedProjection?.subject,
+           previousSubject.entry !== subject.entry,
+           previousSubject.intentID != subject.intentID {
+            dismissPicker(animated: true)
+            return
         }
-
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let visibleRequests = requests.filter { request in
+        let visibleRequests = subject.entryRequests.filter { request in
             request.matchesDisplaySearchText(query)
         }
+        renderedProjection = RenderedProjection(
+            subject: subject,
+            visibleRequestsByID: Dictionary(
+                uniqueKeysWithValues: visibleRequests.map { ($0.id, $0) }
+            )
+        )
 
         var snapshot = NSDiffableDataSourceSnapshot<Section, ItemID>()
         snapshot.appendSections([.requests])
-        snapshot.appendItems([.entry(entry.id)])
+        snapshot.appendItems([.entry(boundEntryID)])
         snapshot.appendItems(visibleRequests.map { .request($0.id) })
         let preservesVisibleItemIdentity = dataSource.snapshot().itemIdentifiers
             == snapshot.itemIdentifiers
@@ -206,8 +242,11 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
             guard let self else {
                 return
             }
+            guard renderedProjection?.subject.hasSameIdentity(as: subject) == true else {
+                return
+            }
             rebindVisibleRequestCells()
-            renderSelection(selection)
+            renderSelection(subject.selection)
         }
         if preservesVisibleItemIdentity {
             rebindVisibleRequestCells()
@@ -271,12 +310,12 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         switch itemID {
         case .entry(let entryID):
             guard entryID == boundEntryID else {
-                preconditionFailure("The Network request picker received an entry from another binding.")
+                cell.unbind()
+                return
             }
             cell.bindAllRequests(renderingActive: isRenderingActive)
         case .request(let requestID):
-            guard model.entryID(containing: requestID) == boundEntryID,
-                  let request = model.request(for: requestID) else {
+            guard let request = renderedProjection?.visibleRequestsByID[requestID] else {
                 cell.unbind()
                 return
             }
@@ -319,6 +358,14 @@ extension NetworkDetailRequestPickerViewController {
 
     var boundEntryIDForTesting: NetworkListEntry.ID {
         boundEntryID
+    }
+
+    var renderedEntryForTesting: NetworkListEntry? {
+        renderedProjection?.subject.entry
+    }
+
+    var renderedIntentIDForTesting: NetworkPanelSelectionIntent.ID? {
+        renderedProjection?.subject.intentID
     }
 
     func requestCellForTesting(

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -116,10 +116,8 @@ package final class NetworkDetailViewController: UIViewController {
     }()
     private var previewRoles: [NetworkBody.Role] = []
     private var hasBoundSelection = false
-    private var observedSelection: NetworkPanelSelection?
-    private weak var observedEntry: NetworkListEntry?
+    private var observedSubject: NetworkDetailSubject?
     private weak var observedRequest: NetworkRequest?
-    private var observedRequests: [NetworkRequest] = []
     private weak var presentedRequestPicker: NetworkDetailRequestPickerViewController?
     private var bodyTopToPreviewContainerConstraint: NSLayoutConstraint?
     private var bodyTopToPreviewRoleControlConstraint: NSLayoutConstraint?
@@ -132,8 +130,11 @@ package final class NetworkDetailViewController: UIViewController {
         let view = NetworkHeadersTextView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isHidden = true
-        view.requestPreviewAction = { [weak self] in
-            self?.activateRequestPreviewFromHeaders()
+        view.requestPreviewAction = { [weak self] subject, request in
+            self?.activateRequestPreviewFromHeaders(
+                subject: subject,
+                request: request
+            )
         }
         return view
     }()
@@ -216,14 +217,10 @@ package final class NetworkDetailViewController: UIViewController {
         modelObservation?.cancel()
         let token = withPortableContinuousObservation { [weak self] _ in
             guard let self else { return }
-            let selection = model.selection
-            let selectedEntry = model.selectedEntry
-            _ = selectedEntry?.requests
-            let selectedRequest = model.selectedRequest
-            bindSelection(
-                selection,
-                entry: selectedEntry,
-                selectedRequest: selectedRequest,
+            let subject = model.detailSubject
+            _ = subject?.renderRequests
+            bindSubject(
+                subject,
                 force: selectedRequestRenderObservation == nil
             )
         }
@@ -235,22 +232,15 @@ package final class NetworkDetailViewController: UIViewController {
 
     private func resumeRendering() {
         guard isRenderingActive == false else {
-            bindSelection(
-                model.selection,
-                entry: model.selectedEntry,
-                selectedRequest: model.selectedRequest,
+            bindSubject(
+                model.detailSubject,
                 force: selectedRequestRenderObservation == nil
             )
             updateBodyRenderingActiveForCurrentSurface()
             return
         }
         isRenderingActive = true
-        bindSelection(
-            model.selection,
-            entry: model.selectedEntry,
-            selectedRequest: model.selectedRequest,
-            force: true
-        )
+        bindSubject(model.detailSubject, force: true)
         startObservingModel()
         updateBodyRenderingActiveForCurrentSurface()
     }
@@ -403,56 +393,33 @@ package final class NetworkDetailViewController: UIViewController {
         renderModeControl()
     }
 
-    private func bindSelection(
-        _ selection: NetworkPanelSelection?,
-        entry: NetworkListEntry?,
-        selectedRequest: NetworkRequest?,
+    private func bindSubject(
+        _ subject: NetworkDetailSubject?,
         force: Bool = false
     ) {
         guard isRenderingActive else {
             return
         }
-
-        let requests: [NetworkRequest]
-        switch selection {
-        case .entry:
-            requests = entry?.requests ?? []
-        case .request:
-            requests = selectedRequest.map { [$0] } ?? []
-        case nil:
-            requests = []
-        }
-        renderRequestPickerItem(entry: entry)
+        renderRequestPickerItem(subject: subject)
 
         guard force
             || hasBoundSelection == false
-            || observedSelection != selection
-            || observedEntry !== entry
-            || requestInstancesMatch(observedRequests, requests) == false else {
-            renderModeControl(selectedRequest: selectedRequest)
+            || subjectsHaveSameIdentity(observedSubject, subject) == false else {
+            renderModeControl(selectedRequest: subject?.activeRequest)
             return
         }
 
-        guard let selection,
-              let entry,
-              let selectedRequest,
-              requests.isEmpty == false else {
+        guard let subject else {
             clearSelectedRequestPresentation(bodySurface: .none)
             return
-        }
-
-        guard selection.entryID == entry.id else {
-            preconditionFailure("A Network detail selection must reference its selected entry.")
         }
 
         hasBoundSelection = true
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
         unbindResponseBodyFetchObservation()
-        observedSelection = selection
-        observedEntry = entry
-        observedRequest = selectedRequest
-        observedRequests = requests
+        observedSubject = subject
+        observedRequest = subject.activeRequest
 #if DEBUG
         selectedRequestRenderObservationDelivery = nil
 #endif
@@ -460,8 +427,8 @@ package final class NetworkDetailViewController: UIViewController {
         if contentUnavailableConfiguration != nil {
             contentUnavailableConfiguration = nil
         }
-        renderModeControl(selectedRequest: selectedRequest)
-        bindSelectedRequestRendering(selection: selection, requests: requests)
+        renderModeControl(selectedRequest: subject.activeRequest)
+        bindSelectedRequestRendering(subject: subject)
     }
 
     private func rebindSelectedRequestRendering() {
@@ -474,30 +441,27 @@ package final class NetworkDetailViewController: UIViewController {
         guard isRenderingActive else {
             return
         }
-        guard let observedSelection,
-              observedRequests.isEmpty == false else {
+        guard let observedSubject else {
             return
         }
-        bindSelectedRequestRendering(selection: observedSelection, requests: observedRequests)
+        bindSelectedRequestRendering(subject: observedSubject)
     }
 
     private func bindSelectedRequestRendering(
-        selection: NetworkPanelSelection,
-        requests: [NetworkRequest]
+        subject: NetworkDetailSubject
     ) {
         guard isRenderingActive else {
             return
         }
         let token = withPortableContinuousObservation { [weak self] _ in
             guard let self,
-                  observedSelection == selection,
-                  requestInstancesMatch(observedRequests, requests) else {
+                  observedSubject?.hasSameIdentity(as: subject) == true else {
                 return
             }
 #if DEBUG
             selectedRequestRenderCountStorageForTesting += 1
 #endif
-            renderSelection(selection, requests: observedRequests)
+            renderSubject(subject)
         }
         selectedRequestRenderObservation = token
 #if DEBUG
@@ -505,72 +469,32 @@ package final class NetworkDetailViewController: UIViewController {
 #endif
     }
 
-    private func renderSelection(
-        _ selection: NetworkPanelSelection,
-        requests: [NetworkRequest]
-    ) {
+    private func renderSubject(_ subject: NetworkDetailSubject) {
         guard isRenderingActive else {
             return
         }
+        let activeRequest = subject.activeRequest
         switch mode {
         case .preview:
-            let activeRequest = activeRequest(for: selection, requests: requests)
-            let activeWebSocket = activeRequest.webSocket
-            if activeWebSocket != nil {
+            if activeRequest.webSocket != nil {
                 renderWebSocketPreviewSurface(request: activeRequest)
                 return
             }
             let candidate: PreviewCandidate
-            switch selection {
+            switch subject.scope {
             case .entry:
-                guard let groupedCandidate = previewCandidate(in: requests) else {
-                    preconditionFailure("A selected Network entry must contain at least one request.")
-                }
-                candidate = groupedCandidate
+                candidate = previewCandidate(in: subject.renderRequests)
+                    ?? .standard(activeRequest)
             case .request:
-                guard requests.count == 1,
-                      let request = requests.first else {
-                    preconditionFailure("An explicit Network request selection must render exactly one request.")
-                }
-                candidate = previewCandidate(for: request) ?? .standard(request)
+                candidate = previewCandidate(for: activeRequest) ?? .standard(activeRequest)
             }
             renderPreviewSurface(candidate: candidate)
         case .headers:
-            switch selection {
-            case .entry:
-                renderHeadersSurface(entryRequests: requests)
-            case .request:
-                guard requests.count == 1,
-                      let request = requests.first else {
-                    preconditionFailure("An explicit Network request selection must render exactly one request.")
-                }
-                renderHeadersSurface(request: request)
-            }
+            renderHeadersSurface(subject: subject)
         case .security:
-            renderSecuritySurface(
-                request: activeRequest(for: selection, requests: requests)
-            )
+            renderSecuritySurface(request: activeRequest)
         case .cookies:
-            renderCookiesSurface(request: activeRequest(for: selection, requests: requests))
-        }
-    }
-
-    private func activeRequest(
-        for selection: NetworkPanelSelection,
-        requests: [NetworkRequest]
-    ) -> NetworkRequest {
-        switch selection {
-        case .entry:
-            guard let representativeRequest = requests.first else {
-                preconditionFailure("A selected Network entry must contain at least one request.")
-            }
-            return representativeRequest
-        case .request:
-            guard requests.count == 1,
-                  let selectedRequest = requests.first else {
-                preconditionFailure("An explicit Network request selection must render exactly one request.")
-            }
-            return selectedRequest
+            renderCookiesSurface(request: activeRequest)
         }
     }
 
@@ -590,24 +514,12 @@ package final class NetworkDetailViewController: UIViewController {
         showWebSocketPreview()
     }
 
-    private func renderHeadersSurface(entryRequests requests: [NetworkRequest]) {
-        guard let representativeRequest = requests.first else {
-            preconditionFailure("A selected Network entry must contain at least one request.")
-        }
-        observedRequest = representativeRequest
-        title = representativeRequest.displayName
-        showHeaders()
-        headersTextView.render(
-            requests: requests,
-            activeRequest: representativeRequest
-        )
-    }
-
-    private func renderHeadersSurface(request: NetworkRequest) {
+    private func renderHeadersSurface(subject: NetworkDetailSubject) {
+        let request = subject.activeRequest
         observedRequest = request
         title = request.displayName
         showHeaders()
-        headersTextView.render(request: request, activeRequest: request)
+        headersTextView.render(subject: subject)
     }
 
     private func renderCookiesSurface(request: NetworkRequest) {
@@ -658,57 +570,31 @@ package final class NetworkDetailViewController: UIViewController {
         rebindSelectedRequestRendering()
     }
 
-    private func activateRequestPreviewFromHeaders() {
+    private func activateRequestPreviewFromHeaders(
+        subject: NetworkDetailSubject,
+        request activeRequest: NetworkRequest
+    ) {
         guard mode == .headers,
               isRenderingActive,
-              let selection = model.selection,
-              let entry = model.selectedEntry,
-              let selectedRequest = model.selectedRequest else {
+              observedSubject?.hasSameIdentity(as: subject) == true else {
             return
         }
-        let currentRequests: [NetworkRequest] = switch selection {
-        case .entry:
-            entry.requests
-        case .request:
-            [selectedRequest]
-        }
-        let activeRequest = activeRequest(for: selection, requests: currentRequests)
         guard activeRequest.webSocket == nil,
               let requestData = activeRequest.headersContext.requestData,
               case .body = requestData else {
             return
         }
 
-        previewRole = .request
-        let explicitRequest = promoteHeadersActiveRequestToExplicitSelection(
+        guard let explicitSubject = model.selectRequest(
             activeRequest,
-            expectedEntryID: entry.id
-        )
-
-        mode = .preview
-        bindSelection(
-            model.selection,
-            entry: model.selectedEntry,
-            selectedRequest: explicitRequest,
-            force: true
-        )
-    }
-
-    private func promoteHeadersActiveRequestToExplicitSelection(
-        _ request: NetworkRequest,
-        expectedEntryID: NetworkListEntry.ID
-    ) -> NetworkRequest {
-        model.selectRequest(request)
-        guard case let .request(entryID, requestID) = model.selection,
-              entryID == expectedEntryID,
-              requestID == request.id,
-              let selectedRequest = model.selectedRequest,
-              selectedRequest === request else {
-            preconditionFailure(
-                "A current Network headers request must become the exact explicit selection."
-            )
+            ifSubjectUnchanged: subject
+        ) else {
+            return
         }
-        return selectedRequest
+
+        previewRole = .request
+        mode = .preview
+        bindSubject(explicitSubject, force: true)
     }
 
     private func renderModeControl(selectedRequest request: NetworkRequest? = nil) {
@@ -721,45 +607,50 @@ package final class NetworkDetailViewController: UIViewController {
         selectedRequestRenderObservation?.cancel()
         selectedRequestRenderObservation = nil
         unbindResponseBodyFetchObservation()
-        observedSelection = nil
-        observedEntry = nil
+        observedSubject = nil
         observedRequest = nil
-        observedRequests = []
 #if DEBUG
         selectedRequestRenderObservationDelivery = nil
 #endif
         title = nil
-        renderRequestPickerItem(entry: nil)
+        renderRequestPickerItem(subject: nil)
         showEmptySelection(bodySurface: bodySurface)
         renderModeControl(selectedRequest: nil)
     }
 
-    private func requestInstancesMatch(
-        _ lhs: [NetworkRequest],
-        _ rhs: [NetworkRequest]
+    private func subjectsHaveSameIdentity(
+        _ lhs: NetworkDetailSubject?,
+        _ rhs: NetworkDetailSubject?
     ) -> Bool {
-        lhs.count == rhs.count && zip(lhs, rhs).allSatisfy { $0 === $1 }
+        switch (lhs, rhs) {
+        case let (.some(lhs), .some(rhs)):
+            lhs.hasSameIdentity(as: rhs)
+        case (.none, .none):
+            true
+        case (.some, .none), (.none, .some):
+            false
+        }
     }
 
-    private func renderRequestPickerItem(entry: NetworkListEntry?) {
-        guard let entry,
-              entry.requests.count > 1 else {
+    private func renderRequestPickerItem(subject: NetworkDetailSubject?) {
+        guard let subject,
+              subject.entryRequests.count > 1 else {
             navigationItem.rightBarButtonItem = nil
             dismissRequestPicker(animated: false)
             return
         }
         navigationItem.rightBarButtonItem = requestPickerItem
-        requestPickerItem.accessibilityValue = String(entry.requests.count)
+        requestPickerItem.accessibilityValue = String(subject.entryRequests.count)
     }
 
     @objc private func presentRequestPicker() {
         guard presentedRequestPicker == nil,
-              let entry = model.selectedEntry,
-              entry.requests.count > 1 else {
+              let subject = model.detailSubject,
+              subject.entryRequests.count > 1 else {
             return
         }
 
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entry.id)
+        let picker = NetworkDetailRequestPickerViewController(model: model, subject: subject)
         let navigationController = UINavigationController(rootViewController: picker)
         navigationController.modalPresentationStyle = .popover
         navigationController.preferredContentSize = picker.preferredContentSize
@@ -968,16 +859,22 @@ package final class NetworkDetailViewController: UIViewController {
         responseBodyFetchObservationBinding.cancel()
     }
 
-    private func fetchResponseBodyIfNeededForVisibleResponse(_ request: NetworkRequest) {
+    func fetchResponseBodyIfNeededForVisibleResponse(_ request: NetworkRequest) {
         guard isRenderingActive,
               mode == .preview,
+              let currentSubject = model.detailSubject,
+              observedSubject?.hasSameIdentity(as: currentSubject) == true,
+              currentSubject.activeRequest === request,
               observedRequest === request,
               selectedPreviewRole(from: availablePreviewRoles(in: request)) == .response,
               (previewCandidate(for: request)?.allowsResponseBodySurface ?? true),
               request.canFetchResponseBody else {
             return
         }
-        model.fetchResponseBodyIfNeeded(for: request)
+        model.fetchResponseBodyIfNeeded(
+            for: request,
+            ifSubjectUnchanged: currentSubject
+        )
     }
 
     private func body(in request: NetworkRequest, for role: NetworkBody.Role) -> NetworkBody? {
@@ -1341,6 +1238,7 @@ extension NetworkDetailViewController {
     var responseBodyFetchObservationDeliveryForTesting: PortableObservationTracking.Token? {
         responseBodyFetchObservationBinding.observationDelivery
     }
+
 
     var previewRequestIDForTesting: NetworkRequest.ID? {
         observedRequest?.id

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -864,7 +864,6 @@ package final class NetworkDetailViewController: UIViewController {
               mode == .preview,
               let currentSubject = model.detailSubject,
               observedSubject?.hasSameIdentity(as: currentSubject) == true,
-              currentSubject.activeRequest === request,
               observedRequest === request,
               selectedPreviewRole(from: availablePreviewRoles(in: request)) == .response,
               (previewCandidate(for: request)?.allowsResponseBodySurface ?? true),

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextView.swift
@@ -39,9 +39,8 @@ final class NetworkHeadersTextView: UIView {
     }()
     private var sectionRules: [SectionRule] = []
     private var renderedSignature: NetworkHeadersTextDocumentSignature?
-    private var renderedRequests: [NetworkRequest] = []
-    private weak var renderedActiveRequest: NetworkRequest?
-    var requestPreviewAction: (@MainActor () -> Void)?
+    private var renderedSubject: NetworkDetailSubject?
+    var requestPreviewAction: (@MainActor (NetworkDetailSubject, NetworkRequest) -> Void)?
 #if DEBUG
     private var attributedTextAssignmentCount = 0
 #endif
@@ -61,30 +60,21 @@ final class NetworkHeadersTextView: UIView {
         updateSectionRuleRuns()
     }
 
-    func render(request: NetworkRequest, activeRequest: NetworkRequest) {
-        render(requests: [request], activeRequest: activeRequest)
-    }
-
-    func render(requests: [NetworkRequest], activeRequest: NetworkRequest) {
+    func render(subject: NetworkDetailSubject) {
         render(
-            requests: requests,
-            activeRequest: activeRequest,
+            subject: subject,
             forceDocumentAssignment: false
         )
     }
 
     private func render(
-        requests: [NetworkRequest],
-        activeRequest: NetworkRequest,
+        subject: NetworkDetailSubject,
         forceDocumentAssignment: Bool
     ) {
-        precondition(requests.isEmpty == false, "Network headers require at least one request.")
-        precondition(requests.contains { $0 === activeRequest })
-        renderedRequests = requests
-        renderedActiveRequest = activeRequest
+        renderedSubject = subject
         let document = NetworkHeadersTextDocumentBuilder(
-            requests: requests,
-            activeRequest: activeRequest,
+            requests: subject.renderRequests,
+            activeRequest: subject.activeRequest,
             traitCollection: traitCollection
         ).makeDocument()
         if forceDocumentAssignment == false, renderedSignature == document.signature {
@@ -112,8 +102,7 @@ final class NetworkHeadersTextView: UIView {
     }
 
     func clear() {
-        renderedRequests = []
-        renderedActiveRequest = nil
+        renderedSubject = nil
         renderedSignature = nil
         sectionRules = []
         textView.attributedText = NSAttributedString()
@@ -149,15 +138,11 @@ final class NetworkHeadersTextView: UIView {
     }
 
     private func rerenderIfNeeded() {
-        guard renderedRequests.isEmpty == false else {
+        guard let renderedSubject else {
             return
         }
-        guard let renderedActiveRequest else {
-            preconditionFailure("Rendered Network headers must retain an active request.")
-        }
         render(
-            requests: renderedRequests,
-            activeRequest: renderedActiveRequest,
+            subject: renderedSubject,
             forceDocumentAssignment: true
         )
     }
@@ -258,19 +243,34 @@ extension NetworkHeadersTextView: UITextViewDelegate {
         guard case .tag(Self.requestPreviewTagIdentifier) = textItem.content else {
             return defaultAction
         }
+        guard let action = capturedRequestPreviewAction() else {
+            return defaultAction
+        }
         let title = String(
             localized: "network.headers.request_data.view_preview",
             defaultValue: "View Request Preview",
             bundle: WebInspectorUILocalization.bundle
         )
-        return UIAction(title: title) { [weak self] _ in
-            self?.requestPreviewAction?()
+        return UIAction(title: title) { _ in
+            action()
         }
     }
 
     nonisolated func scrollViewDidScroll(_ scrollView: UIScrollView) {
         MainActor.assumeIsolated {
             updateSectionRuleRuns()
+        }
+    }
+}
+
+extension NetworkHeadersTextView {
+    private func capturedRequestPreviewAction() -> (@MainActor () -> Void)? {
+        guard let subject = renderedSubject else {
+            return nil
+        }
+        let request = subject.activeRequest
+        return { [weak self] in
+            self?.requestPreviewAction?(subject, request)
         }
     }
 }
@@ -367,7 +367,11 @@ extension NetworkHeadersTextView {
     }
 
     func activateRequestPreviewForTesting() {
-        requestPreviewAction?()
+        capturedRequestPreviewAction()?()
+    }
+
+    func captureRequestPreviewActionForTesting() -> (@MainActor () -> Void)? {
+        capturedRequestPreviewAction()
     }
 }
 #endif

--- a/Sources/WebInspectorUINetwork/List/NetworkListCell.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListCell.swift
@@ -63,6 +63,10 @@ package final class NetworkListCell: UICollectionViewListCell {
         render(displayName: "", statusSeverity: .neutral, fileTypeLabel: "")
     }
 
+    var boundEntry: NetworkListEntry? {
+        observedEntry
+    }
+
     private func startRequestObservationIfNeeded() {
         guard entryObservation == nil,
               let observedEntry else {

--- a/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 
 @MainActor
 package final class NetworkListViewController: UICollectionViewController, UISearchResultsUpdating {
-    package typealias EntrySelectionAction = @MainActor (NetworkListEntry.ID?) -> Void
+    package typealias EntrySelectionAction = @MainActor (NetworkListEntry?) -> Void
 
     @MainActor
     private final class ListSnapshotBuildCoordinator {
@@ -317,8 +317,8 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             builderFactory: snapshotBuilderFactory
         )
         self.snapshotApplyCompletionScheduler = snapshotApplyCompletionScheduler
-        entrySelectionAction = { [model] entryID in
-            model.selectEntry(entryID)
+        entrySelectionAction = { [model] entry in
+            model.selectEntry(entry)
         }
         super.init(collectionViewLayout: Self.makeListLayout())
         startObservingModel()
@@ -856,7 +856,15 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     override package func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        entrySelectionAction(dataSource.itemIdentifier(for: indexPath))
+        guard let entryID = dataSource.itemIdentifier(for: indexPath),
+              let cell = collectionView.cellForItem(at: indexPath) as? NetworkListCell,
+              let entry = cell.boundEntry,
+              entry.id == entryID else {
+            renderSelectedEntryID(model.selectedEntryID)
+            return
+        }
+        entrySelectionAction(entry)
+        renderSelectedEntryID(model.selectedEntryID)
     }
 }
 

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -605,25 +605,46 @@ package final class NetworkPanelModel {
         context.network.clearRequests()
     }
 
-    package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
+    @discardableResult
+    package func fetchResponseBodyIfNeeded(for request: NetworkRequest) -> Bool {
         guard registrationsByRequestID[request.id]?.request === request,
               request.canFetchResponseBody else {
-            return
+            return false
         }
         Task { @MainActor in
             await request.fetchResponseBody()
         }
+        return true
     }
 
+    @discardableResult
     func fetchResponseBodyIfNeeded(
         for request: NetworkRequest,
         ifSubjectUnchanged expectedSubject: NetworkDetailSubject
-    ) {
-        guard detailSubject?.hasSameIdentity(as: expectedSubject) == true,
-              expectedSubject.activeRequest === request else {
-            return
+    ) -> Bool {
+        guard let currentSubject = detailSubject,
+              currentSubject.hasSameIdentity(as: expectedSubject),
+              isRegistered(request, in: currentSubject) else {
+            return false
         }
-        fetchResponseBodyIfNeeded(for: request)
+        return fetchResponseBodyIfNeeded(for: request)
+    }
+
+    private func isRegistered(
+        _ request: NetworkRequest,
+        in subject: NetworkDetailSubject
+    ) -> Bool {
+        guard let registration = registrationsByRequestID[request.id],
+              registration.request === request,
+              registration.entry === subject.entry else {
+            return false
+        }
+        switch subject.scope {
+        case .entry:
+            return true
+        case .request:
+            return subject.activeRequest === request
+        }
     }
 
     private func startObservingFetchedResultsTransactions() {

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -165,14 +165,114 @@ package struct NetworkPanelListProjection: Equatable, Sendable {
     package let entryIDs: [NetworkListEntry.ID]
 }
 
-package enum NetworkPanelSelection: Equatable, Sendable {
+enum NetworkPanelSelection: Equatable, Sendable {
     case entry(NetworkListEntry.ID)
     case request(entryID: NetworkListEntry.ID, requestID: NetworkRequest.ID)
 
-    package var entryID: NetworkListEntry.ID {
+    var entryID: NetworkListEntry.ID {
         switch self {
         case .entry(let entryID), .request(let entryID, _):
             entryID
+        }
+    }
+}
+
+enum NetworkPanelSelectionIntent {
+    struct ID: Equatable, Hashable, Sendable {
+        fileprivate let rawValue: UInt64
+    }
+}
+
+@MainActor
+struct NetworkDetailSubject {
+    enum Scope: Equatable, Sendable {
+        case entry
+        case request
+    }
+
+    private enum Storage {
+        case entry(NetworkListEntry)
+        case request(entry: NetworkListEntry, request: NetworkRequest)
+    }
+
+    let intentID: NetworkPanelSelectionIntent.ID
+    private let storage: Storage
+
+    fileprivate init(
+        entry: NetworkListEntry,
+        intentID: NetworkPanelSelectionIntent.ID
+    ) {
+        storage = .entry(entry)
+        self.intentID = intentID
+    }
+
+    fileprivate init(
+        entry: NetworkListEntry,
+        request: NetworkRequest,
+        intentID: NetworkPanelSelectionIntent.ID
+    ) {
+        storage = .request(entry: entry, request: request)
+        self.intentID = intentID
+    }
+
+    var scope: Scope {
+        switch storage {
+        case .entry:
+            .entry
+        case .request:
+            .request
+        }
+    }
+
+    var entry: NetworkListEntry {
+        switch storage {
+        case .entry(let entry), .request(let entry, _):
+            entry
+        }
+    }
+
+    var activeRequest: NetworkRequest {
+        switch storage {
+        case .entry(let entry):
+            entry.representativeRequest
+        case .request(_, let request):
+            request
+        }
+    }
+
+    var renderRequests: [NetworkRequest] {
+        switch storage {
+        case .entry(let entry):
+            entry.requests
+        case .request(_, let request):
+            [request]
+        }
+    }
+
+    var entryRequests: [NetworkRequest] {
+        entry.requests
+    }
+
+    var selection: NetworkPanelSelection {
+        switch storage {
+        case .entry(let entry):
+            .entry(entry.id)
+        case .request(let entry, let request):
+            .request(entryID: entry.id, requestID: request.id)
+        }
+    }
+
+    func hasSameIdentity(as other: Self) -> Bool {
+        guard intentID == other.intentID else {
+            return false
+        }
+        switch (storage, other.storage) {
+        case let (.entry(lhsEntry), .entry(rhsEntry)):
+            return lhsEntry === rhsEntry
+        case let (.request(lhsEntry, lhsRequest), .request(rhsEntry, rhsRequest)):
+            return lhsEntry === rhsEntry && lhsRequest === rhsRequest
+        case (.entry, .request), (.request, .entry):
+            return false
         }
     }
 }
@@ -249,27 +349,32 @@ package final class NetworkPanelModel {
         var lifecycleRevision: UInt64
     }
 
+    private struct RequestRegistration {
+        var request: NetworkRequest
+        var entry: NetworkListEntry
+        var statusSeverity: NetworkDisplay.StatusSeverity
+        var creation: RequestCreationMetadata
+    }
+
     package let context: WebInspectorContext
     package let requests: WebInspectorFetchedResults<NetworkRequest>
     private let fetchedResultsController: WebInspectorFetchedResultsController<NetworkRequest>
     private let collectionState: NetworkRequestStore
 
-    package private(set) var selection: NetworkPanelSelection?
+    private(set) var detailSubject: NetworkDetailSubject?
     package private(set) var searchText = ""
     package private(set) var activeResourceFilters: Set<NetworkDisplay.ResourceFilter> = []
 
     @ObservationIgnored private let listInvalidationRelay = NetworkPanelListInvalidationRelay()
     @ObservationIgnored private var fetchedResultsTransactionTask: Task<Void, Never>?
     @ObservationIgnored private var entriesByID: [NetworkListEntry.ID: NetworkListEntry] = [:]
-    @ObservationIgnored private var entryIDByRequestID: [NetworkRequest.ID: NetworkListEntry.ID] = [:]
-    @ObservationIgnored private var requestsByID: [NetworkRequest.ID: NetworkRequest] = [:]
-    @ObservationIgnored private var requestStatusSeverityByID: [NetworkRequest.ID: NetworkDisplay.StatusSeverity] = [:]
-    @ObservationIgnored private var requestCreationMetadataByID: [NetworkRequest.ID: RequestCreationMetadata] = [:]
+    @ObservationIgnored private var registrationsByRequestID: [NetworkRequest.ID: RequestRegistration] = [:]
     @ObservationIgnored private var orderedEntryIDs: [NetworkListEntry.ID] = []
     @ObservationIgnored private var visibleEntryIDs: [NetworkListEntry.ID] = []
     @ObservationIgnored private var visibleEntryIDSet: Set<NetworkListEntry.ID> = []
     @ObservationIgnored private var nextListTransactionRevision: UInt64 = 0
     @ObservationIgnored private var listEntryIdentityGeneration: UInt64 = 0
+    @ObservationIgnored private var nextSelectionIntentID: UInt64 = 0
 #if DEBUG
     private struct RawTransactionDeliveryWaiter {
         var id: Int
@@ -353,39 +458,28 @@ package final class NetworkPanelModel {
         NetworkDisplay.ResourceFilter.normalizedSelection(activeResourceFilters)
     }
 
-    package var selectedEntry: NetworkListEntry? {
-        guard let selectedEntryID else {
-            return nil
-        }
-        return entriesByID[selectedEntryID]
+    var selection: NetworkPanelSelection? {
+        detailSubject?.selection
     }
 
-    package var selectedRequest: NetworkRequest? {
-        guard let selection else {
-            return nil
-        }
-        switch selection {
-        case .entry:
-            return selectedEntry?.representativeRequest
-        case let .request(entryID, requestID):
-            guard entryIDByRequestID[requestID] == entryID,
-                  let request = requestsByID[requestID] else {
-                preconditionFailure("A selected Network request must belong to its selected entry.")
-            }
-            return request
-        }
+    var selectedEntry: NetworkListEntry? {
+        detailSubject?.entry
     }
 
-    package var selectedEntryRequests: [NetworkRequest] {
-        selectedEntry?.requests ?? []
+    var selectedRequest: NetworkRequest? {
+        detailSubject?.activeRequest
     }
 
-    package var selectedEntryID: NetworkListEntry.ID? {
-        selection?.entryID
+    var selectedEntryRequests: [NetworkRequest] {
+        detailSubject?.entryRequests ?? []
     }
 
-    package var selectedRequestID: NetworkRequest.ID? {
-        selectedRequest?.id
+    var selectedEntryID: NetworkListEntry.ID? {
+        detailSubject?.entry.id
+    }
+
+    var selectedRequestID: NetworkRequest.ID? {
+        detailSubject?.activeRequest.id
     }
 
     package func entry(for id: NetworkListEntry.ID) -> NetworkListEntry? {
@@ -393,44 +487,86 @@ package final class NetworkPanelModel {
     }
 
     package func entryID(containing requestID: NetworkRequest.ID) -> NetworkListEntry.ID? {
-        entryIDByRequestID[requestID]
+        registrationsByRequestID[requestID]?.entry.id
     }
 
     package func request(for id: NetworkRequest.ID) -> NetworkRequest? {
-        requestsByID[id] ?? context.registeredRequest(for: id)
+        registrationsByRequestID[id]?.request
     }
 
-    package func selectEntry(_ id: NetworkListEntry.ID?) {
-        guard let id else {
-            selection = nil
+    func selectEntry(_ entry: NetworkListEntry?) {
+        guard let entry else {
+            detailSubject = nil
             return
         }
-        guard entriesByID[id] != nil else {
-            selection = nil
+        guard entriesByID[entry.id] === entry else {
             return
         }
-        selection = .entry(id)
+        detailSubject = NetworkDetailSubject(
+            entry: entry,
+            intentID: takeSelectionIntentID()
+        )
     }
 
-    package func selectRequest(_ request: NetworkRequest?) {
-        selectRequest(id: request?.id)
-    }
-
-    package func selectRequest(id requestID: NetworkRequest.ID?) {
-        guard let requestID,
-              requestsByID[requestID] != nil,
-              let entryID = entryIDByRequestID[requestID] else {
-            selection = nil
+    func selectRequest(_ request: NetworkRequest?) {
+        guard let request else {
+            detailSubject = nil
             return
         }
-        selection = .request(entryID: entryID, requestID: requestID)
-    }
-
-    package func clearSelection(ifUnchanged expectedSelection: NetworkPanelSelection) {
-        guard selection == expectedSelection else {
+        guard let registration = registrationsByRequestID[request.id],
+              registration.request === request else {
             return
         }
-        selection = nil
+        detailSubject = NetworkDetailSubject(
+            entry: registration.entry,
+            request: request,
+            intentID: takeSelectionIntentID()
+        )
+    }
+
+    func selectRequest(
+        _ request: NetworkRequest,
+        ifSubjectUnchanged expectedSubject: NetworkDetailSubject
+    ) -> NetworkDetailSubject? {
+        guard detailSubject?.hasSameIdentity(as: expectedSubject) == true,
+              let registration = registrationsByRequestID[request.id],
+              registration.request === request,
+              registration.entry === expectedSubject.entry else {
+            return nil
+        }
+        let subject = NetworkDetailSubject(
+            entry: registration.entry,
+            request: request,
+            intentID: takeSelectionIntentID()
+        )
+        detailSubject = subject
+        return subject
+    }
+
+    func selectEntry(
+        _ entry: NetworkListEntry,
+        ifSubjectUnchanged expectedSubject: NetworkDetailSubject
+    ) -> NetworkDetailSubject? {
+        guard detailSubject?.hasSameIdentity(as: expectedSubject) == true,
+              expectedSubject.entry === entry,
+              entriesByID[entry.id] === entry else {
+            return nil
+        }
+        let subject = NetworkDetailSubject(
+            entry: entry,
+            intentID: takeSelectionIntentID()
+        )
+        detailSubject = subject
+        return subject
+    }
+
+    func clearSelection(
+        ifIntentUnchanged expectedIntentID: NetworkPanelSelectionIntent.ID
+    ) {
+        guard detailSubject?.intentID == expectedIntentID else {
+            return
+        }
+        detailSubject = nil
     }
 
     package func setSearchText(_ text: String) {
@@ -465,17 +601,29 @@ package final class NetworkPanelModel {
     }
 
     package func clearRequests() {
-        selection = nil
+        detailSubject = nil
         context.network.clearRequests()
     }
 
     package func fetchResponseBodyIfNeeded(for request: NetworkRequest) {
-        guard request.canFetchResponseBody else {
+        guard registrationsByRequestID[request.id]?.request === request,
+              request.canFetchResponseBody else {
             return
         }
         Task { @MainActor in
             await request.fetchResponseBody()
         }
+    }
+
+    func fetchResponseBodyIfNeeded(
+        for request: NetworkRequest,
+        ifSubjectUnchanged expectedSubject: NetworkDetailSubject
+    ) {
+        guard detailSubject?.hasSameIdentity(as: expectedSubject) == true,
+              expectedSubject.activeRequest === request else {
+            return
+        }
+        fetchResponseBodyIfNeeded(for: request)
     }
 
     private func startObservingFetchedResultsTransactions() {
@@ -495,10 +643,10 @@ package final class NetworkPanelModel {
         rawTransactionDeliveryCountStorageForTesting &+= 1
         resolveRawTransactionDeliveryWaitersForTesting(result: true)
 #endif
-        let selectionBeforeTransaction = selection
+        let subjectBeforeTransaction = detailSubject
         if transaction.isReset {
             rebuildEntries(from: requests.items)
-            reconcileSelection(selectionBeforeTransaction, forceRebind: true)
+            reconcileSubjectAfterReset(subjectBeforeTransaction)
             publishListTransaction(
                 topologyChangedEntryIDs: Set(visibleEntryIDs),
                 rebindsStableEntries: true
@@ -525,7 +673,8 @@ package final class NetworkPanelModel {
             case let .insert(requestID, _),
                  let .move(requestID, _, _),
                  let .update(requestID, _):
-                guard let request = context.registeredRequest(for: requestID) else {
+                guard let request = registrationsByRequestID[requestID]?.request
+                    ?? context.registeredRequest(for: requestID) else {
                     continue
                 }
                 upsertRequest(
@@ -545,7 +694,7 @@ package final class NetworkPanelModel {
             )
         }
 
-        reconcileSelection(selectionBeforeTransaction)
+        reconcileSubjectAfterIncrementalChange(subjectBeforeTransaction)
 
         publishListTransaction(
             topologyChangedEntryIDs: topologyChangedEntryIDs,
@@ -558,10 +707,7 @@ package final class NetworkPanelModel {
         fullEntryRebuildCountStorageForTesting &+= 1
 #endif
         entriesByID.removeAll(keepingCapacity: true)
-        entryIDByRequestID.removeAll(keepingCapacity: true)
-        requestsByID.removeAll(keepingCapacity: true)
-        requestStatusSeverityByID.removeAll(keepingCapacity: true)
-        requestCreationMetadataByID.removeAll(keepingCapacity: true)
+        registrationsByRequestID.removeAll(keepingCapacity: true)
         orderedEntryIDs.removeAll(keepingCapacity: true)
         visibleEntryIDs.removeAll(keepingCapacity: true)
         visibleEntryIDSet.removeAll(keepingCapacity: true)
@@ -590,23 +736,33 @@ package final class NetworkPanelModel {
     }
 
     private func insertRequestWithoutPublishing(_ request: NetworkRequest) {
-        requestCreationMetadataByID[request.id] = RequestCreationMetadata(
+        let creation = RequestCreationMetadata(
             timestamp: request.logicalStartTimestamp,
             sequence: request.chronologySequence,
             lifecycleRevision: request.lifecycleRevision
         )
-        requestsByID[request.id] = request
-        requestStatusSeverityByID[request.id] = request.statusSeverity
         let entryID = listEntryID(for: request)
-        entryIDByRequestID[request.id] = entryID
         if let entry = entriesByID[entryID] {
+            registrationsByRequestID[request.id] = RequestRegistration(
+                request: request,
+                entry: entry,
+                statusSeverity: request.statusSeverity,
+                creation: creation
+            )
             entry.appendRequest(request)
         } else {
-            entriesByID[entryID] = NetworkListEntry(
+            let entry = NetworkListEntry(
                 id: entryID,
                 request: request,
                 chronologyTimestamp: request.logicalStartTimestamp,
                 chronologySequence: request.chronologySequence
+            )
+            entriesByID[entryID] = entry
+            registrationsByRequestID[request.id] = RequestRegistration(
+                request: request,
+                entry: entry,
+                statusSeverity: request.statusSeverity,
+                creation: creation
             )
             orderedEntryIDs.append(entryID)
         }
@@ -617,84 +773,102 @@ package final class NetworkPanelModel {
         affectedEntryIDs: inout Set<NetworkListEntry.ID>,
         topologyChangedEntryIDs: inout Set<NetworkListEntry.ID>
     ) {
-        let previousRequest = requestsByID[request.id]
-        let previousStatusSeverity = requestStatusSeverityByID[request.id]
-        let lifecycleRestarted: Bool
-        let chronologyChanged: Bool
-        if var metadata = requestCreationMetadataByID[request.id] {
-            lifecycleRestarted = metadata.lifecycleRevision != request.lifecycleRevision
-            chronologyChanged = metadata.timestamp != request.logicalStartTimestamp
-                || metadata.sequence != request.chronologySequence
-            if lifecycleRestarted || chronologyChanged {
-                metadata = RequestCreationMetadata(
-                    timestamp: request.logicalStartTimestamp,
-                    sequence: request.chronologySequence,
-                    lifecycleRevision: request.lifecycleRevision
-                )
-                requestCreationMetadataByID[request.id] = metadata
-            }
-        } else {
-            lifecycleRestarted = false
-            chronologyChanged = false
-            requestCreationMetadataByID[request.id] = RequestCreationMetadata(
-                timestamp: request.logicalStartTimestamp,
-                sequence: request.chronologySequence,
-                lifecycleRevision: request.lifecycleRevision
-            )
-        }
-        requestsByID[request.id] = request
-        requestStatusSeverityByID[request.id] = request.statusSeverity
+        let creation = RequestCreationMetadata(
+            timestamp: request.logicalStartTimestamp,
+            sequence: request.chronologySequence,
+            lifecycleRevision: request.lifecycleRevision
+        )
         let nextEntryID = listEntryID(for: request)
-        if let currentEntryID = entryIDByRequestID[request.id],
-           currentEntryID == nextEntryID {
-            guard let previousRequest,
-                  let previousStatusSeverity,
-                  let entry = entriesByID[currentEntryID] else {
-                preconditionFailure("A registered Network request must belong to a registered entry.")
+        guard var registration = registrationsByRequestID[request.id] else {
+            if let entry = entriesByID[nextEntryID] {
+                registrationsByRequestID[request.id] = RequestRegistration(
+                    request: request,
+                    entry: entry,
+                    statusSeverity: request.statusSeverity,
+                    creation: creation
+                )
+                insertRequest(request, into: entry)
+                refreshEntryChronologyAndOrdering(
+                    entry,
+                    topologyChangedEntryIDs: &topologyChangedEntryIDs
+                )
+                if hasActiveDisplayCriteria {
+                    affectedEntryIDs.insert(nextEntryID)
+                }
+            } else {
+                let entry = NetworkListEntry(
+                    id: nextEntryID,
+                    request: request,
+                    chronologyTimestamp: creation.timestamp,
+                    chronologySequence: creation.sequence
+                )
+                registrationsByRequestID[request.id] = RequestRegistration(
+                    request: request,
+                    entry: entry,
+                    statusSeverity: request.statusSeverity,
+                    creation: creation
+                )
+                entriesByID[nextEntryID] = entry
+                insertOrderedEntryID(nextEntryID)
+                topologyChangedEntryIDs.insert(nextEntryID)
+                affectedEntryIDs.insert(nextEntryID)
             }
-            entry.updateStatusSeverity(
+            return
+        }
+
+        let previousRequest = registration.request
+        let previousEntry = registration.entry
+        let previousStatusSeverity = registration.statusSeverity
+        let lifecycleRestarted = registration.creation.lifecycleRevision != creation.lifecycleRevision
+        let chronologyChanged = registration.creation.timestamp != creation.timestamp
+            || registration.creation.sequence != creation.sequence
+
+        if previousEntry.id == nextEntryID {
+            registration.request = request
+            registration.statusSeverity = request.statusSeverity
+            registration.creation = creation
+            registrationsByRequestID[request.id] = registration
+            previousEntry.updateStatusSeverity(
                 from: previousStatusSeverity,
                 to: request.statusSeverity
             )
             if previousRequest !== request || lifecycleRestarted || chronologyChanged {
 #if DEBUG
-                memberTraversalCountStorageForTesting += entry.requests.count
+                memberTraversalCountStorageForTesting += previousEntry.requests.count
 #endif
-                guard let index = entry.requests.firstIndex(where: { $0.id == request.id }) else {
+                guard let index = previousEntry.requests.firstIndex(where: { $0.id == request.id }) else {
                     preconditionFailure("A registered Network request must be present in its entry.")
                 }
                 if previousRequest !== request {
-                    entry.replaceRequest(at: index, with: request)
+                    previousEntry.replaceRequest(at: index, with: request)
                 }
                 if lifecycleRestarted || chronologyChanged {
-                    repositionRequest(at: index, in: entry)
+                    repositionRequest(at: index, in: previousEntry)
                     refreshEntryChronologyAndOrdering(
-                        entry,
+                        previousEntry,
                         topologyChangedEntryIDs: &topologyChangedEntryIDs
                     )
                 }
             }
             if hasActiveDisplayCriteria {
-                affectedEntryIDs.insert(currentEntryID)
+                affectedEntryIDs.insert(previousEntry.id)
             }
             return
         }
 
-        if let currentEntryID = entryIDByRequestID[request.id] {
-            guard let previousStatusSeverity else {
-                preconditionFailure("A registered Network request must have cached status severity.")
-            }
-            removeRequestFromEntry(
-                request.id,
-                entryID: currentEntryID,
-                statusSeverity: previousStatusSeverity,
-                affectedEntryIDs: &affectedEntryIDs,
-                topologyChangedEntryIDs: &topologyChangedEntryIDs
-            )
-        }
-
-        entryIDByRequestID[request.id] = nextEntryID
+        removeRequestFromEntry(
+            request.id,
+            entry: previousEntry,
+            statusSeverity: previousStatusSeverity,
+            affectedEntryIDs: &affectedEntryIDs,
+            topologyChangedEntryIDs: &topologyChangedEntryIDs
+        )
         if let entry = entriesByID[nextEntryID] {
+            registration.request = request
+            registration.entry = entry
+            registration.statusSeverity = request.statusSeverity
+            registration.creation = creation
+            registrationsByRequestID[request.id] = registration
             insertRequest(request, into: entry)
             refreshEntryChronologyAndOrdering(
                 entry,
@@ -704,15 +878,17 @@ package final class NetworkPanelModel {
                 affectedEntryIDs.insert(nextEntryID)
             }
         } else {
-            guard let metadata = requestCreationMetadataByID[request.id] else {
-                preconditionFailure("A Network request must have creation metadata before entry insertion.")
-            }
             let entry = NetworkListEntry(
                 id: nextEntryID,
                 request: request,
-                chronologyTimestamp: metadata.timestamp,
-                chronologySequence: metadata.sequence
+                chronologyTimestamp: creation.timestamp,
+                chronologySequence: creation.sequence
             )
+            registration.request = request
+            registration.entry = entry
+            registration.statusSeverity = request.statusSeverity
+            registration.creation = creation
+            registrationsByRequestID[request.id] = registration
             entriesByID[nextEntryID] = entry
             insertOrderedEntryID(nextEntryID)
             topologyChangedEntryIDs.insert(nextEntryID)
@@ -726,18 +902,13 @@ package final class NetworkPanelModel {
         affectedEntryIDs: inout Set<NetworkListEntry.ID>,
         topologyChangedEntryIDs: inout Set<NetworkListEntry.ID>
     ) {
-        guard let entryID = entryIDByRequestID.removeValue(forKey: requestID) else {
+        guard let registration = registrationsByRequestID.removeValue(forKey: requestID) else {
             return
         }
-        requestsByID.removeValue(forKey: requestID)
-        guard let statusSeverity = requestStatusSeverityByID.removeValue(forKey: requestID) else {
-            preconditionFailure("A registered Network request must have cached status severity.")
-        }
-        requestCreationMetadataByID.removeValue(forKey: requestID)
         removeRequestFromEntry(
             requestID,
-            entryID: entryID,
-            statusSeverity: statusSeverity,
+            entry: registration.entry,
+            statusSeverity: registration.statusSeverity,
             affectedEntryIDs: &affectedEntryIDs,
             topologyChangedEntryIDs: &topologyChangedEntryIDs
         )
@@ -746,21 +917,21 @@ package final class NetworkPanelModel {
 
     private func removeRequestFromEntry(
         _ requestID: NetworkRequest.ID,
-        entryID: NetworkListEntry.ID,
+        entry: NetworkListEntry,
         statusSeverity: NetworkDisplay.StatusSeverity,
         affectedEntryIDs: inout Set<NetworkListEntry.ID>,
         topologyChangedEntryIDs: inout Set<NetworkListEntry.ID>
     ) {
-        guard let entry = entriesByID[entryID] else {
+        guard entriesByID[entry.id] === entry else {
             preconditionFailure("A Network request referenced an unregistered entry.")
         }
         let remainingRequests = entry.requests.filter { $0.id != requestID }
         if remainingRequests.isEmpty {
-            entriesByID.removeValue(forKey: entryID)
-            orderedEntryIDs.removeAll { $0 == entryID }
-            if visibleEntryIDSet.remove(entryID) != nil {
-                visibleEntryIDs.removeAll { $0 == entryID }
-                topologyChangedEntryIDs.insert(entryID)
+            entriesByID.removeValue(forKey: entry.id)
+            orderedEntryIDs.removeAll { $0 == entry.id }
+            if visibleEntryIDSet.remove(entry.id) != nil {
+                visibleEntryIDs.removeAll { $0 == entry.id }
+                topologyChangedEntryIDs.insert(entry.id)
             }
         } else {
 #if DEBUG
@@ -773,33 +944,89 @@ package final class NetworkPanelModel {
                 topologyChangedEntryIDs: &topologyChangedEntryIDs
             )
             if hasActiveDisplayCriteria {
-                affectedEntryIDs.insert(entryID)
+                affectedEntryIDs.insert(entry.id)
             }
         }
     }
 
-    private func reconcileSelection(
-        _ previousSelection: NetworkPanelSelection?,
-        forceRebind: Bool = false
+    private func reconcileSubjectAfterIncrementalChange(
+        _ previousSubject: NetworkDetailSubject?
     ) {
-        let reconciledSelection: NetworkPanelSelection?
-        switch previousSelection {
-        case .entry(let entryID):
-            reconciledSelection = entriesByID[entryID] == nil ? nil : previousSelection
-        case .request(_, let requestID):
-            guard requestsByID[requestID] != nil,
-                  let entryID = entryIDByRequestID[requestID] else {
-                reconciledSelection = nil
-                break
-            }
-            reconciledSelection = .request(entryID: entryID, requestID: requestID)
-        case nil:
-            reconciledSelection = nil
-        }
-        guard forceRebind || selection != reconciledSelection else {
+        guard detailSubject?.intentID == previousSubject?.intentID else {
             return
         }
-        selection = reconciledSelection
+        guard let previousSubject else {
+            return
+        }
+        let subject: NetworkDetailSubject
+        switch previousSubject.scope {
+        case .entry:
+            guard entriesByID[previousSubject.entry.id] === previousSubject.entry else {
+                detailSubject = nil
+                return
+            }
+            subject = NetworkDetailSubject(
+                entry: previousSubject.entry,
+                intentID: previousSubject.intentID
+            )
+        case .request:
+            guard let registration = registrationsByRequestID[previousSubject.activeRequest.id] else {
+                detailSubject = nil
+                return
+            }
+            subject = NetworkDetailSubject(
+                entry: registration.entry,
+                request: registration.request,
+                intentID: previousSubject.intentID
+            )
+        }
+        if previousSubject.hasSameIdentity(as: subject) == false {
+            detailSubject = subject
+        }
+    }
+
+    private func reconcileSubjectAfterReset(
+        _ previousSubject: NetworkDetailSubject?
+    ) {
+        guard detailSubject?.intentID == previousSubject?.intentID else {
+            return
+        }
+        guard let previousSubject else {
+            detailSubject = nil
+            return
+        }
+        switch previousSubject.scope {
+        case .entry:
+            guard let entry = entriesByID[previousSubject.entry.id] else {
+                detailSubject = nil
+                return
+            }
+            let previousRequestIdentities = Set(
+                previousSubject.entryRequests.map(ObjectIdentifier.init)
+            )
+            guard entry.requests.contains(where: {
+                previousRequestIdentities.contains(ObjectIdentifier($0))
+            }) else {
+                detailSubject = nil
+                return
+            }
+            detailSubject = NetworkDetailSubject(
+                entry: entry,
+                intentID: previousSubject.intentID
+            )
+        case .request:
+            let previousRequest = previousSubject.activeRequest
+            guard let registration = registrationsByRequestID[previousRequest.id],
+                  registration.request === previousRequest else {
+                detailSubject = nil
+                return
+            }
+            detailSubject = NetworkDetailSubject(
+                entry: registration.entry,
+                request: registration.request,
+                intentID: previousSubject.intentID
+            )
+        }
     }
 
     private func reapplyDisplayCriteria() {
@@ -957,12 +1184,12 @@ package final class NetworkPanelModel {
     private func entryChronology(
         for entry: NetworkListEntry
     ) -> (timestamp: Double?, sequence: UInt64) {
-        guard let representativeMetadata = requestCreationMetadataByID[entry.representativeRequest.id] else {
+        guard let representativeMetadata = registrationsByRequestID[entry.representativeRequest.id]?.creation else {
             preconditionFailure("A Network entry representative must have creation metadata.")
         }
         var sequence = representativeMetadata.sequence
         for request in entry.requests.dropFirst() {
-            guard let metadata = requestCreationMetadataByID[request.id] else {
+            guard let metadata = registrationsByRequestID[request.id]?.creation else {
                 preconditionFailure("A Network entry member must have creation metadata.")
             }
             sequence = min(sequence, metadata.sequence)
@@ -974,8 +1201,8 @@ package final class NetworkPanelModel {
 #if DEBUG
         requestOrderComparisonCountStorageForTesting &+= 1
 #endif
-        guard let lhsMetadata = requestCreationMetadataByID[lhs.id],
-              let rhsMetadata = requestCreationMetadataByID[rhs.id] else {
+        guard let lhsMetadata = registrationsByRequestID[lhs.id]?.creation,
+              let rhsMetadata = registrationsByRequestID[rhs.id]?.creation else {
             preconditionFailure("A Network request must have creation metadata before sorting.")
         }
         return chronologyOrdersBefore(
@@ -1071,12 +1298,21 @@ package final class NetworkPanelModel {
 #endif
         listInvalidationRelay.yield(invalidation)
     }
+
+    private func takeSelectionIntentID() -> NetworkPanelSelectionIntent.ID {
+        precondition(
+            nextSelectionIntentID < UInt64.max,
+            "Network panel selection intent identity exhausted."
+        )
+        defer { nextSelectionIntentID += 1 }
+        return NetworkPanelSelectionIntent.ID(rawValue: nextSelectionIntentID)
+    }
 }
 
 #if DEBUG
 extension NetworkPanelModel {
     package func upsertRequestForTesting(_ request: NetworkRequest) {
-        let selectionBeforeTransaction = selection
+        let subjectBeforeTransaction = detailSubject
         var affectedEntryIDs: Set<NetworkListEntry.ID> = []
         var topologyChangedEntryIDs: Set<NetworkListEntry.ID> = []
         upsertRequest(
@@ -1090,7 +1326,7 @@ extension NetworkPanelModel {
                 topologyChangedEntryIDs: &topologyChangedEntryIDs
             )
         }
-        reconcileSelection(selectionBeforeTransaction)
+        reconcileSubjectAfterIncrementalChange(subjectBeforeTransaction)
         publishListTransaction(
             topologyChangedEntryIDs: topologyChangedEntryIDs,
             rebindsStableEntries: false
@@ -1098,9 +1334,9 @@ extension NetworkPanelModel {
     }
 
     package func rebuildEntriesForTesting() {
-        let selectionBeforeRebuild = selection
+        let subjectBeforeRebuild = detailSubject
         rebuildEntries(from: requests.items)
-        reconcileSelection(selectionBeforeRebuild, forceRebind: true)
+        reconcileSubjectAfterReset(subjectBeforeRebuild)
         publishListTransaction(
             topologyChangedEntryIDs: Set(visibleEntryIDs),
             rebindsStableEntries: true

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -5822,6 +5822,45 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func compactContainerKeepsReplacementAfterCancelledPopOvertakesPush() async throws {
+        let context = makeContext()
+        let firstRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "cancel-first",
+                url: "https://example.com/first.js"
+            )
+        )
+        let secondRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "cancel-second",
+                url: "https://example.com/second.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(firstRequest)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
+        navigationController.syncStackForTesting()
+
+        navigationController.cancelDetailPopWhilePushTransitionIsStillTrackedForTesting {
+            model.selectRequest(secondRequest)
+            navigationController.syncStackForTesting()
+        }
+
+        #expect(model.detailSubject?.intentID != originalIntentID)
+        #expect(model.selectedRequest === secondRequest)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
     func compactContainerConvergesToReplacementSelectionAfterUserPop() async throws {
         let context = makeContext()
         let firstRequest = try #require(
@@ -5839,14 +5878,17 @@ struct NetworkDetailViewControllerTests {
             detailViewController: detailViewController
         )
         model.selectRequest(firstRequest)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
         navigationController.syncStackForTesting()
 
-        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+        let poppedViewController = navigationController
+            .popDetailWhilePushTransitionIsStillTrackedForTesting {
+            model.selectRequest(nil)
             model.selectRequest(secondRequest)
-            navigationController.syncStackForTesting()
         }
 
         #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject?.intentID != originalIntentID)
         #expect(model.selectedRequest === secondRequest)
         #expect(navigationController.viewControllers == [listViewController, detailViewController])
     }
@@ -5873,7 +5915,8 @@ struct NetworkDetailViewControllerTests {
         let originalIntentID = try #require(model.detailSubject?.intentID)
         navigationController.syncStackForTesting()
 
-        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+        let poppedViewController = navigationController
+            .popDetailWhilePushTransitionIsStillTrackedForTesting {
             model.selectRequest(request)
             navigationController.syncStackForTesting()
         }
@@ -5908,7 +5951,8 @@ struct NetworkDetailViewControllerTests {
         let originalIntentID = try #require(model.detailSubject?.intentID)
         navigationController.syncStackForTesting()
 
-        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+        let poppedViewController = navigationController
+            .popDetailWhilePushTransitionIsStillTrackedForTesting {
             model.selectEntry(entry)
             navigationController.syncStackForTesting()
         }
@@ -5952,7 +5996,8 @@ struct NetworkDetailViewControllerTests {
         let intentID = try #require(model.detailSubject?.intentID)
         navigationController.syncStackForTesting()
 
-        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+        let poppedViewController = navigationController
+            .popDetailWhilePushTransitionIsStillTrackedForTesting {
             request.applyRequestWillBeSent(
                 request: Network.Request(
                     id: request.proxyID,

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -5797,6 +5797,117 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func compactContainerClearsSelectionAfterUntrackedNonanimatedPop() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "untracked-pop",
+                url: "https://example.com/untracked.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(request)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController
+            .popDetailWithoutTrackedTransitionForTesting()
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject == nil)
+        #expect(navigationController.viewControllers == [listViewController])
+    }
+
+    @Test
+    func compactContainerKeepsReplacementAfterUntrackedNonanimatedPop() async throws {
+        let context = makeContext()
+        let firstRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "untracked-pop-first",
+                url: "https://example.com/first.js"
+            )
+        )
+        let secondRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "untracked-pop-second",
+                url: "https://example.com/second.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(firstRequest)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController
+            .popDetailWithoutTrackedTransitionForTesting {
+            model.selectRequest(secondRequest)
+        }
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject?.intentID != originalIntentID)
+        #expect(model.selectedRequest === secondRequest)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
+    func compactContainerKeepsReplacementAfterCancelledUntrackedNonanimatedPop() async throws {
+        let context = makeContext()
+        let firstRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "untracked-cancel-first",
+                url: "https://example.com/first.js"
+            )
+        )
+        let secondRequest = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "untracked-cancel-second",
+                url: "https://example.com/second.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(firstRequest)
+        navigationController.syncStackForTesting()
+
+        navigationController.cancelDetailPopWithoutTrackedTransitionForTesting {
+            model.selectRequest(secondRequest)
+        }
+
+        #expect(model.selectedRequest === secondRequest)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+
+        let poppedViewController = navigationController
+            .popDetailWithoutTrackedTransitionForTesting()
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject == nil)
+        #expect(navigationController.viewControllers == [listViewController])
+    }
+
+    @Test
     func compactContainerKeepsDetailAfterCancelledUserPop() async throws {
         let context = makeContext()
         let request = try #require(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -4286,6 +4286,78 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func groupedPreviewFetchesTheVisibleNonRepresentativeResponseBody() async throws {
+        let fixture = try await makeLiveNetworkDetailFixture()
+        let frameID = FrameID("grouped-response-fetch-frame")
+        let nodeID = DOM.Node.ID("grouped-response-fetch-node")
+        installNavigationVisit(in: fixture.context, frameID: frameID)
+        let representative = try #require(await applyGroupedRequest(
+            to: fixture.context,
+            requestID: "grouped-response-representative",
+            url: "https://example.test/representative.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            responseHeaders: ["content-type": "application/json"],
+            responseMIMEType: "application/json",
+            resourceType: .xhr,
+            timestamp: 1
+        ))
+        let visibleCandidate = try #require(await applyGroupedRequest(
+            to: fixture.context,
+            requestID: "grouped-response-visible-candidate",
+            url: "https://example.test/visible.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            responseHeaders: ["content-type": "application/json"],
+            responseMIMEType: "application/json",
+            resourceType: .xhr,
+            timestamp: 4
+        ))
+        await fixture.runtime.backend.enqueue(
+            Network.Body(data: #"{"visible":true}"#, base64Encoded: false),
+            for: "Network",
+            method: "getResponseBody"
+        )
+        let model = NetworkPanelModel(context: fixture.context)
+        try selectEntry(containing: visibleCandidate, in: model)
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .preview
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        #expect(model.detailSubject?.activeRequest === representative)
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.previewRequestIDForTesting == visibleCandidate.id
+        })
+        let commands = await fixture.runtime.backend.waitForRecordedCommands(
+            domain: "Network",
+            method: "getResponseBody",
+            count: 1
+        )
+        #expect(commands.count == 1)
+        #expect(
+            await waitForNetworkBodyPhase(in: visibleCandidate.responseBody) {
+                $0 == .loaded
+            } != nil
+        )
+        #expect(visibleCandidate.responseBody.text == #"{"visible":true}"#)
+        #expect(representative.responseBody.phase == .available)
+        #expect(await fixture.runtime.backend.recordedCommands().filter {
+            $0.domain == "Network" && $0.method == "getResponseBody"
+        }.count == 1)
+
+        await fixture.runtime.backend.enqueue((), for: "Console", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Runtime", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Network", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Page", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Inspector", method: "disable")
+        await fixture.context.stop()
+        #expect(fixture.context.state == .detached)
+    }
+
+    @Test
     func supersededResponseObservationCannotFetchThePreviouslySelectedRequest() async throws {
         let fixture = try await makeLiveNetworkDetailFixture()
         let first = try #require(await applyRequest(

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -500,14 +500,19 @@ struct NetworkDetailViewControllerTests {
         })
 
         let entryID = try #require(model.entryID(containing: explicit.id))
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: try #require(model.detailSubject)
+        )
+        let pickerWindow = showInWindow(picker, useUIKitVisibility: true)
+        defer { pickerWindow.isHidden = true }
         picker.resumeRenderingForTesting()
         let explicitIndex = try #require(
             picker.itemIDsForTesting.firstIndex(of: .request(explicit.id))
         )
-        picker.collectionView(
-            picker.collectionView,
-            didSelectItemAt: IndexPath(item: explicitIndex, section: 0)
+        try selectPickerItem(
+            at: IndexPath(item: explicitIndex, section: 0),
+            in: picker
         )
         #expect(await waitUntilRendered(in: viewController) {
             let security = viewController.securityViewControllerForTesting
@@ -4281,6 +4286,73 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func supersededResponseObservationCannotFetchThePreviouslySelectedRequest() async throws {
+        let fixture = try await makeLiveNetworkDetailFixture()
+        let first = try #require(await applyRequest(
+            to: fixture.context,
+            requestID: "stale-fetch-first",
+            url: "https://example.test/first.json",
+            responseHeaders: ["content-type": "application/json"],
+            responseMimeType: "application/json",
+            finishes: false
+        ))
+        let second = try #require(await applyRequest(
+            to: fixture.context,
+            requestID: "stale-fetch-second",
+            url: "https://example.test/second.json",
+            responseHeaders: ["content-type": "application/json"],
+            responseMimeType: "application/json",
+            finishes: false
+        ))
+        let model = NetworkPanelModel(context: fixture.context)
+        model.selectRequest(first)
+        let viewController = makeNetworkDetailViewController(
+            model: model,
+            initialMode: .preview
+        )
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.previewRequestIDForTesting == first.id
+                && viewController.responseBodyFetchObservationDeliveryForTesting != nil
+        })
+        model.selectRequest(second)
+        first.finish(timestamp: 3, sourceMapURL: nil, metrics: nil)
+        viewController.fetchResponseBodyIfNeededForVisibleResponse(first)
+
+        #expect(await fixture.runtime.backend.recordedCommands().filter {
+            $0.domain == "Network" && $0.method == "getResponseBody"
+        }.isEmpty)
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.previewRequestIDForTesting == second.id
+                && viewController.responseBodyFetchObservationDeliveryForTesting != nil
+        })
+        await fixture.runtime.backend.enqueue(
+            Network.Body(data: #"{"current":true}"#, base64Encoded: false),
+            for: "Network",
+            method: "getResponseBody"
+        )
+
+        second.finish(timestamp: 4, sourceMapURL: nil, metrics: nil)
+        viewController.fetchResponseBodyIfNeededForVisibleResponse(second)
+
+        let responseBodyCommands = await fixture.runtime.backend.waitForRecordedCommands(
+            domain: "Network",
+            method: "getResponseBody",
+            count: 1
+        )
+        #expect(responseBodyCommands.count == 1)
+        #expect(await waitForNetworkBodyPhase(in: second.responseBody) { $0 == .loaded } != nil)
+        await fixture.runtime.backend.enqueue((), for: "Console", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Runtime", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Network", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Page", method: "disable")
+        await fixture.runtime.backend.enqueue((), for: "Inspector", method: "disable")
+        await fixture.context.stop()
+        #expect(fixture.context.state == .detached)
+    }
+
+    @Test
     func failedResponseBodyDoesNotRefetchFromRendering() async throws {
         let context = makeContext()
         let request = try #require(
@@ -4907,6 +4979,100 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func staleHeadersPreviewActionCannotPromoteAReplacementSelection() async throws {
+        let context = makeContext()
+        let first = try #require(await applyRequest(
+            to: context,
+            requestID: "headers-stale-action-first",
+            url: "https://example.com/first",
+            requestHeaders: ["Content-Type": "application/json"],
+            postData: #"{"request":"first"}"#,
+            finishes: false
+        ))
+        let second = try #require(await applyRequest(
+            to: context,
+            requestID: "headers-stale-action-second",
+            url: "https://example.com/second",
+            requestHeaders: ["Content-Type": "application/json"],
+            postData: #"{"request":"second"}"#,
+            finishes: false
+        ))
+        let model = NetworkPanelModel(context: context)
+        model.selectRequest(first)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+        })
+        let staleAction = try #require(
+            viewController.headersTextViewForTesting.captureRequestPreviewActionForTesting()
+        )
+
+        model.selectRequest(second)
+        let replacementSubject = try #require(model.detailSubject)
+        staleAction()
+
+        #expect(model.detailSubject?.hasSameIdentity(as: replacementSubject) == true)
+        #expect(model.detailSubject?.activeRequest === second)
+        #expect(viewController.currentModeForTesting == .headers)
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.renderedTextForTesting
+                .contains("https://example.com/second")
+        })
+    }
+
+    @Test
+    func capturedHeadersActionKeepsTheExactRepresentativeShownByItsDocument() async throws {
+        let context = makeContext()
+        let frameID = FrameID("headers-captured-representative-frame")
+        let nodeID = DOM.Node.ID("headers-captured-representative-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let originalRepresentative = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "headers-captured-representative",
+            url: "https://example.com/original-representative",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            requestHeaders: ["Content-Type": "application/json"],
+            postData: #"{"request":"original"}"#,
+            timestamp: 10
+        ))
+        let model = NetworkPanelModel(context: context)
+        try selectEntry(containing: originalRepresentative, in: model)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
+        let viewController = makeNetworkDetailViewController(model: model)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        #expect(await waitUntilRendered(in: viewController) {
+            viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
+        })
+        let capturedAction = try #require(
+            viewController.headersTextViewForTesting.captureRequestPreviewActionForTesting()
+        )
+
+        let transactionBaseline = model.rawTransactionDeliveryCountForTesting
+        let newRepresentative = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "headers-new-representative",
+            url: "https://example.com/new-representative",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 5
+        ))
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: transactionBaseline))
+        #expect(model.detailSubject?.intentID == originalIntentID)
+        #expect(model.detailSubject?.activeRequest === newRepresentative)
+
+        capturedAction()
+
+        #expect(model.detailSubject?.scope == .request)
+        #expect(model.detailSubject?.activeRequest === originalRepresentative)
+        #expect(viewController.currentModeForTesting == .preview)
+        #expect(viewController.currentPreviewRoleForTesting == .request)
+    }
+
+    @Test
     func webSocketRequestDataNeverExposesBodyPreviewAction() async throws {
         let context = makeContext()
         let requestID = Network.Request.ID("headers-websocket-body")
@@ -5437,7 +5603,11 @@ struct NetworkDetailViewControllerTests {
             listViewController: listViewController,
             detailViewController: detailViewController
         )
-        let window = showInWindow(navigationController, makeVisible: true)
+        let window = showInWindow(
+            navigationController,
+            makeVisible: true,
+            useUIKitVisibility: true
+        )
         defer { window.isHidden = true }
 
         model.selectRequest(request)
@@ -5473,8 +5643,9 @@ struct NetworkDetailViewControllerTests {
 
         await listViewController.flushPendingSnapshotUpdateForTesting()
         #expect(listViewController.displayedRequestIDsForTesting.count == 1)
+        let entry = try #require(model.displayEntries.first)
 
-        selectListItem(at: IndexPath(item: 0, section: 0), in: listViewController)
+        model.selectEntry(entry)
         let didPush = await waitUntilNavigationStackSynced(in: navigationController) {
             navigationController.viewControllers.last === detailViewController
         }
@@ -5492,7 +5663,7 @@ struct NetworkDetailViewControllerTests {
         }
         #expect(didReturnToList)
 
-        selectListItem(at: IndexPath(item: 0, section: 0), in: listViewController)
+        model.selectEntry(entry)
         let didPushAgain = await waitUntilNavigationStackSynced(in: navigationController) {
             navigationController.viewControllers.last === detailViewController
         }
@@ -5606,6 +5777,136 @@ struct NetworkDetailViewControllerTests {
         #expect(poppedViewController === detailViewController)
         #expect(model.selectedRequest === secondRequest)
         #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
+    func compactBackDoesNotClearTheSameRequestExplicitlyReselectedDuringThePop() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "compact-reselect",
+                url: "https://example.com/reselect.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(request)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+            model.selectRequest(request)
+            navigationController.syncStackForTesting()
+        }
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject?.intentID != originalIntentID)
+        #expect(model.detailSubject?.activeRequest === request)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
+    func compactBackDoesNotClearTheSameEntryExplicitlyReselectedDuringThePop() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "compact-entry-reselect",
+                url: "https://example.com/entry-reselect.js"
+            )
+        )
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: request.id))
+        let entry = try #require(model.entry(for: entryID))
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectEntry(entry)
+        let originalIntentID = try #require(model.detailSubject?.intentID)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+            model.selectEntry(entry)
+            navigationController.syncStackForTesting()
+        }
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject?.intentID != originalIntentID)
+        #expect(model.detailSubject?.entry === entry)
+        #expect(navigationController.viewControllers == [listViewController, detailViewController])
+    }
+
+    @Test
+    func compactBackClearsAnAutomaticallyRegroupedRequestWithTheCapturedIntent() async throws {
+        let context = makeContext()
+        let request = try #require(
+            await applyRequest(
+                to: context,
+                requestID: "compact-regroup",
+                url: "https://example.com/regroup.js"
+            )
+        )
+        let frameID = FrameID("compact-regroup-frame")
+        let nodeID = DOM.Node.ID("compact-regroup-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let groupedSibling = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "compact-regroup-sibling",
+            url: "https://example.com/sibling.js",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 10
+        ))
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let navigationController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        model.selectRequest(request)
+        let intentID = try #require(model.detailSubject?.intentID)
+        navigationController.syncStackForTesting()
+
+        let poppedViewController = navigationController.popDetailFromUserNavigationForTesting {
+            request.applyRequestWillBeSent(
+                request: Network.Request(
+                    id: request.proxyID,
+                    url: request.url,
+                    method: request.method,
+                    origin: Network.Request.Origin(
+                        frameID: frameID,
+                        loaderID: "loader",
+                        targetID: "page"
+                    )
+                ),
+                initiator: groupedSibling.initiator,
+                navigationVisit: groupedSibling.navigationVisit,
+                resourceType: request.resourceType,
+                timestamp: 20,
+                chronologySequence: 20
+            )
+            model.upsertRequestForTesting(request)
+            #expect(model.detailSubject?.intentID == intentID)
+            #expect(model.detailSubject?.entry.id == model.entryID(containing: request.id))
+            navigationController.syncStackForTesting()
+        }
+
+        #expect(poppedViewController === detailViewController)
+        #expect(model.detailSubject == nil)
+        #expect(navigationController.viewControllers == [listViewController])
     }
 
     @Test
@@ -6127,6 +6428,51 @@ struct NetworkDetailViewControllerTests {
         let rebuiltEntry = try #require(model.entry(for: entryID))
         #expect(rebuiltEntry !== originalEntry)
         #expect(cell.observedEntryForTesting === rebuiltEntry)
+    }
+
+    @Test
+    func staleVisibleListCellCannotSelectARebuiltSameIDEntry() async throws {
+        let context = makeContext()
+        let request = try #require(await applyRequest(
+            to: context,
+            requestID: "stale-list-entry",
+            url: "https://example.test/stale-list-entry.json"
+        ))
+        let model = NetworkPanelModel(context: context)
+        let listViewController = NetworkListViewController(model: model)
+        let window = showInWindow(listViewController, makeVisible: true)
+        defer { window.isHidden = true }
+        await listViewController.flushPendingSnapshotUpdateForTesting()
+        listViewController.collectionViewForTesting.layoutIfNeeded()
+        let indexPath = try #require(
+            listViewController.collectionViewForTesting.indexPathsForVisibleItems.first
+        )
+        let cell = try #require(listViewController.networkListCellForTesting(at: indexPath))
+        let oldEntry = try #require(cell.observedEntryForTesting)
+        let entryID = try #require(model.entryID(containing: request.id))
+
+        model.rebuildEntriesForTesting()
+        let rebuiltEntry = try #require(model.entry(for: entryID))
+        #expect(rebuiltEntry !== oldEntry)
+        #expect(cell.observedEntryForTesting === oldEntry)
+
+        listViewController.collectionViewForTesting.selectItem(
+            at: indexPath,
+            animated: false,
+            scrollPosition: []
+        )
+        #expect(
+            listViewController.collectionViewForTesting.indexPathsForSelectedItems == [indexPath]
+        )
+        listViewController.collectionView(
+            listViewController.collectionViewForTesting,
+            didSelectItemAt: indexPath
+        )
+
+        #expect(model.detailSubject == nil)
+        #expect(
+            (listViewController.collectionViewForTesting.indexPathsForSelectedItems ?? []).isEmpty
+        )
     }
 
     @Test
@@ -7191,8 +7537,11 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(context: context)
         let entryID = try #require(model.entryID(containing: firstRequest.id))
         let entry = try #require(model.entry(for: entryID))
-        model.selectEntry(entryID)
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        model.selectEntry(entry)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: try #require(model.detailSubject)
+        )
         let window = showInWindow(picker, useUIKitVisibility: true)
         defer { window.isHidden = true }
         picker.resumeRenderingForTesting()
@@ -7310,8 +7659,11 @@ struct NetworkDetailViewControllerTests {
         let entryID = try #require(model.entryID(containing: firstRequest.id))
         let entry = try #require(model.entry(for: entryID))
         let originalRequestIDs = entry.requests.map(\.id)
-        model.selectEntry(entryID)
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        model.selectEntry(entry)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: try #require(model.detailSubject)
+        )
         picker.resumeRenderingForTesting()
         let emptyQueryObservation = try #require(picker.modelObservationDeliveryForTesting)
 
@@ -7362,6 +7714,157 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
+    func stalePickerRequestRowCannotSelectARequestThatLeftItsBoundEntry() async throws {
+        let context = makeContext()
+        let frameID = FrameID("picker-stale-frame")
+        let nodeID = DOM.Node.ID("picker-stale-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let first = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-stale-first",
+            url: "https://example.com/first.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        _ = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-stale-second",
+            url: "https://example.com/second.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: first.id))
+        let entry = try #require(model.entry(for: entryID))
+        model.selectEntry(entry)
+        let subject = try #require(model.detailSubject)
+        let picker = NetworkDetailRequestPickerViewController(model: model, subject: subject)
+        let window = showInWindow(picker, useUIKitVisibility: true)
+        defer { window.isHidden = true }
+        picker.resumeRenderingForTesting()
+        let firstIndex = try #require(
+            picker.itemIDsForTesting.firstIndex(of: .request(first.id))
+        )
+        let firstCell = try #require(picker.requestCellForTesting(requestID: first.id))
+        #expect(firstCell.boundRequest === first)
+        picker.suspendRenderingForTesting()
+
+        first.applyRequestWillBeSent(
+            request: Network.Request(
+                id: first.proxyID,
+                url: first.url,
+                method: first.method
+            ),
+            initiator: nil,
+            navigationVisit: nil,
+            resourceType: first.resourceType,
+            timestamp: 20,
+            chronologySequence: 20
+        )
+        model.upsertRequestForTesting(first)
+        let currentSubject = try #require(model.detailSubject)
+        #expect(currentSubject.intentID == subject.intentID)
+        #expect(currentSubject.entry === entry)
+
+        try selectPickerItem(
+            at: IndexPath(item: firstIndex, section: 0),
+            in: picker
+        )
+
+        #expect(model.detailSubject?.hasSameIdentity(as: currentSubject) == true)
+        #expect(model.selection == .entry(entryID))
+        #expect(model.entryID(containing: first.id) != entryID)
+    }
+
+    @Test
+    func pickerCarriesExactQueryResetLineageButRejectsNewGenerationSameIDs() async throws {
+        let context = makeContext()
+        let frameID = FrameID("picker-lineage-frame")
+        let nodeID = DOM.Node.ID("picker-lineage-node")
+        installNavigationVisit(in: context, frameID: frameID)
+        let first = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-lineage-first",
+            url: "https://example.com/first.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 1
+        ))
+        _ = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-lineage-second",
+            url: "https://example.com/second.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 4
+        ))
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: first.id))
+        let entry = try #require(model.entry(for: entryID))
+        model.selectEntry(entry)
+        let initialSubject = try #require(model.detailSubject)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: initialSubject
+        )
+        picker.resumeRenderingForTesting()
+        let observation = try #require(picker.modelObservationDeliveryForTesting)
+        let reboundEntry = await observation.values {
+            guard let currentEntry = model.detailSubject?.entry else {
+                return false
+            }
+            return picker.renderedEntryForTesting === currentEntry
+                && picker.renderedEntryForTesting !== entry
+        }
+        defer { reboundEntry.cancel() }
+        let resetBaseline = model.rawTransactionDeliveryCountForTesting
+
+        try model.requests.updateQuery(NetworkRequestQuery())
+
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: resetBaseline))
+        #expect(await reboundEntry.waitUntilValue(true))
+        #expect(picker.isObservingModelForTesting)
+        #expect(picker.renderedIntentIDForTesting == initialSubject.intentID)
+        let carriedSubject = try #require(model.detailSubject)
+        let stalePicker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: carriedSubject
+        )
+
+        let generationBaseline = model.rawTransactionDeliveryCountForTesting
+        context.clearNetworkRequests()
+        let replacementFirst = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-lineage-first",
+            url: "https://example.com/replacement-first.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 20
+        ))
+        _ = try #require(await applyGroupedRequest(
+            to: context,
+            requestID: "picker-lineage-second",
+            url: "https://example.com/replacement-second.json",
+            frameID: frameID,
+            initiatorNodeID: nodeID,
+            timestamp: 23
+        ))
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: generationBaseline + 6))
+        let replacementEntryID = try #require(model.entryID(containing: replacementFirst.id))
+        let replacementEntry = try #require(model.entry(for: replacementEntryID))
+        #expect(replacementEntryID == entryID)
+        model.selectEntry(replacementEntry)
+        #expect(model.detailSubject?.intentID != carriedSubject.intentID)
+
+        stalePicker.resumeRenderingForTesting()
+
+        #expect(stalePicker.isObservingModelForTesting == false)
+        #expect(stalePicker.renderedEntryForTesting === carriedSubject.entry)
+    }
+
+    @Test
     func requestPickerUsesStableEntryAndRequestItemsWithSearch() async throws {
         let context = makeContext()
         let frameID = FrameID("main-frame")
@@ -7402,11 +7905,17 @@ struct NetworkDetailViewControllerTests {
         ))
         let model = NetworkPanelModel(context: context)
         let entryID = try #require(model.entryID(containing: firstRequest.id))
-        model.selectEntry(entryID)
+        let entry = try #require(model.entry(for: entryID))
+        model.selectEntry(entry)
         let detailViewController = makeNetworkDetailViewController(model: model)
         let window = showInWindow(detailViewController)
         defer { window.isHidden = true }
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: try #require(model.detailSubject)
+        )
+        let pickerWindow = showInWindow(picker, useUIKitVisibility: true)
+        defer { pickerWindow.isHidden = true }
         let presentationController = UIPresentationController(
             presentedViewController: picker,
             presenting: nil
@@ -7444,20 +7953,14 @@ struct NetworkDetailViewControllerTests {
             .request(secondRequest.id),
         ])
 
-        picker.collectionView(
-            picker.collectionView,
-            didSelectItemAt: IndexPath(item: 1, section: 0)
-        )
+        try selectPickerItem(at: IndexPath(item: 1, section: 0), in: picker)
 
         #expect(model.selection == .request(entryID: entryID, requestID: secondRequest.id))
         #expect(picker.isObservingModelForTesting == false)
 
         picker.setSearchTextForTesting("")
         picker.resumeRenderingForTesting()
-        picker.collectionView(
-            picker.collectionView,
-            didSelectItemAt: IndexPath(item: 0, section: 0)
-        )
+        try selectPickerItem(at: IndexPath(item: 0, section: 0), in: picker)
 
         #expect(model.selection == .entry(entryID))
 
@@ -7503,8 +8006,9 @@ struct NetworkDetailViewControllerTests {
         ])
         let originalItemIDs = picker.itemIDsForTesting
         let otherEntryID = try #require(model.entryID(containing: otherFirstRequest.id))
+        let otherEntry = try #require(model.entry(for: otherEntryID))
 
-        model.selectEntry(otherEntryID)
+        model.selectEntry(otherEntry)
 
         #expect(await stoppedObserving.waitUntilValue(true))
         #expect(picker.isObservingModelForTesting == false)
@@ -7531,8 +8035,12 @@ struct NetworkDetailViewControllerTests {
         }
         let model = NetworkPanelModel(context: context)
         let entryID = try #require(model.displayEntryIDs.first)
-        model.selectEntry(entryID)
-        let picker = NetworkDetailRequestPickerViewController(model: model, entryID: entryID)
+        let entry = try #require(model.entry(for: entryID))
+        model.selectEntry(entry)
+        let picker = NetworkDetailRequestPickerViewController(
+            model: model,
+            subject: try #require(model.detailSubject)
+        )
 
         picker.resumeRenderingForTesting()
 
@@ -8001,7 +8509,7 @@ struct NetworkDetailViewControllerTests {
         let entryID: NetworkListEntry.ID = try #require(
             model.entryID(containing: request.id)
         )
-        model.selectEntry(entryID)
+        model.selectEntry(try #require(model.entry(for: entryID)))
     }
 
     private func installNavigationVisit(
@@ -8474,11 +8982,16 @@ struct NetworkDetailViewControllerTests {
         viewController.selectModeForTesting(mode)
     }
 
-    private func selectListItem(
+    private func selectPickerItem(
         at indexPath: IndexPath,
-        in viewController: NetworkListViewController
-    ) {
-        let collectionView = viewController.collectionViewForTesting
+        in viewController: NetworkDetailRequestPickerViewController
+    ) throws {
+        let collectionView = try #require(viewController.collectionView)
+        collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        collectionView.layoutIfNeeded()
+        _ = try #require(
+            collectionView.cellForItem(at: indexPath) as? NetworkDetailRequestPickerCell
+        )
         collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
         viewController.collectionView(collectionView, didSelectItemAt: indexPath)
     }

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -1424,6 +1424,112 @@ func resolvedSubjectsCarryExactValuesAndEveryExplicitSelectionGetsANewIntent() a
 
 @Test
 @MainActor
+func conditionalResponseFetchUsesExactScopeAndRegistrationOwnership() async throws {
+    let context = makeContext()
+    let frameID = FrameID("response-fetch-ownership-frame")
+    let nodeID = DOM.Node.ID("response-fetch-ownership-node")
+    context.apply(WebInspectorTargetLifecycleEvent.frameNavigated(WebInspectorPageFrameLifecycle(
+        id: frameID,
+        parentID: nil,
+        pageBindingID: "page",
+        loaderID: "loader",
+        name: "Main",
+        url: "https://example.test",
+        securityOrigin: "https://example.test",
+        mimeType: "text/html"
+    )))
+    let firstID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "response-fetch-first",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 1
+    )
+    let secondID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "response-fetch-second",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 2
+    )
+    await applyResponseReceived(
+        to: context,
+        requestID: "response-fetch-first",
+        url: "https://example.test/first",
+        resourceType: .fetch,
+        mimeType: "application/json",
+        timestamp: 3
+    )
+    await applyLoadingFinished(to: context, requestID: "response-fetch-first", timestamp: 4)
+    await applyResponseReceived(
+        to: context,
+        requestID: "response-fetch-second",
+        url: "https://example.test/second",
+        resourceType: .fetch,
+        mimeType: "application/json",
+        timestamp: 5
+    )
+    await applyLoadingFinished(to: context, requestID: "response-fetch-second", timestamp: 6)
+    let model = NetworkPanelModel(context: context)
+    let first = try #require(context.registeredRequest(for: firstID))
+    let second = try #require(context.registeredRequest(for: secondID))
+    let groupedEntryID = try #require(model.entryID(containing: firstID))
+    let groupedEntry = try #require(model.entry(for: groupedEntryID))
+
+    model.selectRequest(first)
+    let requestSubject = try #require(model.detailSubject)
+    let requestScopeTraversalBaseline = model.memberTraversalCountForTesting
+    #expect(
+        model.fetchResponseBodyIfNeeded(
+            for: second,
+            ifSubjectUnchanged: requestSubject
+        ) == false
+    )
+    #expect(model.memberTraversalCountForTesting == requestScopeTraversalBaseline)
+
+    model.selectEntry(groupedEntry)
+    let entrySubject = try #require(model.detailSubject)
+    var deliveryBaseline = model.rawTransactionDeliveryCountForTesting
+    let reusedID = await applyPendingRequest(
+        to: context,
+        requestID: "response-fetch-second",
+        url: "https://example.test/regrouped-second",
+        resourceType: .fetch,
+        timestamp: 7
+    )
+    #expect(reusedID == secondID)
+    #expect(await model.waitForRawTransactionDeliveryForTesting(after: deliveryBaseline))
+    deliveryBaseline = model.rawTransactionDeliveryCountForTesting
+    await applyResponseReceived(
+        to: context,
+        requestID: "response-fetch-second",
+        url: "https://example.test/regrouped-second",
+        resourceType: .fetch,
+        mimeType: "application/json",
+        timestamp: 8
+    )
+    await applyLoadingFinished(to: context, requestID: "response-fetch-second", timestamp: 9)
+    #expect(await model.waitForRawTransactionDeliveryForTesting(after: deliveryBaseline))
+    #expect(context.registeredRequest(for: secondID) === second)
+    #expect(model.detailSubject?.hasSameIdentity(as: entrySubject) == true)
+    #expect(model.entryID(containing: secondID) != groupedEntryID)
+
+    let regroupedTraversalBaseline = model.memberTraversalCountForTesting
+    #expect(
+        model.fetchResponseBodyIfNeeded(
+            for: second,
+            ifSubjectUnchanged: entrySubject
+        ) == false
+    )
+    #expect(model.memberTraversalCountForTesting == regroupedTraversalBaseline)
+}
+
+@Test
+@MainActor
 func foreignAndStaleSameIDSelectionActionsDoNotReplaceTheCurrentSubject() throws {
     let context = makeContext()
     let request = try seedFinishedRequest(
@@ -1479,6 +1585,7 @@ func bufferedResetAndSameIDReinsertionCannotResurrectEitherSelectionScope() asyn
         case .request:
             model.selectRequest(oldRequest)
         }
+        let oldSubject = try #require(model.detailSubject)
         let deliveryBaseline = model.rawTransactionDeliveryCountForTesting
 
         context.clearNetworkRequests()
@@ -1494,6 +1601,12 @@ func bufferedResetAndSameIDReinsertionCannotResurrectEitherSelectionScope() asyn
         #expect(model.detailSubject == nil)
         #expect(model.selection == nil)
         #expect(model.request(for: newRequest.id) === newRequest)
+        #expect(
+            model.fetchResponseBodyIfNeeded(
+                for: newRequest,
+                ifSubjectUnchanged: oldSubject
+            ) == false
+        )
     }
 }
 
@@ -1559,6 +1672,50 @@ func authoritativeSameIDInstanceReplacementRebindsSubjectAndCarriesIntent() thro
     #expect(reboundSubject.entry === previousSubject.entry)
     #expect(reboundSubject.activeRequest === replacement)
     #expect(model.request(for: replacement.id) === replacement)
+}
+
+@Test
+@MainActor
+func entryScopedConditionalFetchRejectsAReplacedSameIDInstance() throws {
+    let context = makeContext()
+    let original = try seedFinishedRequest(
+        in: context,
+        requestID: "entry-fetch-replacement",
+        url: "https://example.test/original",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(context: context)
+    let entryID = try #require(model.entryID(containing: original.id))
+    let entry = try #require(model.entry(for: entryID))
+    model.selectEntry(entry)
+    let entrySubject = try #require(model.detailSubject)
+    let proxyID = Network.Request.ID("entry-fetch-replacement")
+    let replacement = NetworkRequest(
+        request: Network.Request(
+            id: proxyID,
+            url: "https://example.test/replacement",
+            method: "GET"
+        ),
+        initiator: original.initiator,
+        navigationVisit: original.navigationVisit,
+        resourceType: original.resourceType,
+        timestamp: original.logicalStartTimestamp,
+        chronologySequence: original.chronologySequence,
+        modelContext: context
+    )
+
+    model.upsertRequestForTesting(replacement)
+
+    #expect(model.detailSubject?.hasSameIdentity(as: entrySubject) == true)
+    #expect(model.request(for: original.id) === replacement)
+    let traversalBaseline = model.memberTraversalCountForTesting
+    #expect(
+        model.fetchResponseBodyIfNeeded(
+            for: original,
+            ifSubjectUnchanged: entrySubject
+        ) == false
+    )
+    #expect(model.memberTraversalCountForTesting == traversalBaseline)
 }
 
 @Test

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -125,8 +125,9 @@ func selectingSingletonEntryUsesEntryScope() async throws {
     )
     let model = NetworkPanelModel(context: context)
     let entryID = try #require(model.entryID(containing: requestID))
+    let entry = try #require(model.entry(for: entryID))
 
-    model.selectEntry(entryID)
+    model.selectEntry(entry)
 
     #expect(model.selection == .entry(entryID))
     #expect(model.selectedRequestID == requestID)
@@ -1340,8 +1341,9 @@ func groupedEntryAndExplicitMemberSelectionsHaveDistinctScopes() async throws {
     )
     let model = NetworkPanelModel(context: context)
     let stableID = try #require(model.displayEntryIDs.first)
+    let stableEntry = try #require(model.entry(for: stableID))
 
-    model.selectEntry(stableID)
+    model.selectEntry(stableEntry)
 
     #expect(model.selection == .entry(stableID))
     #expect(model.selectedEntryID == stableID)
@@ -1354,6 +1356,209 @@ func groupedEntryAndExplicitMemberSelectionsHaveDistinctScopes() async throws {
     #expect(model.selectedEntryID == stableID)
     #expect(model.selectedRequest?.id == secondID)
     #expect(model.selectedEntryRequests.map(\.id) == [firstID, secondID])
+}
+
+@Test
+@MainActor
+func resolvedSubjectsCarryExactValuesAndEveryExplicitSelectionGetsANewIntent() async throws {
+    let context = makeContext()
+    let frameID = FrameID("subject-frame")
+    let nodeID = DOM.Node.ID("subject-node")
+    context.apply(WebInspectorTargetLifecycleEvent.frameNavigated(WebInspectorPageFrameLifecycle(
+        id: frameID,
+        parentID: nil,
+        pageBindingID: "page",
+        loaderID: "loader",
+        name: "Main",
+        url: "https://example.test",
+        securityOrigin: "https://example.test",
+        mimeType: "text/html"
+    )))
+    let firstID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "subject-first",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 1
+    )
+    let secondID = await applyOriginatedPendingRequest(
+        to: context,
+        requestID: "subject-second",
+        frameID: frameID,
+        loaderID: "loader",
+        pageBindingID: "page",
+        initiatorNodeID: nodeID,
+        timestamp: 2
+    )
+    let model = NetworkPanelModel(context: context)
+    let entryID = try #require(model.entryID(containing: firstID))
+    let entry = try #require(model.entry(for: entryID))
+    let second = try #require(context.registeredRequest(for: secondID))
+
+    model.selectEntry(entry)
+    let firstEntrySubject = try #require(model.detailSubject)
+    #expect(firstEntrySubject.scope == .entry)
+    #expect(firstEntrySubject.entry === entry)
+    #expect(firstEntrySubject.activeRequest === entry.representativeRequest)
+    #expect(firstEntrySubject.renderRequests.map(\.id) == [firstID, secondID])
+
+    model.selectEntry(entry)
+    let secondEntrySubject = try #require(model.detailSubject)
+    #expect(secondEntrySubject.intentID != firstEntrySubject.intentID)
+    #expect(secondEntrySubject.entry === entry)
+
+    model.selectRequest(second)
+    let requestSubject = try #require(model.detailSubject)
+    #expect(requestSubject.scope == .request)
+    #expect(requestSubject.entry === entry)
+    #expect(requestSubject.activeRequest === second)
+    #expect(requestSubject.renderRequests.count == 1)
+    #expect(requestSubject.renderRequests.first === second)
+    #expect(requestSubject.intentID != secondEntrySubject.intentID)
+
+    model.selectRequest(second)
+    #expect(model.detailSubject?.intentID != requestSubject.intentID)
+}
+
+@Test
+@MainActor
+func foreignAndStaleSameIDSelectionActionsDoNotReplaceTheCurrentSubject() throws {
+    let context = makeContext()
+    let request = try seedFinishedRequest(
+        in: context,
+        requestID: "selection-identity",
+        url: "https://example.test/current",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(context: context)
+    model.selectRequest(request)
+    let selectedSubject = try #require(model.detailSubject)
+
+    let foreignContext = makeContext()
+    let foreign = try seedFinishedRequest(
+        in: foreignContext,
+        requestID: "selection-identity",
+        url: "https://example.test/foreign",
+        timestamp: 2
+    )
+    model.selectRequest(foreign)
+
+    #expect(model.detailSubject?.hasSameIdentity(as: selectedSubject) == true)
+    #expect(model.detailSubject?.activeRequest === request)
+
+    let staleEntry = selectedSubject.entry
+    model.rebuildEntriesForTesting()
+    let rebuiltSubject = try #require(model.detailSubject)
+    #expect(rebuiltSubject.intentID == selectedSubject.intentID)
+    #expect(rebuiltSubject.entry !== staleEntry)
+
+    model.selectEntry(staleEntry)
+
+    #expect(model.detailSubject?.hasSameIdentity(as: rebuiltSubject) == true)
+}
+
+@Test
+@MainActor
+func bufferedResetAndSameIDReinsertionCannotResurrectEitherSelectionScope() async throws {
+    for scope in [NetworkDetailSubject.Scope.entry, .request] {
+        let context = makeContext()
+        let oldRequest = try seedFinishedRequest(
+            in: context,
+            requestID: "buffered-reset",
+            url: "https://example.test/old",
+            timestamp: 1
+        )
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: oldRequest.id))
+        let entry = try #require(model.entry(for: entryID))
+        switch scope {
+        case .entry:
+            model.selectEntry(entry)
+        case .request:
+            model.selectRequest(oldRequest)
+        }
+        let deliveryBaseline = model.rawTransactionDeliveryCountForTesting
+
+        context.clearNetworkRequests()
+        let newRequest = try seedFinishedRequest(
+            in: context,
+            requestID: "buffered-reset",
+            url: "https://example.test/new",
+            timestamp: 2
+        )
+
+        #expect(oldRequest !== newRequest)
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: deliveryBaseline + 1))
+        #expect(model.detailSubject == nil)
+        #expect(model.selection == nil)
+        #expect(model.request(for: newRequest.id) === newRequest)
+    }
+}
+
+@Test
+@MainActor
+func sameInstanceQueryResetRebindsEntryAndCarriesSelectionIntent() async throws {
+    for scope in [NetworkDetailSubject.Scope.entry, .request] {
+        let context = makeContext()
+        let request = try seedFinishedRequest(
+            in: context,
+            requestID: "query-reset-continuity",
+            url: "https://example.test/query-reset",
+            timestamp: 1
+        )
+        let model = NetworkPanelModel(context: context)
+        let entryID = try #require(model.entryID(containing: request.id))
+        let entry = try #require(model.entry(for: entryID))
+        switch scope {
+        case .entry:
+            model.selectEntry(entry)
+        case .request:
+            model.selectRequest(request)
+        }
+        let previousSubject = try #require(model.detailSubject)
+        let deliveryBaseline = model.rawTransactionDeliveryCountForTesting
+
+        try model.requests.updateQuery(NetworkRequestQuery())
+
+        #expect(await model.waitForRawTransactionDeliveryForTesting(after: deliveryBaseline))
+        let reboundSubject = try #require(model.detailSubject)
+        #expect(reboundSubject.intentID == previousSubject.intentID)
+        #expect(reboundSubject.entry !== previousSubject.entry)
+        #expect(reboundSubject.activeRequest === request)
+        #expect(reboundSubject.scope == scope)
+    }
+}
+
+@Test
+@MainActor
+func authoritativeSameIDInstanceReplacementRebindsSubjectAndCarriesIntent() throws {
+    let context = makeContext()
+    let original = try seedFinishedRequest(
+        in: context,
+        requestID: "authoritative-replacement",
+        url: "https://example.test/original",
+        timestamp: 1
+    )
+    let model = NetworkPanelModel(context: context)
+    model.selectRequest(original)
+    let previousSubject = try #require(model.detailSubject)
+
+    let replacementContext = makeContext()
+    let replacement = try seedFinishedRequest(
+        in: replacementContext,
+        requestID: "authoritative-replacement",
+        url: "https://example.test/replacement",
+        timestamp: 2
+    )
+    model.upsertRequestForTesting(replacement)
+
+    let reboundSubject = try #require(model.detailSubject)
+    #expect(reboundSubject.intentID == previousSubject.intentID)
+    #expect(reboundSubject.entry === previousSubject.entry)
+    #expect(reboundSubject.activeRequest === replacement)
+    #expect(model.request(for: replacement.id) === replacement)
 }
 
 @Test
@@ -1465,7 +1670,7 @@ func liveGroupedInsertionPreservesEntryIdentityRowPositionAndChronologicalMember
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
     let stableEntryID = try #require(model.entryID(containing: firstID))
     let stableEntry = try #require(model.entry(for: stableEntryID))
-    model.selectEntry(stableEntryID)
+    model.selectEntry(stableEntry)
 
     rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
     let newerSingletonID = await applyPendingRequest(
@@ -1570,9 +1775,11 @@ func entrySelectionPersistsWhenMemberLeavesAndExplicitRequestFollowsRegrouping()
     )
     let model = NetworkPanelModel(context: context)
     let groupedEntryID = try #require(model.entryID(containing: firstID))
+    let groupedEntry = try #require(model.entry(for: groupedEntryID))
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID, secondID, thirdID])
 
-    model.selectEntry(groupedEntryID)
+    model.selectEntry(groupedEntry)
+    let entryIntentID = try #require(model.detailSubject?.intentID)
     var rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
     await applyLoadingFinished(to: context, requestID: "second", timestamp: 4)
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
@@ -1588,9 +1795,11 @@ func entrySelectionPersistsWhenMemberLeavesAndExplicitRequestFollowsRegrouping()
     #expect(model.selection == .entry(groupedEntryID))
     #expect(model.selectedEntryID == groupedEntryID)
     #expect(model.selectedRequestID == firstID)
+    #expect(model.detailSubject?.intentID == entryIntentID)
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID, thirdID])
 
     model.selectRequest(context.registeredRequest(for: thirdID))
+    let requestIntentID = try #require(model.detailSubject?.intentID)
     rawTransactionBaseline = model.rawTransactionDeliveryCountForTesting
     await applyLoadingFinished(to: context, requestID: "third", timestamp: 6)
     #expect(await model.waitForRawTransactionDeliveryForTesting(after: rawTransactionBaseline))
@@ -1608,6 +1817,7 @@ func entrySelectionPersistsWhenMemberLeavesAndExplicitRequestFollowsRegrouping()
     #expect(model.selectedEntryID == regroupedEntryID)
     #expect(model.selection == .request(entryID: regroupedEntryID, requestID: thirdID))
     #expect(model.selectedRequest?.id == thirdID)
+    #expect(model.detailSubject?.intentID == requestIntentID)
     #expect(model.entry(for: groupedEntryID)?.requests.map(\.id) == [firstID])
 }
 
@@ -1954,6 +2164,25 @@ func largeGroupContentEventsDoNotTraverseOrResortMembership() async throws {
     #expect(model.filterEvaluationCountForTesting == filterEvaluationBaseline)
     #expect(model.listTransactionPublicationCountForTesting == publicationBaseline)
 }
+}
+
+@MainActor
+private func seedFinishedRequest(
+    in context: WebInspectorContext,
+    requestID: String,
+    url: String,
+    timestamp: Double
+) throws -> NetworkRequest {
+    let id = context.seedNetworkRequest(
+        requestID: requestID,
+        url: url,
+        resourceTypeRawValue: "Fetch",
+        responseMIMEType: "application/json",
+        responseStatus: 200,
+        responseStatusText: "OK",
+        timestamp: timestamp
+    )
+    return try #require(context.registeredRequest(for: id))
 }
 
 @MainActor


### PR DESCRIPTION
## Purpose

Make Network panel registration and detail selection one model-owned, presentation-ready subject so UI consumers cannot reconstruct mismatched entry/request state.

## Changes

- Replace four parallel request metadata maps with one canonical request registration value containing the exact request, entry, prior severity, and creation metadata.
- Store one resolved `NetworkDetailSubject` with exact entry/request associations and expose the former ID selection as a computed projection.
- Add monotonic user-intent identity so Compact Back clears only the selection it captured, while automatic regrouping and exact-instance rebinding preserve intent.
- Move Detail, Headers, request picker, List, Cookies, Security, and WebSocket routing to exact bound subjects and reject stale same-ID actions.
- Preserve selection across filtering and continuous regroup/query reset, while preventing reset plus same-ID reinsertion from resurrecting an old selection.
- Authorize grouped Preview body fetches through O(1) exact registration/entry/scope checks, including non-representative candidates, while rejecting stale or request-scope sibling targets.
- Capture Compact user-pop intent at `willShow`, including active-push and coordinator-free removals, so later explicit reselections survive while matching original intents clear.
- Leave the #255 list snapshot/version/build/apply pipeline unchanged.

## Testing

- NetworkPanel: 47/47
- NetworkDetail: 142/142
- Full UI: 358/358
- DataKit: 322/322
- ContractTests: 13/13
- Repository default suite: 892 tests / 948 invocations, 0 failures or skips
- DataKit symbol-boundary check
- Both localization catalogs compiled
- `git diff --check`
- Two independent audits: no P0-P2 findings
- Branch-wide Codex review: 0 findings

Closes #254
