### PR TITLE
Unify Network list snapshot state

### DIFF
--- a/Sources/WebInspectorUINetwork/List/NetworkListInvalidationAccumulator.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListInvalidationAccumulator.swift
@@ -1,18 +1,18 @@
 #if canImport(UIKit)
-package struct NetworkListFrameRequest: Sendable {}
+struct NetworkListFrameRequest: Sendable {}
 
-package actor NetworkListInvalidationAccumulator {
-    package nonisolated let frameRequests: AsyncStream<NetworkListFrameRequest>
+actor NetworkListInvalidationAccumulator {
+    nonisolated let frameRequests: AsyncStream<NetworkListFrameRequest>
 
     private let frameRequestContinuation: AsyncStream<NetworkListFrameRequest>.Continuation
     private var latestVersion: NetworkPanelListVersion?
     private var lastCapturedRevision: UInt64 = 0
-    private var frameRequestOutstanding = false
+    private var outstandingRevision: UInt64?
 #if DEBUG
     private var frameRequestPublicationCount = 0
 #endif
 
-    package init() {
+    init() {
         let pair = AsyncStream<NetworkListFrameRequest>.makeStream(
             bufferingPolicy: .bufferingNewest(1)
         )
@@ -20,7 +20,7 @@ package actor NetworkListInvalidationAccumulator {
         frameRequestContinuation = pair.continuation
     }
 
-    package func consume(
+    func consume(
         _ invalidations: AsyncStream<NetworkPanelListInvalidation>
     ) async {
         for await invalidation in invalidations {
@@ -28,9 +28,12 @@ package actor NetworkListInvalidationAccumulator {
         }
     }
 
-    package func didCapture(_ version: NetworkPanelListVersion) {
+    func didCapture(_ version: NetworkPanelListVersion) {
         lastCapturedRevision = max(lastCapturedRevision, version.revision)
-        frameRequestOutstanding = false
+        if let outstandingRevision,
+           version.revision >= outstandingRevision {
+            self.outstandingRevision = nil
+        }
         requestFrameIfNeeded()
     }
 
@@ -48,10 +51,10 @@ package actor NetworkListInvalidationAccumulator {
     private func requestFrameIfNeeded() {
         guard let latestVersion,
               latestVersion.revision > lastCapturedRevision,
-              frameRequestOutstanding == false else {
+              outstandingRevision == nil else {
             return
         }
-        frameRequestOutstanding = true
+        outstandingRevision = latestVersion.revision
 #if DEBUG
         frameRequestPublicationCount += 1
 #endif
@@ -65,22 +68,22 @@ package actor NetworkListInvalidationAccumulator {
 
 #if DEBUG
 extension NetworkListInvalidationAccumulator {
-    package struct StateForTesting: Equatable, Sendable {
-        package let latestVersion: NetworkPanelListVersion?
-        package let lastCapturedRevision: UInt64
-        package let frameRequestOutstanding: Bool
-        package let frameRequestPublicationCount: Int
+    struct StateForTesting: Equatable, Sendable {
+        let latestVersion: NetworkPanelListVersion?
+        let lastCapturedRevision: UInt64
+        let outstandingRevision: UInt64?
+        let frameRequestPublicationCount: Int
     }
 
-    package func receiveForTesting(_ invalidation: NetworkPanelListInvalidation) {
+    func receiveForTesting(_ invalidation: NetworkPanelListInvalidation) {
         receive(invalidation)
     }
 
-    package var stateForTesting: StateForTesting {
+    var stateForTesting: StateForTesting {
         StateForTesting(
             latestVersion: latestVersion,
             lastCapturedRevision: lastCapturedRevision,
-            frameRequestOutstanding: frameRequestOutstanding,
+            outstandingRevision: outstandingRevision,
             frameRequestPublicationCount: frameRequestPublicationCount
         )
     }

--- a/Sources/WebInspectorUINetwork/List/NetworkListSnapshotApplyCompletionScheduler.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListSnapshotApplyCompletionScheduler.swift
@@ -1,16 +1,16 @@
 #if canImport(UIKit)
 @MainActor
-package protocol NetworkListSnapshotApplyCompletionScheduling: AnyObject {
+protocol NetworkListSnapshotApplyCompletionScheduling: AnyObject {
     func schedule(_ completion: @escaping @MainActor @Sendable () -> Void)
 }
 
 @MainActor
-package final class NetworkListImmediateSnapshotApplyCompletionScheduler:
+final class NetworkListImmediateSnapshotApplyCompletionScheduler:
     NetworkListSnapshotApplyCompletionScheduling
 {
-    package init() {}
+    init() {}
 
-    package func schedule(_ completion: @escaping @MainActor @Sendable () -> Void) {
+    func schedule(_ completion: @escaping @MainActor @Sendable () -> Void) {
         completion()
     }
 }

--- a/Sources/WebInspectorUINetwork/List/NetworkListSnapshotBuilder.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListSnapshotBuilder.swift
@@ -1,34 +1,50 @@
 #if canImport(UIKit)
 import UIKit
 
-package enum NetworkListSnapshotSection: Hashable, Sendable {
+enum NetworkListSnapshotSection: Hashable, Sendable {
     case main
 }
 
-package struct NetworkListSnapshotBaseline: Sendable {
-    package let generation: UInt64
-    package let version: NetworkPanelListVersion
-    package let entryIDs: [NetworkListEntry.ID]
-    package let snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
+struct NetworkListSnapshotBaseline: Sendable {
+    let generation: UInt64
+    let version: NetworkPanelListVersion
+    fileprivate let snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
 
-    package init(
+    init(
         generation: UInt64,
         version: NetworkPanelListVersion,
-        entryIDs: [NetworkListEntry.ID],
-        snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
+        entryIDs: [NetworkListEntry.ID]
+    ) {
+        var snapshot = NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(entryIDs, toSection: .main)
+        self.init(
+            generation: generation,
+            version: version,
+            cleanSnapshot: snapshot
+        )
+    }
+
+    fileprivate init(
+        generation: UInt64,
+        version: NetworkPanelListVersion,
+        cleanSnapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
     ) {
         self.generation = generation
         self.version = version
-        self.entryIDs = entryIDs
-        self.snapshot = snapshot
+        snapshot = cleanSnapshot
+    }
+
+    var entryIDs: [NetworkListEntry.ID] {
+        snapshot.itemIdentifiers
     }
 }
 
-package struct NetworkListSnapshotBuildInput: Equatable, Sendable {
-    package let baseline: NetworkListSnapshotBaseline
-    package let target: NetworkPanelListProjection
+struct NetworkListSnapshotBuildInput: Equatable, Sendable {
+    let baseline: NetworkListSnapshotBaseline
+    let target: NetworkPanelListProjection
 
-    package init(
+    init(
         baseline: NetworkListSnapshotBaseline,
         target: NetworkPanelListProjection
     ) {
@@ -36,35 +52,36 @@ package struct NetworkListSnapshotBuildInput: Equatable, Sendable {
         self.target = target
     }
 
-    package static func == (
+    // Do not compare row arrays here: their owners advance these versions before
+    // publishing a different baseline or target, keeping 10k-row submission O(1).
+    static func == (
         lhs: NetworkListSnapshotBuildInput,
         rhs: NetworkListSnapshotBuildInput
     ) -> Bool {
         lhs.baseline.generation == rhs.baseline.generation
             && lhs.baseline.version == rhs.baseline.version
-            && lhs.baseline.entryIDs == rhs.baseline.entryIDs
-            && lhs.target == rhs.target
+            && lhs.target.version == rhs.target.version
     }
 }
 
-package struct NetworkListSnapshotChangeCounts: Equatable, Sendable {
-    package let inserted: Int
-    package let deleted: Int
-    package let moved: Int
-    package let reconfigured: Int
+struct NetworkListSnapshotChangeCounts: Equatable, Sendable {
+    let inserted: Int
+    let deleted: Int
+    let moved: Int
+    let reconfigured: Int
 
-    package var requiresApply: Bool {
+    var requiresApply: Bool {
         inserted > 0 || deleted > 0 || moved > 0 || reconfigured > 0
     }
 }
 
-package struct NetworkListSnapshotArtifact: Sendable {
-    package let input: NetworkListSnapshotBuildInput
-    package let snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
-    package let cleanSnapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
-    package let changeCounts: NetworkListSnapshotChangeCounts
+struct NetworkListSnapshotArtifact: Sendable {
+    let input: NetworkListSnapshotBuildInput
+    let snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
+    let changeCounts: NetworkListSnapshotChangeCounts
+    private let cleanSnapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
 
-    package init(
+    fileprivate init(
         input: NetworkListSnapshotBuildInput,
         snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>,
         cleanSnapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>,
@@ -75,44 +92,43 @@ package struct NetworkListSnapshotArtifact: Sendable {
         self.cleanSnapshot = cleanSnapshot
         self.changeCounts = changeCounts
     }
+
+    func makeSubmittedBaseline(generation: UInt64) -> NetworkListSnapshotBaseline {
+        NetworkListSnapshotBaseline(
+            generation: generation,
+            version: input.target.version,
+            cleanSnapshot: cleanSnapshot
+        )
+    }
 }
 
-package protocol NetworkListSnapshotBuilding: Actor {
+protocol NetworkListSnapshotBuilding: Actor {
     func build(
         _ input: NetworkListSnapshotBuildInput
     ) async throws(CancellationError) -> NetworkListSnapshotArtifact
 }
 
-package protocol NetworkListSnapshotBuilderMaking: Sendable {
+protocol NetworkListSnapshotBuilderMaking: Sendable {
     func makeBuilder() -> any NetworkListSnapshotBuilding
 }
 
-package struct NetworkListSnapshotBuilderFactory: NetworkListSnapshotBuilderMaking {
-    package init() {}
+struct NetworkListSnapshotBuilderFactory: NetworkListSnapshotBuilderMaking {
+    init() {}
 
-    package func makeBuilder() -> any NetworkListSnapshotBuilding {
+    func makeBuilder() -> any NetworkListSnapshotBuilding {
         NetworkListSnapshotBuilder()
     }
 }
 
-package actor NetworkListSnapshotBuilder: NetworkListSnapshotBuilding {
+actor NetworkListSnapshotBuilder: NetworkListSnapshotBuilding {
     private static let cooperativeBatchSize = 256
 
-    package init() {}
+    init() {}
 
-    package func build(
+    func build(
         _ input: NetworkListSnapshotBuildInput
     ) async throws(CancellationError) -> NetworkListSnapshotArtifact {
         try checkCancellation()
-        precondition(
-            input.baseline.snapshot.sectionIdentifiers == [.main],
-            "A Network list snapshot baseline must contain exactly the main section."
-        )
-        precondition(
-            input.baseline.snapshot.itemIdentifiers == input.baseline.entryIDs,
-            "A Network list snapshot baseline must own its declared row order."
-        )
-
         let baselineEntryIDs = input.baseline.entryIDs
         let targetEntryIDs = input.target.entryIDs
         let baselineEntryIDSet = try await uniqueEntryIDs(in: baselineEntryIDs)

--- a/Sources/WebInspectorUINetwork/List/NetworkListSnapshotState.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListSnapshotState.swift
@@ -1,96 +1,203 @@
 #if canImport(UIKit)
-import WebInspectorUIBase
 import WebInspectorDataKit
 import UIKit
 
 extension NetworkListViewController {
-    struct SnapshotRows: Equatable, Sendable {
-        let entryIDs: [NetworkListEntry.ID]
-
-        init(entryIDs: [NetworkListEntry.ID]) {
-            self.entryIDs = entryIDs
-        }
-    }
-}
-
-extension NetworkListViewController {
     @MainActor
     struct SnapshotState {
-        private(set) var appliedRows = NetworkListViewController.SnapshotRows(entryIDs: [])
-        private(set) var applyingRows: NetworkListViewController.SnapshotRows?
+        struct Application {
+            struct ID: Equatable, Sendable {
+                fileprivate let rawValue: UInt64
+            }
+
+            let id: ID
+            let snapshot: NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>
+        }
+
+        enum ReceiveResult: Equatable {
+            case stale
+            case unchanged
+            case ready
+        }
+
+        enum PrepareResult {
+            case none
+            case stale
+            case apply(Application)
+        }
+
+        enum FinishResult: Equatable {
+            case stale
+            case idle
+            case ready
+        }
+
+        private struct ReadyArtifact {
+            let artifact: NetworkListSnapshotArtifact
+        }
+
+        private enum Phase {
+            case idle
+            case ready(ReadyArtifact)
+            case applying(Application.ID, readyArtifact: ReadyArtifact?)
+        }
+
         private(set) var submittedBaseline: NetworkListSnapshotBaseline
-        private var nextBaselineGeneration: UInt64 = 0
+        private var phase = Phase.idle
 
         init() {
-            var snapshot = NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>()
-            snapshot.appendSections([.main])
-            submittedBaseline = NetworkListSnapshotBaseline(
+            self.init(submittedBaseline: NetworkListSnapshotBaseline(
                 generation: 0,
                 version: NetworkPanelListVersion(revision: 0, entryIdentityGeneration: 0),
-                entryIDs: [],
-                snapshot: snapshot
-            )
+                entryIDs: []
+            ))
+        }
+
+        init(submittedBaseline: NetworkListSnapshotBaseline) {
+            self.submittedBaseline = submittedBaseline
         }
 
         var isApplying: Bool {
-            applyingRows != nil
+            guard case .applying = phase else {
+                return false
+            }
+            return true
         }
 
-        mutating func beginApplying(
-            _ artifact: NetworkListSnapshotArtifact
-        ) -> NetworkListViewController.SnapshotRows {
-            precondition(
-                applyingRows == nil,
-                "A Network list snapshot apply must finish before another begins."
-            )
-            precondition(
-                artifact.input.baseline.generation == submittedBaseline.generation,
-                "A Network list snapshot apply must start from the submitted UIKit baseline."
-            )
-            precondition(
-                nextBaselineGeneration < UInt64.max,
-                "Network list snapshot baseline generation overflowed."
-            )
-            nextBaselineGeneration += 1
-            let rows = NetworkListViewController.SnapshotRows(
-                entryIDs: artifact.input.target.entryIDs
-            )
-            submittedBaseline = NetworkListSnapshotBaseline(
-                generation: nextBaselineGeneration,
-                version: artifact.input.target.version,
-                entryIDs: artifact.input.target.entryIDs,
-                snapshot: artifact.cleanSnapshot
-            )
-            applyingRows = rows
-            return rows
+        var hasReadyArtifact: Bool {
+            switch phase {
+            case .idle:
+                false
+            case .ready:
+                true
+            case .applying(_, let readyArtifact):
+                readyArtifact != nil
+            }
         }
 
-        mutating func acknowledgeUnchanged(
-            _ artifact: NetworkListSnapshotArtifact
-        ) {
-            precondition(
-                artifact.changeCounts.requiresApply == false,
-                "Only a no-op Network list delta may advance without a UIKit apply."
-            )
-            precondition(
-                artifact.input.baseline.generation == submittedBaseline.generation,
-                "A no-op Network list delta must start from the submitted UIKit baseline."
-            )
-            submittedBaseline = NetworkListSnapshotBaseline(
-                generation: submittedBaseline.generation,
-                version: artifact.input.target.version,
-                entryIDs: artifact.input.target.entryIDs,
-                snapshot: artifact.cleanSnapshot
-            )
+        mutating func receive(
+            _ artifact: NetworkListSnapshotArtifact,
+            currentVersion: NetworkPanelListVersion
+        ) -> ReceiveResult {
+            guard isCurrent(artifact, currentVersion: currentVersion) else {
+                return preserveCurrentReadyArtifact(currentVersion: currentVersion)
+                    ? .ready
+                    : .stale
+            }
+
+            guard artifact.changeCounts.requiresApply else {
+                submittedBaseline = artifact.makeSubmittedBaseline(
+                    generation: submittedBaseline.generation
+                )
+                switch phase {
+                case .idle, .ready:
+                    phase = .idle
+                case .applying(let applicationID, _):
+                    phase = .applying(applicationID, readyArtifact: nil)
+                }
+                return .unchanged
+            }
+
+            let readyArtifact = ReadyArtifact(artifact: artifact)
+            switch phase {
+            case .idle, .ready:
+                phase = .ready(readyArtifact)
+            case .applying(let applicationID, _):
+                phase = .applying(applicationID, readyArtifact: readyArtifact)
+            }
+            return .ready
         }
 
-        mutating func finishApplying(_ rows: NetworkListViewController.SnapshotRows) {
+        mutating func prepare(
+            currentVersion: NetworkPanelListVersion
+        ) -> PrepareResult {
+            guard case .ready(let readyArtifact) = phase else {
+                return .none
+            }
+            phase = .idle
+
+            let artifact = readyArtifact.artifact
+            guard isCurrent(artifact, currentVersion: currentVersion) else {
+                return .stale
+            }
             precondition(
-                applyingRows == rows,
-                "A Network list snapshot apply must finish the rows it started."
+                submittedBaseline.generation < UInt64.max,
+                "Network list snapshot application identity exhausted."
             )
-            applyingRows = nil
-            appliedRows = rows
+            let applicationID = Application.ID(
+                rawValue: submittedBaseline.generation + 1
+            )
+            submittedBaseline = artifact.makeSubmittedBaseline(
+                generation: applicationID.rawValue
+            )
+            phase = .applying(applicationID, readyArtifact: nil)
+            return .apply(Application(id: applicationID, snapshot: artifact.snapshot))
+        }
+
+        mutating func finish(_ applicationID: Application.ID) -> FinishResult {
+            guard case .applying(let currentApplicationID, let readyArtifact) = phase,
+                  currentApplicationID == applicationID else {
+                return .stale
+            }
+            if let readyArtifact {
+                phase = .ready(readyArtifact)
+                return .ready
+            }
+            phase = .idle
+            return .idle
+        }
+
+        @discardableResult
+        mutating func discardReadyArtifact() -> Bool {
+            switch phase {
+            case .idle:
+                return false
+            case .ready:
+                phase = .idle
+                return true
+            case .applying(let applicationID, let readyArtifact):
+                phase = .applying(applicationID, readyArtifact: nil)
+                return readyArtifact != nil
+            }
+        }
+
+        private func isCurrent(
+            _ artifact: NetworkListSnapshotArtifact,
+            currentVersion: NetworkPanelListVersion
+        ) -> Bool {
+            artifact.input.target.version == currentVersion
+                && artifact.input.baseline.generation == submittedBaseline.generation
+                && artifact.input.baseline.version == submittedBaseline.version
+        }
+
+        private mutating func preserveCurrentReadyArtifact(
+            currentVersion: NetworkPanelListVersion
+        ) -> Bool {
+            switch phase {
+            case .idle:
+                return false
+            case .ready(let readyArtifact):
+                guard isCurrent(
+                    readyArtifact.artifact,
+                    currentVersion: currentVersion
+                ) else {
+                    phase = .idle
+                    return false
+                }
+                return true
+            case .applying(let applicationID, let readyArtifact):
+                guard let readyArtifact else {
+                    return false
+                }
+                guard isCurrent(
+                    readyArtifact.artifact,
+                    currentVersion: currentVersion
+                ) else {
+                    phase = .applying(applicationID, readyArtifact: nil)
+                    return false
+                }
+                return true
+            }
         }
     }
 }

--- a/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
@@ -205,7 +205,6 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private struct SnapshotCoordinator {
         var isRenderingActive = false
         var needsReloadOnNextAppearance = true
-        var readyArtifact: NetworkListSnapshotArtifact?
         var state = NetworkListViewController.SnapshotState()
 
         mutating func resumeRendering() {
@@ -214,10 +213,9 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
         mutating func suspendRendering() {
             isRenderingActive = false
-            if readyArtifact != nil {
+            if state.discardReadyArtifact() {
                 needsReloadOnNextAppearance = true
             }
-            readyArtifact = nil
         }
 
         mutating func markNeedsReloadOnNextAppearance() {
@@ -289,7 +287,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         )
     }
 
-    package convenience init(
+    convenience init(
         model: NetworkPanelModel,
         listFrameScheduler: any NetworkFrameScheduling,
         listSnapshotBuilderFactory: any NetworkListSnapshotBuilderMaking,
@@ -632,72 +630,70 @@ package final class NetworkListViewController: UICollectionViewController, UISea
             snapshotCoordinator.markNeedsReloadOnNextAppearance()
             return
         }
-        guard artifact.input.target.version == model.listProjectionVersion,
-              artifact.input.baseline.generation
-                == snapshotCoordinator.state.submittedBaseline.generation else {
+        switch snapshotCoordinator.state.receive(
+            artifact,
+            currentVersion: model.listProjectionVersion
+        ) {
+        case .stale:
             requestListProjectionCapture()
-            return
+        case .unchanged:
+            snapshotCoordinator.needsReloadOnNextAppearance = false
+        case .ready:
+            snapshotCoordinator.needsReloadOnNextAppearance = false
+            scheduleListRenderingFrameIfNeeded()
         }
-        snapshotCoordinator.needsReloadOnNextAppearance = false
-        guard artifact.changeCounts.requiresApply else {
-            snapshotCoordinator.state.acknowledgeUnchanged(artifact)
-            snapshotCoordinator.readyArtifact = nil
-            return
-        }
-        snapshotCoordinator.readyArtifact = artifact
-        scheduleListRenderingFrameIfNeeded()
     }
 
     private func applyReadySnapshotArtifactOnDisplayFrameIfNeeded() {
         guard snapshotCoordinator.isRenderingActive else {
-            if snapshotCoordinator.readyArtifact != nil {
-                snapshotCoordinator.readyArtifact = nil
+            if snapshotCoordinator.state.discardReadyArtifact() {
                 snapshotCoordinator.markNeedsReloadOnNextAppearance()
             }
             return
         }
-        guard !snapshotCoordinator.state.isApplying,
-              let artifact = snapshotCoordinator.readyArtifact else {
+        let application: NetworkListViewController.SnapshotState.Application
+        switch snapshotCoordinator.state.prepare(
+            currentVersion: model.listProjectionVersion
+        ) {
+        case .none:
             return
-        }
-        guard artifact.input.target.version == model.listProjectionVersion,
-              artifact.input.baseline.generation
-                == snapshotCoordinator.state.submittedBaseline.generation else {
-            snapshotCoordinator.readyArtifact = nil
+        case .stale:
             requestListProjectionCapture()
             return
+        case .apply(let preparedApplication):
+            application = preparedApplication
         }
-        precondition(
-            artifact.changeCounts.requiresApply,
-            "A ready Network list snapshot artifact must change UIKit state."
-        )
-        snapshotCoordinator.readyArtifact = nil
-        let rows = snapshotCoordinator.state.beginApplying(artifact)
 
+        let applicationID = application.id
+        let snapshot = application.snapshot
         let completion: @MainActor @Sendable () -> Void = { [weak self] in
-            self?.snapshotUpdateDidFinish(appliedRows: rows)
+            self?.snapshotUpdateDidFinish(applicationID: applicationID)
         }
 #if DEBUG
         snapshotApplyCountStorageForTesting += 1
 #endif
         let snapshotApplyCompletionScheduler = self.snapshotApplyCompletionScheduler
-        dataSource.apply(artifact.snapshot, animatingDifferences: false) {
+        dataSource.apply(snapshot, animatingDifferences: false) {
             snapshotApplyCompletionScheduler.schedule(completion)
         }
     }
 
     private func snapshotUpdateDidFinish(
-        appliedRows: NetworkListViewController.SnapshotRows
+        applicationID: NetworkListViewController.SnapshotState.Application.ID
     ) {
 #if DEBUG
         defer {
             resumeSnapshotUpdateCompletionWaitersForTesting()
         }
 #endif
-        snapshotCoordinator.state.finishApplying(appliedRows)
+        switch snapshotCoordinator.state.finish(applicationID) {
+        case .stale:
+            return
+        case .idle, .ready:
+            break
+        }
         guard snapshotCoordinator.isRenderingActive else {
-            if snapshotCoordinator.readyArtifact != nil {
-                snapshotCoordinator.readyArtifact = nil
+            if snapshotCoordinator.state.discardReadyArtifact() {
                 snapshotCoordinator.markNeedsReloadOnNextAppearance()
             }
             return
@@ -720,7 +716,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private func scheduleListRenderingFrameIfNeeded() {
         guard snapshotCoordinator.isRenderingActive,
-              needsListProjectionCapture || snapshotCoordinator.readyArtifact != nil else {
+              needsListProjectionCapture || snapshotCoordinator.state.hasReadyArtifact else {
             return
         }
         listFrameScheduler.schedule { [weak self] in
@@ -730,9 +726,9 @@ package final class NetworkListViewController: UICollectionViewController, UISea
 
     private func listRenderingDisplayFrameDidFire() {
         guard snapshotCoordinator.isRenderingActive else {
-            if needsListProjectionCapture || snapshotCoordinator.readyArtifact != nil {
+            let discardedReadyArtifact = snapshotCoordinator.state.discardReadyArtifact()
+            if needsListProjectionCapture || discardedReadyArtifact {
                 needsListProjectionCapture = false
-                snapshotCoordinator.readyArtifact = nil
                 snapshotCoordinator.markNeedsReloadOnNextAppearance()
             }
             return
@@ -930,7 +926,7 @@ extension NetworkListViewController {
     }
 
     package var hasPendingSnapshotUpdateForTesting: Bool {
-        snapshotCoordinator.readyArtifact != nil
+        snapshotCoordinator.state.hasReadyArtifact
     }
 
     package var hasActiveListSnapshotBuildForTesting: Bool {
@@ -960,7 +956,7 @@ extension NetworkListViewController {
                 await waitForSnapshotUpdateCompletionForTesting()
                 return
             }
-            if needsListProjectionCapture || snapshotCoordinator.readyArtifact != nil {
+            if needsListProjectionCapture || snapshotCoordinator.state.hasReadyArtifact {
                 listFrameScheduler.cancel()
                 listRenderingDisplayFrameDidFire()
                 continue

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -6523,7 +6523,7 @@ struct NetworkDetailViewControllerTests {
             entryIdentityGeneration: 1
         ))
         #expect(state.frameRequestPublicationCount == 1)
-        #expect(state.frameRequestOutstanding)
+        #expect(state.outstandingRevision == 1)
 
         await accumulator.didCapture(NetworkPanelListVersion(
             revision: 2_305,
@@ -6531,7 +6531,37 @@ struct NetworkDetailViewControllerTests {
         ))
         state = await accumulator.stateForTesting
         #expect(state.frameRequestPublicationCount == 1)
-        #expect(state.frameRequestOutstanding == false)
+        #expect(state.outstandingRevision == nil)
+    }
+
+    @Test
+    func staleListCaptureAcknowledgementCannotClearANewerFrameRequest() async {
+        let accumulator = NetworkListInvalidationAccumulator()
+        let version1 = NetworkPanelListVersion(revision: 1, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 2, entryIdentityGeneration: 0)
+        let version3 = NetworkPanelListVersion(revision: 3, entryIdentityGeneration: 1)
+
+        await accumulator.receiveForTesting(NetworkPanelListInvalidation(version: version1))
+        await accumulator.didCapture(version2)
+        await accumulator.receiveForTesting(NetworkPanelListInvalidation(version: version3))
+
+        var state = await accumulator.stateForTesting
+        #expect(state.lastCapturedRevision == 2)
+        #expect(state.outstandingRevision == 3)
+        #expect(state.frameRequestPublicationCount == 2)
+
+        await accumulator.didCapture(version1)
+
+        state = await accumulator.stateForTesting
+        #expect(state.lastCapturedRevision == 2)
+        #expect(state.outstandingRevision == 3)
+        #expect(state.frameRequestPublicationCount == 2)
+
+        await accumulator.didCapture(version3)
+        state = await accumulator.stateForTesting
+        #expect(state.lastCapturedRevision == 3)
+        #expect(state.outstandingRevision == nil)
+        #expect(state.frameRequestPublicationCount == 2)
     }
 
     @Test
@@ -6615,13 +6645,432 @@ struct NetworkDetailViewControllerTests {
 
         #expect(artifact.snapshot.itemIdentifiers == entryIDs)
         #expect(Set(artifact.snapshot.reconfiguredItemIdentifiers) == Set(entryIDs))
-        #expect(artifact.cleanSnapshot.reconfiguredItemIdentifiers.isEmpty)
+        let cleanBaseline = artifact.makeSubmittedBaseline(generation: 4)
+        let cleanArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: cleanBaseline,
+                target: input.target
+            )
+        )
+        #expect(cleanArtifact.snapshot.reconfiguredItemIdentifiers.isEmpty)
         #expect(artifact.changeCounts == NetworkListSnapshotChangeCounts(
             inserted: 0,
             deleted: 0,
             moved: 0,
             reconfigured: entryIDs.count
         ))
+    }
+
+    @Test
+    func listSnapshotBaselineConstructsOneCanonicalMainSection() async throws {
+        let context = makeContext()
+        for index in 0..<3 {
+            context.seedNetworkRequest(
+                requestID: "canonical-baseline-\(index)",
+                url: "https://example.test/canonical-baseline-\(index).json",
+                resourceTypeRawValue: "Fetch",
+                responseMIMEType: "application/json",
+                responseStatus: 200,
+                responseStatusText: "OK",
+                timestamp: Double(index)
+            )
+        }
+        let entryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let version = NetworkPanelListVersion(revision: 20, entryIdentityGeneration: 0)
+        let baseline = makeNetworkListSnapshotBaseline(
+            entryIDs: entryIDs,
+            version: version,
+            generation: 8
+        )
+
+        let artifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(version: version, entryIDs: entryIDs)
+            )
+        )
+
+        #expect(baseline.entryIDs == entryIDs)
+        #expect(artifact.snapshot.sectionIdentifiers == [.main])
+        #expect(artifact.snapshot.itemIdentifiers == entryIDs)
+        #expect(artifact.changeCounts.requiresApply == false)
+    }
+
+    @Test
+    func listSnapshotStateOwnsNoOpAndBothFreshnessBoundaries() async throws {
+        let context = makeContext()
+        for index in 0..<2 {
+            context.seedNetworkRequest(
+                requestID: "state-freshness-\(index)",
+                url: "https://example.test/state-freshness-\(index).json",
+                resourceTypeRawValue: "Fetch",
+                responseMIMEType: "application/json",
+                responseStatus: 200,
+                responseStatusText: "OK",
+                timestamp: Double(index)
+            )
+        }
+        let allEntryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let baselineEntryIDs = Array(allEntryIDs.prefix(1))
+        let version1 = NetworkPanelListVersion(revision: 21, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 22, entryIdentityGeneration: 0)
+        let version3 = NetworkPanelListVersion(revision: 23, entryIdentityGeneration: 0)
+        let version4 = NetworkPanelListVersion(revision: 24, entryIdentityGeneration: 0)
+        let originalBaseline = makeNetworkListSnapshotBaseline(
+            entryIDs: baselineEntryIDs,
+            version: version1,
+            generation: 4
+        )
+        var state = NetworkListViewController.SnapshotState(
+            submittedBaseline: originalBaseline
+        )
+        let noOpArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: originalBaseline,
+                target: NetworkPanelListProjection(
+                    version: version2,
+                    entryIDs: baselineEntryIDs
+                )
+            )
+        )
+
+        let noOpResult = state.receive(noOpArtifact, currentVersion: version2)
+        #expect(noOpResult == .unchanged)
+        #expect(state.submittedBaseline.generation == originalBaseline.generation)
+        #expect(state.submittedBaseline.version == version2)
+        #expect(state.submittedBaseline.entryIDs == baselineEntryIDs)
+        #expect(state.hasReadyArtifact == false)
+
+        let oldBaselineArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: originalBaseline,
+                target: NetworkPanelListProjection(
+                    version: version3,
+                    entryIDs: allEntryIDs
+                )
+            )
+        )
+        let staleBaselineResult = state.receive(
+            oldBaselineArtifact,
+            currentVersion: version3
+        )
+        #expect(staleBaselineResult == .stale)
+        #expect(state.hasReadyArtifact == false)
+
+        let currentArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(
+                    version: version3,
+                    entryIDs: allEntryIDs
+                )
+            )
+        )
+        let currentResult = state.receive(currentArtifact, currentVersion: version3)
+        #expect(currentResult == .ready)
+        guard case .stale = state.prepare(currentVersion: version4) else {
+            Issue.record("A ready artifact must be rejected when its target version becomes stale.")
+            return
+        }
+        #expect(state.isApplying == false)
+        #expect(state.hasReadyArtifact == false)
+        #expect(state.submittedBaseline.version == version2)
+    }
+
+    @Test
+    func staleIncomingSnapshotArtifactPreservesAnExistingCurrentReadyArtifact() async throws {
+        let context = makeContext()
+        for index in 0..<2 {
+            context.seedNetworkRequest(
+                requestID: "state-ready-\(index)",
+                url: "https://example.test/state-ready-\(index).json",
+                resourceTypeRawValue: "Fetch",
+                responseMIMEType: "application/json",
+                responseStatus: 200,
+                responseStatusText: "OK",
+                timestamp: Double(index)
+            )
+        }
+        let allEntryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let baselineEntryIDs = Array(allEntryIDs.prefix(1))
+        let version1 = NetworkPanelListVersion(revision: 25, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 26, entryIdentityGeneration: 0)
+        let baseline = makeNetworkListSnapshotBaseline(
+            entryIDs: baselineEntryIDs,
+            version: version1,
+            generation: 2
+        )
+        var state = NetworkListViewController.SnapshotState(submittedBaseline: baseline)
+        let currentArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(
+                    version: version2,
+                    entryIDs: allEntryIDs
+                )
+            )
+        )
+        let staleArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(
+                    version: version1,
+                    entryIDs: baselineEntryIDs
+                )
+            )
+        )
+
+        let currentResult = state.receive(currentArtifact, currentVersion: version2)
+        #expect(currentResult == .ready)
+        let preservedReadyResult = state.receive(staleArtifact, currentVersion: version2)
+        #expect(preservedReadyResult == .ready)
+        #expect(state.hasReadyArtifact)
+        guard case .apply(let application) = state.prepare(currentVersion: version2) else {
+            Issue.record("The current ready artifact must remain available after a stale arrival.")
+            return
+        }
+        #expect(application.snapshot.itemIdentifiers == allEntryIDs)
+        let finishResult = state.finish(application.id)
+        #expect(finishResult == .idle)
+    }
+
+    @Test
+    func listSnapshotStateSerializesReadyArtifactsAndRejectsOldApplicationCompletions() async throws {
+        let context = makeContext()
+        context.seedNetworkRequest(
+            requestID: "state-application-id",
+            url: "https://example.test/state-application-id.json",
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: 0
+        )
+        let entryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let version1 = NetworkPanelListVersion(revision: 27, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 28, entryIdentityGeneration: 1)
+        let version3 = NetworkPanelListVersion(revision: 29, entryIdentityGeneration: 2)
+        let baseline = makeNetworkListSnapshotBaseline(
+            entryIDs: entryIDs,
+            version: version1,
+            generation: 0
+        )
+        var state = NetworkListViewController.SnapshotState(submittedBaseline: baseline)
+        let firstArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(version: version2, entryIDs: entryIDs)
+            )
+        )
+        let firstReceiveResult = state.receive(firstArtifact, currentVersion: version2)
+        #expect(firstReceiveResult == .ready)
+        guard case .apply(let firstApplication) = state.prepare(currentVersion: version2) else {
+            Issue.record("The first reconfiguration must begin applying.")
+            return
+        }
+        #expect(state.isApplying)
+        #expect(state.submittedBaseline.generation == 1)
+
+        let secondArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(version: version3, entryIDs: entryIDs)
+            )
+        )
+        let secondReceiveResult = state.receive(secondArtifact, currentVersion: version3)
+        #expect(secondReceiveResult == .ready)
+        let preservedQueuedResult = state.receive(firstArtifact, currentVersion: version3)
+        #expect(preservedQueuedResult == .ready)
+        #expect(state.hasReadyArtifact)
+        guard case .none = state.prepare(currentVersion: version3) else {
+            Issue.record("A second artifact must wait for the active UIKit application.")
+            return
+        }
+        let firstFinishResult = state.finish(firstApplication.id)
+        #expect(firstFinishResult == .ready)
+        guard case .apply(let secondApplication) = state.prepare(currentVersion: version3) else {
+            Issue.record("The queued artifact must apply after the first completion.")
+            return
+        }
+        #expect(secondApplication.id != firstApplication.id)
+        let staleFinishResult = state.finish(firstApplication.id)
+        #expect(staleFinishResult == .stale)
+        #expect(state.isApplying)
+        let secondFinishResult = state.finish(secondApplication.id)
+        #expect(secondFinishResult == .idle)
+        #expect(state.isApplying == false)
+
+        let cleanArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(version: version3, entryIDs: entryIDs)
+            )
+        )
+        #expect(cleanArtifact.changeCounts.requiresApply == false)
+        #expect(cleanArtifact.snapshot.reconfiguredItemIdentifiers.isEmpty)
+    }
+
+    @Test
+    func listSnapshotStateNoOpAndDiscardSupersedeQueuedArtifacts() async throws {
+        let context = makeContext()
+        for index in 0..<2 {
+            context.seedNetworkRequest(
+                requestID: "state-discard-\(index)",
+                url: "https://example.test/state-discard-\(index).json",
+                resourceTypeRawValue: "Fetch",
+                responseMIMEType: "application/json",
+                responseStatus: 200,
+                responseStatusText: "OK",
+                timestamp: Double(index)
+            )
+        }
+        let allEntryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let baselineEntryIDs = Array(allEntryIDs.prefix(1))
+        let version1 = NetworkPanelListVersion(revision: 30, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 31, entryIdentityGeneration: 0)
+        let version3 = NetworkPanelListVersion(revision: 32, entryIdentityGeneration: 0)
+        let version4 = NetworkPanelListVersion(revision: 33, entryIdentityGeneration: 0)
+        let version5 = NetworkPanelListVersion(revision: 34, entryIdentityGeneration: 0)
+        let baseline = makeNetworkListSnapshotBaseline(
+            entryIDs: baselineEntryIDs,
+            version: version1,
+            generation: 0
+        )
+        var state = NetworkListViewController.SnapshotState(submittedBaseline: baseline)
+        let readyArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(version: version2, entryIDs: allEntryIDs)
+            )
+        )
+        let noOpArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(version: version3, entryIDs: baselineEntryIDs)
+            )
+        )
+
+        let readyResult = state.receive(readyArtifact, currentVersion: version2)
+        #expect(readyResult == .ready)
+        let noOpResult = state.receive(noOpArtifact, currentVersion: version3)
+        #expect(noOpResult == .unchanged)
+        #expect(state.hasReadyArtifact == false)
+        #expect(state.submittedBaseline.version == version3)
+
+        let applyingArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(version: version4, entryIDs: allEntryIDs)
+            )
+        )
+        let applyingResult = state.receive(applyingArtifact, currentVersion: version4)
+        #expect(applyingResult == .ready)
+        guard case .apply(let application) = state.prepare(currentVersion: version4) else {
+            Issue.record("The current artifact must begin applying.")
+            return
+        }
+        let queuedArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(
+                    version: version5,
+                    entryIDs: baselineEntryIDs
+                )
+            )
+        )
+        let queuedResult = state.receive(queuedArtifact, currentVersion: version5)
+        #expect(queuedResult == .ready)
+        let discardedReadyArtifact = state.discardReadyArtifact()
+        #expect(discardedReadyArtifact)
+        #expect(state.hasReadyArtifact == false)
+        #expect(state.isApplying)
+        let finishResult = state.finish(application.id)
+        #expect(finishResult == .idle)
+        guard case .none = state.prepare(currentVersion: version5) else {
+            Issue.record("Discarding queued work must leave no application to prepare.")
+            return
+        }
+    }
+
+    @Test
+    func listSnapshotStateNoOpSupersedesQueuedWorkWithoutFinishingTheActiveApplication() async throws {
+        let context = makeContext()
+        for index in 0..<3 {
+            context.seedNetworkRequest(
+                requestID: "state-applying-no-op-\(index)",
+                url: "https://example.test/state-applying-no-op-\(index).json",
+                resourceTypeRawValue: "Fetch",
+                responseMIMEType: "application/json",
+                responseStatus: 200,
+                responseStatusText: "OK",
+                timestamp: Double(index)
+            )
+        }
+        let allEntryIDs = NetworkPanelModel(context: context).displayEntryIDs
+        let baselineEntryIDs = Array(allEntryIDs.prefix(1))
+        let applyingEntryIDs = Array(allEntryIDs.prefix(2))
+        let version1 = NetworkPanelListVersion(revision: 35, entryIdentityGeneration: 0)
+        let version2 = NetworkPanelListVersion(revision: 36, entryIdentityGeneration: 0)
+        let version3 = NetworkPanelListVersion(revision: 37, entryIdentityGeneration: 0)
+        let version4 = NetworkPanelListVersion(revision: 38, entryIdentityGeneration: 0)
+        let baseline = makeNetworkListSnapshotBaseline(
+            entryIDs: baselineEntryIDs,
+            version: version1,
+            generation: 0
+        )
+        var state = NetworkListViewController.SnapshotState(submittedBaseline: baseline)
+        let applyingArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: baseline,
+                target: NetworkPanelListProjection(
+                    version: version2,
+                    entryIDs: applyingEntryIDs
+                )
+            )
+        )
+        let applyingReceiveResult = state.receive(
+            applyingArtifact,
+            currentVersion: version2
+        )
+        #expect(applyingReceiveResult == .ready)
+        guard case .apply(let application) = state.prepare(currentVersion: version2) else {
+            Issue.record("The first artifact must begin applying.")
+            return
+        }
+        let submittedGeneration = state.submittedBaseline.generation
+
+        let queuedArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(version: version3, entryIDs: allEntryIDs)
+            )
+        )
+        let noOpArtifact = try await NetworkListSnapshotBuilder().build(
+            makeNetworkListSnapshotBuildInput(
+                baseline: state.submittedBaseline,
+                target: NetworkPanelListProjection(
+                    version: version4,
+                    entryIDs: applyingEntryIDs
+                )
+            )
+        )
+        let queuedResult = state.receive(queuedArtifact, currentVersion: version3)
+        #expect(queuedResult == .ready)
+        let noOpResult = state.receive(noOpArtifact, currentVersion: version4)
+
+        #expect(noOpResult == .unchanged)
+        #expect(state.isApplying)
+        #expect(state.hasReadyArtifact == false)
+        #expect(state.submittedBaseline.generation == submittedGeneration)
+        #expect(state.submittedBaseline.version == version4)
+        #expect(state.submittedBaseline.entryIDs == applyingEntryIDs)
+
+        let finishResult = state.finish(application.id)
+        #expect(finishResult == .idle)
+        guard case .none = state.prepare(currentVersion: version4) else {
+            Issue.record("A no-op must supersede queued work without creating another apply.")
+            return
+        }
     }
 
     @Test
@@ -6741,7 +7190,10 @@ struct NetworkDetailViewControllerTests {
         let artifact = try await NetworkListSnapshotBuilder().build(input)
 
         #expect(artifact.snapshot.itemIdentifiers == targetEntryIDs)
-        #expect(artifact.cleanSnapshot.itemIdentifiers == targetEntryIDs)
+        #expect(
+            artifact.makeSubmittedBaseline(generation: 5).entryIDs
+                == targetEntryIDs
+        )
         #expect(artifact.changeCounts.inserted == 10)
         #expect(artifact.changeCounts.deleted == 10)
         #expect(artifact.changeCounts.moved > 0)
@@ -7395,6 +7847,141 @@ struct NetworkDetailViewControllerTests {
         #expect(listViewController.displayedRequestIDsForTesting == [request.id])
         #expect(listViewController.displayRequestIDsEvaluationCountForTesting == evaluationCountBeforeHiddenUpdate + 1)
         #expect(applyCompletionScheduler.pendingCompletionCount == 0)
+    }
+
+    @Test
+    func listSnapshotStateSurvivesCompactToRegularReparentDuringDelayedApply() async throws {
+        let context = makeContext()
+        let firstRequestID = context.seedNetworkRequest(
+            requestID: "reparent-first",
+            url: "https://example.test/reparent-first.json",
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: 0
+        )
+        let model = NetworkPanelModel(context: context)
+        let firstRequest = try #require(context.registeredRequest(for: firstRequestID))
+        model.selectRequest(firstRequest)
+        let selectedSubject = try #require(model.detailSubject)
+        let frameScheduler = ManualNetworkFrameScheduler()
+        let snapshotBuilder = BarrierNetworkListSnapshotBuilderFactory()
+        let applyCompletionScheduler = ManualNetworkListSnapshotApplyCompletionScheduler()
+        let listViewController = NetworkListViewController(
+            model: model,
+            listFrameScheduler: frameScheduler,
+            listSnapshotBuilderFactory: snapshotBuilder,
+            snapshotApplyCompletionScheduler: applyCompletionScheduler
+        )
+        let detailViewController = makeNetworkDetailViewController(model: model)
+        let compactViewController = NetworkCompactNavigationController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        let window = showInWindow(compactViewController, makeVisible: false)
+        defer { window.isHidden = true }
+        listViewController.resumeRenderingForTesting()
+
+        try #require(frameScheduler.hasScheduledFrame)
+        frameScheduler.fireScheduledFrame()
+        await snapshotBuilder.waitUntilStartedBuildCount(1)
+        await snapshotBuilder.releaseBuild(1)
+        await listViewController.waitForListSnapshotBuildIdleForTesting()
+        try #require(frameScheduler.hasScheduledFrame)
+        frameScheduler.fireScheduledFrame()
+        await applyCompletionScheduler.waitUntilScheduledCompletionCount(1)
+        #expect(listViewController.snapshotApplyCountForTesting == 1)
+        #expect(applyCompletionScheduler.pendingCompletionCount == 1)
+
+        let transactionDeliveryBaseline = listViewController
+            .fetchedResultsTransactionDeliveryCountForTesting
+        let secondRequestID = context.seedNetworkRequest(
+            requestID: "reparent-second",
+            url: "https://example.test/reparent-second.json",
+            resourceTypeRawValue: "Fetch",
+            responseMIMEType: "application/json",
+            responseStatus: 200,
+            responseStatusText: "OK",
+            timestamp: 1
+        )
+        let secondRequest = try #require(context.registeredRequest(for: secondRequestID))
+        #expect(await listViewController.waitForFetchedResultsTransactionDeliveryForTesting(
+            after: transactionDeliveryBaseline
+        ))
+        try #require(frameScheduler.hasScheduledFrame)
+        frameScheduler.fireScheduledFrame()
+        await snapshotBuilder.waitUntilStartedBuildCount(2)
+        await snapshotBuilder.releaseBuild(2)
+        await listViewController.waitForListSnapshotBuildIdleForTesting()
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting)
+        #expect(listViewController.snapshotApplyCountForTesting == 1)
+        try #require(frameScheduler.hasScheduledFrame)
+
+        listViewController.suspendRenderingForTesting()
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting == false)
+        #expect(frameScheduler.hasScheduledFrame == false)
+        #expect(applyCompletionScheduler.pendingCompletionCount == 1)
+
+        let splitViewController = NetworkSplitViewController(
+            model: model,
+            listViewController: listViewController,
+            detailViewController: detailViewController
+        )
+        window.rootViewController = splitViewController
+        splitViewController.loadViewIfNeeded()
+        splitViewController.view.frame = window.bounds
+        window.layoutIfNeeded()
+        let primaryNavigationController = try #require(
+            splitViewController.viewController(for: .primary) as? UINavigationController
+        )
+        #expect(primaryNavigationController.viewControllers.first === listViewController)
+        #expect(compactViewController.viewControllers.contains(where: { $0 === listViewController }) == false)
+
+        listViewController.resumeRenderingForTesting()
+        try #require(frameScheduler.hasScheduledFrame)
+        frameScheduler.fireScheduledFrame()
+        await snapshotBuilder.waitUntilStartedBuildCount(3)
+        await snapshotBuilder.releaseBuild(3)
+        await listViewController.waitForListSnapshotBuildIdleForTesting()
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting)
+        #expect(listViewController.snapshotApplyCountForTesting == 1)
+
+        applyCompletionScheduler.runNextCompletion()
+        try #require(frameScheduler.hasScheduledFrame)
+        frameScheduler.fireScheduledFrame()
+        await applyCompletionScheduler.waitUntilScheduledCompletionCount(2)
+        #expect(listViewController.snapshotApplyCountForTesting == 2)
+        #expect(
+            listViewController.displayedRequestIDsForTesting
+                == [secondRequest.id, firstRequest.id]
+        )
+
+        applyCompletionScheduler.runNextCompletion()
+        await listViewController.waitForSnapshotPipelineQuiescenceForTesting()
+
+        #expect(listViewController.displayedEntryIDsForTesting == model.displayEntryIDs)
+        #expect(model.detailSubject?.hasSameIdentity(as: selectedSubject) == true)
+        let selectedEntryID = try #require(model.selectedEntryID)
+        #expect(
+            listViewController.collectionViewForTesting.indexPathsForSelectedItems
+                == [IndexPath(
+                    item: try #require(
+                        model.displayEntryIDs.firstIndex(of: selectedEntryID)
+                    ),
+                    section: 0
+                )]
+        )
+        #expect(applyCompletionScheduler.pendingCompletionCount == 0)
+        #expect(listViewController.hasPendingSnapshotUpdateForTesting == false)
+        #expect(listViewController.hasActiveListSnapshotBuildForTesting == false)
+        #expect(listViewController.hasDeferredListSnapshotBuildForTesting == false)
+        #expect(listViewController.trackedListSnapshotBuildTaskCountForTesting == 0)
+        let buildStatistics = await snapshotBuilder.statistics()
+        #expect(buildStatistics.startedBuildCount == 3)
+        #expect(buildStatistics.activeBuildCount == 0)
+        #expect(buildStatistics.maximumActiveBuildCount == 1)
     }
 
     @Test
@@ -9493,14 +10080,10 @@ private func makeNetworkListSnapshotBaseline(
     ),
     generation: UInt64 = 0
 ) -> NetworkListSnapshotBaseline {
-    var snapshot = NSDiffableDataSourceSnapshot<NetworkListSnapshotSection, NetworkListEntry.ID>()
-    snapshot.appendSections([.main])
-    snapshot.appendItems(entryIDs, toSection: .main)
-    return NetworkListSnapshotBaseline(
+    NetworkListSnapshotBaseline(
         generation: generation,
         version: version,
-        entryIDs: entryIDs,
-        snapshot: snapshot
+        entryIDs: entryIDs
     )
 }
 


### PR DESCRIPTION
## Purpose

Make Network list baseline, artifact admission, and native apply lifecycle one source of truth while preserving the existing diffable, cancellation, and 10,000-row performance contracts.

## Changes

- Store row order only in a canonical clean diffable snapshot and derive baseline entry IDs from it.
- Construct the main section by design and restrict raw clean-snapshot construction to the builder boundary.
- Move ready artifacts, build/apply freshness checks, no-op acknowledgement, queued work, and exact completion identity into one `SnapshotState` phase owner.
- Replace row-array completion matching with monotonic `Application.ID` values so old same-row reconfigure completions cannot finish newer applies.
- Keep applying plus queued-ready state legal, preserve in-flight native applies across hide/reparent, and discard only ready work when lifecycle requires reload.
- Make invalidation coalescing revision-aware so a stale capture acknowledgement cannot clear a newer outstanding frame request.
- Narrow snapshot plumbing to module-internal access and leave #254 selection/detail ownership unchanged.

## Testing

- NetworkDetail/list snapshot suite: 151/151
- Full UI: 366/366
- DataKit: 322/322
- ContractTests: 13/13
- Repository default suite: 900 tests, 0 failures
- Pure baseline/State/Application ID/freshness/no-op/discard matrix
- Out-of-order capture acknowledgement regression
- Compact-to-regular reparent during delayed apply with exact final rows and selection
- Existing cancellation, coalescing, 10,000-row, hide/show, delayed completion, and deinit coverage
- DataKit symbol-boundary check
- Both localization catalogs compiled
- `git diff --check`
- Two independent final audits: no P0-P2 findings
- Branch-wide Codex review: 0 findings

Closes #255