### PR TITLE
Refine inspector copy and empty states

### DIFF
--- a/Sources/WebInspectorUIBase/Localizable.xcstrings
+++ b/Sources/WebInspectorUIBase/Localizable.xcstrings
@@ -287,6 +287,57 @@
         }
       }
     },
+    "dom.element.styles.failed.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Load Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み込み失敗"
+          }
+        }
+      }
+    },
+    "dom.element.styles.loading.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loading"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み込み中"
+          }
+        }
+      }
+    },
+    "dom.element.styles.no_selection.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Selection"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未選択"
+          }
+        }
+      }
+    },
     "dom.element.styles.not_editable.accessibility_value" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1574,6 +1625,40 @@
         }
       }
     },
+    "dom.element.styles.unavailable.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unavailable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用不可"
+          }
+        }
+      }
+    },
+    "dom.tree.copy.selected_text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected Text"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲"
+          }
+        }
+      }
+    },
     "dom.tree.extend_selection_down" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2432,6 +2517,23 @@
         }
       }
     },
+    "network.body.empty" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Body"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボディなし"
+          }
+        }
+      }
+    },
     "network.body.fetch.error.decode_failed" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2714,6 +2816,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本文無法使用"
+          }
+        }
+      }
+    },
+    "network.body.fetch.error.timeout" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@.%2$@ timed out."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@.%2$@がタイムアウトしました。"
           }
         }
       }
@@ -3357,13 +3476,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No request cookies"
+            "value" : "None"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストCookieなし"
+            "value" : "なし"
           }
         }
       }
@@ -3374,13 +3493,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No request, served from the memory cache"
+            "value" : "Memory Cache"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストなし（メモリキャッシュから提供）"
+            "value" : "メモリキャッシュ"
           }
         }
       }
@@ -3391,13 +3510,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Request cookies were not captured"
+            "value" : "Not Captured"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストCookieは取得されませんでした"
+            "value" : "未取得"
           }
         }
       }
@@ -3408,13 +3527,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No response cookies"
+            "value" : "None"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスCookieなし"
+            "value" : "なし"
           }
         }
       }
@@ -3425,13 +3544,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Waiting for response"
+            "value" : "Waiting"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスを待機中"
+            "value" : "待機中"
           }
         }
       }
@@ -3442,13 +3561,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No response was received"
+            "value" : "Not Received"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスを受信しませんでした"
+            "value" : "未受信"
           }
         }
       }
@@ -3504,6 +3623,23 @@
         }
       }
     },
+    "network.cookies.value.not_set" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not Set"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
+          }
+        }
+      }
+    },
     "network.cookies.value.unavailable" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3544,13 +3680,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Combined cookie header cannot be parsed safely"
+            "value" : "Combined header cannot be parsed safely"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "結合されたCookieヘッダーを安全に解析できません"
+            "value" : "結合されたヘッダーを安全に解析できません"
           }
         }
       }
@@ -3561,13 +3697,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Some cookie data could not be parsed"
+            "value" : "Some data could not be parsed"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一部のCookieデータを解析できませんでした"
+            "value" : "一部のデータを解析できませんでした"
           }
         }
       }
@@ -3578,13 +3714,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Cookie header could not be parsed"
+            "value" : "Header could not be parsed"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cookieヘッダーを解析できませんでした"
+            "value" : "ヘッダーを解析できませんでした"
           }
         }
       }
@@ -3796,6 +3932,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "概覽"
+          }
+        }
+      }
+    },
+    "network.empty.none.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "None"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
           }
         }
       }
@@ -4082,6 +4235,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有請求"
+          }
+        }
+      }
+    },
+    "network.no_results.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Results"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該当なし"
           }
         }
       }
@@ -4949,13 +5119,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No parameters"
+            "value" : "None"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "パラメータがありません"
+            "value" : "なし"
           }
         }
       }
@@ -5014,13 +5184,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No request headers"
+            "value" : "None"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストヘッダーなし"
+            "value" : "なし"
           }
         }
       }
@@ -5078,7 +5248,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unparsed Content-Type Parameter"
+            "value" : "Unparsed Content-Type Parameters"
           }
         },
         "ja" : {
@@ -5121,6 +5291,23 @@
         }
       }
     },
+    "network.headers.request_data.view_preview.inline" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Preview"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビューを表示"
+          }
+        }
+      }
+    },
     "network.headers.request_data.view_preview" : {
       "localizations" : {
         "en" : {
@@ -5143,13 +5330,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "No response headers"
+            "value" : "None"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスヘッダーなし"
+            "value" : "なし"
           }
         }
       }
@@ -5528,6 +5715,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未報告"
+          }
+        }
+      }
+    },
+    "network.search.placeholder.short" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Search"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
           }
         }
       }
@@ -6406,13 +6610,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Show Less DNS Names"
+            "value" : "Show Fewer DNS Names"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DNS名の表示を減らす"
+            "value" : "DNS名を一部のみ表示"
           }
         }
       }
@@ -6423,13 +6627,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Show Less IP Addresses"
+            "value" : "Show Fewer IP Addresses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IPアドレスの表示を減らす"
+            "value" : "IPアドレスを一部のみ表示"
           }
         }
       }
@@ -6623,6 +6827,23 @@
         }
       }
     },
+    "network.security.field.metadata" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Metadata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メタデータ"
+          }
+        }
+      }
+    },
     "network.security.field.reason" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -6704,6 +6925,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サブジェクト"
+          }
+        }
+      }
+    },
+    "network.security.field.tls" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "TLS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TLS"
           }
         }
       }
@@ -6816,13 +7054,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "The request was canceled before a response was reported."
+            "value" : "Request Canceled"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスが報告される前にリクエストがキャンセルされました。"
+            "value" : "リクエストをキャンセル"
           }
         }
       }
@@ -6833,13 +7071,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Loading completed without a reported response."
+            "value" : "No Response"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスが報告されずに読み込みが完了しました。"
+            "value" : "レスポンスなし"
           }
         }
       }
@@ -6850,13 +7088,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "The request failed before a response was reported."
+            "value" : "Request Failed"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レスポンスが報告される前にリクエストが失敗しました。"
+            "value" : "リクエスト失敗"
           }
         }
       }
@@ -6980,6 +7218,23 @@
         }
       }
     },
+    "network.security.value.empty" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空"
+          }
+        }
+      }
+    },
     "network.security.value.empty_reported" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -6993,6 +7248,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空の値が報告されました"
+          }
+        }
+      }
+    },
+    "network.security.value.none" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "None"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
           }
         }
       }
@@ -7031,6 +7303,23 @@
         }
       }
     },
+    "network.security.value.not_classified" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not Classified"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未分類"
+          }
+        }
+      }
+    },
     "network.security.value.not_reported" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -7054,7 +7343,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Response pending"
+            "value" : "Waiting for Response"
           }
         },
         "ja" : {
@@ -7105,13 +7394,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "WebSocket Connection Closed"
+            "value" : "Connection Closed"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebSocket接続を終了"
+            "value" : "接続を終了"
           }
         }
       }
@@ -7122,13 +7411,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "WebSocket Connection Established"
+            "value" : "Connection Established"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebSocket接続を確立"
+            "value" : "接続を確立"
           }
         }
       }
@@ -7309,13 +7598,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "WebSocket Handshake Rejected"
+            "value" : "Handshake Rejected"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebSocketハンドシェイクを拒否"
+            "value" : "ハンドシェイクを拒否"
           }
         }
       }
@@ -7326,13 +7615,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "WebSocket Handshake Response"
+            "value" : "Handshake Response"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebSocketハンドシェイク応答"
+            "value" : "ハンドシェイク応答"
           }
         }
       }

--- a/Sources/WebInspectorUIDOM/Element/DOMElementStylePresentationModel.swift
+++ b/Sources/WebInspectorUIDOM/Element/DOMElementStylePresentationModel.swift
@@ -103,7 +103,10 @@ package final class DOMElementStyleSnapshotCoordinator {
 
     package enum PlaceholderMode: Equatable {
         case none
+        case noSelection
+        case loading
         case unavailable
+        case failed
     }
 
     package struct SnapshotUpdate {
@@ -208,16 +211,21 @@ package final class DOMElementStyleSnapshotCoordinator {
             return updateLoadedSnapshot(styles.sections)
         case .loading, .needsRefresh:
             return updatePendingSnapshot(styles.sections)
-        case .unavailable, .failed:
-            return updateUnavailableSnapshot()
+        case .unavailable:
+            return resetSnapshot(placeholderMode: .unavailable)
+        case .failed:
+            return resetSnapshot(placeholderMode: .failed)
         }
     }
 
-    /// No selected element styles exist (no selection, or the selection is
-    /// not an element node).
+    package func updateNoSelection() -> SnapshotUpdate {
+        selectionEpoch = nil
+        return resetSnapshot(placeholderMode: .noSelection)
+    }
+
     package func updateUnavailable() -> SnapshotUpdate {
         selectionEpoch = nil
-        return updateUnavailableSnapshot()
+        return resetSnapshot(placeholderMode: .unavailable)
     }
 
     package func revealHiddenUnusedVariables(
@@ -339,11 +347,11 @@ package final class DOMElementStyleSnapshotCoordinator {
     /// modified-by-inspector badge must update immediately (the legacy build
     /// rendered this through per-object observation in the cells).
     private func updatePendingSnapshot(_ sections: [CSSStyleSection]) -> SnapshotUpdate {
-        guard displayedSections != nil else {
-            return updateUnavailableSnapshot()
-        }
         guard selectionEpoch?.hasRenderedLoadedSnapshot == true else {
-            return SnapshotUpdate(snapshot: nil, applyMode: .none, placeholderMode: .none)
+            return resetSnapshot(placeholderMode: .loading)
+        }
+        guard displayedSections != nil else {
+            return resetSnapshot(placeholderMode: .loading)
         }
 
         let prospectiveVisibleSections = DOMElementStyleDiffableSnapshotBuilder.visibleSections(
@@ -391,7 +399,7 @@ package final class DOMElementStyleSnapshotCoordinator {
         )
     }
 
-    private func updateUnavailableSnapshot() -> SnapshotUpdate {
+    private func resetSnapshot(placeholderMode: PlaceholderMode) -> SnapshotUpdate {
         let oldSectionIDs = visibleSectionIDs
         let oldItemIDs = visibleItemIDs
         expandedUnusedVariableSectionIDs.removeAll()
@@ -404,7 +412,11 @@ package final class DOMElementStyleSnapshotCoordinator {
             oldItemIDs: oldItemIDs,
             snapshot: snapshot
         ) ? .diff(animated: false) : .none
-        return SnapshotUpdate(snapshot: snapshot, applyMode: applyMode, placeholderMode: .unavailable)
+        return SnapshotUpdate(
+            snapshot: snapshot,
+            applyMode: applyMode,
+            placeholderMode: placeholderMode
+        )
     }
 
     private func rebuildVisibleSections() {

--- a/Sources/WebInspectorUIDOM/Element/DOMElementViewController.swift
+++ b/Sources/WebInspectorUIDOM/Element/DOMElementViewController.swift
@@ -12,6 +12,7 @@ package final class DOMElementViewController: UICollectionViewController {
     private var selectedStylesObservation: PortableObservationTracking.Token?
     private var observedSelectedNodeObjectID: ObjectIdentifier?
     private var hasBoundSelectedNode = false
+    private var renderedPlaceholderMode = DOMElementStyleSnapshotCoordinator.PlaceholderMode.none
     private let styleSnapshotCoordinator = DOMElementStyleSnapshotCoordinator()
 
 #if DEBUG
@@ -202,7 +203,7 @@ package final class DOMElementViewController: UICollectionViewController {
         selectedStylesObservation?.cancel()
         guard let node else {
             selectedStylesObservation = nil
-            renderSelectedStyles(nil)
+            applySnapshotUpdate(styleSnapshotCoordinator.updateNoSelection())
             return
         }
         let token = withPortableContinuousObservation { [weak self, weak node, nodeObjectID] _ in
@@ -211,7 +212,7 @@ package final class DOMElementViewController: UICollectionViewController {
                 return
             }
             guard let node else {
-                self.renderSelectedStyles(nil)
+                self.applySnapshotUpdate(self.styleSnapshotCoordinator.updateNoSelection())
                 return
             }
             self.renderSelectedStyles(node.elementStyles)
@@ -283,22 +284,53 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     private func applyPlaceholder(_ placeholderMode: DOMElementStyleSnapshotCoordinator.PlaceholderMode) {
+        guard renderedPlaceholderMode != placeholderMode
+                || (placeholderMode == .none) != (contentUnavailableConfiguration == nil) else {
+            return
+        }
+        renderedPlaceholderMode = placeholderMode
         switch placeholderMode {
         case .none:
-            if contentUnavailableConfiguration != nil {
-                contentUnavailableConfiguration = nil
-            }
-        case .unavailable:
-            let title = String(localized: "dom.element.styles.empty.title", bundle: WebInspectorUILocalization.bundle)
-            if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
-               configuration.text == title {
-                return
-            }
-            var configuration = UIContentUnavailableConfiguration.empty()
-            configuration.text = title
+            contentUnavailableConfiguration = nil
+        case .noSelection:
+            contentUnavailableConfiguration = placeholderConfiguration(
+                key: "dom.element.styles.no_selection.title",
+                defaultValue: "No Selection"
+            )
+        case .loading:
+            var configuration = UIContentUnavailableConfiguration.loading()
+            configuration.text = String(
+                localized: "dom.element.styles.loading.title",
+                defaultValue: "Loading",
+                bundle: WebInspectorUILocalization.bundle
+            )
             configuration.textProperties.color = .secondaryLabel
             contentUnavailableConfiguration = configuration
+        case .unavailable:
+            contentUnavailableConfiguration = placeholderConfiguration(
+                key: "dom.element.styles.unavailable.title",
+                defaultValue: "Unavailable"
+            )
+        case .failed:
+            contentUnavailableConfiguration = placeholderConfiguration(
+                key: "dom.element.styles.failed.title",
+                defaultValue: "Load Failed"
+            )
         }
+    }
+
+    private func placeholderConfiguration(
+        key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> UIContentUnavailableConfiguration {
+        var configuration = UIContentUnavailableConfiguration.empty()
+        configuration.text = String(
+            localized: key,
+            defaultValue: defaultValue,
+            bundle: WebInspectorUILocalization.bundle
+        )
+        configuration.textProperties.color = .secondaryLabel
+        return configuration
     }
 
     /// Section headers are supplementary views; diffable snapshots never
@@ -353,6 +385,10 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
 #if DEBUG
+    package var placeholderModeForTesting: DOMElementStyleSnapshotCoordinator.PlaceholderMode {
+        renderedPlaceholderMode
+    }
+
     package var styleRenderGenerationForTesting: Int {
         styleRenderGeneration
     }
@@ -388,7 +424,11 @@ package final class DOMElementViewController: UICollectionViewController {
     }
 
     package func renderCurrentStylesForTesting() {
-        renderSelectedStyles(context.selectedNode?.elementStyles)
+        guard let selectedNode = context.selectedNode else {
+            applySnapshotUpdate(styleSnapshotCoordinator.updateNoSelection())
+            return
+        }
+        renderSelectedStyles(selectedNode.elementStyles)
     }
 
     private func finishStyleRenderForTesting() {

--- a/Sources/WebInspectorUIDOM/Tree/DOMTreeMenu.swift
+++ b/Sources/WebInspectorUIDOM/Tree/DOMTreeMenu.swift
@@ -229,7 +229,14 @@ struct DOMTreeMenuView: View {
                 Button {
                     model.copySelectedText()
                 } label: {
-                    Label(String(localized: "Copy", bundle: WebInspectorUILocalization.bundle), systemImage: "doc.on.doc")
+                    Label(
+                        String(
+                            localized: "dom.tree.copy.selected_text",
+                            defaultValue: "Selected Text",
+                            bundle: WebInspectorUILocalization.bundle
+                        ),
+                        systemImage: "doc.on.doc"
+                    )
                 }
                 .disabled(!model.canCopySelectedText)
             }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkBodyPreviewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkBodyPreviewController.swift
@@ -6,6 +6,7 @@ import WebInspectorDataKit
 @MainActor
 package enum NetworkBodySurface {
     case none
+    case emptyBodyPlaceholder
     case unavailableBodyPlaceholder
     case body(NetworkBody, metadata: NetworkMediaPreviewMetadata?)
 
@@ -27,14 +28,16 @@ package enum NetworkBodySurface {
         switch self {
         case .none:
             false
-        case .unavailableBodyPlaceholder, .body:
+        case .emptyBodyPlaceholder, .unavailableBodyPlaceholder, .body:
             true
         }
     }
 
     package func isEquivalent(to other: NetworkBodySurface) -> Bool {
         switch (self, other) {
-        case (.none, .none), (.unavailableBodyPlaceholder, .unavailableBodyPlaceholder):
+        case (.none, .none),
+             (.emptyBodyPlaceholder, .emptyBodyPlaceholder),
+             (.unavailableBodyPlaceholder, .unavailableBodyPlaceholder):
             return true
         case (.body(let body, let metadata), .body(let otherBody, let otherMetadata)):
             return body === otherBody && metadata == otherMetadata

--- a/Sources/WebInspectorUINetwork/Detail/NetworkCookieCell.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkCookieCell.swift
@@ -4,11 +4,18 @@ import UIKit
 package struct NetworkCookieFieldContent: Hashable, Sendable {
     package let label: String
     package let value: String
+    package let accessibilityValue: String?
     package let isFullWidth: Bool
 
-    package init(label: String, value: String, isFullWidth: Bool = false) {
+    package init(
+        label: String,
+        value: String,
+        accessibilityValue: String? = nil,
+        isFullWidth: Bool = false
+    ) {
         self.label = label
         self.value = value
+        self.accessibilityValue = accessibilityValue
         self.isFullWidth = isFullWidth
     }
 }
@@ -178,7 +185,7 @@ package final class NetworkCookieCell: UICollectionViewListCell {
 
     private func renderAccessibility(_ content: NetworkCookieRowContent) {
         accessibilityLabel = content.fields
-            .map { "\($0.label), \($0.value)" }
+            .map { "\($0.label), \($0.accessibilityValue ?? $0.value)" }
             .joined(separator: ", ")
         accessibilityValue = nil
     }

--- a/Sources/WebInspectorUINetwork/Detail/NetworkCookiesViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkCookiesViewController.swift
@@ -80,6 +80,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
         package let kind: Kind
         package let title: String
         package let detail: String?
+        package let accessibilityLabel: String
     }
 
     private enum RowContent: Hashable, Sendable {
@@ -217,7 +218,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
             content.text = Self.title(for: section)
             header.contentConfiguration = content
             header.isAccessibilityElement = true
-            header.accessibilityLabel = content.text
+            header.accessibilityLabel = Self.accessibilityTitle(for: section)
             header.accessibilityTraits = .header
         }
         dataSource.supplementaryViewProvider = { collectionView, elementKind, indexPath in
@@ -261,7 +262,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 kind: .requestNotCaptured,
                 title: localized(
                     "network.cookies.request.not_captured",
-                    defaultValue: "Request cookies were not captured"
+                    defaultValue: "Not Captured"
                 )
             )]
         case .unavailable(.servedFromMemoryCache):
@@ -270,8 +271,12 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 section: .request,
                 kind: .requestMemoryCache,
                 title: localized(
+                    "network.cookies.request.not_captured",
+                    defaultValue: "Not Captured"
+                ),
+                detail: localized(
                     "network.cookies.request.memory_cache",
-                    defaultValue: "No request, served from the memory cache"
+                    defaultValue: "Memory Cache"
                 )
             )]
         case .empty:
@@ -281,7 +286,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 kind: .requestEmpty,
                 title: localized(
                     "network.cookies.request.empty",
-                    defaultValue: "No request cookies"
+                    defaultValue: "None"
                 )
             )]
         case .values(let report):
@@ -316,7 +321,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 kind: .responseLoading,
                 title: localized(
                     "network.cookies.response.loading",
-                    defaultValue: "Waiting for response"
+                    defaultValue: "Waiting"
                 ),
                 messageKind: .loading
             )]
@@ -327,7 +332,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 kind: .responseMissing,
                 title: localized(
                     "network.cookies.response.missing",
-                    defaultValue: "No response was received"
+                    defaultValue: "Not Received"
                 )
             )]
         case .empty:
@@ -337,7 +342,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 kind: .responseEmpty,
                 title: localized(
                     "network.cookies.response.empty",
-                    defaultValue: "No response cookies"
+                    defaultValue: "None"
                 )
             )]
         case .values(let report):
@@ -365,11 +370,18 @@ package final class NetworkCookiesViewController: UICollectionViewController {
         section: SectionID,
         kind: StateKind,
         title: String,
+        detail: String? = nil,
         messageKind: MessageContent.Kind = .information
     ) -> (ItemID, RowContent) {
         (
             .state(epoch: requestEpoch, section: section, kind: kind),
-            .message(MessageContent(kind: messageKind, title: title, detail: nil))
+            .message(MessageContent(
+                kind: messageKind,
+                title: title,
+                detail: detail,
+                accessibilityLabel: [Self.accessibilityTitle(for: section), title]
+                    .joined(separator: ", ")
+            ))
         )
     }
 
@@ -385,48 +397,40 @@ package final class NetworkCookiesViewController: UICollectionViewController {
         case .ambiguousCombined:
             title = localized(
                 "network.cookies.warning.ambiguous_combined",
-                defaultValue: "Combined cookie header cannot be parsed safely"
+                defaultValue: "Combined header cannot be parsed safely"
             )
         case .partial:
             title = localized(
                 "network.cookies.warning.partial",
-                defaultValue: "Some cookie data could not be parsed"
+                defaultValue: "Some data could not be parsed"
             )
         case .unparsed:
             title = localized(
                 "network.cookies.warning.unparsed",
-                defaultValue: "Cookie header could not be parsed"
+                defaultValue: "Header could not be parsed"
             )
         case .complete:
             title = localized(
                 "network.cookies.warning.unparsed",
-                defaultValue: "Cookie header could not be parsed"
+                defaultValue: "Header could not be parsed"
             )
         }
 
-        if diagnostics.isEmpty {
-            guard status != .complete else {
-                return []
-            }
-            return [(
-                .diagnostic(epoch: requestEpoch, section: section, ordinal: 0),
-                .message(MessageContent(
-                    kind: .warning,
-                    title: title,
-                    detail: rawHeaderValues.joined(separator: "\n")
-                ))
-            )]
+        guard diagnostics.isEmpty == false || status != .complete else {
+            return []
         }
-        return diagnostics.enumerated().map { index, diagnostic in
-            (
-                .diagnostic(epoch: requestEpoch, section: section, ordinal: index),
-                .message(MessageContent(
-                    kind: .warning,
-                    title: title,
-                    detail: diagnostic.rawFragment
-                ))
-            )
-        }
+        let detail = (diagnostics.isEmpty ? rawHeaderValues : diagnostics.map(\.rawFragment))
+            .joined(separator: "\n")
+        return [(
+            .diagnostic(epoch: requestEpoch, section: section, ordinal: 0),
+            .message(MessageContent(
+                kind: .warning,
+                title: title,
+                detail: detail,
+                accessibilityLabel: [Self.accessibilityTitle(for: section), title]
+                    .joined(separator: ", ")
+            ))
+        )]
     }
 
     private func requestRowContent(_ cookie: NetworkRequestCookie) -> NetworkCookieRowContent {
@@ -440,26 +444,41 @@ package final class NetworkCookiesViewController: UICollectionViewController {
     }
 
     private func responseRowContent(_ cookie: NetworkResponseCookie) -> NetworkCookieRowContent {
-        let missingValue = localized("network.cookies.value.unavailable", defaultValue: "Not reported")
+        let missingAccessibilityValue = localized(
+            "network.cookies.value.not_set",
+            defaultValue: "Not Set"
+        )
         var fields = [
             field("network.cookies.field.name", defaultValue: "Name", value: cookie.name),
             field("network.cookies.field.value", defaultValue: "Value", value: cookie.value),
-            field("network.cookies.field.domain", defaultValue: "Domain", value: cookie.domain ?? missingValue),
-            field("network.cookies.field.path", defaultValue: "Path", value: cookie.path ?? missingValue),
+            optionalField(
+                "network.cookies.field.domain",
+                defaultValue: "Domain",
+                value: cookie.domain,
+                missingAccessibilityValue: missingAccessibilityValue
+            ),
+            optionalField(
+                "network.cookies.field.path",
+                defaultValue: "Path",
+                value: cookie.path,
+                missingAccessibilityValue: missingAccessibilityValue
+            ),
             field(
                 "network.cookies.field.partitioned",
                 defaultValue: "Partitioned",
                 value: booleanText(cookie.isPartitioned)
             ),
-            field(
+            optionalField(
                 "network.cookies.field.expires",
                 defaultValue: "Expires",
-                value: expiresText(cookie, missingValue: missingValue)
+                value: expiresText(cookie),
+                missingAccessibilityValue: missingAccessibilityValue
             ),
-            field(
+            optionalField(
                 "network.cookies.field.max_age",
                 defaultValue: "Max-Age",
-                value: cookie.maxAgeSeconds.map(String.init) ?? cookie.rawMaxAge ?? missingValue
+                value: cookie.maxAgeSeconds.map(String.init) ?? cookie.rawMaxAge,
+                missingAccessibilityValue: missingAccessibilityValue
             ),
             field(
                 "network.cookies.field.secure",
@@ -471,10 +490,11 @@ package final class NetworkCookiesViewController: UICollectionViewController {
                 defaultValue: "HttpOnly",
                 value: booleanText(cookie.isHTTPOnly)
             ),
-            field(
+            optionalField(
                 "network.cookies.field.same_site",
                 defaultValue: "SameSite",
-                value: sameSiteText(cookie.sameSite, missingValue: missingValue)
+                value: sameSiteText(cookie.sameSite),
+                missingAccessibilityValue: missingAccessibilityValue
             ),
         ]
         fields.append(contentsOf: cookie.unknownAttributes.map { attribute in
@@ -495,26 +515,42 @@ package final class NetworkCookiesViewController: UICollectionViewController {
         _ key: StaticString,
         defaultValue: String.LocalizationValue,
         value: String,
+        accessibilityValue: String? = nil,
         isFullWidth: Bool = false
     ) -> NetworkCookieFieldContent {
         NetworkCookieFieldContent(
             label: localized(key, defaultValue: defaultValue),
             value: value,
+            accessibilityValue: accessibilityValue,
             isFullWidth: isFullWidth
         )
     }
 
-    private func expiresText(_ cookie: NetworkResponseCookie, missingValue: String) -> String {
+    private func optionalField(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue,
+        value: String?,
+        missingAccessibilityValue: String
+    ) -> NetworkCookieFieldContent {
+        field(
+            key,
+            defaultValue: defaultValue,
+            value: value ?? "-",
+            accessibilityValue: value == nil ? missingAccessibilityValue : nil
+        )
+    }
+
+    private func expiresText(_ cookie: NetworkResponseCookie) -> String? {
         if let expires = cookie.expires {
             return expires.formatted(date: .abbreviated, time: .standard)
         }
-        return cookie.rawExpires ?? missingValue
+        return cookie.rawExpires
     }
 
-    private func sameSiteText(_ sameSite: NetworkCookieSameSite, missingValue: String) -> String {
+    private func sameSiteText(_ sameSite: NetworkCookieSameSite) -> String? {
         switch sameSite {
         case .absent:
-            missingValue
+            nil
         case .none:
             "None"
         case .lax:
@@ -616,7 +652,7 @@ package final class NetworkCookiesViewController: UICollectionViewController {
         cell.accessories = content.kind == .loading ? [Self.loadingAccessory()] : []
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = .staticText
-        cell.accessibilityLabel = content.title
+        cell.accessibilityLabel = content.accessibilityLabel
         cell.accessibilityValue = content.detail
     }
 
@@ -637,6 +673,23 @@ package final class NetworkCookiesViewController: UICollectionViewController {
     }
 
     private static func title(for section: SectionID) -> String {
+        switch section {
+        case .request:
+            String(
+                localized: "network.section.request",
+                defaultValue: "Request",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        case .response:
+            String(
+                localized: "network.section.response",
+                defaultValue: "Response",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        }
+    }
+
+    private static func accessibilityTitle(for section: SectionID) -> String {
         switch section {
         case .request:
             String(

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailRequestPickerViewController.swift
@@ -71,7 +71,13 @@ final class NetworkDetailRequestPickerViewController: UICollectionViewController
         let searchController = UISearchController(searchResultsController: nil)
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = String(
+            localized: "network.search.placeholder.short",
+            defaultValue: "Search",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        searchController.searchBar.searchTextField.accessibilityLabel = String(
             localized: "network.search.placeholder",
+            defaultValue: "Search Requests",
             bundle: WebInspectorUILocalization.bundle
         )
         searchController.searchResultsUpdater = self

--- a/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkDetailViewController.swift
@@ -780,7 +780,7 @@ package final class NetworkDetailViewController: UIViewController {
         renderPreviewRoleControl(roles: roles, selectedRole: selectedRole)
 
         guard let role = selectedRole else {
-            bodyViewController.setSurface(.unavailableBodyPlaceholder)
+            bodyViewController.setSurface(.emptyBodyPlaceholder)
             unbindResponseBodyFetchObservation()
             return
         }
@@ -895,7 +895,7 @@ package final class NetworkDetailViewController: UIViewController {
             return .unavailableBodyPlaceholder
         }
         guard let body = body(in: request, for: role) else {
-            return .unavailableBodyPlaceholder
+            return .emptyBodyPlaceholder
         }
         return .body(
             body,

--- a/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkHeadersTextDocumentBuilder.swift
@@ -323,7 +323,7 @@ struct NetworkHeadersTextDocumentBuilder {
                 Row(
                     key: String(
                         localized: "network.headers.parameters.empty",
-                        defaultValue: "No parameters",
+                        defaultValue: "None",
                         bundle: WebInspectorUILocalization.bundle
                     ),
                     value: nil,
@@ -354,8 +354,8 @@ struct NetworkHeadersTextDocumentBuilder {
                 rows.append(
                     Row(
                         key: String(
-                            localized: "network.headers.request_data.view_preview",
-                            defaultValue: "View Request Preview",
+                            localized: "network.headers.request_data.view_preview.inline",
+                            defaultValue: "View Preview",
                             bundle: WebInspectorUILocalization.bundle
                         ),
                         value: nil,
@@ -373,12 +373,8 @@ struct NetworkHeadersTextDocumentBuilder {
                 case let .decoded(_, value) = parameter.value
             else {
                 return Row(
-                    key: String(
-                        localized: "network.headers.parameters.unparsed",
-                        defaultValue: "Unparsed Parameter",
-                        bundle: WebInspectorUILocalization.bundle
-                    ),
-                    value: "\(parameter.rawFragment) — \(malformedReasonText(for: parameter))",
+                    key: parameter.rawFragment,
+                    value: malformedReasonText(for: parameter),
                     style: .warning,
                     alwaysShowsValueSeparator: true
                 )
@@ -435,27 +431,23 @@ struct NetworkHeadersTextDocumentBuilder {
             return [
                 Row(
                     key: contentTypeLabel,
-                    value: String(
-                        localized: "network.headers.value.not_reported",
-                        defaultValue: "Not reported",
-                        bundle: WebInspectorUILocalization.bundle
-                    ),
+                    value: "-",
                     style: .message
                 )
             ]
         case .ambiguous(let rawValues):
-            return rawValues.map { rawValue in
+            return [
                 Row(
                     key: String(
                         localized: "network.headers.request_data.content_type_ambiguous",
                         defaultValue: "Ambiguous Content Type",
                         bundle: WebInspectorUILocalization.bundle
                     ),
-                    value: rawValue,
+                    value: rawValues.joined(separator: "\n"),
                     style: .warning,
                     alwaysShowsValueSeparator: true
                 )
-            }
+            ]
         case .value(let contentType):
             var rows = [
                 Row(
@@ -503,22 +495,23 @@ struct NetworkHeadersTextDocumentBuilder {
                         alwaysShowsValueSeparator: true
                     )
                 })
-            rows.append(
-                contentsOf: contentType.parameters.compactMap { parameter in
-                    guard parameter.issue != nil else {
-                        return nil
-                    }
-                    return Row(
+            let unparsedParameters = contentType.parameters.compactMap { parameter in
+                parameter.issue == nil ? nil : parameter.rawFragment
+            }
+            if unparsedParameters.isEmpty == false {
+                rows.append(
+                    Row(
                         key: String(
                             localized: "network.headers.request_data.content_type_parameter_unparsed",
-                            defaultValue: "Unparsed Content-Type Parameter",
+                            defaultValue: "Unparsed Content-Type Parameters",
                             bundle: WebInspectorUILocalization.bundle
                         ),
-                        value: parameter.rawFragment,
+                        value: unparsedParameters.joined(separator: "\n"),
                         style: .warning,
                         alwaysShowsValueSeparator: true
                     )
-                })
+                )
+            }
             return rows
         }
     }
@@ -535,7 +528,7 @@ struct NetworkHeadersTextDocumentBuilder {
             rows.append(
                 Row(
                     key: String(
-                        localized: "network.headers.request.empty", defaultValue: "No request headers",
+                        localized: "network.headers.request.empty", defaultValue: "None",
                         bundle: WebInspectorUILocalization.bundle),
                     value: nil,
                     style: .message
@@ -564,7 +557,7 @@ struct NetworkHeadersTextDocumentBuilder {
             rows.append(
                 Row(
                     key: String(
-                        localized: "network.headers.response.empty", defaultValue: "No response headers",
+                        localized: "network.headers.response.empty", defaultValue: "None",
                         bundle: WebInspectorUILocalization.bundle),
                     value: nil,
                     style: .message

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityDocument.swift
@@ -57,6 +57,7 @@ struct NetworkSecurityItemID: Hashable {
 struct NetworkSecurityRowContent: Equatable {
     let label: String
     let value: String?
+    let accessibilityLabel: String?
     let usesTechnicalValueDirection: Bool
     let disclosureList: NetworkSecurityListKind?
     let isExpanded: Bool
@@ -79,22 +80,31 @@ struct NetworkSecurityDocumentBuilder {
         var builder = Builder(epoch: epoch)
         switch summary {
         case .plaintextScheme(let scheme):
-            builder.appendStatus(
-                value: plaintextStatus(for: scheme),
-                scheme: plaintextSchemeText(scheme)
+            builder.appendScheme(plaintextSchemeText(scheme))
+            builder.append(
+                section: .status,
+                kind: .status,
+                label: tlsLabel,
+                value: notApplicableText
             )
-            builder.appendUnavailableMetadata(value: notApplicableText)
         case .pending(let scheme):
-            builder.appendStatus(value: pendingText, scheme: encryptedSchemeText(scheme))
-            builder.appendUnavailableMetadata(value: pendingText)
-        case let .encryptedScheme(scheme, metadata):
-            builder.appendStatus(
-                value: metadataStatus(for: scheme, metadata: metadata),
-                scheme: encryptedSchemeText(scheme)
+            builder.appendScheme(encryptedSchemeText(scheme))
+            builder.appendState(
+                section: .status,
+                kind: .status,
+                accessibilityLabel: statusLabel,
+                value: pendingText
             )
+        case let .encryptedScheme(scheme, metadata):
+            builder.appendScheme(encryptedSchemeText(scheme))
             switch metadata {
             case .notReported:
-                builder.appendMetadataNotReported()
+                builder.append(
+                    section: .status,
+                    kind: .securityMetadata,
+                    label: securityMetadataLabel,
+                    value: notReportedText
+                )
             case .reported(let security):
                 builder.append(
                     section: .status,
@@ -105,9 +115,12 @@ struct NetworkSecurityDocumentBuilder {
                 appendReportedSecurity(security, to: &builder)
             }
         case let .unavailable(scheme, reason):
-            builder.appendStatus(
-                value: unavailableStatus(for: reason),
-                scheme: encryptedSchemeText(scheme)
+            builder.appendScheme(encryptedSchemeText(scheme))
+            builder.appendState(
+                section: .status,
+                kind: .status,
+                accessibilityLabel: statusLabel,
+                value: unavailableStatus(for: reason)
             )
             if let reasonText = rawUnavailableReason(reason) {
                 builder.append(
@@ -117,21 +130,14 @@ struct NetworkSecurityDocumentBuilder {
                     display: reportedScalar(reasonText)
                 )
             }
-            builder.appendUnavailableMetadata(value: unavailableText)
         case .notApplicable(let scheme):
+            builder.appendScheme(scheme)
             builder.append(
                 section: .status,
                 kind: .status,
-                label: statusLabel,
+                label: tlsLabel,
                 value: notClassifiedText
             )
-            builder.append(
-                section: .status,
-                kind: .scheme,
-                label: schemeLabel,
-                display: reportedScalar(scheme)
-            )
-            builder.appendUnavailableMetadata(value: notApplicableText)
         }
         return builder.document
     }
@@ -141,12 +147,6 @@ struct NetworkSecurityDocumentBuilder {
         to builder: inout Builder
     ) {
         if let connection = security.connection {
-            builder.append(
-                section: .connection,
-                kind: .connectionMetadata,
-                label: connectionMetadataLabel,
-                value: reportedText
-            )
             builder.append(
                 section: .connection,
                 kind: .tlsProtocol,
@@ -160,29 +160,23 @@ struct NetworkSecurityDocumentBuilder {
                 display: reportedScalar(connection.cipher)
             )
         } else {
-            builder.append(
+            builder.appendState(
                 section: .connection,
                 kind: .connectionMetadata,
-                label: connectionMetadataLabel,
+                accessibilityLabel: connectionMetadataLabel,
                 value: notReportedText
             )
         }
 
         guard let certificate = security.certificate else {
-            builder.append(
+            builder.appendState(
                 section: .certificate,
                 kind: .certificateMetadata,
-                label: certificateMetadataLabel,
+                accessibilityLabel: certificateMetadataLabel,
                 value: notReportedText
             )
             return
         }
-        builder.append(
-            section: .certificate,
-            kind: .certificateMetadata,
-            label: certificateMetadataLabel,
-            value: reportedText
-        )
         builder.append(
             section: .certificate,
             kind: .subject,
@@ -223,7 +217,7 @@ struct NetworkSecurityDocumentBuilder {
                 section: .certificate,
                 kind: kind == .dnsNames ? .dnsState : .ipAddressState,
                 label: kind == .dnsNames ? dnsNamesLabel : ipAddressesLabel,
-                value: notReportedText
+                display: notReportedDisplay
             )
             return
         }
@@ -232,7 +226,11 @@ struct NetworkSecurityDocumentBuilder {
                 section: .certificate,
                 kind: kind == .dnsNames ? .dnsState : .ipAddressState,
                 label: kind == .dnsNames ? dnsNamesLabel : ipAddressesLabel,
-                value: noValuesReportedText
+                display: DisplayValue(
+                    value: noneText,
+                    accessibilityValue: noValuesReportedText,
+                    isTechnical: false
+                )
             )
             return
         }
@@ -262,57 +260,6 @@ struct NetworkSecurityDocumentBuilder {
         )
     }
 
-    private func plaintextStatus(
-        for scheme: NetworkSecuritySummary.PlaintextScheme
-    ) -> String {
-        switch scheme {
-        case .http:
-            localized(
-                "network.security.status.http",
-                defaultValue: "HTTP scheme reported; TLS does not apply."
-            )
-        case .ws:
-            localized(
-                "network.security.status.ws",
-                defaultValue: "WS scheme reported; TLS does not apply."
-            )
-        }
-    }
-
-    private func metadataStatus(
-        for scheme: NetworkSecuritySummary.EncryptedScheme,
-        metadata: NetworkSecuritySummary.Metadata
-    ) -> String {
-        switch metadata {
-        case .notReported:
-            switch scheme {
-            case .https:
-                localized(
-                    "network.security.status.https_not_reported",
-                    defaultValue: "HTTPS scheme reported; security metadata was not reported."
-                )
-            case .wss:
-                localized(
-                    "network.security.status.wss_not_reported",
-                    defaultValue: "WSS scheme reported; security metadata was not reported."
-                )
-            }
-        case .reported:
-            switch scheme {
-            case .https:
-                localized(
-                    "network.security.status.https_reported",
-                    defaultValue: "HTTPS scheme and security metadata reported."
-                )
-            case .wss:
-                localized(
-                    "network.security.status.wss_reported",
-                    defaultValue: "WSS scheme and security metadata reported."
-                )
-            }
-        }
-    }
-
     private func unavailableStatus(
         for reason: NetworkSecuritySummary.UnavailableReason
     ) -> String {
@@ -320,17 +267,17 @@ struct NetworkSecurityDocumentBuilder {
         case .failedBeforeResponse:
             localized(
                 "network.security.status.failed_before_response",
-                defaultValue: "The request failed before a response was reported."
+                defaultValue: "Request Failed"
             )
         case .canceledBeforeResponse:
             localized(
                 "network.security.status.canceled_before_response",
-                defaultValue: "The request was canceled before a response was reported."
+                defaultValue: "Request Canceled"
             )
         case .completedWithoutResponse:
             localized(
                 "network.security.status.completed_without_response",
-                defaultValue: "Loading completed without a reported response."
+                defaultValue: "No Response"
             )
         }
     }
@@ -371,20 +318,25 @@ struct NetworkSecurityDocumentBuilder {
 
     private func reportedScalar(_ value: String?) -> DisplayValue {
         guard let value else {
-            return DisplayValue(value: notReportedText, isTechnical: false)
+            return notReportedDisplay
         }
         guard value.isEmpty == false else {
-            return DisplayValue(value: emptyValueReportedText, isTechnical: false)
+            return DisplayValue(
+                value: emptyText,
+                accessibilityValue: emptyValueReportedText,
+                isTechnical: false
+            )
         }
-        return DisplayValue(value: value, isTechnical: true)
+        return DisplayValue(value: value, accessibilityValue: nil, isTechnical: true)
     }
 
     private func reportedDate(_ date: Date?) -> DisplayValue {
         guard let date else {
-            return DisplayValue(value: notReportedText, isTechnical: false)
+            return notReportedDisplay
         }
         return DisplayValue(
             value: date.formatted(date: .numeric, time: .complete),
+            accessibilityValue: nil,
             isTechnical: false
         )
     }
@@ -413,12 +365,12 @@ struct NetworkSecurityDocumentBuilder {
         case .dnsNames:
             localized(
                 "network.security.action.show_less_dns_names",
-                defaultValue: "Show Less DNS Names"
+                defaultValue: "Show Fewer DNS Names"
             )
         case .ipAddresses:
             localized(
                 "network.security.action.show_less_ip_addresses",
-                defaultValue: "Show Less IP Addresses"
+                defaultValue: "Show Fewer IP Addresses"
             )
         }
     }
@@ -436,7 +388,7 @@ struct NetworkSecurityDocumentBuilder {
     }
 
     private var securityMetadataLabel: String {
-        localized("network.security.field.security_metadata", defaultValue: "Security Metadata")
+        localized("network.security.field.metadata", defaultValue: "Metadata")
     }
 
     private var connectionMetadataLabel: String {
@@ -445,6 +397,10 @@ struct NetworkSecurityDocumentBuilder {
 
     private var tlsProtocolLabel: String {
         localized("network.security.field.tls_protocol", defaultValue: "TLS Protocol")
+    }
+
+    private var tlsLabel: String {
+        localized("network.security.field.tls", defaultValue: "TLS")
     }
 
     private var cipherLabel: String {
@@ -491,6 +447,22 @@ struct NetworkSecurityDocumentBuilder {
         localized("network.security.value.not_reported", defaultValue: "Not reported")
     }
 
+    private var notReportedDisplay: DisplayValue {
+        DisplayValue(
+            value: "-",
+            accessibilityValue: notReportedText,
+            isTechnical: false
+        )
+    }
+
+    private var emptyText: String {
+        localized("network.security.value.empty", defaultValue: "Empty")
+    }
+
+    private var noneText: String {
+        localized("network.security.value.none", defaultValue: "None")
+    }
+
     private var emptyValueReportedText: String {
         localized("network.security.value.empty_reported", defaultValue: "Empty value reported")
     }
@@ -500,11 +472,7 @@ struct NetworkSecurityDocumentBuilder {
     }
 
     private var pendingText: String {
-        localized("network.security.value.pending", defaultValue: "Response pending")
-    }
-
-    private var unavailableText: String {
-        localized("network.security.value.unavailable", defaultValue: "Unavailable")
+        localized("network.security.value.pending", defaultValue: "Waiting for Response")
     }
 
     private var notApplicableText: String {
@@ -513,8 +481,8 @@ struct NetworkSecurityDocumentBuilder {
 
     private var notClassifiedText: String {
         localized(
-            "network.security.status.not_classified",
-            defaultValue: "TLS applicability is not classified for this scheme."
+            "network.security.value.not_classified",
+            defaultValue: "Not Classified"
         )
     }
 
@@ -524,6 +492,7 @@ struct NetworkSecurityDocumentBuilder {
 
     private struct DisplayValue {
         let value: String
+        let accessibilityValue: String?
         let isTechnical: Bool
     }
 
@@ -536,50 +505,31 @@ struct NetworkSecurityDocumentBuilder {
             rowsByItemID: [:]
         )
 
-        mutating func appendStatus(value: String, scheme: String) {
-            append(section: .status, kind: .status, label: statusLabel, value: value)
+        mutating func appendScheme(_ scheme: String?) {
             append(
                 section: .status,
                 kind: .scheme,
                 label: schemeLabel,
-                value: scheme,
+                value: scheme ?? "-",
+                accessibilityLabel: scheme == nil
+                    ? [schemeLabel, notReportedText].joined(separator: ", ")
+                    : nil,
                 usesTechnicalValueDirection: true
             )
         }
 
-        mutating func appendMetadataNotReported() {
+        mutating func appendState(
+            section: NetworkSecuritySectionID,
+            kind: NetworkSecurityItemID.Kind,
+            accessibilityLabel: String,
+            value: String
+        ) {
             append(
-                section: .status,
-                kind: .securityMetadata,
-                label: securityMetadataLabel,
-                value: notReportedText
-            )
-            append(
-                section: .connection,
-                kind: .connectionMetadata,
-                label: connectionMetadataLabel,
-                value: notReportedText
-            )
-            append(
-                section: .certificate,
-                kind: .certificateMetadata,
-                label: certificateMetadataLabel,
-                value: notReportedText
-            )
-        }
-
-        mutating func appendUnavailableMetadata(value: String) {
-            append(
-                section: .connection,
-                kind: .connectionMetadata,
-                label: connectionMetadataLabel,
-                value: value
-            )
-            append(
-                section: .certificate,
-                kind: .certificateMetadata,
-                label: certificateMetadataLabel,
-                value: value
+                section: section,
+                kind: kind,
+                label: value,
+                value: nil,
+                accessibilityLabel: [accessibilityLabel, value].joined(separator: ", ")
             )
         }
 
@@ -594,6 +544,9 @@ struct NetworkSecurityDocumentBuilder {
                 kind: kind,
                 label: label,
                 value: display.value,
+                accessibilityLabel: display.accessibilityValue.map {
+                    [label, $0].joined(separator: ", ")
+                },
                 usesTechnicalValueDirection: display.isTechnical
             )
         }
@@ -602,7 +555,8 @@ struct NetworkSecurityDocumentBuilder {
             section: NetworkSecuritySectionID,
             kind: NetworkSecurityItemID.Kind,
             label: String,
-            value: String,
+            value: String?,
+            accessibilityLabel: String? = nil,
             usesTechnicalValueDirection: Bool = false
         ) {
             let itemID = NetworkSecurityItemID(epoch: epoch, kind: kind)
@@ -611,6 +565,7 @@ struct NetworkSecurityDocumentBuilder {
             document.rowsByItemID[itemID] = NetworkSecurityRowContent(
                 label: label,
                 value: value,
+                accessibilityLabel: accessibilityLabel,
                 usesTechnicalValueDirection: usesTechnicalValueDirection,
                 disclosureList: nil,
                 isExpanded: false
@@ -628,30 +583,15 @@ struct NetworkSecurityDocumentBuilder {
             document.rowsByItemID[itemID] = NetworkSecurityRowContent(
                 label: title,
                 value: nil,
+                accessibilityLabel: nil,
                 usesTechnicalValueDirection: false,
                 disclosureList: kind,
                 isExpanded: isExpanded
             )
         }
 
-        private var statusLabel: String {
-            localized("network.security.field.status", defaultValue: "Status")
-        }
-
         private var schemeLabel: String {
             localized("network.security.field.scheme", defaultValue: "Scheme")
-        }
-
-        private var securityMetadataLabel: String {
-            localized("network.security.field.security_metadata", defaultValue: "Security Metadata")
-        }
-
-        private var connectionMetadataLabel: String {
-            localized("network.security.field.connection_metadata", defaultValue: "Connection Metadata")
-        }
-
-        private var certificateMetadataLabel: String {
-            localized("network.security.field.certificate_metadata", defaultValue: "Certificate Metadata")
         }
 
         private var notReportedText: String {

--- a/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkSecurityViewController.swift
@@ -107,8 +107,11 @@ final class NetworkSecurityViewController: UICollectionViewController {
         currentDocument = document
 
         var snapshot = NSDiffableDataSourceSnapshot<NetworkSecuritySectionID, NetworkSecurityItemID>()
-        snapshot.appendSections(NetworkSecuritySectionID.allCases)
-        for section in NetworkSecuritySectionID.allCases {
+        let visibleSections = NetworkSecuritySectionID.allCases.filter {
+            document.itemsBySection[$0]?.isEmpty == false
+        }
+        snapshot.appendSections(visibleSections)
+        for section in visibleSections {
             snapshot.appendItems(document.itemsBySection[section] ?? [], toSection: section)
         }
         let retainedItemIDs = snapshot.itemIdentifiers.filter(previousItemIDs.contains)
@@ -245,9 +248,10 @@ final class NetworkSecurityViewController: UICollectionViewController {
         configuration.secondaryTextProperties.adjustsFontForContentSizeCategory = true
         cell.contentConfiguration = configuration
         cell.accessories = []
-        cell.accessibilityLabel = [content.label, content.value]
-            .compactMap { $0 }
-            .joined(separator: ", ")
+        cell.accessibilityLabel = content.accessibilityLabel
+            ?? [content.label, content.value]
+                .compactMap { $0 }
+                .joined(separator: ", ")
         cell.accessibilityValue = nil
         cell.accessibilityHint = nil
         cell.accessibilityTraits = .staticText

--- a/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
+++ b/Sources/WebInspectorUINetwork/Detail/NetworkWebSocketPreviewViewController.swift
@@ -494,7 +494,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         case .connectionEstablished:
             let title = localized(
                 "network.websocket.connection.established",
-                defaultValue: "WebSocket Connection Established"
+                defaultValue: "Connection Established"
             )
             return RowContent(
                 title: title,
@@ -507,7 +507,7 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         case .connectionClosed:
             let title = localized(
                 "network.websocket.connection.closed",
-                defaultValue: "WebSocket Connection Closed"
+                defaultValue: "Connection Closed"
             )
             return RowContent(
                 title: title,
@@ -553,14 +553,20 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         }
 
         let title: String
+        let accessibilityLabel: String
+        let accessibilityValue: String
         switch frame.kind {
         case .text:
             guard case let .text(payload) = frame.payload else {
                 preconditionFailure("A text WebSocket frame must carry a text payload.")
             }
             title = Self.renderedTextPayload(payload)
+            accessibilityLabel = title
+            accessibilityValue = [direction, frameKind, time].joined(separator: " · ")
         case .continuation, .binary, .close, .ping, .pong, .unknown:
-            title = [frameKind, byteCountText(frame.payloadLength)].joined(separator: " · ")
+            title = byteCountText(frame.payloadLength)
+            accessibilityLabel = [frameKind, title].joined(separator: ", ")
+            accessibilityValue = [direction, time].joined(separator: ", ")
         }
         let subtitle = [direction, frameKind, time].joined(separator: " · ")
         return RowContent(
@@ -568,8 +574,8 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
             subtitle: subtitle,
             symbolName: symbolName,
             style: style,
-            accessibilityLabel: title,
-            accessibilityValue: subtitle
+            accessibilityLabel: accessibilityLabel,
+            accessibilityValue: accessibilityValue
         )
     }
 
@@ -584,14 +590,14 @@ package final class NetworkWebSocketPreviewViewController: UICollectionViewContr
         case .switchingProtocols, .unreported:
             title = localized(
                 "network.websocket.handshake.response",
-                defaultValue: "WebSocket Handshake Response"
+                defaultValue: "Handshake Response"
             )
             symbolName = "arrow.left.arrow.right"
             style = .lifecycle
         case .rejected:
             title = localized(
                 "network.websocket.handshake.rejected",
-                defaultValue: "WebSocket Handshake Rejected"
+                defaultValue: "Handshake Rejected"
             )
             symbolName = "exclamationmark.shield"
             style = .error

--- a/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
+++ b/Sources/WebInspectorUINetwork/List/NetworkListViewController.swift
@@ -227,6 +227,11 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         }
     }
 
+    private enum EmptyPresentation: Equatable {
+        case noRequests
+        case noMatches
+    }
+
     private let model: NetworkPanelModel
     private var entrySelectionAction: EntrySelectionAction
     private let listInvalidationAccumulator: NetworkListInvalidationAccumulator
@@ -243,6 +248,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private let snapshotApplyCompletionScheduler: any NetworkListSnapshotApplyCompletionScheduling
     private var isApplyingSearchPresentation = false
     private var activeSearchController: UISearchController?
+    private var renderedEmptyPresentation: EmptyPresentation?
 #if DEBUG
     private struct FetchedResultsTransactionDeliveryWaiter {
         var id: Int
@@ -547,7 +553,16 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     private func makeSearchController() -> UISearchController {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = String(localized: "network.search.placeholder", bundle: WebInspectorUILocalization.bundle)
+        searchController.searchBar.placeholder = String(
+            localized: "network.search.placeholder.short",
+            defaultValue: "Search",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        searchController.searchBar.searchTextField.accessibilityLabel = String(
+            localized: "network.search.placeholder",
+            defaultValue: "Search Requests",
+            bundle: WebInspectorUILocalization.bundle
+        )
         searchController.searchBar.text = model.searchText
         searchController.searchResultsUpdater = self
         return searchController
@@ -758,7 +773,7 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         Task.detached {
             await accumulator.didCapture(projection.version)
         }
-        renderEmptyState(isEmpty: projection.entryIDs.isEmpty)
+        renderEmptyState(for: projection.content)
         requestListSnapshotBuild(target: projection)
     }
 
@@ -792,11 +807,10 @@ package final class NetworkListViewController: UICollectionViewController, UISea
     }
 
     private func renderInitialEmptyStateIfNeeded() {
-        guard dataSource.snapshot().itemIdentifiers.isEmpty,
-              model.isEmpty else {
+        guard dataSource.snapshot().itemIdentifiers.isEmpty else {
             return
         }
-        renderEmptyState(isEmpty: true)
+        renderEmptyState(for: model.captureListProjection().content)
     }
 
     private func requestListProjectionCapture() {
@@ -820,25 +834,43 @@ package final class NetworkListViewController: UICollectionViewController, UISea
         collectionView.selectItem(at: targetIndexPath, animated: false, scrollPosition: [])
     }
 
-    private func renderEmptyState(isEmpty: Bool) {
+    private func renderEmptyState(for content: NetworkPanelListContent) {
+        let nextPresentation: EmptyPresentation? = switch content {
+        case .entries: nil
+        case .noRequests: .noRequests
+        case .noMatches: .noMatches
+        }
+        let isEmpty = nextPresentation != nil
         if collectionView.isHidden != isEmpty {
             collectionView.isHidden = isEmpty
         }
-        if isEmpty {
-            let title = String(localized: "network.empty.title", bundle: WebInspectorUILocalization.bundle)
-            if let configuration = contentUnavailableConfiguration as? UIContentUnavailableConfiguration,
-               configuration.text == title,
-               configuration.secondaryText == nil,
-               configuration.image == nil,
-               configuration.textProperties.color == .secondaryLabel {
-                return
-            }
+        guard renderedEmptyPresentation != nextPresentation
+                || (nextPresentation == nil) != (contentUnavailableConfiguration == nil) else {
+            return
+        }
+        renderedEmptyPresentation = nextPresentation
+        switch nextPresentation {
+        case .none:
+            contentUnavailableConfiguration = nil
+        case .noRequests:
             var configuration = UIContentUnavailableConfiguration.empty()
-            configuration.text = title
+            configuration.text = String(
+                localized: "network.empty.none.title",
+                defaultValue: "None",
+                bundle: WebInspectorUILocalization.bundle
+            )
             configuration.textProperties.color = .secondaryLabel
             contentUnavailableConfiguration = configuration
-        } else if contentUnavailableConfiguration != nil {
-            contentUnavailableConfiguration = nil
+        case .noMatches:
+            var configuration = UIContentUnavailableConfiguration.search()
+            configuration.text = String(
+                localized: "network.no_results.title",
+                defaultValue: "No Results",
+                bundle: WebInspectorUILocalization.bundle
+            )
+            configuration.secondaryText = nil
+            configuration.textProperties.color = .secondaryLabel
+            contentUnavailableConfiguration = configuration
         }
     }
 

--- a/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
+++ b/Sources/WebInspectorUINetwork/NetworkPanelModel.swift
@@ -160,9 +160,26 @@ package struct NetworkPanelListInvalidation: Equatable, Sendable {
     package let version: NetworkPanelListVersion
 }
 
+package enum NetworkPanelListContent: Equatable, Sendable {
+    case entries([NetworkListEntry.ID])
+    case noRequests
+    case noMatches
+
+    package var entryIDs: [NetworkListEntry.ID] {
+        guard case .entries(let entryIDs) = self else {
+            return []
+        }
+        return entryIDs
+    }
+}
+
 package struct NetworkPanelListProjection: Equatable, Sendable {
     package let version: NetworkPanelListVersion
-    package let entryIDs: [NetworkListEntry.ID]
+    package let content: NetworkPanelListContent
+
+    package var entryIDs: [NetworkListEntry.ID] {
+        content.entryIDs
+    }
 }
 
 enum NetworkPanelSelection: Equatable, Sendable {
@@ -424,9 +441,17 @@ package final class NetworkPanelModel {
     }
 
     package func captureListProjection() -> NetworkPanelListProjection {
-        NetworkPanelListProjection(
+        let content: NetworkPanelListContent
+        if visibleEntryIDs.isEmpty == false {
+            content = .entries(visibleEntryIDs)
+        } else if orderedEntryIDs.isEmpty {
+            content = .noRequests
+        } else {
+            content = .noMatches
+        }
+        return NetworkPanelListProjection(
             version: listProjectionVersion,
-            entryIDs: visibleEntryIDs
+            content: content
         )
     }
 

--- a/Sources/WebInspectorUISyntaxBody/NetworkBodyViewController.swift
+++ b/Sources/WebInspectorUISyntaxBody/NetworkBodyViewController.swift
@@ -289,28 +289,33 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
         switch surface {
         case .none:
             return
+        case .emptyBodyPlaceholder:
+            renderBodyPlaceholder(
+                String(
+                    localized: "network.body.empty",
+                    defaultValue: "No Body",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+            )
         case .unavailableBodyPlaceholder:
-            renderBody(nil)
+            renderBodyPlaceholder(unavailableBodyText)
         case .body(let body, _):
             renderBody(body)
         }
     }
 
-    private func renderBody(_ body: NetworkBody?) {
+    private func renderBodyPlaceholder(_ text: String) {
+        textPreviewCoordinator.cancel()
+        hideMediaPreview()
+        applyBodyDisplay(text: text, syntaxKind: .plainText)
+    }
+
+    private func renderBody(_ body: NetworkBody) {
         guard isRenderingActive else {
             return
         }
         let displayText: String
         let syntaxKind: NetworkBody.SyntaxKind
-        guard let body else {
-            textPreviewCoordinator.cancel()
-            hideMediaPreview()
-            applyBodyDisplay(
-                text: String(localized: "network.body.unavailable", bundle: WebInspectorUILocalization.bundle),
-                syntaxKind: .plainText
-            )
-            return
-        }
 
         if case .loaded = body.phase,
            surface.metadata?.sourcePolicy == .syntax,
@@ -326,10 +331,7 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
                 syntaxBody = rawBody
             }
             applyBodyDisplay(
-                text: syntaxBody ?? String(
-                    localized: "network.body.unavailable",
-                    bundle: WebInspectorUILocalization.bundle
-                ),
+                text: syntaxBody ?? unavailableBodyText,
                 syntaxKind: body.sourceSyntaxKind
             )
             return
@@ -352,7 +354,7 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
             }
             switch textAction {
             case .unavailable:
-                displayText = String(localized: "network.body.unavailable", bundle: WebInspectorUILocalization.bundle)
+                displayText = unavailableBodyText
                 syntaxKind = .plainText
             case .active(let text, let preparedSyntaxKind), .ready(let text, let preparedSyntaxKind):
                 displayText = text
@@ -361,9 +363,10 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
         case .failed(let error):
             textPreviewCoordinator.cancel()
             hideMediaPreview()
-            let text = body.textRepresentation
-                ?? String(localized: "network.body.unavailable", bundle: WebInspectorUILocalization.bundle)
-            displayText = text + "\n\n" + localizedDescription(for: error)
+            displayText = failureDisplayText(
+                bodyText: body.textRepresentation,
+                errorText: localizedDescription(for: error)
+            )
             syntaxKind = body.textRepresentationSyntaxKind
         }
 
@@ -393,8 +396,35 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
              .commandFailed(_, _, let message):
             message
         case .timeout(let domain, let method):
-            "\(domain).\(method) timed out."
+            String.localizedStringWithFormat(
+                String(
+                    localized: "network.body.fetch.error.timeout",
+                    defaultValue: "%1$@.%2$@ timed out.",
+                    bundle: WebInspectorUILocalization.bundle
+                ),
+                domain,
+                method
+            )
         }
+    }
+
+    private func failureDisplayText(bodyText: String?, errorText: String) -> String {
+        var components: [String] = []
+        for component in [bodyText, errorText] {
+            guard let component, component.isEmpty == false,
+                  components.contains(component) == false else {
+                continue
+            }
+            components.append(component)
+        }
+        return components.isEmpty ? unavailableBodyText : components.joined(separator: "\n\n")
+    }
+
+    private var unavailableBodyText: String {
+        String(
+            localized: "network.body.unavailable",
+            bundle: WebInspectorUILocalization.bundle
+        )
     }
 
     private func applyBodyDisplay(
@@ -493,11 +523,8 @@ package final class NetworkBodyViewController: UIViewController, NetworkBodyPrev
         clearMoviePreviewSourceIfNeeded(bodyID: bodyID, resetsFailure: false)
         var configuration = UIContentUnavailableConfiguration.empty()
         configuration.image = UIImage(systemName: "exclamationmark.triangle")
-        configuration.text = String(
-            localized: "network.body.unavailable",
-            bundle: WebInspectorUILocalization.bundle
-        )
-        configuration.secondaryText = message
+        configuration.text = unavailableBodyText
+        configuration.secondaryText = message == unavailableBodyText ? nil : message
         showMoviePreviewStatus(configuration)
         previewRenderState.showMovieUnavailable(bodyID: bodyID)
     }

--- a/Tests/WebInspectorUITests/DOMContainerTests.swift
+++ b/Tests/WebInspectorUITests/DOMContainerTests.swift
@@ -13,7 +13,7 @@ extension WebInspectorUIRenderingTests {
 @Suite
 struct DOMContainerTests {
     @Test
-    func elementViewControllerShowsUnavailableStateWithoutSelectedStyles() {
+    func elementViewControllerShowsNoSelectionStateWithoutSelectedNode() {
         let context = makeElementContext()
         let viewController = makeElementViewController(context: context)
         let window = showInWindow(viewController)
@@ -22,8 +22,13 @@ struct DOMContainerTests {
         #expect(viewController.view.backgroundColor == .systemBackground)
         #expect(viewController.contentUnavailableConfiguration != nil)
         let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
-        #expect(configuration?.text?.isEmpty == false)
+        #expect(configuration?.text == String(
+            localized: "dom.element.styles.no_selection.title",
+            defaultValue: "No Selection",
+            bundle: WebInspectorUILocalization.bundle
+        ))
         #expect(configuration?.textProperties.color == .secondaryLabel)
+        #expect(viewController.placeholderModeForTesting == .noSelection)
         #expect(viewController.collectionView.isHidden == false)
         #expect(viewController.collectionView.numberOfSections == 0)
     }
@@ -45,7 +50,7 @@ struct DOMContainerTests {
     }
 
     @Test
-    func elementViewControllerKeepsUnavailableStateWhenDocumentRootArrivesWithoutSelection() async throws {
+    func elementViewControllerKeepsNoSelectionStateWhenDocumentRootArrives() async throws {
         let context = makeWebInspectorContext()
         let viewController = makeElementViewController(context: context)
         let window = showInWindow(viewController)
@@ -58,7 +63,7 @@ struct DOMContainerTests {
         context.seedDOMDocument(documentNode())
 
         let didKeepUnavailableState = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration != nil
+            viewController.placeholderModeForTesting == .noSelection
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
         }
@@ -307,7 +312,7 @@ struct DOMContainerTests {
     }
 
     @Test
-    func elementViewControllerKeepsCurrentRowsWhileNewSelectionStylesAreHydrating() async throws {
+    func elementViewControllerClearsPreviousRowsWhileNewSelectionStylesAreHydrating() async throws {
         let context = makeElementContext()
         _ = try selectElement(named: "body", in: context)
         applyBodyStyles(to: context)
@@ -341,15 +346,18 @@ struct DOMContainerTests {
 
         #expect(body !== input)
         #expect(inputStyles.phase == .loading)
-        let didKeepBodyRowsWhileInputLoads = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration == nil
+        let didShowLoadingWithoutBodyRows = await waitUntilRendered(in: viewController) {
+            viewController.placeholderModeForTesting == .loading
+                && (viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration)?.text
+                    == String(
+                        localized: "dom.element.styles.loading.title",
+                        defaultValue: "Loading",
+                        bundle: WebInspectorUILocalization.bundle
+                    )
                 && viewController.collectionView.isHidden == false
-                && viewController.collectionView.numberOfSections == 1
-                && stylePropertyViews(in: viewController)
-                    .map(\.declarationTextForTesting)
-                    .contains("margin: 0;")
+                && viewController.collectionView.numberOfSections == 0
         }
-        #expect(didKeepBodyRowsWhileInputLoads)
+        #expect(didShowLoadingWithoutBodyRows)
 
         applyBodyStyles(
             to: context,
@@ -366,7 +374,7 @@ struct DOMContainerTests {
 
         #expect(didRenderInputRows)
         #expect(viewController.collectionView.isHidden == false)
-        #expect(viewController.lastSnapshotApplyModeForTesting == .reloadData)
+        #expect(viewController.lastSnapshotApplyModeForTesting == .diff(animated: false))
     }
 
     @Test
@@ -377,15 +385,29 @@ struct DOMContainerTests {
         defer { window.isHidden = true }
 
         let body = try selectElement(named: "body", in: context)
-        #expect(body.elementStyles?.phase == .loading)
+        let styles = try #require(body.elementStyles)
+        // Preview contexts have no live page, so their synthetic refresh
+        // otherwise advances immediately from loading to unavailable.
+        styles.markLoading()
+        #expect(styles.phase == .loading)
 
         let didRenderPlaceholder = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration != nil
+            viewController.placeholderModeForTesting == .loading
+                && viewController.contentUnavailableConfiguration != nil
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
         }
 
         #expect(didRenderPlaceholder)
+        #expect(viewController.placeholderModeForTesting == .loading)
+        #expect(
+            (viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration)?.text
+                == String(
+                    localized: "dom.element.styles.loading.title",
+                    defaultValue: "Loading",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
     }
 
     @Test
@@ -407,12 +429,11 @@ struct DOMContainerTests {
 
         let input = try selectElement(named: "input", in: context)
         #expect(input.elementStyles?.phase == .loading)
-        #expect(stylePropertyViews(in: viewController).map(\.declarationTextForTesting).contains("margin: 0;"))
 
         context.select(nil)
 
         let didClearRows = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration != nil
+            viewController.placeholderModeForTesting == .noSelection
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
         }
@@ -440,7 +461,7 @@ struct DOMContainerTests {
         context.apply(.childNodeRemoved(parent: DOM.Node.ID("html"), node: DOM.Node.ID("body")))
 
         let didClearRows = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration != nil
+            viewController.placeholderModeForTesting == .noSelection
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
         }
@@ -469,12 +490,46 @@ struct DOMContainerTests {
         styles.markUnavailable()
 
         let didClearRows = await waitUntilRendered(in: viewController) {
-            viewController.contentUnavailableConfiguration != nil
+            viewController.placeholderModeForTesting == .unavailable
                 && viewController.collectionView.isHidden == false
                 && viewController.collectionView.numberOfSections == 0
         }
 
         #expect(didClearRows)
+        #expect(
+            (viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration)?.text
+                == String(
+                    localized: "dom.element.styles.unavailable.title",
+                    defaultValue: "Unavailable",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
+    }
+
+    @Test
+    func elementViewControllerShowsFailedStateWhenStyleLoadingFails() async throws {
+        let context = makeElementContext()
+        let body = try selectElement(named: "body", in: context)
+        let viewController = makeElementViewController(context: context)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        let styles = try #require(body.elementStyles)
+
+        styles.fail(.closed)
+
+        let didShowFailure = await waitUntilRendered(in: viewController) {
+            viewController.placeholderModeForTesting == .failed
+                && viewController.collectionView.numberOfSections == 0
+        }
+        #expect(didShowFailure)
+        #expect(
+            (viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration)?.text
+                == String(
+                    localized: "dom.element.styles.failed.title",
+                    defaultValue: "Load Failed",
+                    bundle: WebInspectorUILocalization.bundle
+                )
+        )
     }
 
     @Test

--- a/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
+++ b/Tests/WebInspectorUITests/DOMElementStylePresentationStateTests.swift
@@ -81,7 +81,7 @@ struct DOMElementStyleSnapshotCoordinatorTests {
     }
 
     @Test
-    func coordinatorKeepsDisplayedRowsWhileSelectionHydratesThenReloadsLoadedReplacement() throws {
+    func coordinatorClearsPreviousSelectionWhileReplacementHydrates() throws {
         let coordinator = DOMElementStyleSnapshotCoordinator()
         let bodyStyles = makeStyles(nodeID: "node-body")
         load(bodyStyles, with: makeFlatMatchedStyles())
@@ -93,10 +93,10 @@ struct DOMElementStyleSnapshotCoordinatorTests {
         let loadingUpdate = coordinator.updateSelectedNodeStyles(inputStyles)
 
         #expect(inputStyles.phase == .loading)
-        #expect(loadingUpdate.applyMode == .none)
-        #expect(loadingUpdate.snapshot == nil)
-        #expect(loadingUpdate.placeholderMode == .none)
-        #expect(coordinator.visibleSectionIDs.isEmpty == false)
+        #expect(loadingUpdate.applyMode == .diff(animated: false))
+        #expect(try #require(loadingUpdate.snapshot).itemIdentifiers.isEmpty)
+        #expect(loadingUpdate.placeholderMode == .loading)
+        #expect(coordinator.visibleSectionIDs.isEmpty)
 
         load(
             inputStyles,
@@ -109,8 +109,31 @@ struct DOMElementStyleSnapshotCoordinatorTests {
         )
         let loadedUpdate = coordinator.updateSelectedNodeStyles(inputStyles)
 
-        #expect(loadedUpdate.applyMode == .reloadData)
+        #expect(loadedUpdate.applyMode == .diff(animated: false))
         #expect(loadedUpdate.placeholderMode == .none)
+    }
+
+    @Test
+    func coordinatorDistinguishesNoSelectionLoadingUnavailableAndFailed() {
+        let coordinator = DOMElementStyleSnapshotCoordinator()
+
+        #expect(coordinator.updateNoSelection().placeholderMode == .noSelection)
+
+        let loadingStyles = makeStyles(nodeID: "loading")
+        #expect(
+            coordinator.updateSelectedNodeStyles(loadingStyles).placeholderMode == .loading
+        )
+
+        loadingStyles.markUnavailable()
+        #expect(
+            coordinator.updateSelectedNodeStyles(loadingStyles).placeholderMode == .unavailable
+        )
+
+        let failedStyles = makeStyles(nodeID: "failed")
+        failedStyles.fail(.closed)
+        #expect(
+            coordinator.updateSelectedNodeStyles(failedStyles).placeholderMode == .failed
+        )
     }
 
     @Test

--- a/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkDetailViewControllerTests.swift
@@ -35,10 +35,62 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.collectionViewForTesting.isHidden)
         #expect(viewController.contentUnavailableConfiguration != nil)
         let configuration = viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
-        #expect(configuration?.text?.isEmpty == false)
+        #expect(
+            configuration?.text == String(
+                localized: "network.empty.none.title",
+                defaultValue: "None",
+                bundle: WebInspectorUILocalization.bundle
+            )
+        )
         #expect(configuration?.secondaryText == nil)
         #expect(configuration?.image == nil)
         #expect(configuration?.textProperties.color == .secondaryLabel)
+    }
+
+    @Test
+    func listDistinguishesNoMatchesFromNoRequests() async throws {
+        let context = makeContext()
+        _ = try #require(await applyRequest(
+            to: context,
+            requestID: "empty-state-search",
+            url: "https://example.com/app.js"
+        ))
+        let model = NetworkPanelModel(context: context)
+        let viewController = NetworkListViewController(model: model)
+        let window = showInWindow(viewController, makeVisible: true)
+        defer { window.isHidden = true }
+        await viewController.flushPendingSnapshotUpdateForTesting()
+
+        var transactionBaseline = viewController.fetchedResultsTransactionDeliveryCountForTesting
+        model.setSearchText("does-not-match")
+        #expect(await waitUntilListShows(
+            [],
+            in: viewController,
+            afterTransactionDeliveryCount: transactionBaseline
+        ))
+
+        let noResults = try #require(
+            viewController.contentUnavailableConfiguration as? UIContentUnavailableConfiguration
+        )
+        #expect(noResults.text == String(
+            localized: "network.no_results.title",
+            defaultValue: "No Results",
+            bundle: WebInspectorUILocalization.bundle
+        ))
+        #expect(noResults.secondaryText == nil)
+        #expect(noResults.image != nil)
+        #expect(viewController.collectionViewForTesting.isHidden)
+
+        transactionBaseline = viewController.fetchedResultsTransactionDeliveryCountForTesting
+        model.setSearchText("")
+        #expect(await waitUntilListShows(
+            [try #require(model.displayRequests.first?.id)],
+            in: viewController,
+            afterTransactionDeliveryCount: transactionBaseline
+        ))
+
+        #expect(viewController.contentUnavailableConfiguration == nil)
+        #expect(viewController.collectionViewForTesting.isHidden == false)
     }
 
     @Test
@@ -120,6 +172,31 @@ struct NetworkDetailViewControllerTests {
         viewController.resumeRendering()
 
         #expect(viewController.syntaxViewForTesting.backgroundColor == .clear)
+    }
+
+    @Test
+    func failedBodyRendersUnavailableMessageOnlyOnce() async throws {
+        let viewController = NetworkBodyViewController()
+        let body = NetworkBody(phase: .failed(.closed))
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+
+        viewController.setSurface(.body(body, metadata: nil))
+        viewController.resumeRendering()
+
+        let observation = try #require(viewController.bodyObservationDeliveryForTesting)
+        let renderedText = await observation.values {
+            viewController.syntaxViewForTesting.text
+        }
+        defer { renderedText.cancel() }
+
+        let unavailable = String(
+            localized: "network.body.unavailable",
+            bundle: WebInspectorUILocalization.bundle
+        )
+        #expect(await renderedText.waitUntilValue(unavailable))
+        let text = try #require(renderedText.latestValue)
+        #expect(text.components(separatedBy: unavailable).count == 2)
     }
 
     @Test
@@ -323,7 +400,7 @@ struct NetworkDetailViewControllerTests {
                 && viewController.webSocketPreviewViewControllerForTesting.view.isHidden
                 && viewController.securityViewControllerForTesting.view.isHidden == false
                 && viewController.securityViewControllerForTesting.snapshotForTesting.sectionIdentifiers
-                    == NetworkSecuritySectionID.allCases
+                    == [.status]
         }
         #expect(didRenderSecurity)
         #expect(
@@ -406,7 +483,7 @@ struct NetworkDetailViewControllerTests {
                 })
                 && security.snapshotForTesting.itemIdentifiers.contains(where: {
                     $0.kind == .connectionMetadata
-                        && security.rowContentForTesting($0)?.value == String(
+                        && security.rowContentForTesting($0)?.label == String(
                             localized: "network.security.value.not_reported",
                             defaultValue: "Not reported",
                             bundle: WebInspectorUILocalization.bundle
@@ -809,21 +886,40 @@ struct NetworkDetailViewControllerTests {
         #expect(
             NetworkCookiesViewController.sectionTitleForTesting(.request)
                 == localized(
-                    "network.cookies.section.request",
-                    defaultValue: "Request Cookies"
+                    "network.section.request",
+                    defaultValue: "Request"
                 )
         )
         #expect(
             NetworkCookiesViewController.sectionTitleForTesting(.response)
                 == localized(
-                    "network.cookies.section.response",
-                    defaultValue: "Response Cookies"
+                    "network.section.response",
+                    defaultValue: "Response"
                 )
         )
+        let requestNotCaptured = viewController.messageContentForTesting(
+            .state(epoch: requestEpoch, section: .request, kind: .requestNotCaptured)
+        )
+        #expect(requestNotCaptured?.title == localized(
+            "network.cookies.request.not_captured",
+            defaultValue: "Not Captured"
+        ))
+        #expect(requestNotCaptured?.accessibilityLabel.contains(localized(
+            "network.cookies.section.request",
+            defaultValue: "Request Cookies"
+        )) == true)
         #expect(
             viewController.messageContentForTesting(
                 .state(epoch: requestEpoch, section: .response, kind: .responseLoading)
             )?.kind == .loading
+        )
+        #expect(
+            viewController.messageContentForTesting(
+                .state(epoch: requestEpoch, section: .response, kind: .responseLoading)
+            )?.title == localized(
+                "network.cookies.response.loading",
+                defaultValue: "Waiting"
+            )
         )
 
         await renderCookies(
@@ -839,6 +935,25 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
             .state(epoch: requestEpoch, section: .response, kind: .responseMissing)
         ])
+        let memoryCache = viewController.messageContentForTesting(
+            .state(epoch: requestEpoch, section: .request, kind: .requestMemoryCache)
+        )
+        #expect(memoryCache?.title == localized(
+            "network.cookies.request.not_captured",
+            defaultValue: "Not Captured"
+        ))
+        #expect(memoryCache?.detail == localized(
+            "network.cookies.request.memory_cache",
+            defaultValue: "Memory Cache"
+        ))
+        #expect(
+            viewController.messageContentForTesting(
+                .state(epoch: requestEpoch, section: .response, kind: .responseMissing)
+            )?.title == localized(
+                "network.cookies.response.missing",
+                defaultValue: "Not Received"
+            )
+        )
 
         await renderCookies(
             NetworkCookieSections(request: .empty, response: .empty),
@@ -850,17 +965,25 @@ struct NetworkDetailViewControllerTests {
         #expect(viewController.snapshotForTesting.itemIdentifiers(inSection: .response) == [
             .state(epoch: requestEpoch, section: .response, kind: .responseEmpty)
         ])
+        let none = localized("network.cookies.request.empty", defaultValue: "None")
+        #expect(viewController.messageContentForTesting(
+            .state(epoch: requestEpoch, section: .request, kind: .requestEmpty)
+        )?.title == none)
+        #expect(viewController.messageContentForTesting(
+            .state(epoch: requestEpoch, section: .response, kind: .responseEmpty)
+        )?.title == localized("network.cookies.response.empty", defaultValue: "None"))
     }
 
     @Test
     func cookiesListKeepsValidRowsWithPartialAndAmbiguousRawWarnings() async throws {
         let requestReport = try #require(NetworkCookieParser.parseRequestHeaders([
-            "Cookie": "z=3; broken; a=1; a=2"
+            "Cookie": "z=3; broken; also-broken; a=1; a=2"
         ]))
         let responseReport = try #require(NetworkCookieParser.parseResponseHeaders([
             "Set-Cookie": "first=1, second=2"
         ]))
         #expect(requestReport.status == .partial)
+        #expect(requestReport.diagnostics.count == 2)
         #expect(responseReport.status == .ambiguousCombined)
 
         let viewController = NetworkCookiesViewController()
@@ -910,7 +1033,7 @@ struct NetworkDetailViewControllerTests {
         #expect(
             viewController.messageContentForTesting(
                 .diagnostic(epoch: requestEpoch, section: .request, ordinal: 0)
-            )?.detail?.contains("broken") == true
+            )?.detail == " broken\n also-broken"
         )
         #expect(
             viewController.messageContentForTesting(
@@ -1076,6 +1199,37 @@ struct NetworkDetailViewControllerTests {
         cell.prepareForReuse()
         #expect(cell.renderedFieldsForTesting.isEmpty)
         #expect(cell.accessibilityLabel == nil)
+    }
+
+    @Test
+    func responseCookieUsesDashForUnsetAttributesAndDescriptiveAccessibility() async throws {
+        let report = try #require(NetworkCookieParser.parseResponseHeaders([
+            "Set-Cookie": "session=abc"
+        ]))
+        let viewController = NetworkCookiesViewController()
+        let requestEpoch = NetworkCookiesViewController.RequestEpoch.testing(viewController)
+        let window = showInWindow(viewController)
+        defer { window.isHidden = true }
+        await renderCookies(
+            NetworkCookieSections(request: .empty, response: .values(report)),
+            in: viewController
+        )
+        let content = try #require(
+            viewController.cookieContentForTesting(.responseCookie(
+                epoch: requestEpoch,
+                key: .init(name: "session", duplicateOccurrence: 0)
+            ))
+        )
+        let domainLabel = localized("network.cookies.field.domain", defaultValue: "Domain")
+        let domain = try #require(content.fields.first { $0.label == domainLabel })
+        let notSet = localized("network.cookies.value.not_set", defaultValue: "Not Set")
+        #expect(domain.value == "-")
+        #expect(domain.accessibilityValue == notSet)
+
+        let cell = NetworkCookieCell(frame: .zero)
+        cell.bind(content)
+        #expect(cell.accessibilityLabel?.contains("\(domainLabel), \(notSet)") == true)
+        #expect(cell.accessibilityLabel?.contains("\(domainLabel), -") == false)
     }
 
     @Test
@@ -1410,6 +1564,11 @@ struct NetworkDetailViewControllerTests {
             defaultValue: "Text Frame",
             bundle: WebInspectorUILocalization.bundle
         )
+        let binaryFrame = String(
+            localized: "network.websocket.frame.binary",
+            defaultValue: "Binary Frame",
+            bundle: WebInspectorUILocalization.bundle
+        )
         let copy = String(
             localized: "Copy",
             defaultValue: "Copy",
@@ -1417,7 +1576,7 @@ struct NetworkDetailViewControllerTests {
         )
         let handshakeResponse = String(
             localized: "network.websocket.handshake.response",
-            defaultValue: "WebSocket Handshake Response",
+            defaultValue: "Handshake Response",
             bundle: WebInspectorUILocalization.bundle
         )
         #expect(contents[0].title == handshakeResponse)
@@ -1437,8 +1596,12 @@ struct NetworkDetailViewControllerTests {
         #expect(contents[3].style == .received)
         #expect(contents[3].symbolName == "arrow.down")
         #expect(contents[3].title.contains(13.formatted()))
+        #expect(contents[3].title.contains(binaryFrame) == false)
+        #expect(contents[3].subtitle.contains(binaryFrame))
+        #expect(contents[3].accessibilityLabel.contains(binaryFrame))
+        #expect(contents[3].accessibilityValue.contains(binaryFrame) == false)
         #expect(viewController.contextMenuConfigurationForTesting(itemIDs[3]) == nil)
-        #expect(contents[8].title.contains("15"))
+        #expect(contents[8].subtitle.contains("15"))
         #expect(contents[9].style == .error)
         #expect(contents[9].title == "decode failed")
         #expect(contents[10].style == .lifecycle)
@@ -1625,12 +1788,12 @@ struct NetworkDetailViewControllerTests {
         }
         let rejectionTitle = String(
             localized: "network.websocket.handshake.rejected",
-            defaultValue: "WebSocket Handshake Rejected",
+            defaultValue: "Handshake Rejected",
             bundle: WebInspectorUILocalization.bundle
         )
         let establishedTitle = String(
             localized: "network.websocket.connection.established",
-            defaultValue: "WebSocket Connection Established",
+            defaultValue: "Connection Established",
             bundle: WebInspectorUILocalization.bundle
         )
         #expect(contents[0].title == rejectionTitle)
@@ -1647,12 +1810,12 @@ struct NetworkDetailViewControllerTests {
     func webSocketPreviewKeepsQuietAndUnreportedHandshakeResponsesNeutral() async throws {
         let handshakeTitle = String(
             localized: "network.websocket.handshake.response",
-            defaultValue: "WebSocket Handshake Response",
+            defaultValue: "Handshake Response",
             bundle: WebInspectorUILocalization.bundle
         )
         let establishedTitle = String(
             localized: "network.websocket.connection.established",
-            defaultValue: "WebSocket Connection Established",
+            defaultValue: "Connection Established",
             bundle: WebInspectorUILocalization.bundle
         )
         let statusNotReported = String(
@@ -2599,7 +2762,7 @@ struct NetworkDetailViewControllerTests {
     }
 
     @Test
-    func previewRequestWithoutBodyReplacesPreviousBodyWithUnavailablePlaceholder() async throws {
+    func previewRequestWithoutBodyReplacesPreviousBodyWithEmptyPlaceholder() async throws {
         let context = makeContext()
         let bodyRequest = try #require(
             await applyRequestWithoutResponse(
@@ -2633,11 +2796,15 @@ struct NetworkDetailViewControllerTests {
 
         model.selectRequest(emptyRequest)
 
-        let unavailableText = String(localized: "network.body.unavailable", bundle: WebInspectorUILocalization.bundle)
+        let emptyText = String(
+            localized: "network.body.empty",
+            defaultValue: "No Body",
+            bundle: WebInspectorUILocalization.bundle
+        )
         let didReplaceBody = await waitUntilRendered(in: viewController) {
             viewController.previewViewForTesting.isHidden == false
                 && viewController.isPreviewRoleControlHiddenForTesting
-                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == unavailableText
+                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == emptyText
         }
         #expect(didReplaceBody)
         #expect(viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text.contains("Jane") == false)
@@ -2780,12 +2947,16 @@ struct NetworkDetailViewControllerTests {
 
         viewController.setModeForTesting(.preview)
 
-        let unavailableText = String(localized: "network.body.unavailable", bundle: WebInspectorUILocalization.bundle)
+        let emptyText = String(
+            localized: "network.body.empty",
+            defaultValue: "No Body",
+            bundle: WebInspectorUILocalization.bundle
+        )
         let didRenderPlaceholder = await waitUntilRendered(in: viewController) {
             viewController.currentModeForTesting == .preview
                 && viewController.previewViewForTesting.isHidden == false
                 && viewController.isPreviewRoleControlHiddenForTesting
-                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == unavailableText
+                && viewController.syntaxBodyViewControllerForTesting.syntaxViewForTesting.text == emptyText
         }
         #expect(didRenderPlaceholder)
     }
@@ -4877,7 +5048,7 @@ struct NetworkDetailViewControllerTests {
         )
         let unparsedContentTypeParameterLabel = String(
             localized: "network.headers.request_data.content_type_parameter_unparsed",
-            defaultValue: "Unparsed Content-Type Parameter",
+            defaultValue: "Unparsed Content-Type Parameters",
             bundle: WebInspectorUILocalization.bundle
         )
 
@@ -4899,8 +5070,8 @@ struct NetworkDetailViewControllerTests {
         #expect(
             (headers.renderedTextForTesting as NSString).substring(with: tagRange)
                 == String(
-                    localized: "network.headers.request_data.view_preview",
-                    defaultValue: "View Request Preview",
+                    localized: "network.headers.request_data.view_preview.inline",
+                    defaultValue: "View Preview",
                     bundle: WebInspectorUILocalization.bundle
                 )
         )
@@ -5313,13 +5484,12 @@ struct NetworkDetailViewControllerTests {
 
         #expect(
             await waitUntilRendered(in: viewController) {
-                model.selectedRequest === replacement
-                    && viewController.headersTextViewForTesting.renderedTextForTesting
-                        .contains("https://example.com/replacement")
-                    && viewController.headersTextViewForTesting.renderedTextForTesting
-                        .contains("\(ambiguousContentTypeLabel): application/json")
-                    && viewController.headersTextViewForTesting.renderedTextForTesting
-                        .contains("\(ambiguousContentTypeLabel): text/plain")
+                let text = viewController.headersTextViewForTesting.renderedTextForTesting
+                return model.selectedRequest === replacement
+                    && text.contains("https://example.com/replacement")
+                    && text.contains("application/json")
+                    && text.contains("text/plain")
+                    && text.components(separatedBy: ambiguousContentTypeLabel).count == 2
                     && viewController.headersTextViewForTesting.requestPreviewTagRangesForTesting.count == 1
             })
 
@@ -6458,7 +6628,7 @@ struct NetworkDetailViewControllerTests {
         let model = NetworkPanelModel(context: context)
         let target = NetworkPanelListProjection(
             version: NetworkPanelListVersion(revision: 41, entryIdentityGeneration: 0),
-            entryIDs: model.displayEntryIDs
+            content: .entries(model.displayEntryIDs)
         )
         let input = makeNetworkListSnapshotBuildInput(target: target)
         let builderFactory = NetworkListSnapshotBuilderFactory()
@@ -6491,7 +6661,7 @@ struct NetworkDetailViewControllerTests {
         }
         let target = NetworkPanelListProjection(
             version: NetworkPanelListVersion(revision: 42, entryIdentityGeneration: 0),
-            entryIDs: NetworkPanelModel(context: context).displayEntryIDs
+            content: .entries(NetworkPanelModel(context: context).displayEntryIDs)
         )
         let input = makeNetworkListSnapshotBuildInput(target: target)
         let builder = NetworkListSnapshotBuilderFactory().makeBuilder()
@@ -6637,7 +6807,7 @@ struct NetworkDetailViewControllerTests {
             baseline: baseline,
             target: NetworkPanelListProjection(
                 version: NetworkPanelListVersion(revision: 8, entryIdentityGeneration: 1),
-                entryIDs: entryIDs
+                content: .entries(entryIDs)
             )
         )
 
@@ -6686,7 +6856,7 @@ struct NetworkDetailViewControllerTests {
         let artifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: baseline,
-                target: NetworkPanelListProjection(version: version, entryIDs: entryIDs)
+                target: NetworkPanelListProjection(version: version, content: .entries(entryIDs))
             )
         )
 
@@ -6729,7 +6899,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: originalBaseline,
                 target: NetworkPanelListProjection(
                     version: version2,
-                    entryIDs: baselineEntryIDs
+                    content: .entries(baselineEntryIDs)
                 )
             )
         )
@@ -6746,7 +6916,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: originalBaseline,
                 target: NetworkPanelListProjection(
                     version: version3,
-                    entryIDs: allEntryIDs
+                    content: .entries(allEntryIDs)
                 )
             )
         )
@@ -6762,7 +6932,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: state.submittedBaseline,
                 target: NetworkPanelListProjection(
                     version: version3,
-                    entryIDs: allEntryIDs
+                    content: .entries(allEntryIDs)
                 )
             )
         )
@@ -6806,7 +6976,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: baseline,
                 target: NetworkPanelListProjection(
                     version: version2,
-                    entryIDs: allEntryIDs
+                    content: .entries(allEntryIDs)
                 )
             )
         )
@@ -6815,7 +6985,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: baseline,
                 target: NetworkPanelListProjection(
                     version: version1,
-                    entryIDs: baselineEntryIDs
+                    content: .entries(baselineEntryIDs)
                 )
             )
         )
@@ -6859,7 +7029,7 @@ struct NetworkDetailViewControllerTests {
         let firstArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: baseline,
-                target: NetworkPanelListProjection(version: version2, entryIDs: entryIDs)
+                target: NetworkPanelListProjection(version: version2, content: .entries(entryIDs))
             )
         )
         let firstReceiveResult = state.receive(firstArtifact, currentVersion: version2)
@@ -6874,7 +7044,7 @@ struct NetworkDetailViewControllerTests {
         let secondArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: state.submittedBaseline,
-                target: NetworkPanelListProjection(version: version3, entryIDs: entryIDs)
+                target: NetworkPanelListProjection(version: version3, content: .entries(entryIDs))
             )
         )
         let secondReceiveResult = state.receive(secondArtifact, currentVersion: version3)
@@ -6903,7 +7073,7 @@ struct NetworkDetailViewControllerTests {
         let cleanArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: state.submittedBaseline,
-                target: NetworkPanelListProjection(version: version3, entryIDs: entryIDs)
+                target: NetworkPanelListProjection(version: version3, content: .entries(entryIDs))
             )
         )
         #expect(cleanArtifact.changeCounts.requiresApply == false)
@@ -6940,13 +7110,13 @@ struct NetworkDetailViewControllerTests {
         let readyArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: baseline,
-                target: NetworkPanelListProjection(version: version2, entryIDs: allEntryIDs)
+                target: NetworkPanelListProjection(version: version2, content: .entries(allEntryIDs))
             )
         )
         let noOpArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: baseline,
-                target: NetworkPanelListProjection(version: version3, entryIDs: baselineEntryIDs)
+                target: NetworkPanelListProjection(version: version3, content: .entries(baselineEntryIDs))
             )
         )
 
@@ -6960,7 +7130,7 @@ struct NetworkDetailViewControllerTests {
         let applyingArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: state.submittedBaseline,
-                target: NetworkPanelListProjection(version: version4, entryIDs: allEntryIDs)
+                target: NetworkPanelListProjection(version: version4, content: .entries(allEntryIDs))
             )
         )
         let applyingResult = state.receive(applyingArtifact, currentVersion: version4)
@@ -6974,7 +7144,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: state.submittedBaseline,
                 target: NetworkPanelListProjection(
                     version: version5,
-                    entryIDs: baselineEntryIDs
+                    content: .entries(baselineEntryIDs)
                 )
             )
         )
@@ -7024,7 +7194,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: baseline,
                 target: NetworkPanelListProjection(
                     version: version2,
-                    entryIDs: applyingEntryIDs
+                    content: .entries(applyingEntryIDs)
                 )
             )
         )
@@ -7042,7 +7212,7 @@ struct NetworkDetailViewControllerTests {
         let queuedArtifact = try await NetworkListSnapshotBuilder().build(
             makeNetworkListSnapshotBuildInput(
                 baseline: state.submittedBaseline,
-                target: NetworkPanelListProjection(version: version3, entryIDs: allEntryIDs)
+                target: NetworkPanelListProjection(version: version3, content: .entries(allEntryIDs))
             )
         )
         let noOpArtifact = try await NetworkListSnapshotBuilder().build(
@@ -7050,7 +7220,7 @@ struct NetworkDetailViewControllerTests {
                 baseline: state.submittedBaseline,
                 target: NetworkPanelListProjection(
                     version: version4,
-                    entryIDs: applyingEntryIDs
+                    content: .entries(applyingEntryIDs)
                 )
             )
         )
@@ -7183,7 +7353,7 @@ struct NetworkDetailViewControllerTests {
             baseline: baseline,
             target: NetworkPanelListProjection(
                 version: NetworkPanelListVersion(revision: 12, entryIdentityGeneration: 0),
-                entryIDs: targetEntryIDs
+                content: .entries(targetEntryIDs)
             )
         )
 
@@ -7216,7 +7386,7 @@ struct NetworkDetailViewControllerTests {
         }
         let target = NetworkPanelListProjection(
             version: NetworkPanelListVersion(revision: 13, entryIdentityGeneration: 0),
-            entryIDs: NetworkPanelModel(context: context).displayEntryIDs
+            content: .entries(NetworkPanelModel(context: context).displayEntryIDs)
         )
         let input = makeNetworkListSnapshotBuildInput(target: target)
         let gate = NetworkListBuilderStartGate()

--- a/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
+++ b/Tests/WebInspectorUITests/NetworkPanelModelTests.swift
@@ -74,17 +74,25 @@ func clearAvailabilityUsesUnfilteredRequestsWhenFiltersHideEveryRequest() async 
 
     #expect(model.hasClearableRequests)
     #expect(observedValues.latestValue == true)
+    #expect(
+        model.captureListProjection().content
+            == .entries(model.displayEntryIDs)
+    )
 
     model.setSearchText("does-not-match")
 
     #expect(model.isEmpty)
     #expect(model.displayRequestIDs.isEmpty)
     #expect(model.hasClearableRequests)
+    #expect(model.captureListProjection().content == .noMatches)
 
+    let transactionBaseline = model.rawTransactionDeliveryCountForTesting
     model.clearRequests()
 
     #expect(model.hasClearableRequests == false)
     #expect(await observedValues.waitUntilValue(false))
+    #expect(await model.waitForRawTransactionDeliveryForTesting(after: transactionBaseline))
+    #expect(model.captureListProjection().content == .noRequests)
     #expect(context.registeredRequest(for: requestID) == nil)
 }
 

--- a/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
+++ b/Tests/WebInspectorUITests/NetworkSecurityViewControllerTests.swift
@@ -19,36 +19,37 @@ struct NetworkSecurityViewControllerTests {
         defer { window.isHidden = true }
 
         await render(.plaintextScheme(.http), epoch: epoch, in: viewController)
-        #expect(
-            viewController.snapshotForTesting.sectionIdentifiers
-                == NetworkSecuritySectionID.allCases
-        )
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.status])
         #expect(row(.scheme, in: viewController)?.value == "HTTP")
-        #expect(
-            row(.status, in: viewController)?.value
-                == localized(
-                    "network.security.status.http",
-                    defaultValue: "HTTP scheme reported; TLS does not apply."
-                )
-        )
-        #expect(
-            row(.connectionMetadata, in: viewController)?.value
-                == localized("network.security.value.not_applicable", defaultValue: "Not applicable")
-        )
+        #expect(row(.status, in: viewController)?.label == localized(
+            "network.security.field.tls",
+            defaultValue: "TLS"
+        ))
+        #expect(row(.status, in: viewController)?.value == localized(
+            "network.security.value.not_applicable",
+            defaultValue: "Not applicable"
+        ))
 
         await render(.pending(.wss), epoch: epoch, in: viewController)
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.status])
         #expect(row(.scheme, in: viewController)?.value == "WSS")
-        #expect(
-            row(.status, in: viewController)?.value
-                == localized("network.security.value.pending", defaultValue: "Response pending")
-        )
+        #expect(row(.status, in: viewController)?.label == localized(
+            "network.security.value.pending",
+            defaultValue: "Waiting for Response"
+        ))
+        #expect(row(.status, in: viewController)?.value == nil)
 
         await render(
             .encryptedScheme(.https, metadata: .notReported),
             epoch: epoch,
             in: viewController
         )
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.status])
         #expect(row(.scheme, in: viewController)?.value == "HTTPS")
+        #expect(row(.securityMetadata, in: viewController)?.label == localized(
+            "network.security.field.metadata",
+            defaultValue: "Metadata"
+        ))
         #expect(
             row(.securityMetadata, in: viewController)?.value
                 == localized("network.security.value.not_reported", defaultValue: "Not reported")
@@ -59,13 +60,26 @@ struct NetworkSecurityViewControllerTests {
             epoch: epoch,
             in: viewController
         )
+        #expect(viewController.snapshotForTesting.sectionIdentifiers == [.status])
+        #expect(row(.status, in: viewController)?.label == localized(
+            "network.security.status.canceled_before_response",
+            defaultValue: "Request Canceled"
+        ))
+        #expect(row(.status, in: viewController)?.value == nil)
         #expect(row(.reason, in: viewController)?.value == "cancelled raw")
         #expect(row(.reason, in: viewController)?.usesTechnicalValueDirection == true)
 
         await render(.notApplicable(scheme: "Custom+Scheme"), epoch: epoch, in: viewController)
         #expect(row(.scheme, in: viewController)?.value == "Custom+Scheme")
-        let visibleText = viewController.snapshotForTesting.itemIdentifiers.compactMap {
-            viewController.rowContentForTesting($0)?.value
+        #expect(row(.status, in: viewController)?.value == localized(
+            "network.security.value.not_classified",
+            defaultValue: "Not Classified"
+        ))
+        let visibleText = viewController.snapshotForTesting.itemIdentifiers.flatMap { itemID -> [String] in
+            guard let row = viewController.rowContentForTesting(itemID) else {
+                return []
+            }
+            return [row.label, row.value].compactMap { $0 }
         }.joined(separator: "\n").lowercased()
         for verdict in ["trusted", "valid certificate", "hostname matched", "expired", "secure connection"] {
             #expect(visibleText.contains(verdict) == false)
@@ -83,7 +97,16 @@ struct NetworkSecurityViewControllerTests {
         defer { window.isHidden = true }
 
         await render(
-            .pending(.https),
+            .encryptedScheme(
+                .https,
+                metadata: .reported(Network.Security(
+                    connection: Network.Security.Connection(),
+                    certificate: Network.Security.Certificate(
+                        dnsNames: [],
+                        ipAddresses: []
+                    )
+                ))
+            ),
             epoch: NetworkSecurityRequestEpoch(request: request),
             in: viewController
         )
@@ -121,14 +144,8 @@ struct NetworkSecurityViewControllerTests {
             defaultValue: "Not reported"
         )
         let reported = localized("network.security.value.reported", defaultValue: "Reported")
-        let empty = localized(
-            "network.security.value.empty_reported",
-            defaultValue: "Empty value reported"
-        )
-        let noValues = localized(
-            "network.security.value.no_values_reported",
-            defaultValue: "No values reported"
-        )
+        let empty = localized("network.security.value.empty", defaultValue: "Empty")
+        let none = localized("network.security.value.none", defaultValue: "None")
 
         await render(
             .encryptedScheme(.https, metadata: .reported(Network.Security())),
@@ -136,8 +153,10 @@ struct NetworkSecurityViewControllerTests {
             in: viewController
         )
         #expect(row(.securityMetadata, in: viewController)?.value == reported)
-        #expect(row(.connectionMetadata, in: viewController)?.value == notReported)
-        #expect(row(.certificateMetadata, in: viewController)?.value == notReported)
+        #expect(row(.connectionMetadata, in: viewController)?.label == notReported)
+        #expect(row(.connectionMetadata, in: viewController)?.value == nil)
+        #expect(row(.certificateMetadata, in: viewController)?.label == notReported)
+        #expect(row(.certificateMetadata, in: viewController)?.value == nil)
         #expect(row(.tlsProtocol, in: viewController) == nil)
 
         let security = Network.Security(
@@ -153,13 +172,15 @@ struct NetworkSecurityViewControllerTests {
             epoch: epoch,
             in: viewController
         )
-        #expect(row(.connectionMetadata, in: viewController)?.value == reported)
-        #expect(row(.tlsProtocol, in: viewController)?.value == notReported)
-        #expect(row(.cipher, in: viewController)?.value == notReported)
-        #expect(row(.certificateMetadata, in: viewController)?.value == reported)
+        #expect(row(.connectionMetadata, in: viewController) == nil)
+        #expect(row(.tlsProtocol, in: viewController)?.value == "-")
+        #expect(row(.tlsProtocol, in: viewController)?.accessibilityLabel?.contains(notReported) == true)
+        #expect(row(.cipher, in: viewController)?.value == "-")
+        #expect(row(.certificateMetadata, in: viewController) == nil)
         #expect(row(.subject, in: viewController)?.value == empty)
-        #expect(row(.dnsState, in: viewController)?.value == notReported)
-        #expect(row(.ipAddressState, in: viewController)?.value == noValues)
+        #expect(row(.dnsState, in: viewController)?.value == "-")
+        #expect(row(.dnsState, in: viewController)?.accessibilityLabel?.contains(notReported) == true)
+        #expect(row(.ipAddressState, in: viewController)?.value == none)
     }
 
     @Test
@@ -199,8 +220,8 @@ struct NetworkSecurityViewControllerTests {
         #expect(
             row(.dnsName(3), in: viewController)?.value
                 == localized(
-                    "network.security.value.empty_reported",
-                    defaultValue: "Empty value reported"
+                    "network.security.value.empty",
+                    defaultValue: "Empty"
                 )
         )
         let dnsDisclosureID = try #require(itemID(.disclosure(.dnsNames), in: viewController))
@@ -280,7 +301,7 @@ struct NetworkSecurityViewControllerTests {
             viewController.rowContentForTesting(dnsDisclosureID)?.label
                 == localized(
                     "network.security.action.show_less_dns_names",
-                    defaultValue: "Show Less DNS Names"
+                    defaultValue: "Show Fewer DNS Names"
                 )
         )
         let expandedDisclosureCell = try #require(visibleCell(dnsDisclosureID, in: viewController))
@@ -305,7 +326,7 @@ struct NetworkSecurityViewControllerTests {
             viewController.rowContentForTesting(ipDisclosureID)?.label
                 == localized(
                     "network.security.action.show_less_ip_addresses",
-                    defaultValue: "Show Less IP Addresses"
+                    defaultValue: "Show Fewer IP Addresses"
                 )
         )
 


### PR DESCRIPTION
## Purpose

Reduce repetitive labels in inspector detail views and make empty, missing, loading, and unavailable states concise without losing semantic distinctions.

## Changes

- Simplify Cookie sections to Request/Response with short state values such as None, Not Captured, and Not Received, while retaining full VoiceOver context.
- Consolidate repeated diagnostics and labels across Headers, Security, Body, and WebSocket detail presentations.
- Distinguish no requests from no search matches, and separate Element no-selection, loading, unavailable, and failed states.
- Clarify the DOM Copy menu and update English/Japanese localizations and rendering tests.

## Testing

- `xcodebuild test -workspace WebInspectorKit.xcworkspace -scheme WebInspectorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`
- `xcrun xcstringstool compile Sources/WebInspectorUIBase/Localizable.xcstrings --serialization-format text`
- `git diff --check`
- `codex-review` (no findings)
